### PR TITLE
NichoCNAE v3: produce functional artifacts for stages 6–9 and add OpenAI request/response backend audit

### DIFF
--- a/docs/registros/pipeline.md
+++ b/docs/registros/pipeline.md
@@ -71,3 +71,16 @@ Subpacotes principais identificados:
 - A leitura administrativa de progresso fica no pacote `com.marketinghub.oprmcoletormei.nichocnae.v3.progress`.
 - O endpoint administrativo de progresso é `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress`.
 - A confirmação de finalização usa `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress/confirm-finalization`.
+
+## 2026-06-27 — Saídas funcionais das etapas 6 a 9 do NichoCNAE v3
+
+- Causa-raiz: as etapas 6 (`source-fetcher`), 7 (`routine-signal-extractor`), 8 (`daily-tasks-synthesizer`) e 9 (`quality-gate`) do executor `oprm-coletor-mei` retornavam apenas contratos genéricos de conclusão, sem artefatos funcionais compatíveis com coleta de evidência, extração de sinais, síntese de tarefas e decisão de qualidade.
+- Correção aplicada: as etapas passaram a transformar entradas persistidas em `sourceSnapshots`, `routineSignals`, `dailyTasks` e decisão de gate com critérios, motivo e etapa recomendada de correção quando bloquear.
+- Prevenção: adicionados testes unitários específicos para cada etapa, garantindo que a saída não volte a ser apenas status genérico.
+
+## 2026-06-27 — Auditoria OpenAI em recebeRequest/recebeResponse no NichoCNAE v3
+
+- Verificação: a única etapa v3 atual que chama OpenAI diretamente é `persona-candidate-generator` no executor `oprm-coletor-mei`.
+- Causa-raiz: a etapa registrava request/response da OpenAI apenas em log local do executor, mas não enviava os payloads ao backend pelos callbacks canônicos `recebeRequest` e `recebeResponse`, deixando a auditoria persistida incompleta.
+- Correção aplicada: antes da chamada à OpenAI o executor envia o request bruto, prompt, schema e plataforma ao endpoint `recebeRequest`; após sucesso ou erro HTTP da OpenAI envia response bruto, modelo, tokens quando disponíveis e descrição de erro ao endpoint `recebeResponse`.
+- Prevenção: o teste do cliente OpenAI passou a validar a sequência backend `recebeRequest` → OpenAI `/responses` → backend `recebeResponse` nos cenários de sucesso e erro.

--- a/oprm-coletor-mei/README.md
+++ b/oprm-coletor-mei/README.md
@@ -32,6 +32,17 @@ A referência oficial do módulo OPRM é o pipeline de importação por snapshot
 - `docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md`
 - `docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md`
 
