### PR TITLE
Add endpoint to query NichoCNAE pipeline audit by status and external id

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
@@ -29,6 +29,9 @@ public class PipelineNichoCnae {
     @Column(name = "data_hora")
     private Instant dataHora;
 
+    @Column(name = "status", length = 32)
+    private String status;
+
     @Column(name = "job_id", length = 128)
     private String jobId;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -101,6 +101,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         pipeline.setRequest(request == null ? null : request.request());
         pipeline.setCodigoEtapa(stageCode);
         pipeline.setDataHora(now);
+        pipeline.setStatus(STATUS_WAITING_MODULE);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request == null ? null : request.plataforma());
         pipeline.setPrompt(request == null ? null : request.prompt());
@@ -131,6 +132,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         pipeline.setResponse(request == null ? null : request.response());
         pipeline.setCodigoEtapa(stageCode);
         pipeline.setDataHora(now);
+        pipeline.setStatus(hasFailure ? STATUS_FAILED : STATUS_COMPLETED);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request == null ? null : request.quantidadeTokenEntrada());
         pipeline.setQuantidadeTokenSaida(request == null ? null : request.quantidadeTokenSaida());

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/controller/BackendNichoCnaeV3PipelineSituacaoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/controller/BackendNichoCnaeV3PipelineSituacaoController.java
@@ -1,0 +1,33 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.controller;
+
+import com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.BackendNichoCnaeV3PipelineSituacaoService;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.searchPipelineSituacao.NichoCnaeV3PipelineSituacaoRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.searchPipelineSituacao.NichoCnaeV3PipelineSituacaoResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller interno para consultar a situação auditada do pipeline NichoCNAE v3. */
+@RestController
+public class BackendNichoCnaeV3PipelineSituacaoController {
+    private final BackendNichoCnaeV3PipelineSituacaoService service;
+
+    /** Inicializa o controller com o service canônico de consulta de situação. */
+    public BackendNichoCnaeV3PipelineSituacaoController(BackendNichoCnaeV3PipelineSituacaoService service) {
+        this.service = service;
+    }
+
+    /** Consulta registros de auditoria por etapa, id externo e lista de status. */
+    @PostMapping({
+        "/api/internal/oprmcoletormei/nichocnae/v1/{etapa}/stage-executions/{idExterno}/situacao",
+        "/api/internal/oprmcoletormei/nichocnae/v3/{etapa}/stage-executions/{idExterno}/situacao"
+    })
+    public List<NichoCnaeV3PipelineSituacaoResponse> search(
+            @PathVariable String etapa,
+            @PathVariable String idExterno,
+            @RequestBody NichoCnaeV3PipelineSituacaoRequest request) {
+        return service.search(etapa, idExterno, request == null ? null : request.status());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
@@ -1,0 +1,73 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service;
+
+import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.searchPipelineSituacao.NichoCnaeV3PipelineSituacaoResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Consulta auditorias do pipeline NichoCNAE v3 por etapa, identificador externo e situação. */
+@Service
+public class BackendNichoCnaeV3PipelineSituacaoService {
+    private final PipelineNichoCnaeRepository repository;
+
+    /** Inicializa o service com o repository canônico da auditoria NichoCNAE. */
+    public BackendNichoCnaeV3PipelineSituacaoService(PipelineNichoCnaeRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Retorna os registros de auditoria que coincidem com etapa, id externo e qualquer status informado. */
+    public List<NichoCnaeV3PipelineSituacaoResponse> search(String etapa, String idExterno, List<String> status) {
+        if (!StringUtils.hasText(etapa)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "etapa é obrigatória.");
+        }
+        if (!StringUtils.hasText(idExterno)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idExterno é obrigatório.");
+        }
+        List<String> normalizedStatus = normalizeStatus(status);
+        if (normalizedStatus.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status deve conter ao menos uma situação.");
+        }
+        return repository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(etapa, idExterno, normalizedStatus)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /** Normaliza a lista de status removendo valores vazios e duplicados. */
+    private List<String> normalizeStatus(List<String> status) {
+        if (status == null) {
+            return List.of();
+        }
+        return status.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    /** Converte a entidade de auditoria para o contrato público do endpoint. */
+    private NichoCnaeV3PipelineSituacaoResponse toResponse(PipelineNichoCnae pipeline) {
+        return new NichoCnaeV3PipelineSituacaoResponse(
+                pipeline.getIdExterno(),
+                pipeline.getCodigoEtapa(),
+                pipeline.getStatus(),
+                pipeline.getDataHora(),
+                pipeline.getJobId(),
+                pipeline.getRequest(),
+                pipeline.getResponse(),
+                pipeline.getQuantidadeTokenEntrada(),
+                pipeline.getQuantidadeTokenSaida(),
+                pipeline.getModelo(),
+                pipeline.getCusto(),
+                pipeline.getDescricaoErro(),
+                pipeline.getJobIdExterno(),
+                pipeline.getPlataforma(),
+                pipeline.getPrompt(),
+                pipeline.getSchema(),
+                pipeline.getVersaoPipeline());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.searchPipelineSituacao;
+
+import java.util.List;
+
+/** Contrato de entrada para consultar auditorias do pipeline por situação. */
+public record NichoCnaeV3PipelineSituacaoRequest(List<String> status) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
@@ -1,0 +1,25 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service.searchPipelineSituacao;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Contrato de saída com uma auditoria do pipeline NichoCNAE encontrada por situação. */
+public record NichoCnaeV3PipelineSituacaoResponse(
+        String idExterno,
+        String codigoEtapa,
+        String status,
+        Instant dataHora,
+        String jobId,
+        String request,
+        String response,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        String modelo,
+        BigDecimal custo,
+        String descricaoErro,
+        String jobIdExterno,
+        String plataforma,
+        String prompt,
+        String schema,
+        String versaoPipeline) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/PipelineNichoCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/PipelineNichoCnaeRepository.java
@@ -2,6 +2,7 @@ package com.marketinghub.repository.jpa.oprm.nichocnae;
 
 import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
 import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +11,10 @@ import org.springframework.data.repository.query.Param;
 public interface PipelineNichoCnaeRepository extends JpaRepository<PipelineNichoCnae, String> {
     /** Verifica se já existe auditoria registrada para um job do pipeline. */
     boolean existsByJobId(String jobId);
+
+    /** Lista auditorias pelo filtro canônico de etapa, identificador externo e status, mais recentes primeiro. */
+    List<PipelineNichoCnae> findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
+            String codigoEtapa, String idExterno, List<String> status);
 
     /** Soma o custo auditado das interações vinculadas a um job do pipeline. */
     @Query("select coalesce(sum(p.custo), 0) from PipelineNichoCnae p where p.jobId = :jobId")

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-nichocnae-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-nichocnae-status.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-27-01-pipeline-nichocnae-status
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_nichocnae
+        - not:
+            - columnExists:
+                tableName: pipeline_nichocnae
+                columnName: status
+      changes:
+        - addColumn:
+            tableName: pipeline_nichocnae
+            columns:
+              - column:
+                  name: status
+                  type: VARCHAR(32)
+        - createIndex:
+            tableName: pipeline_nichocnae
+            indexName: idx_pipeline_nichocnae_situacao
+            columns:
+              - column:
+                  name: codigo_etapa
+              - column:
+                  name: id_externo
+              - column:
+                  name: status
+              - column:
+                  name: data_hora

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-27-pipeline-nichocnae-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-mois-sales-page-pipeline-dossieproduto-column-names.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.situacao.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida a consulta de situação auditada do pipeline NichoCNAE v3. */
+@ExtendWith(MockitoExtension.class)
+class BackendNichoCnaeV3PipelineSituacaoServiceTest {
+    @Mock
+    private PipelineNichoCnaeRepository repository;
+
+    @InjectMocks
+    private BackendNichoCnaeV3PipelineSituacaoService service;
+
+    /** Deve consultar por OR na lista de status normalizada e preservar a ordenação do repository. */
+    @Test
+    void searchShouldFilterByStageExternalIdAndStatuses() {
+        PipelineNichoCnae record = new PipelineNichoCnae();
+        record.setIdExterno("4781400");
+        record.setCodigoEtapa("source-searcher");
+        record.setStatus("CONCLUIDO");
+        record.setDataHora(Instant.parse("2026-06-27T10:00:00Z"));
+        record.setJobId("job-1");
+        when(repository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
+                        "source-searcher", "4781400", List.of("CONCLUIDO", "FALHA")))
+                .thenReturn(List.of(record));
+
+        var response = service.search("source-searcher", "4781400", List.of(" CONCLUIDO ", "FALHA", "CONCLUIDO", ""));
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().idExterno()).isEqualTo("4781400");
+        assertThat(response.getFirst().codigoEtapa()).isEqualTo("source-searcher");
+        assertThat(response.getFirst().status()).isEqualTo("CONCLUIDO");
+        ArgumentCaptor<List<String>> statusCaptor = ArgumentCaptor.forClass(List.class);
+        verify(repository).findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
+                org.mockito.ArgumentMatchers.eq("source-searcher"),
+                org.mockito.ArgumentMatchers.eq("4781400"),
+                statusCaptor.capture());
+        assertThat(statusCaptor.getValue()).containsExactly("CONCLUIDO", "FALHA");
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1610,3 +1610,8 @@
 - Ajuste: a saída da etapa `cnae-intake` agora explicita que o pipeline está analisando MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.
 - Motivo: esse recorte precisa nascer na primeira etapa para orientar a geração de personas e evitar que as próximas etapas pesquisem funcionários CLT de empresas do CNAE.
 - Prevenção: teste unitário da etapa 1 passou a validar `targetAudienceType`, `targetAudienceDefinition` e `employmentBoundary`.
+
+## 2026-06-27 — Backend NichoCNAE v3: consulta de situação da auditoria
+
+- Criado endpoint interno `POST /api/internal/oprmcoletormei/nichocnae/v1/<etapa>/stage-executions/{idExterno}/situacao` para consultar `pipeline_nichocnae` por etapa, identificador externo e lista de status, retornando registros ordenados por `data_hora` decrescente.
+- Adicionada coluna `status` à auditoria `pipeline_nichocnae`, preenchida nos callbacks v3 como `AGUARDANDO_MODULO`, `CONCLUIDO` ou `FALHA`, permitindo filtro direto no banco em vez de inferência por payload.

--- a/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
@@ -167,6 +167,37 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/BackendError'
+  /api/internal/oprmcoletormei/nichocnae/v1/{stage}/stage-executions/{idExterno}/situacao:
+    post:
+      tags:
+        - Backend queue consumed by oprm-coletor-mei
+      summary: Consulta auditorias do pipeline NichoCNAE por etapa, id externo e lista de status.
+      description: |
+        Retorna os registros existentes na tabela `pipeline_nichocnae` para a etapa,
+        `idExterno` e qualquer status informado no corpo, ordenados por `dataHora`
+        decrescente. O caminho v1 preserva a versão do contrato de auditoria usado
+        pelos callbacks do executor, mesmo dentro do pacote operacional v3.
+      operationId: searchNichoCnaeV3PipelineSituacao
+      parameters:
+        - $ref: '#/components/parameters/StagePath'
+        - $ref: '#/components/parameters/IdExternoPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NichoCnaeV3PipelineSituacaoRequest'
+      responses:
+        '200':
+          description: Registros de auditoria encontrados para o filtro.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NichoCnaeV3PipelineSituacaoResponse'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
   /api/oprm-mei/health:
     get:
       tags:
@@ -235,6 +266,75 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
   schemas:
+    NichoCnaeV3PipelineSituacaoRequest:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+            - AGUARDANDO_MODULO
+            - CONCLUIDO
+            - FALHA
+      additionalProperties: false
+    NichoCnaeV3PipelineSituacaoResponse:
+      type: object
+      properties:
+        idExterno:
+          type: string
+          example: '4781400'
+        codigoEtapa:
+          $ref: '#/components/schemas/NichoCnaeV3StageCode'
+        status:
+          type: string
+          example: CONCLUIDO
+        dataHora:
+          type: string
+          format: date-time
+        jobId:
+          type: string
+        request:
+          type: string
+          nullable: true
+        response:
+          type: string
+          nullable: true
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+          nullable: true
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+          nullable: true
+        modelo:
+          type: string
+          nullable: true
+        custo:
+          type: number
+          nullable: true
+        descricaoErro:
+          type: string
+          nullable: true
+        jobIdExterno:
+          type: string
+          nullable: true
+        plataforma:
+          type: string
+          nullable: true
+        prompt:
+          type: string
+          nullable: true
+        schema:
+          type: string
+          nullable: true
+        versaoPipeline:
+          type: string
+          nullable: true
     NichoCnaeV3StageCode:
       type: string
       enum:


### PR DESCRIPTION
### Motivation

- Provide an internal backend API so operators/executors can query audit records for NichoCNAE by stage, external id and a list of statuses without inferring state from payloads.  
- Persist an explicit `status` in the `pipeline_nichocnae` audit table to allow efficient DB filtering and ordering instead of relying on payload inspection.

### Description

- Added controller `BackendNichoCnaeV3PipelineSituacaoController` exposing `POST /api/internal/oprmcoletormei/nichocnae/v1/{etapa}/stage-executions/{idExterno}/situacao` (also mapped for v3) to accept `{ "status": [] }` and return matching audit rows.  
- Implemented `BackendNichoCnaeV3PipelineSituacaoService` and DTO records `NichoCnaeV3PipelineSituacaoRequest` / `NichoCnaeV3PipelineSituacaoResponse` to validate input, normalize the status list and map entities to responses.  
- Extended `PipelineNichoCnaeRepository` with `findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(...)` to perform the OR-style status lookup ordered by `data_hora` desc.  
- Added `status` field to `PipelineNichoCnae` entity and updated `OprmNichoCnaeV3StageServiceSupport` to persist `AGUARDANDO_MODULO`, `CONCLUIDO` or `FALHA` when recording request/response audit entries.  
- Added Liquibase changeset `changesets/2026-06-27-pipeline-nichocnae-status.yaml` and included it in the master changelog to add the `status` column and an index `idx_pipeline_nichocnae_situacao` for the query pattern.  
- Updated API documentation `docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml` and recorded the change in `docs/registros/oprm1.md`.  
- Added unit test `BackendNichoCnaeV3PipelineSituacaoServiceTest` to verify status normalization and repository invocation.

### Testing

- Ran unit test `BackendNichoCnaeV3PipelineSituacaoServiceTest`, which passed.  
- Ran combined tests `BackendCnaeIntakeServiceTest`, `BackendPersonaRoutineMaterializerServiceTest` and `BackendNichoCnaeV3PipelineSituacaoServiceTest`, and the test run completed successfully with all tests passing.  
- Maven test execution reported `BUILD SUCCESS` for the executed test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40369d12708321bb4f836c74706b25)