### PR TITLE
Remove card "Contexto do framework da hipótese" da aba Conteúdo

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5492,3 +5492,9 @@
 - Sintoma: a tela de experimento falhava ao salvar criativos quando o pipeline gerava `primaryText` maior que o campo persistido.
 - Causa-raiz confirmada: o schema/prompt de `AD_COPY` não limitava `primaryText`, `headline` e `description` aos tamanhos operacionais recomendados para Meta Ads; ampliar a coluna apenas mascarava o problema e permitiria copy longa/truncada na publicação.
 - Correção: revertida a ampliação de banco e adicionados limites no prompt/schema da etapa: `primaryText` até 125 caracteres, `headline` até 40 e `description` até 25, para bloquear a recorrência na origem da geração.
+
+## 2026-06-27 — Remoção do card de contexto da aba Conteúdo
+
+- Solicitação: retirar da aba Conteúdo do experimento o card “Contexto do framework da hipótese”, que ocupava espaço e repetia os resumos de Dor, Resultado, Mecanismo, Prova e Oferta.
+- Ajuste aplicado: o frontend deixou de renderizar esse card na aba de geração de conteúdo, mantendo o botão de relatório consolidado e os painéis operacionais da tela.
+- Prevenção de recorrência: removida também a montagem local dos cards, evitando manter lógica visual sem uso na tela.

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -648,10 +648,6 @@ const REPORT_DOMAIN_ALIASES: Record<string, ContentGenerationSectionKey> = {
   "landing-html": "landing-html",
 };
 
-function getFrameworkSummary(value?: string) {
-  return value?.trim() || "Resumo ainda não preenchido na hipótese.";
-}
-
 function formatDateTime(value?: string) {
   if (!value) return "—";
   const date = new Date(value);
@@ -1423,59 +1419,6 @@ export default function ExperimentContentGenerationTab({
     return bySection;
   }, [mergedRequestsBySection]);
 
-  const frameworkContext = useMemo(
-    () => ({
-      pain: getFrameworkSummary(hypothesis?.framework?.pain?.summary),
-      result: getFrameworkSummary(hypothesis?.framework?.result?.summary),
-      mechanism: getFrameworkSummary(hypothesis?.framework?.mechanism?.summary),
-      proof: getFrameworkSummary(hypothesis?.framework?.proof?.summary),
-      offer: getFrameworkSummary(hypothesis?.framework?.offer?.summary),
-    }),
-    [
-      hypothesis?.framework?.mechanism?.summary,
-      hypothesis?.framework?.offer?.summary,
-      hypothesis?.framework?.pain?.summary,
-      hypothesis?.framework?.proof?.summary,
-      hypothesis?.framework?.result?.summary,
-    ],
-  );
-
-  const frameworkSummaryCards = useMemo(
-    () => [
-      {
-        key: "pain",
-        title: "Dor",
-        description: "Problema central que precisa ser resolvido.",
-        content: frameworkContext.pain,
-      },
-      {
-        key: "result",
-        title: "Resultado",
-        description: "Transformação desejada pelo público.",
-        content: frameworkContext.result,
-      },
-      {
-        key: "mechanism",
-        title: "Mecanismo",
-        description: "Como a solução funciona na prática.",
-        content: frameworkContext.mechanism,
-      },
-      {
-        key: "proof",
-        title: "Prova",
-        description: "Evidências que sustentam a promessa.",
-        content: frameworkContext.proof,
-      },
-      {
-        key: "offer",
-        title: "Oferta",
-        description: "Estrutura da entrega e chamada para ação.",
-        content: frameworkContext.offer,
-      },
-    ],
-    [frameworkContext],
-  );
-
   const persistedCampaignAngle = useMemo(
     () => parseCampaignAnglePayload(campaignAngle),
     [campaignAngle],
@@ -2132,31 +2075,6 @@ export default function ExperimentContentGenerationTab({
           )}
         </button>
       </div>
-
-      <section className="card">
-        <div className="card-body">
-          <h5 className="card-title mb-1">Contexto do framework da hipótese</h5>
-          <p className="text-muted mb-3">
-            Esses resumos de Dor, Resultado, Mecanismo, Prova e Oferta serão
-            enviados junto com cada solicitação para orientar o Worker IA.
-          </p>
-          <div className="row g-3">
-            {frameworkSummaryCards.map((card) => (
-              <div key={card.key} className="col-12 col-md-6 col-xl">
-                <div className="border rounded p-3 h-100 bg-light-subtle d-flex flex-column gap-2">
-                  <div>
-                    <h6 className="mb-1">
-                      Resumo da {card.title.toLowerCase()}
-                    </h6>
-                    <p className="mb-0 text-muted small">{card.description}</p>
-                  </div>
-                  <p className="mb-0 small lh-base">{card.content}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
 
       <PipelinePromptVersionsPanel
         versionsBySection={promptVersionsBySection}


### PR DESCRIPTION
### Motivation
- A aba de geração de conteúdo exibia um card redundante "Contexto do framework da hipótese" que ocupava espaço e repetia informações já presentes na hipótese; a intenção é simplificar a tela e reduzir ruído visual mantendo os painéis operacionais e o botão de relatório.

### Description
- Remove a montagem local e a renderização do card de contexto no arquivo `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` (remoção de `getFrameworkSummary`, `frameworkContext`, `frameworkSummaryCards` e do bloco JSX do `section.card`).
- Atualiza `docs/registros/experimentos.md` registrando a alteração e a justificativa operacional.
- Mudanças principais em: `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` e `docs/registros/experimentos.md`.

### Testing
- Executed `npm ci` in `frontend` to install dependencies and the command completed successfully.
- Executed `npm run typecheck` and it passed after installing dependencies (`tsc --noEmit` succeeded).
- Executed `npm run build` and the Vite production build completed successfully (warning about large chunks present but unrelated to the change).
- Ran `git diff --check` to verify no trailing whitespace or simple diff issues (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a404296a3b0832195936a4c59edcc44)