+## Pipeline NichoCNAE v3
+
+O módulo também executa o pipeline `com.marketinghub.pipelines.nichocnae.v3` para pesquisa de rotina por CNAE. As etapas 6 a 9 devem gerar saídas funcionais compatíveis com seus objetivos:
+
+6. `source-fetcher`: transforma fontes selecionadas em `sourceSnapshots` auditáveis, com URL, título, trecho de evidência e relevância de rotina.
+7. `routine-signal-extractor`: extrai `routineSignals` com tarefa, dor operacional, sinal de compra e referência do snapshot.
+8. `daily-tasks-synthesizer`: consolida `dailyTasks` com dor, evidência, fonte e alavanca de facilidade.
+9. `quality-gate`: decide avanço por critérios persistíveis de evidência e informa causa/correção quando bloquear.
+
+A etapa `persona-candidate-generator`, quando chama OpenAI, audita o request pelo endpoint backend `recebeRequest` antes do envio ao provedor e audita o retorno pelo `recebeResponse` tanto em sucesso quanto em erro HTTP da OpenAI.
+
 ## Build Docker
 ```bash
 docker build -t oprm-coletor-mei:local .

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
@@ -10,18 +10,72 @@ import java.util.Map;
 
 /** Processa a etapa daily-tasks-synthesizer do pipeline NichoCNAE v3. */
 public final class DailyTasksSynthesizerProcessor implements StageProcessor {
-    /** Executa a etapa daily-tasks-synthesizer produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "TAREFAS_DIARIAS_SINTETIZADAS";
+
+    /** Executa a etapa daily-tasks-synthesizer consolidando sinais em mapa de tarefas, dores e oportunidades de facilidade. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> signals = maps(context.input().get("routineSignals"));
+        if (signals.isEmpty()) {
+            throw new IllegalStateException("Entrada de daily-tasks-synthesizer não contém routineSignals para sintetizar tarefas.");
+        }
+        List<Map<String, Object>> dailyTasks = signals.stream().map(this::task).toList();
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "daily-tasks-synthesizer");
-        output.put("status", "TAREFAS_DIARIAS_SINTETIZADAS");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("dailyTaskCount", dailyTasks.size());
+        output.put("dailyTasks", dailyTasks);
+        output.put("commercialReading", "Mapa de rotina pronto para orientar produto futuro em facilidade, economia de esforço e redução de dor, sem gerar oferta nesta etapa.");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "quality-gate");
-        return new StageResult("TAREFAS_DIARIAS_SINTETIZADAS", output, List.of(new StageArtifact("TAREFAS_DIARIAS_SINTETIZADAS", "inline://nichocnae-v3/daily-tasks-synthesizer", "Etapa daily-tasks-synthesizer concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/daily-tasks-synthesizer", "Tarefas diárias sintetizadas a partir de sinais evidenciados.")));
+    }
+
+    /** Normaliza a lista de sinais recebida da etapa anterior. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().filter(Map.class::isInstance).map(item -> {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            ((Map<?, ?>) item).forEach((key, val) -> normalized.put(String.valueOf(key), val));
+            return normalized;
+        }).toList();
+    }
+
+    /** Cria uma tarefa diária com dor, evidência e alavanca de facilidade. */
+    private Map<String, Object> task(Map<String, Object> signal) {
+        Map<String, Object> task = new LinkedHashMap<>();
+        task.put("task", text(signal.get("routineTask")));
+        task.put("pain", text(signal.get("painSignal")));
+        task.put("buyingSignal", text(signal.get("buyingSignal")));
+        task.put("evidenceText", text(signal.get("evidenceText")));
+        task.put("sourceUrl", text(signal.get("sourceUrl")));
+        task.put("easeLever", easeLever(text(signal.get("painSignal"))));
+        return task;
+    }
+
+    /** Traduz a dor operacional em alavanca de facilidade para uso posterior no pipeline. */
+    private String easeLever(String pain) {
+        if (pain.contains("TEMPO")) {
+            return "economizar tempo em tarefa recorrente";
+        }
+        if (pain.contains("ERRO") || pain.contains("RETRABALHO")) {
+            return "reduzir erro e retrabalho";
+        }
+        if (pain.contains("CONTROLE")) {
+            return "simplificar controle operacional";
+        }
+        return "reduzir esforço operacional percebido";
+    }
+
+    /** Converte valor opcional em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -32,6 +33,7 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
     private final PersonaCandidateOpenAiProperties properties;
     private final PersonaCandidatePromptBuilder promptBuilder;
     private final PersonaCandidateSchemaLoader schemaLoader;
+    private final String backendBaseUrl;
 
     /** Inicializa o cliente OpenAI com prompt, schema e propriedades da etapa. */
     public OpenAiPersonaCandidateGenerationClient(
@@ -39,12 +41,14 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
             ObjectMapper objectMapper,
             PersonaCandidateOpenAiProperties properties,
             PersonaCandidatePromptBuilder promptBuilder,
-            PersonaCandidateSchemaLoader schemaLoader) {
+            PersonaCandidateSchemaLoader schemaLoader,
+            @Value("${backend.base-url:http://191.252.181.168}") String backendBaseUrl) {
         this.restClient = restClient;
         this.objectMapper = objectMapper;
         this.properties = properties;
         this.promptBuilder = promptBuilder;
         this.schemaLoader = schemaLoader;
+        this.backendBaseUrl = backendBaseUrl == null || backendBaseUrl.isBlank() ? "http://191.252.181.168" : backendBaseUrl;
     }
 
     /** Gera personas candidatas por OpenAI e retorna o payload funcional validado pelo schema. */
@@ -66,9 +70,11 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         String url = properties.baseUrl() + RESPONSES_PATH;
         Map<String, Object> requestBody = buildRequestBody(promptBuilder.build(request), properties.model());
         logOpenAiRequest(url, request, requestBody);
+        sendBackendRequestAudit(request, requestBody);
         try {
             Map<String, Object> raw = responseBody(url, requestBody, apiKey);
             logOpenAiResponse(url, request, raw);
+            sendBackendResponseAudit(request, raw, null);
             if (raw == null) {
                 log.error(
                         "OpenAI retornou corpo vazio para persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, model={}, serviceTier={})",
@@ -84,6 +90,7 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
             return objectMapper.readValue(modelResponse, MAP_TYPE);
         } catch (RestClientResponseException ex) {
             logOpenAiHttpError(url, request, ex);
+            sendBackendResponseAudit(request, responseErrorPayload(ex), ex.getClass().getSimpleName() + ": " + ex.getMessage());
             throw new IllegalStateException("Falha na OpenAI ao gerar personas candidatas do NichoCNAE v3.", ex);
         } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
             log.error(
@@ -201,6 +208,71 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
                 request.stageExecutionId(),
                 request.cnaeCode(),
                 toJsonForLog(raw));
+    }
+
+
+    /** Envia ao backend o request bruto encaminhado à OpenAI pelo endpoint recebeRequest. */
+    private void sendBackendRequestAudit(PersonaCandidateGenerationRequest request, Map<String, Object> requestBody) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("request", toJsonForLog(requestBody));
+        payload.put("plataforma", "OPENAI_RESPONSES_API");
+        payload.put("prompt", String.valueOf(requestBody.getOrDefault("input", "")));
+        payload.put("schema", toJsonForLog(schemaLoader.load()));
+        String endpoint = backendStageExecutionUrl(request, "recebeRequest");
+        log.info(
+                "Enviando request OpenAI persona-candidate-generator ao backend (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={})",
+                endpoint,
+                request.jobId(),
+                request.stageExecutionId(),
+                request.cnaeCode());
+        restClient.post().uri(URI.create(endpoint)).body(payload).retrieve().toBodilessEntity();
+    }
+
+    /** Envia ao backend a resposta bruta da OpenAI ou o erro capturado pelo endpoint recebeResponse. */
+    private void sendBackendResponseAudit(PersonaCandidateGenerationRequest request, Map<String, Object> responseBody, String errorMessage) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("response", toJsonForLog(responseBody));
+        payload.put("descricaoErro", errorMessage);
+        payload.put("quantidadeTokenEntrada", tokenUsage(responseBody, "input_tokens"));
+        payload.put("quantidadeTokenSaida", tokenUsage(responseBody, "output_tokens"));
+        payload.put("custo", null);
+        payload.put("modelo", properties.model());
+        String endpoint = backendStageExecutionUrl(request, "recebeResponse");
+        log.info(
+                "Enviando response OpenAI persona-candidate-generator ao backend (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, hasError={})",
+                endpoint,
+                request.jobId(),
+                request.stageExecutionId(),
+                request.cnaeCode(),
+                errorMessage != null && !errorMessage.isBlank());
+        restClient.post().uri(URI.create(endpoint)).body(payload).retrieve().toBodilessEntity();
+    }
+
+    /** Monta payload estruturado para auditoria de erro HTTP da OpenAI. */
+    private Map<String, Object> responseErrorPayload(RestClientResponseException ex) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("statusCode", ex.getStatusCode().value());
+        payload.put("statusText", ex.getStatusText());
+        payload.put("responseBody", ex.getResponseBodyAsString());
+        return payload;
+    }
+
+    /** Monta a URL canônica do callback backend para auditoria request/response. */
+    private String backendStageExecutionUrl(PersonaCandidateGenerationRequest request, String callback) {
+        String base = backendBaseUrl.endsWith("/") ? backendBaseUrl.substring(0, backendBaseUrl.length() - 1) : backendBaseUrl;
+        return base + "/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/"
+                + request.cnaeCode() + "/" + request.jobId() + "/" + callback;
+    }
+
+    /** Extrai tokens retornados pela OpenAI quando o campo usage estiver disponível. */
+    private Long tokenUsage(Map<String, Object> responseBody, String field) {
+        if (responseBody != null && responseBody.get("usage") instanceof Map<?, ?> usage) {
+            Object value = usage.get(field);
+            if (value instanceof Number number) {
+                return number.longValue();
+            }
+        }
+        return null;
     }
 
     /** Serializa payloads para log preservando diagnóstico mesmo quando houver valor não serializável. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessor.java
@@ -10,18 +10,44 @@ import java.util.Map;
 
 /** Processa a etapa quality-gate do pipeline NichoCNAE v3. */
 public final class QualityGateProcessor implements StageProcessor {
-    /** Executa a etapa quality-gate produzindo saída estruturada para o backend decidir avanço. */
+    /** Executa a etapa quality-gate decidindo se a rotina tem evidência suficiente para materialização. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> dailyTasks = maps(context.input().get("dailyTasks"));
+        boolean approved = dailyTasks.size() >= 2 && dailyTasks.stream().anyMatch(task -> !text(task.get("sourceUrl")).isBlank());
+        String status = approved ? "QUALIDADE_APROVADA" : "QUALIDADE_BLOQUEADA";
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "quality-gate");
-        output.put("status", "QUALIDADE_APROVADA");
+        output.put("status", status);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("approved", approved);
+        output.put("evidenceTaskCount", dailyTasks.size());
+        output.put("gateCriteria", List.of("mínimo de duas tarefas sintetizadas", "ao menos uma tarefa com fonte rastreável", "ausência de oferta/campanha/landing prematura"));
+        output.put("decisionReason", approved ? "Há sinais suficientes de rotina e fonte rastreável para materializar relatório da persona." : "Faltam tarefas suficientes ou fonte rastreável; reprocessar busca/coleta antes de avançar.");
+        output.put("recommendedCorrectionStage", approved ? "" : "source-searcher");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
-        output.put("nextStageCode", "persona-routine-materializer");
-        return new StageResult("QUALIDADE_APROVADA", output, List.of(new StageArtifact("QUALIDADE_APROVADA", "inline://nichocnae-v3/quality-gate", "Etapa quality-gate concluída com contrato estruturado.")));
+        output.put("nextStageCode", approved ? "persona-routine-materializer" : "");
+        return new StageResult(status, output, List.of(new StageArtifact(status, "inline://nichocnae-v3/quality-gate", "Gate de qualidade executado com decisão e causa persistíveis.")));
+    }
+
+    /** Normaliza a lista de tarefas sintetizadas recebida da etapa anterior. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().filter(Map.class::isInstance).map(item -> {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            ((Map<?, ?>) item).forEach((key, val) -> normalized.put(String.valueOf(key), val));
+            return normalized;
+        }).toList();
+    }
+
+    /** Converte valor opcional em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessor.java
@@ -10,18 +10,94 @@ import java.util.Map;
 
 /** Processa a etapa routine-signal-extractor do pipeline NichoCNAE v3. */
 public final class RoutineSignalExtractorProcessor implements StageProcessor {
-    /** Executa a etapa routine-signal-extractor produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "SINAIS_EXTRAIDOS";
+
+    /** Executa a etapa routine-signal-extractor extraindo tarefas, dores e sinais de compra dos snapshots. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> snapshots = maps(context.input().get("sourceSnapshots"));
+        if (snapshots.isEmpty()) {
+            throw new IllegalStateException("Entrada de routine-signal-extractor não contém sourceSnapshots para extrair sinais.");
+        }
+        List<Map<String, Object>> routineSignals = snapshots.stream().map(this::signal).toList();
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "routine-signal-extractor");
-        output.put("status", "SINAIS_EXTRAIDOS");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("signalCount", routineSignals.size());
+        output.put("routineSignals", routineSignals);
+        output.put("extractionRules", List.of("extrair apenas sinais sustentados por evidenceText", "classificar tarefa/dor/sinal de compra", "preservar referência do snapshot"));
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "daily-tasks-synthesizer");
-        return new StageResult("SINAIS_EXTRAIDOS", output, List.of(new StageArtifact("SINAIS_EXTRAIDOS", "inline://nichocnae-v3/routine-signal-extractor", "Etapa routine-signal-extractor concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/routine-signal-extractor", "Sinais funcionais de rotina extraídos dos snapshots coletados.")));
+    }
+
+    /** Normaliza a lista de snapshots recebida da etapa anterior. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().filter(Map.class::isInstance).map(item -> {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            ((Map<?, ?>) item).forEach((key, val) -> normalized.put(String.valueOf(key), val));
+            return normalized;
+        }).toList();
+    }
+
+    /** Transforma um snapshot em sinal de rotina classificado. */
+    private Map<String, Object> signal(Map<String, Object> snapshot) {
+        String evidence = text(snapshot.get("evidenceText"));
+        String lower = evidence.toLowerCase();
+        Map<String, Object> signal = new LinkedHashMap<>();
+        signal.put("snapshotId", text(snapshot.get("snapshotId")));
+        signal.put("sourceUrl", text(snapshot.get("url")));
+        signal.put("evidenceText", evidence);
+        signal.put("routineTask", inferTask(evidence));
+        signal.put("painSignal", inferPain(lower));
+        signal.put("buyingSignal", inferBuyingSignal(lower));
+        signal.put("confidence", evidence.isBlank() ? "BAIXA" : "MEDIA");
+        return signal;
+    }
+
+    /** Infere uma tarefa objetiva sem inventar além do trecho recebido. */
+    private String inferTask(String evidence) {
+        if (evidence.isBlank()) {
+            return "Tarefa não identificada no trecho";
+        }
+        return evidence.length() > 160 ? evidence.substring(0, 160) : evidence;
+    }
+
+    /** Classifica dor operacional conforme palavras observáveis no texto. */
+    private String inferPain(String lowerEvidence) {
+        if (lowerEvidence.contains("erro") || lowerEvidence.contains("retrabalho")) {
+            return "RISCO_DE_ERRO_OU_RETRABALHO";
+        }
+        if (lowerEvidence.contains("tempo") || lowerEvidence.contains("demora")) {
+            return "PERDA_DE_TEMPO";
+        }
+        if (lowerEvidence.contains("estoque") || lowerEvidence.contains("controle")) {
+            return "CONTROLE_OPERACIONAL_MANUAL";
+        }
+        return "DOR_OPERACIONAL_A_VALIDAR";
+    }
+
+    /** Classifica sinais de compra por busca explícita de solução ou ferramenta. */
+    private String inferBuyingSignal(String lowerEvidence) {
+        if (lowerEvidence.contains("sistema") || lowerEvidence.contains("software") || lowerEvidence.contains("planilha")) {
+            return "PROCURA_FERRAMENTA_OU_MODELO";
+        }
+        if (lowerEvidence.contains("consultoria") || lowerEvidence.contains("curso")) {
+            return "PROCURA_AJUDA_ESPECIALIZADA";
+        }
+        return "SINAL_DE_COMPRA_A_VALIDAR";
+    }
+
+    /** Converte valor opcional em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessor.java
@@ -7,21 +7,93 @@ import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Processa a etapa source-fetcher do pipeline NichoCNAE v3. */
 public final class SourceFetcherProcessor implements StageProcessor {
-    /** Executa a etapa source-fetcher produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "SNAPSHOTS_COLETADOS";
+
+    /** Executa a etapa source-fetcher materializando snapshots de evidência a partir das fontes selecionadas. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> selectedSources = maps(context.input().get("selectedSources"));
+        if (selectedSources.isEmpty()) {
+            selectedSources = maps(context.input().get("foundSources"));
+        }
+        if (selectedSources.isEmpty()) {
+            throw new IllegalStateException("Entrada de source-fetcher não contém selectedSources/foundSources para coletar snapshots úteis.");
+        }
+        AtomicInteger sequence = new AtomicInteger(1);
+        List<Map<String, Object>> snapshots = selectedSources.stream()
+                .map(source -> snapshot(source, sequence.getAndIncrement()))
+                .filter(Objects::nonNull)
+                .toList();
+        if (snapshots.isEmpty()) {
+            throw new IllegalStateException("Source-fetcher não conseguiu transformar fontes em snapshots auditáveis.");
+        }
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "source-fetcher");
-        output.put("status", "SNAPSHOTS_COLETADOS");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("snapshotCount", snapshots.size());
+        output.put("sourceSnapshots", snapshots);
+        output.put("collectionCriteria", List.of("preservar URL/título/trecho de evidência", "separar evidência funcional de metadado técnico", "não inventar fatos ausentes na fonte"));
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "routine-signal-extractor");
-        return new StageResult("SNAPSHOTS_COLETADOS", output, List.of(new StageArtifact("SNAPSHOTS_COLETADOS", "inline://nichocnae-v3/source-fetcher", "Etapa source-fetcher concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/source-fetcher", "Snapshots auditáveis coletados para extração de sinais de rotina.")));
+    }
+
+    /** Converte uma lista de objetos em mapas estruturados. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream()
+                .filter(Map.class::isInstance)
+                .map(item -> {
+                    Map<String, Object> normalized = new LinkedHashMap<>();
+                    ((Map<?, ?>) item).forEach((key, val) -> normalized.put(String.valueOf(key), val));
+                    return normalized;
+                })
+                .toList();
+    }
+
+    /** Monta um snapshot funcional mínimo da fonte para a etapa de extração. */
+    private Map<String, Object> snapshot(Map<String, Object> source, int sequence) {
+        String url = text(first(source, "url", "sourceUrl", "link"));
+        String title = text(first(source, "title", "sourceTitle", "name"));
+        String evidence = text(first(source, "snippet", "excerpt", "evidence", "description"));
+        if (url.isBlank() && title.isBlank() && evidence.isBlank()) {
+            return null;
+        }
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("snapshotId", "snapshot-" + sequence);
+        snapshot.put("url", url);
+        snapshot.put("title", title);
+        snapshot.put("evidenceText", evidence);
+        snapshot.put("sourceType", text(first(source, "sourceType", "type", "category")));
+        snapshot.put("routineRelevance", text(first(source, "routineRelevance", "objective", "whyRelevant")));
+        snapshot.put("capturedFields", List.of("url", "title", "evidenceText", "sourceType", "routineRelevance"));
+        return snapshot;
+    }
+
+    /** Retorna o primeiro campo existente no mapa de fonte. */
+    private Object first(Map<String, Object> source, String... keys) {
+        for (String key : keys) {
+            if (source.containsKey(key)) {
+                return source.get(key);
+            }
+        }
+        return "";
+    }
+
+    /** Converte valor opcional em texto sem nulos. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessorTest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.pipelines.nichocnae.v3.dailytaskssynthesizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida que a síntese transforma sinais em tarefas diárias acionáveis. */
+class DailyTasksSynthesizerProcessorTest {
+    /** Garante saída com tarefa, dor, evidência e alavanca de facilidade. */
+    @Test
+    void shouldSynthesizeDailyTasksFromSignals() {
+        StageResult result = new DailyTasksSynthesizerProcessor().process(new StageContext("job", "8", Map.of("routineSignals", List.of(Map.of(
+                "routineTask", "Conferir estoque", "painSignal", "CONTROLE_OPERACIONAL_MANUAL", "buyingSignal", "PROCURA_FERRAMENTA_OU_MODELO", "sourceUrl", "https://exemplo.com")))));
+
+        assertThat(result.status()).isEqualTo("TAREFAS_DIARIAS_SINTETIZADAS");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> task = (Map<String, Object>) ((List<?>) result.output().get("dailyTasks")).getFirst();
+        assertThat(task).containsEntry("easeLever", "simplificar controle operacional");
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
@@ -35,6 +35,12 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 {\"candidatePersonas\":[{\"name\":\"p1\"},{\"name\":\"p2\"},{\"name\":\"p3\"}],\"personaSummary\":\"p1;p2;p3\"}
                 """.trim();
         String response = new ObjectMapper().writeValueAsString(Map.of("output_text", modelJson));
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-1/recebeRequest")))
+                .andExpect(jsonPath("$.plataforma").value("OPENAI_RESPONSES_API"))
+                .andExpect(jsonPath("$.request").exists())
+                .andExpect(jsonPath("$.prompt").exists())
+                .andExpect(jsonPath("$.schema").exists())
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
                 .andExpect(jsonPath("$.model").value("gpt-test"))
                 .andExpect(jsonPath("$.service_tier").value("flex"))
@@ -42,12 +48,17 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 .andExpect(jsonPath("$.text.format.strict").value(true))
                 .andExpect(jsonPath("$.text.format.schema.required[6]").value("candidatePersonas"))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-1/recebeResponse")))
+                .andExpect(jsonPath("$.response").exists())
+                .andExpect(jsonPath("$.modelo").value("gpt-test"))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         OpenAiPersonaCandidateGenerationClient client = new OpenAiPersonaCandidateGenerationClient(
                 builder.build(),
                 new ObjectMapper(),
                 new PersonaCandidateOpenAiProperties("https://api.openai.com/v1", "direct-key", "", "gpt-test", null),
                 new PersonaCandidatePromptBuilder(),
-                new PersonaCandidateSchemaLoader(new ObjectMapper()));
+                new PersonaCandidateSchemaLoader(new ObjectMapper()),
+                "http://backend.test");
 
         Map<String, Object> output = client.generate(new PersonaCandidateGenerationRequest(
                 "job-1",
@@ -79,7 +90,8 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 new ObjectMapper(),
                 new PersonaCandidateOpenAiProperties("https://api.openai.com/v1", "", apiKeyFile.toString(), "gpt-test", null),
                 new PersonaCandidatePromptBuilder(),
-                new PersonaCandidateSchemaLoader(new ObjectMapper()));
+                new PersonaCandidateSchemaLoader(new ObjectMapper()),
+                "http://backend.test");
 
         String apiKey = client.resolveApiKey(new PersonaCandidateGenerationRequest(
                 "job-1",
@@ -98,16 +110,23 @@ class OpenAiPersonaCandidateGenerationClientTest {
         RestClient.Builder builder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
         String errorBody = "{\"error\":{\"message\":\"invalid schema\",\"type\":\"invalid_request_error\"}}";
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-err/recebeRequest")))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
                 .andRespond(withStatus(HttpStatus.BAD_REQUEST)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(errorBody));
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-err/recebeResponse")))
+                .andExpect(jsonPath("$.descricaoErro").exists())
+                .andExpect(jsonPath("$.response").exists())
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         OpenAiPersonaCandidateGenerationClient client = new OpenAiPersonaCandidateGenerationClient(
                 builder.build(),
                 new ObjectMapper(),
                 new PersonaCandidateOpenAiProperties("https://api.openai.com/v1", "direct-key", "", "gpt-test", null),
                 new PersonaCandidatePromptBuilder(),
-                new PersonaCandidateSchemaLoader(new ObjectMapper()));
+                new PersonaCandidateSchemaLoader(new ObjectMapper()),
+                "http://backend.test");
 
         assertThatThrownBy(() -> client.generate(new PersonaCandidateGenerationRequest(
                         "job-err",

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessorTest.java
@@ -1,0 +1,23 @@
+package com.marketinghub.pipelines.nichocnae.v3.qualitygate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida que o gate decide avanço por evidência persistível. */
+class QualityGateProcessorTest {
+    /** Garante aprovação apenas quando há volume mínimo e fonte rastreável. */
+    @Test
+    void shouldApproveWhenTasksHaveEnoughEvidence() {
+        StageResult result = new QualityGateProcessor().process(new StageContext("job", "9", Map.of("dailyTasks", List.of(
+                Map.of("task", "Conferir estoque", "sourceUrl", "https://exemplo.com/1"),
+                Map.of("task", "Acompanhar metas", "sourceUrl", "")))));
+
+        assertThat(result.status()).isEqualTo("QUALIDADE_APROVADA");
+        assertThat(result.output()).containsEntry("approved", true).containsEntry("nextStageCode", "persona-routine-materializer");
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessorTest.java
@@ -1,0 +1,25 @@
+package com.marketinghub.pipelines.nichocnae.v3.routinesignalextractor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida que a etapa extrai sinais funcionais dos snapshots coletados. */
+class RoutineSignalExtractorProcessorTest {
+    /** Garante extração de tarefa, dor e sinal de compra sem saída genérica. */
+    @Test
+    void shouldExtractRoutineSignalsFromSnapshots() {
+        StageResult result = new RoutineSignalExtractorProcessor().process(new StageContext("job", "7", Map.of("sourceSnapshots", List.of(Map.of(
+                "snapshotId", "s1", "url", "https://exemplo.com", "evidenceText", "Controle manual de estoque gera retrabalho em planilhas e busca por sistema simples.")))));
+
+        assertThat(result.status()).isEqualTo("SINAIS_EXTRAIDOS");
+        assertThat(result.output()).containsEntry("nextStageCode", "daily-tasks-synthesizer");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> signal = (Map<String, Object>) ((List<?>) result.output().get("routineSignals")).getFirst();
+        assertThat(signal).containsEntry("painSignal", "RISCO_DE_ERRO_OU_RETRABALHO").containsEntry("buyingSignal", "PROCURA_FERRAMENTA_OU_MODELO");
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessorTest.java
@@ -1,0 +1,23 @@
+package com.marketinghub.pipelines.nichocnae.v3.sourcefetcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida que a etapa de coleta gera snapshots compatíveis com extração de rotina. */
+class SourceFetcherProcessorTest {
+    /** Garante que fontes selecionadas viram snapshots auditáveis e rastreáveis. */
+    @Test
+    void shouldCreateAuditableSourceSnapshots() {
+        StageResult result = new SourceFetcherProcessor().process(new StageContext("job", "6", Map.of("selectedSources", List.of(Map.of(
+                "url", "https://exemplo.com/estoque", "title", "Controle de estoque", "snippet", "Gerente perde tempo com controle manual de estoque e retrabalho em planilhas.")))));
+
+        assertThat(result.status()).isEqualTo("SNAPSHOTS_COLETADOS");
+        assertThat(result.output()).containsEntry("nextStageCode", "routine-signal-extractor");
+        assertThat((List<?>) result.output().get("sourceSnapshots")).hasSize(1);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix pipeline regressions where stages 6–9 returned only generic completion contracts and therefore produced no functional artifacts for evidence collection, signal extraction, task synthesis or quality decisions.
- Ensure the `persona-candidate-generator` stage audites OpenAI payloads via the canonical backend callbacks to persist complete request/response traces for investigation.
- Make outputs persistible and machine-readable so downstream materialization can decide reliably whether to advance or recommend correction.
- Prevent regressions by adding focused unit tests that assert functional outputs instead of generic statuses.

### Description
- Implemented functional outputs for pipeline stages: `source-fetcher` now emits `sourceSnapshots` with `snapshotId`, `url`, `title`, `evidenceText` and metadata; `routine-signal-extractor` produces `routineSignals` with inferred `routineTask`, `painSignal`, `buyingSignal` and `confidence`; `daily-tasks-synthesizer` consolidates `dailyTasks` including `easeLever` derivation; `quality-gate` emits a decision with `approved`, `gateCriteria`, `decisionReason` and `recommendedCorrectionStage` when blocked.
- Updated each processor to return structured `StageResult` and `StageArtifact` values and added small normalizers/helpers (`maps`, `text`, `first`, inference helpers and `easeLever`) to avoid generic outputs and nulls.
- Extended `OpenAiPersonaCandidateGenerationClient` to send backend audit callbacks before and after the OpenAI call using `recebeRequest` and `recebeResponse` endpoints, to include raw request/response, prompt, schema, model and token usage, and added a configurable `backendBaseUrl` for tests/containers.
- Documentation updates in `README.md` and `docs/registros/pipeline.md` to describe the expected functional outputs for NichoCNAE v3 stages and the OpenAI audit flow.
- Added unit tests for the new behavior: `SourceFetcherProcessorTest`, `RoutineSignalExtractorProcessorTest`, `DailyTasksSynthesizerProcessorTest`, `QualityGateProcessorTest`, and enhanced `OpenAiPersonaCandidateGenerationClientTest` to assert the backend audit sequence and error reporting.

### Testing
- Ran unit tests for the modified components: `SourceFetcherProcessorTest`, `RoutineSignalExtractorProcessorTest`, `DailyTasksSynthesizerProcessorTest`, and `QualityGateProcessorTest`, which assert structured outputs and passed.
- Executed `OpenAiPersonaCandidateGenerationClientTest` with a `MockRestServiceServer` that verifies backend `recebeRequest` → OpenAI `/responses` → backend `recebeResponse` sequencing in both success and HTTP error scenarios, and the test passed.
- All added tests passed in the CI-local run used during this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a404444e36c832199278006520754c4)