### PR TITLE
Add MOIS dossieproduto v1 situacao endpoint and pipeline status persistence

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -52,6 +52,7 @@ public class DossierDossierSynthesisService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierDossierSynthesisService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierDossierSynthesisService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierDossierSynthesisService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -52,6 +52,7 @@ public class DossierIntakeService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierIntakeService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierIntakeService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierIntakeService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -52,6 +52,7 @@ public class DossierInvestigationAnchorBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierInvestigationAnchorBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -52,6 +52,7 @@ public class DossierProductUnderstandingService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierProductUnderstandingService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierProductUnderstandingService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierProductUnderstandingService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/controller/DossierSituacaoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/controller/DossierSituacaoController.java
@@ -1,0 +1,29 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.controller;
+
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.DossierSituacaoService;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao.DossierSituacaoRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao.DossierSituacaoResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a consulta interna de situação das etapas do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/{etapa}/stage-executions")
+@RequiredArgsConstructor
+public class DossierSituacaoController {
+    private final DossierSituacaoService service;
+
+    /** Retorna registros da auditoria que existem para a etapa, identificador externo e status informados. */
+    @PostMapping("/{idExterno}/situacao")
+    public DossierSituacaoResponse situacao(
+            @PathVariable("etapa") String etapa,
+            @PathVariable("idExterno") String idExterno,
+            @Valid @RequestBody DossierSituacaoRequest request) {
+        return service.consultar(etapa, idExterno, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
@@ -1,0 +1,59 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service;
+
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao.DossierSituacaoItem;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao.DossierSituacaoRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao.DossierSituacaoResponse;
+import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
+import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Consulta a situação auditada das etapas do pipeline de dossiê de produto MOIS v1. */
+@Service
+public class DossierSituacaoService {
+    private final PipelineDossieProdutoRepository repository;
+
+    /** Cria o service com acesso ao repositório canônico da auditoria do pipeline. */
+    public DossierSituacaoService(PipelineDossieProdutoRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Pesquisa registros da auditoria pelo identificador externo, etapa e lista de status. */
+    public DossierSituacaoResponse consultar(String codigoEtapa, String idExterno, DossierSituacaoRequest request) {
+        List<String> status = request.status().stream()
+                .filter(valor -> valor != null && !valor.isBlank())
+                .map(String::trim)
+                .toList();
+        List<DossierSituacaoItem> registros = status.isEmpty()
+                ? List.of()
+                : repository.findByIdExternoAndCodigoEtapaAndStatusInOrderByDataHoraDescIdDesc(
+                                idExterno, codigoEtapa, status)
+                        .stream()
+                        .map(this::toItem)
+                        .toList();
+        return new DossierSituacaoResponse(idExterno, codigoEtapa, status, registros);
+    }
+
+    /** Converte a entidade de auditoria para o contrato de consulta de situação. */
+    private DossierSituacaoItem toItem(PipelineDossieProduto pipeline) {
+        return new DossierSituacaoItem(
+                pipeline.getId(),
+                pipeline.getIdExterno(),
+                pipeline.getCodigoEtapa(),
+                pipeline.getStatus(),
+                pipeline.getDataHora(),
+                pipeline.getJobId(),
+                pipeline.getRequest(),
+                pipeline.getResponse(),
+                pipeline.getQuantidadeTokenEntrada(),
+                pipeline.getQuantidadeTokenSaida(),
+                pipeline.getModelo(),
+                pipeline.getCusto(),
+                pipeline.getDescricaoErro(),
+                pipeline.getJobIdExterno(),
+                pipeline.getPlataforma(),
+                pipeline.getPrompt(),
+                pipeline.getSchema(),
+                pipeline.getVersaoPipeline());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoItem.java
@@ -1,0 +1,25 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Contrato de saída responsável por expor um registro encontrado na auditoria do dossiê. */
+public record DossierSituacaoItem(
+        Long id,
+        String idExterno,
+        String codigoEtapa,
+        String status,
+        Instant dataHora,
+        String jobId,
+        String request,
+        String response,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        String modelo,
+        BigDecimal custo,
+        String descricaoErro,
+        String jobIdExterno,
+        String plataforma,
+        String prompt,
+        String schema,
+        String versaoPipeline) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+/** Contrato de entrada responsável por informar os status pesquisados na auditoria do dossiê. */
+public record DossierSituacaoRequest(@NotEmpty List<String> status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situacao.service.situacao;
+
+import java.util.List;
+
+/** Contrato de saída responsável por listar os registros da auditoria filtrados por situação. */
+public record DossierSituacaoResponse(String idExterno, String codigoEtapa, List<String> status, List<DossierSituacaoItem> registros) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -52,6 +52,7 @@ public class DossierSourceProductMatchService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierSourceProductMatchService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierSourceProductMatchService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierSourceProductMatchService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -52,6 +52,7 @@ public class DossierWarmupMapBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierWarmupMapBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -52,6 +52,7 @@ public class DossierWarmupResourceDiscoveryService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierWarmupResourceDiscoveryService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -52,6 +52,7 @@ public class DossierWarmupSignalExtractionService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
@@ -74,6 +75,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setIdExterno(productKey);
         pipeline.setRequest(request.request());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_WAITING);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setPlataforma(request.plataforma());
@@ -108,6 +110,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(status);
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
@@ -171,6 +174,7 @@ public class DossierWarmupSignalExtractionService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setStatus(STATUS_STARTED);
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
@@ -14,4 +14,8 @@ public interface PipelineDossieProdutoRepository extends JpaRepository<PipelineD
     /** Busca o registro operacional mais recente do produto e da etapa para recuperar o jobId ativo. */
     Optional<PipelineDossieProduto> findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(
             String idExterno, String codigoEtapa);
+
+    /** Lista auditorias filtradas por produto, etapa e lista de status, trazendo as mais recentes primeiro. */
+    List<PipelineDossieProduto> findByIdExternoAndCodigoEtapaAndStatusInOrderByDataHoraDescIdDesc(
+            String idExterno, String codigoEtapa, List<String> status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
@@ -33,6 +33,9 @@ public class PipelineDossieProduto {
     @Column(name = "codigo_etapa", length = 120)
     private String codigoEtapa;
 
+    @Column(name = "status", length = 40)
+    private String status;
+
     @Column(name = "data_hora")
     private Instant dataHora;
 

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-dossieproduto-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-dossieproduto-status.yaml
@@ -1,0 +1,69 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-27-pipeline-dossieproduto-status-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            columnExists:
+              tableName: pipeline_dossieproduto
+              columnName: status
+      changes:
+        - addColumn:
+            tableName: pipeline_dossieproduto
+            columns:
+              - column:
+                  name: status
+                  type: VARCHAR(40)
+  - changeSet:
+      id: 2026-06-27-pipeline-dossieproduto-status-02
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - columnExists:
+            tableName: pipeline_dossieproduto
+            columnName: status
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE pipeline_dossieproduto
+                 SET status = CASE
+                   WHEN descricao_erro IS NOT NULL AND TRIM(descricao_erro) <> '' THEN 'FALHA'
+                   WHEN response IS NOT NULL AND TRIM(response) <> '' THEN 'CONCLUIDO'
+                   WHEN request IS NOT NULL AND TRIM(request) <> '' THEN 'AGUARDANDO_RETORNO_MODULO'
+                   ELSE 'INICIADO'
+                 END
+               WHERE status IS NULL;
+  - changeSet:
+      id: 2026-06-27-pipeline-dossieproduto-status-03
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            indexExists:
+              tableName: pipeline_dossieproduto
+              indexName: idx_pipeline_dossieproduto_situacao
+      changes:
+        - createIndex:
+            tableName: pipeline_dossieproduto
+            indexName: idx_pipeline_dossieproduto_situacao
+            columns:
+              - column:
+                  name: id_externo
+              - column:
+                  name: codigo_etapa
+              - column:
+                  name: status
+              - column:
+                  name: data_hora

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-27-pipeline-dossieproduto-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-mois-sales-page-pipeline-dossieproduto-column-names.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1893,3 +1893,9 @@ Arquivos principais:
 - Removida da tela de detalhe da Biblioteca Sales Pages a dependência do endpoint legado de `market-warmup` para exibir o dossiê do produto.
 - Criado endpoint público de leitura do pipeline novo `dossieproduto.v1`, expondo auditoria de cada etapa com entrada, saída, prompt, schema, modelo, tokens, custo, erro e resultado final.
 - Atualizada a tela para apresentar o resultado final consolidado e os registros de cada etapa diretamente a partir do backend novo.
+
+## 2026-06-27 — Consulta de situação do pipeline dossieproduto.v1
+
+- Criado endpoint interno `POST /api/internal/moissaleslibraryworker/dossieproduto/v1/{etapa}/stage-executions/{idExterno}/situacao` para consultar auditorias existentes por etapa, identificador externo e lista de status.
+- Adicionada coluna `status` em `pipeline_dossieproduto`, com preenchimento nas novas auditorias e backfill dos registros existentes por request/response/erro.
+- Atualizado o Swagger canônico do pipeline MOIS dossiê v1 com o contrato de entrada e resposta da consulta.

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -14,6 +14,38 @@ tags:
   - name: moissaleslibraryworker.dossieproduto.v1
     description: Pipeline v1 de dossiê de produto da biblioteca de páginas de venda MOIS
 paths:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/{etapa}/stage-executions/{idExterno}/situacao:
+    post:
+      tags:
+        - moissaleslibraryworker.dossieproduto.v1
+      summary: Consulta registros existentes da auditoria por etapa, identificador externo e status
+      operationId: situacaoMoisDossieProdutoV1StageExecutions
+      parameters:
+        - name: etapa
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Código slug da etapa do pipeline.
+        - name: idExterno
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Chave operacional da página/produto MOIS.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DossierSituacaoRequest"
+      responses:
+        '200':
+          description: Registros encontrados com OR entre os status informados, ordenados por dataHora descendente.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DossierSituacaoResponse"
   /api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/{idExterno}/start:
     post:
       tags:
@@ -776,6 +808,59 @@ paths:
                 $ref: "#/components/schemas/DossierDossierSynthesisRecebeResponseResponse"
 components:
   schemas:
+    DossierSituacaoRequest:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: array
+          items:
+            type: string
+          description: Lista de status usada como filtro OR.
+    DossierSituacaoResponse:
+      type: object
+      properties:
+        idExterno: { type: string }
+        codigoEtapa: { type: string }
+        status:
+          type: array
+          items:
+            type: string
+        registros:
+          type: array
+          items:
+            $ref: "#/components/schemas/DossierSituacaoItem"
+    DossierSituacaoItem:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        idExterno: { type: string }
+        codigoEtapa: { type: string }
+        status: { type: string }
+        dataHora:
+          type: string
+          format: date-time
+        jobId: { type: string }
+        request: { type: string }
+        response: { type: string }
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        modelo: { type: string }
+        custo:
+          type: number
+        descricaoErro: { type: string }
+        jobIdExterno: { type: string }
+        plataforma: { type: string }
+        prompt: { type: string }
+        schema: { type: string }
+        versaoPipeline: { type: string }
     DossierIntakePendingRequest:
       type: object
       required:


### PR DESCRIPTION
### Motivation
- Provide an internal lookup for existing pipeline audit records by stage, external id and a list of statuses to help workers and operators inspect pipeline history and unblock flows.
- Persist a canonical `status` on `pipeline_dossieproduto` so queries can filter by status efficiently and legacy records can be backfilled for consistent behavior.

### Description
- Added a new controller `DossierSituacaoController` exposing `POST /api/internal/moissaleslibraryworker/dossieproduto/v1/{etapa}/stage-executions/{idExterno}/situacao` that accepts a list of `status` and returns matching audit records ordered by `dataHora` desc. (`backend/.../situacao/controller/DossierSituacaoController.java`).
- Implemented `DossierSituacaoService` and DTO contracts `DossierSituacaoRequest`, `DossierSituacaoResponse`, `DossierSituacaoItem` to perform the query and map entities to response records. (`backend/.../situacao/service` and `.../situacao/service/situacao`).
- Extended `PipelineDossieProduto` entity with `status` and added a derived repository method `findByIdExternoAndCodigoEtapaAndStatusInOrderByDataHoraDescIdDesc(...)` used by the new service. (`repository/jpa/mois/dossieproduto`).
- Updated all existing dossie v1 stage services to persist `status` when writing pipeline audit lines (start/recebeRequest/recebeResponse/rebuild jobId) so new records include canonical status. (multiple `moissaleslibraryworker.pipelines.dossieproduto.v1.*.service` files).
- Added Liquibase changelog `changesets/2026-06-27-pipeline-dossieproduto-status.yaml` that (1) adds the `status` column if missing, (2) backfills existing rows using `request/response/descricao_erro` into a sensible status (`INICIADO`/`AGUARDANDO_RETORNO_MODULO`/`CONCLUIDO`/`FALHA`), and (3) creates an index `idx_pipeline_dossieproduto_situacao` to support the new query; the master changelog was updated with `relativeToChangelogFile: true` include. (`backend/.../db/changelog`).
- Updated the canonical Swagger `docs/swagger/mois-dossie-v1-swagger.yaml` with the new path and component schemas for request/response items, and recorded the change in `docs/registros/mois1.md`.

### Testing
- Ran unit/integration test suite for the backend module with `../mvnw test -DskipITs`; build succeeded and tests passed (total tests run in the session: `966`, failures `0`, errors `0`, skipped `1`).
- Verified quick compilation with `../mvnw -q -DskipTests compile` which succeeded locally during the rollout.
- Performed static checks: `git diff --check` and a custom validation script that confirmed all `include` entries use `relativeToChangelogFile: true` in the changelog master; both passed.
- Confirmed formatting/build hooks while running the module build; no runtime test failures related to the changes were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40367f94a08321a9bbad08537a5cc4)