### PR TITLE
Add geracaoanuncios status lookup endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
@@ -31,6 +31,9 @@ public class PipelineGeracaoAnuncios {
     @Column(name = "codigo_etapa", length = 96)
     private String codigoEtapa;
 
+    @Column(name = "status", length = 40)
+    private String status;
+
     @Column(name = "data_hora")
     private Instant dataHora;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
@@ -1,6 +1,8 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.controller;
 
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.GeraAnuncioImagemService;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao.GeraAnuncioImagemSituacaoRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao.GeraAnuncioImagemSituacaoResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.detailStageExecution.GeraAnuncioImagemDetailResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.listStageExecutions.GeraAnuncioImagemExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.pending.GeraAnuncioImagemPendingResponse;
@@ -52,6 +54,13 @@ public class GeraAnuncioImagemController {
     @PostMapping("/pending")
     public List<GeraAnuncioImagemPendingResponse> pending() {
         return service.pending();
+    }
+
+    /** Consulta auditorias da etapa filtrando pelo identificador externo e pela lista de status. */
+    @PostMapping("/{idExterno}/situacao")
+    public List<GeraAnuncioImagemSituacaoResponse> consultaSituacao(
+            @PathVariable String idExterno, @RequestBody GeraAnuncioImagemSituacaoRequest request) {
+        return service.consultaSituacao(idExterno, request);
     }
 
     /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -7,6 +7,8 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao.GeraAnuncioImagemSituacaoRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao.GeraAnuncioImagemSituacaoResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.detailStageExecution.GeraAnuncioImagemDetailResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.listStageExecutions.GeraAnuncioImagemExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.pending.GeraAnuncioImagemPendingResponse;
@@ -42,6 +44,7 @@ public class GeraAnuncioImagemService {
     private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
     private static final String PIPELINE_VERSION = "v1";
     private static final String STATUS_FAILED = "FALHA";
+    private static final String STATUS_DONE = "CONCLUIDO";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
     private final MoisSalesPageRepository salesPageRepository;
@@ -123,6 +126,7 @@ public class GeraAnuncioImagemService {
         pipeline.setIdExterno(experimentKey);
         pipeline.setRequest(serializeRequest(request.request()));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId.trim());
         pipeline.setPlataforma(request.plataforma());
@@ -165,6 +169,7 @@ public class GeraAnuncioImagemService {
         pipeline.setIdExterno(experimentKey);
         pipeline.setResponse(serializeRequest(resolveResponsePayload(request)));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_DONE);
         pipeline.setDataHora(now);
         pipeline.setVersaoPipeline(PIPELINE_VERSION);
         pipeline.setJobId(jobId.trim());
@@ -178,6 +183,17 @@ public class GeraAnuncioImagemService {
         return StringUtils.hasText(descricaoErro) ? null : resolveNextStageCode();
     }
 
+    /** Pesquisa auditorias da etapa por identificador externo e lista de status. */
+    public List<GeraAnuncioImagemSituacaoResponse> consultaSituacao(String idExterno, GeraAnuncioImagemSituacaoRequest request) {
+        if (!StringUtils.hasText(idExterno)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idExterno required");
+        }
+        List<String> status = normalizeStatus(request);
+        return pipelineRepository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(STAGE_CODE, idExterno.trim(), status).stream()
+                .map(this::toSituacaoResponse)
+                .toList();
+    }
+
     /** Busca o detalhe auditável de uma execução da etapa. */
     public GeraAnuncioImagemDetailResponse detailStageExecution(String stageExecutionId) {
         Long experimentId = extractExperimentId(stageExecutionId);
@@ -187,6 +203,45 @@ public class GeraAnuncioImagemService {
         Experiment experiment = experimentService.get(experimentId);
         return new GeraAnuncioImagemDetailResponse(stageExecutionId, stageJobId(experiment), experiment.getCreativeGenerationStatus().name(),
                 Objects.requireNonNullElse(experiment.getCreativeGenerationRequestedAt(), Instant.now()), context(experiment));
+    }
+
+    /** Normaliza a lista de status recebida no filtro de situação. */
+    private List<String> normalizeStatus(GeraAnuncioImagemSituacaoRequest request) {
+        if (request == null || request.status() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
+        }
+        List<String> status = request.status().stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+        if (status.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
+        }
+        return status;
+    }
+
+    /** Converte uma auditoria persistida em resposta do endpoint de situação. */
+    private GeraAnuncioImagemSituacaoResponse toSituacaoResponse(PipelineGeracaoAnuncios pipeline) {
+        return new GeraAnuncioImagemSituacaoResponse(
+                pipeline.getId(),
+                pipeline.getIdExterno(),
+                pipeline.getCodigoEtapa(),
+                pipeline.getStatus(),
+                pipeline.getDataHora(),
+                pipeline.getJobId(),
+                pipeline.getRequest(),
+                pipeline.getResponse(),
+                pipeline.getModelo(),
+                pipeline.getQuantidadeTokenEntrada(),
+                pipeline.getQuantidadeTokenSaida(),
+                pipeline.getCusto(),
+                pipeline.getDescricaoErro(),
+                pipeline.getJobIdExterno(),
+                pipeline.getPlataforma(),
+                pipeline.getPrompt(),
+                pipeline.getSchema(),
+                pipeline.getVersaoPipeline());
     }
 
     /** Converte o experimento em resumo auditável da etapa. */
@@ -212,6 +267,7 @@ public class GeraAnuncioImagemService {
         PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
         pipeline.setIdExterno(String.valueOf(cnae.getId()));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline(PIPELINE_VERSION);

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/consultaSituacao/GeraAnuncioImagemSituacaoRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/consultaSituacao/GeraAnuncioImagemSituacaoRequest.java
@@ -1,0 +1,6 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao;
+
+import java.util.List;
+
+/** Requisição com os status usados para filtrar auditorias da etapa Imagem. */
+public record GeraAnuncioImagemSituacaoRequest(List<String> status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/consultaSituacao/GeraAnuncioImagemSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/consultaSituacao/GeraAnuncioImagemSituacaoResponse.java
@@ -1,0 +1,25 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.consultaSituacao;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resposta auditável de situação registrada na tabela do pipeline da etapa Imagem. */
+public record GeraAnuncioImagemSituacaoResponse(
+        Long id,
+        String idExterno,
+        String codigoEtapa,
+        String status,
+        Instant dataHora,
+        String jobId,
+        String request,
+        String response,
+        String modelo,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String descricaoErro,
+        String jobIdExterno,
+        String plataforma,
+        String prompt,
+        String schema,
+        String versaoPipeline) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
@@ -1,6 +1,8 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.controller;
 
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.GeraAnuncioTextoService;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao.GeraAnuncioTextoSituacaoRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao.GeraAnuncioTextoSituacaoResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.detailStageExecution.GeraAnuncioTextoDetailResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.listStageExecutions.GeraAnuncioTextoExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.pending.GeraAnuncioTextoPendingResponse;
@@ -52,6 +54,13 @@ public class GeraAnuncioTextoController {
     @PostMapping("/pending")
     public List<GeraAnuncioTextoPendingResponse> pending() {
         return service.pending();
+    }
+
+    /** Consulta auditorias da etapa filtrando pelo identificador externo e pela lista de status. */
+    @PostMapping("/{idExterno}/situacao")
+    public List<GeraAnuncioTextoSituacaoResponse> consultaSituacao(
+            @PathVariable String idExterno, @RequestBody GeraAnuncioTextoSituacaoRequest request) {
+        return service.consultaSituacao(idExterno, request);
     }
 
     /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -7,6 +7,8 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao.GeraAnuncioTextoSituacaoRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao.GeraAnuncioTextoSituacaoResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.detailStageExecution.GeraAnuncioTextoDetailResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.listStageExecutions.GeraAnuncioTextoExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.pending.GeraAnuncioTextoPendingResponse;
@@ -42,6 +44,7 @@ public class GeraAnuncioTextoService {
     private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
     private static final String PIPELINE_VERSION = "v1";
     private static final String STATUS_FAILED = "FALHA";
+    private static final String STATUS_DONE = "CONCLUIDO";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
     private final MoisSalesPageRepository salesPageRepository;
@@ -137,6 +140,7 @@ public class GeraAnuncioTextoService {
         pipeline.setIdExterno(experimentKey);
         pipeline.setRequest(serializeRequest(request.request()));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId.trim());
         pipeline.setPlataforma(request.plataforma());
@@ -179,6 +183,7 @@ public class GeraAnuncioTextoService {
         pipeline.setIdExterno(experimentKey);
         pipeline.setResponse(serializeRequest(resolveResponsePayload(request)));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_DONE);
         pipeline.setDataHora(now);
         pipeline.setVersaoPipeline(PIPELINE_VERSION);
         pipeline.setJobId(jobId.trim());
@@ -192,6 +197,17 @@ public class GeraAnuncioTextoService {
         return StringUtils.hasText(descricaoErro) ? null : resolveNextStageCode();
     }
 
+    /** Pesquisa auditorias da etapa por identificador externo e lista de status. */
+    public List<GeraAnuncioTextoSituacaoResponse> consultaSituacao(String idExterno, GeraAnuncioTextoSituacaoRequest request) {
+        if (!StringUtils.hasText(idExterno)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idExterno required");
+        }
+        List<String> status = normalizeStatus(request);
+        return pipelineRepository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(STAGE_CODE, idExterno.trim(), status).stream()
+                .map(this::toSituacaoResponse)
+                .toList();
+    }
+
     /** Busca o detalhe auditável de uma execução da etapa. */
     public GeraAnuncioTextoDetailResponse detailStageExecution(String stageExecutionId) {
         Long experimentId = extractExperimentId(stageExecutionId);
@@ -201,6 +217,45 @@ public class GeraAnuncioTextoService {
         Experiment experiment = experimentService.get(experimentId);
         return new GeraAnuncioTextoDetailResponse(stageExecutionId, stageJobId(experiment), experiment.getCreativeGenerationStatus().name(),
                 Objects.requireNonNullElse(experiment.getCreativeGenerationRequestedAt(), Instant.now()), context(experiment));
+    }
+
+    /** Normaliza a lista de status recebida no filtro de situação. */
+    private List<String> normalizeStatus(GeraAnuncioTextoSituacaoRequest request) {
+        if (request == null || request.status() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
+        }
+        List<String> status = request.status().stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+        if (status.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
+        }
+        return status;
+    }
+
+    /** Converte uma auditoria persistida em resposta do endpoint de situação. */
+    private GeraAnuncioTextoSituacaoResponse toSituacaoResponse(PipelineGeracaoAnuncios pipeline) {
+        return new GeraAnuncioTextoSituacaoResponse(
+                pipeline.getId(),
+                pipeline.getIdExterno(),
+                pipeline.getCodigoEtapa(),
+                pipeline.getStatus(),
+                pipeline.getDataHora(),
+                pipeline.getJobId(),
+                pipeline.getRequest(),
+                pipeline.getResponse(),
+                pipeline.getModelo(),
+                pipeline.getQuantidadeTokenEntrada(),
+                pipeline.getQuantidadeTokenSaida(),
+                pipeline.getCusto(),
+                pipeline.getDescricaoErro(),
+                pipeline.getJobIdExterno(),
+                pipeline.getPlataforma(),
+                pipeline.getPrompt(),
+                pipeline.getSchema(),
+                pipeline.getVersaoPipeline());
     }
 
     /** Converte o experimento em resumo auditável da etapa. */
@@ -226,6 +281,7 @@ public class GeraAnuncioTextoService {
         PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
         pipeline.setIdExterno(String.valueOf(cnae.getId()));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline(PIPELINE_VERSION);
@@ -237,6 +293,7 @@ public class GeraAnuncioTextoService {
         PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
         pipeline.setIdExterno(String.valueOf(experiment.getId()));
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline(PIPELINE_VERSION);

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/consultaSituacao/GeraAnuncioTextoSituacaoRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/consultaSituacao/GeraAnuncioTextoSituacaoRequest.java
@@ -1,0 +1,6 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao;
+
+import java.util.List;
+
+/** Requisição com os status usados para filtrar auditorias da etapa Texto. */
+public record GeraAnuncioTextoSituacaoRequest(List<String> status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/consultaSituacao/GeraAnuncioTextoSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/consultaSituacao/GeraAnuncioTextoSituacaoResponse.java
@@ -1,0 +1,25 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.consultaSituacao;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resposta auditável de situação registrada na tabela do pipeline da etapa Texto. */
+public record GeraAnuncioTextoSituacaoResponse(
+        Long id,
+        String idExterno,
+        String codigoEtapa,
+        String status,
+        Instant dataHora,
+        String jobId,
+        String request,
+        String response,
+        String modelo,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String descricaoErro,
+        String jobIdExterno,
+        String plataforma,
+        String prompt,
+        String schema,
+        String versaoPipeline) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
@@ -18,4 +18,8 @@ public interface PipelineGeracaoAnunciosRepository extends JpaRepository<Pipelin
 
     /** Busca a auditoria mais recente de uma etapa vinculada a um identificador externo. */
     Optional<PipelineGeracaoAnuncios> findTopByIdExternoAndCodigoEtapaOrderByDataHoraDesc(String idExterno, String codigoEtapa);
+
+    /** Lista auditorias por etapa, identificador externo e conjunto de status em ordem mais recente. */
+    List<PipelineGeracaoAnuncios> findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
+            String codigoEtapa, String idExterno, List<String> status);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-geracaoanuncios-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-geracaoanuncios-status.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-27-01-add-status-pipeline-geracaoanuncios
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_geracaoanuncios
+        - not:
+            columnExists:
+              tableName: pipeline_geracaoanuncios
+              columnName: status
+      changes:
+        - addColumn:
+            tableName: pipeline_geracaoanuncios
+            columns:
+              - column:
+                  name: status
+                  type: VARCHAR(40)
+                  afterColumn: codigo_etapa
+        - createIndex:
+            tableName: pipeline_geracaoanuncios
+            indexName: idx_pipeline_geracaoanuncios_situacao
+            columns:
+              - column:
+                  name: codigo_etapa
+              - column:
+                  name: id_externo
+              - column:
+                  name: status
+              - column:
+                  name: data_hora
+      rollback:
+        - dropIndex:
+            tableName: pipeline_geracaoanuncios
+            indexName: idx_pipeline_geracaoanuncios_situacao
+        - dropColumn:
+            tableName: pipeline_geracaoanuncios
+            columnName: status

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-27-pipeline-geracaoanuncios-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-mois-sales-page-pipeline-dossieproduto-column-names.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml
+++ b/docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml
@@ -75,6 +75,29 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/situacao:
+    post:
+      tags: [Texto]
+      operationId: consultaAiWorkerGeracaoAnunciosV1TextoSituacao
+      summary: Consulta auditorias da etapa Texto por status
+      description: Retorna registros da tabela pipeline_geracaoanuncios filtrados por etapa texto, idExterno e lista de status, ordenados por dataHora descendente.
+      parameters:
+        - $ref: '#/components/parameters/IdExternoPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SituacaoRequest'
+      responses:
+        '200':
+          description: Registros auditáveis encontrados.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SituacaoPipelineRecord'
   /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags: [Texto]
@@ -221,6 +244,29 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/situacao:
+    post:
+      tags: [Imagem]
+      operationId: consultaAiWorkerGeracaoAnunciosV1ImagemSituacao
+      summary: Consulta auditorias da etapa Imagem por status
+      description: Retorna registros da tabela pipeline_geracaoanuncios filtrados por etapa imagem, idExterno e lista de status, ordenados por dataHora descendente.
+      parameters:
+        - $ref: '#/components/parameters/IdExternoPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SituacaoRequest'
+      responses:
+        '200':
+          description: Registros auditáveis encontrados.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SituacaoPipelineRecord'
   /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags: [Imagem]
@@ -379,6 +425,71 @@ components:
           $ref: '#/components/schemas/JsonObject'
         previousArtifacts:
           $ref: '#/components/schemas/JsonObject'
+    SituacaoRequest:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example: [INICIADO, AGUARDANDO_RETORNO_MODULO, CONCLUIDO]
+    SituacaoPipelineRecord:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        idExterno:
+          type: string
+        codigoEtapa:
+          type: string
+        status:
+          type: string
+        dataHora:
+          type: string
+          format: date-time
+        jobId:
+          type: string
+        request:
+          type: string
+          nullable: true
+        response:
+          type: string
+          nullable: true
+        modelo:
+          type: string
+          nullable: true
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+          nullable: true
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+          nullable: true
+        custo:
+          type: number
+          nullable: true
+        descricaoErro:
+          type: string
+          nullable: true
+        jobIdExterno:
+          type: string
+          nullable: true
+        plataforma:
+          type: string
+          nullable: true
+        prompt:
+          type: string
+          nullable: true
+        schema:
+          type: string
+          nullable: true
+        versaoPipeline:
+          type: string
+          nullable: true
     OperationalRequestAudit:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- Permitir que o AI Worker e ferramentas administrativas consultem o histórico de auditoria do pipeline `geracaoanuncios.v1` filtrando por `etapa`, `idExterno` e uma lista de `status`, retornando registros ordenados por `dataHora` decrescente.
- Registrar e indexar o campo `status` na tabela de auditoria para consultas eficientes e criar contrato HTTP/Swagger canônico para as etapas `texto` e `imagem`.

### Description
- Adiciona o campo `status` à entidade `PipelineGeracaoAnuncios` e cria migration Liquibase `2026-06-27-pipeline-geracaoanuncios-status.yaml` que também cria o índice `idx_pipeline_geracaoanuncios_situacao` para buscas por (`codigo_etapa`, `id_externo`, `status`, `data_hora`).
- Expõe novo endpoint `POST /api/internal/aiworker/geracaoanuncios/v1/<etapa>/stage-executions/{idExterno}/situacao` implementado nas controladoras das etapas `texto` e `imagem` que recebe `{ "status": [ ... ] }` e retorna registros auditáveis; o serviço normaliza e valida a lista de status antes da consulta.
- Adiciona métodos JPA no `PipelineGeracaoAnunciosRepository`: `findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(...)` e mapeia as respostas para DTOs `GeraAnuncio{Texto,Imagem}SituacaoResponse` (novos `record`s imutáveis).
- Atualiza o `db.changelog-master.yaml` com o include relativo da migration e estende o Swagger `docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml` com os novos contratos `SituacaoRequest` e `SituacaoPipelineRecord` para `texto` e `imagem`.

### Testing
- Executado `cd backend/ads-service && mvn -q -DskipTests compile` com sucesso para validar compilação do código alterado.
- Executado `cd backend/ads-service && mvn -q -Dtest=ArquiteturaTest test` e o teste de arquitetura passou, validando normas de pacote/arquitetura aplicáveis ao backend modificado.
- Tentativa de rodar a suíte completa `cd backend/ads-service && mvn -q test` identificou uma falha pré-existente não relacionada em `FacebookPageControllerTest` por violação de FK no H2 durante limpeza de dados, portanto a execução completa foi interrompida após confirmar que o erro é externo às alterações deste PR.
- `git diff --check` e commit foram gerados (`Add geracaoanuncios status lookup endpoint`) e estão incluídos neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40366f1d988321a7863d453e50628a)