### PR TITLE
source-searcher: block advance to source-fetcher when no real sources and add unit tests

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1615,3 +1615,10 @@
 
 - Criado endpoint interno `POST /api/internal/oprmcoletormei/nichocnae/v1/<etapa>/stage-executions/{idExterno}/situacao` para consultar `pipeline_nichocnae` por etapa, identificador externo e lista de status, retornando registros ordenados por `data_hora` decrescente.
 - Adicionada coluna `status` à auditoria `pipeline_nichocnae`, preenchida nos callbacks v3 como `AGUARDANDO_MODULO`, `CONCLUIDO` ou `FALHA`, permitindo filtro direto no banco em vez de inferência por payload.
+
+## 2026-06-28 — NichoCNAE v3: revisão do source-searcher contra avanço sem fontes
+
+- Diagnóstico: os logs do `oprm-coletor-mei` mostraram falha recorrente em `source-fetcher` porque a etapa anterior concluía como `FONTES_ENCONTRADAS`, mas não entregava `selectedSources` nem `foundSources`.
+- Causa-raiz: contrato incompleto entre `source-searcher` e `source-fetcher`; o pipeline avançava com queries planejadas como se fossem fontes reais.
+- Correção: `source-searcher` agora só libera `nextStageCode=source-fetcher` quando recebe fontes reais auditáveis; sem fontes, conclui bloqueado com `FONTES_NAO_COLETADAS`, motivo persistível e etapa recomendada de correção.
+- Prevenção: adicionado teste unitário cobrindo bloqueio sem fontes e avanço apenas com `foundSources` reais.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -10,18 +10,51 @@ import java.util.Map;
 
 /** Processa a etapa source-searcher do pipeline NichoCNAE v3. */
 public final class SourceSearcherProcessor implements StageProcessor {
-    /** Executa a etapa source-searcher produzindo saída estruturada para o backend decidir avanço. */
+    /** Executa a etapa source-searcher validando se há fontes reais antes de permitir a coleta de snapshots. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> foundSources = maps(context.input().get("foundSources"));
+        if (foundSources.isEmpty()) {
+            foundSources = maps(context.input().get("selectedSources"));
+        }
+        List<Map<String, Object>> plannedQueries = maps(context.input().get("plannedQueries"));
+        boolean hasSources = !foundSources.isEmpty();
+        String status = hasSources ? "FONTES_ENCONTRADAS" : "FONTES_NAO_COLETADAS";
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "source-searcher");
-        output.put("status", "FONTES_ENCONTRADAS");
+        output.put("status", status);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("plannedQueries", plannedQueries);
+        output.put("foundSourceCount", foundSources.size());
+        output.put("foundSources", foundSources);
+        output.put("blocked", !hasSources);
+        output.put("decisionReason", hasSources
+                ? "Fontes reais disponíveis para coleta de snapshots auditáveis."
+                : "A etapa source-searcher ainda não recebeu fontes reais; não é seguro avançar para source-fetcher apenas com queries planejadas.");
+        output.put("recommendedCorrectionStage", hasSources ? "" : "source-searcher");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
-        output.put("nextStageCode", "source-fetcher");
-        return new StageResult("FONTES_ENCONTRADAS", output, List.of(new StageArtifact("FONTES_ENCONTRADAS", "inline://nichocnae-v3/source-searcher", "Etapa source-searcher concluída com contrato estruturado.")));
+        output.put("nextStageCode", hasSources ? "source-fetcher" : "");
+        return new StageResult(status, output, List.of(new StageArtifact(status, "inline://nichocnae-v3/source-searcher", hasSources
+                ? "Fontes reais encontradas para coleta de snapshots."
+                : "Busca de fontes bloqueada por ausência de fontes reais auditáveis.")));
+    }
+
+    /** Converte uma lista de objetos em mapas estruturados. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream()
+                .filter(Map.class::isInstance)
+                .map(item -> {
+                    Map<String, Object> normalized = new LinkedHashMap<>();
+                    ((Map<?, ?>) item).forEach((key, val) -> normalized.put(String.valueOf(key), val));
+                    return normalized;
+                })
+                .toList();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
@@ -1,0 +1,42 @@
+package com.marketinghub.pipelines.nichocnae.v3.sourcesearcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a decisão de avanço da etapa source-searcher no pipeline NichoCNAE v3. */
+class SourceSearcherProcessorTest {
+    /** Bloqueia avanço quando existem apenas queries planejadas, mas nenhuma fonte real auditável. */
+    @Test
+    void shouldBlockWithoutRealSources() {
+        StageResult result = new SourceSearcherProcessor().process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "gerente loja rotina estoque")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_NAO_COLETADAS");
+        assertThat(result.output()).containsEntry("nextStageCode", "");
+        assertThat(result.output()).containsEntry("blocked", true);
+        assertThat(result.output()).containsEntry("recommendedCorrectionStage", "source-searcher");
+        assertThat((List<?>) result.output().get("foundSources")).isEmpty();
+    }
+
+    /** Permite avanço somente quando a entrada traz fontes reais para o source-fetcher coletar. */
+    @Test
+    void shouldAdvanceWithRealFoundSources() {
+        StageResult result = new SourceSearcherProcessor().process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "gerente loja rotina estoque")),
+                "foundSources", List.of(Map.of(
+                        "url", "https://exemplo.com/rotina-loja",
+                        "title", "Rotina de loja",
+                        "snippet", "Gerente acompanha estoque, metas e atendimento diariamente.")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        assertThat(result.output()).containsEntry("nextStageCode", "source-fetcher");
+        assertThat(result.output()).containsEntry("blocked", false);
+        assertThat(result.output()).containsEntry("foundSourceCount", 1);
+        assertThat((List<?>) result.output().get("foundSources")).hasSize(1);
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent the pipeline from advancing to `source-fetcher` when `source-searcher` only has planned queries and no real, auditable sources. 
- Make the `source-searcher` output auditable and actionable so the backend can decide to block, surface a reason, and recommend a correction stage. 

### Description

- `SourceSearcherProcessor` now inspects `foundSources`, falls back to `selectedSources`, and treats absence of real sources as `FONTES_NAO_COLETADAS` while otherwise returning `FONTES_ENCONTRADAS`. 
- The processor output was enriched with `plannedQueries`, `foundSourceCount`, `foundSources`, `blocked`, `decisionReason`, and `recommendedCorrectionStage`, and `nextStageCode` is emitted only when real sources are present. 
- Added a private helper `maps(Object)` to normalize incoming list values into `List<Map<String,Object>>`. 
- Added `SourceSearcherProcessorTest` with two unit tests covering blocking behavior without real sources and advancing behavior when `foundSources` are present, and updated `docs/registros/oprm1.md` with the rollout note about this change. 

### Testing

- Ran the new unit tests in `SourceSearcherProcessorTest` which assert status, `nextStageCode`, `blocked` flag, `foundSourceCount`, and `foundSources`, and they passed. 
- Module-level unit tests that include the `sourcesearcher` tests were executed via the project's test runner and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4065e2fe9883218017c7c0f23d6cf1)