### PR TITLE
fix(oprm): audit raw OpenAI payloads in NichoCNAE v3

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1622,3 +1622,9 @@
 - Causa-raiz: contrato incompleto entre `source-searcher` e `source-fetcher`; o pipeline avançava com queries planejadas como se fossem fontes reais.
 - Correção: `source-searcher` agora só libera `nextStageCode=source-fetcher` quando recebe fontes reais auditáveis; sem fontes, conclui bloqueado com `FONTES_NAO_COLETADAS`, motivo persistível e etapa recomendada de correção.
 - Prevenção: adicionado teste unitário cobrindo bloqueio sem fontes e avanço apenas com `foundSources` reais.
+
+## 2026-06-28 — NichoCNAE v3: auditoria OpenAI bruta nos callbacks
+
+- Ajustada a etapa `persona-candidate-generator` para serializar uma única vez o body enviado à OpenAI e reutilizar exatamente esse conteúdo no callback `recebeRequest`.
+- Ajustado o callback `recebeResponse` para enviar exatamente o corpo bruto retornado pela OpenAI, incluindo respostas HTTP de erro, antes de qualquer extração ou transformação operacional.
+- Prevenção de recorrência: teste da etapa valida que o request auditado no backend é idêntico ao body enviado para a OpenAI e que o response auditado é o corpo bruto recebido do provedor.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
@@ -69,12 +69,14 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         }
         String url = properties.baseUrl() + RESPONSES_PATH;
         Map<String, Object> requestBody = buildRequestBody(promptBuilder.build(request), properties.model());
-        logOpenAiRequest(url, request, requestBody);
-        sendBackendRequestAudit(request, requestBody);
+        String rawRequestBody = toJsonForLog(requestBody);
+        logOpenAiRequest(url, request, rawRequestBody);
+        sendBackendRequestAudit(request, rawRequestBody, requestBody);
         try {
-            Map<String, Object> raw = responseBody(url, requestBody, apiKey);
-            logOpenAiResponse(url, request, raw);
-            sendBackendResponseAudit(request, raw, null);
+            String rawResponseBody = responseBody(url, rawRequestBody, apiKey);
+            logOpenAiResponse(url, request, rawResponseBody);
+            sendBackendResponseAudit(request, rawResponseBody, null);
+            Map<String, Object> raw = parseOpenAiResponse(rawResponseBody);
             if (raw == null) {
                 log.error(
                         "OpenAI retornou corpo vazio para persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, model={}, serviceTier={})",
@@ -90,7 +92,7 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
             return objectMapper.readValue(modelResponse, MAP_TYPE);
         } catch (RestClientResponseException ex) {
             logOpenAiHttpError(url, request, ex);
-            sendBackendResponseAudit(request, responseErrorPayload(ex), ex.getClass().getSimpleName() + ": " + ex.getMessage());
+            sendBackendResponseAudit(request, ex.getResponseBodyAsString(), ex.getClass().getSimpleName() + ": " + ex.getMessage());
             throw new IllegalStateException("Falha na OpenAI ao gerar personas candidatas do NichoCNAE v3.", ex);
         } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
             log.error(
@@ -189,32 +191,31 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
     }
 
     /** Registra o payload enviado à OpenAI sem expor credenciais de autenticação. */
-    private void logOpenAiRequest(String url, PersonaCandidateGenerationRequest request, Map<String, Object> requestBody) {
+    private void logOpenAiRequest(String url, PersonaCandidateGenerationRequest request, String rawRequestBody) {
         log.info(
                 "Request OpenAI persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, payload={})",
                 url,
                 request.jobId(),
                 request.stageExecutionId(),
                 request.cnaeCode(),
-                toJsonForLog(requestBody));
+                rawRequestBody);
     }
 
     /** Registra a resposta bruta recebida da OpenAI para auditoria operacional. */
-    private void logOpenAiResponse(String url, PersonaCandidateGenerationRequest request, Map<String, Object> raw) {
+    private void logOpenAiResponse(String url, PersonaCandidateGenerationRequest request, String rawResponseBody) {
         log.info(
                 "Response OpenAI persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, payload={})",
                 url,
                 request.jobId(),
                 request.stageExecutionId(),
                 request.cnaeCode(),
-                toJsonForLog(raw));
+                rawResponseBody);
     }
 
-
-    /** Envia ao backend o request bruto encaminhado à OpenAI pelo endpoint recebeRequest. */
-    private void sendBackendRequestAudit(PersonaCandidateGenerationRequest request, Map<String, Object> requestBody) {
+    /** Envia ao backend exatamente o request bruto encaminhado à OpenAI pelo endpoint recebeRequest. */
+    private void sendBackendRequestAudit(PersonaCandidateGenerationRequest request, String rawRequestBody, Map<String, Object> requestBody) {
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("request", toJsonForLog(requestBody));
+        payload.put("request", rawRequestBody);
         payload.put("plataforma", "OPENAI_RESPONSES_API");
         payload.put("prompt", String.valueOf(requestBody.getOrDefault("input", "")));
         payload.put("schema", toJsonForLog(schemaLoader.load()));
@@ -228,10 +229,11 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         restClient.post().uri(URI.create(endpoint)).body(payload).retrieve().toBodilessEntity();
     }
 
-    /** Envia ao backend a resposta bruta da OpenAI ou o erro capturado pelo endpoint recebeResponse. */
-    private void sendBackendResponseAudit(PersonaCandidateGenerationRequest request, Map<String, Object> responseBody, String errorMessage) {
+    /** Envia ao backend exatamente a resposta bruta da OpenAI ou o erro capturado pelo endpoint recebeResponse. */
+    private void sendBackendResponseAudit(PersonaCandidateGenerationRequest request, String rawResponseBody, String errorMessage) {
+        Map<String, Object> responseBody = parseOpenAiResponse(rawResponseBody);
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("response", toJsonForLog(responseBody));
+        payload.put("response", rawResponseBody);
         payload.put("descricaoErro", errorMessage);
         payload.put("quantidadeTokenEntrada", tokenUsage(responseBody, "input_tokens"));
         payload.put("quantidadeTokenSaida", tokenUsage(responseBody, "output_tokens"));
@@ -246,15 +248,6 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
                 request.cnaeCode(),
                 errorMessage != null && !errorMessage.isBlank());
         restClient.post().uri(URI.create(endpoint)).body(payload).retrieve().toBodilessEntity();
-    }
-
-    /** Monta payload estruturado para auditoria de erro HTTP da OpenAI. */
-    private Map<String, Object> responseErrorPayload(RestClientResponseException ex) {
-        Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("statusCode", ex.getStatusCode().value());
-        payload.put("statusText", ex.getStatusText());
-        payload.put("responseBody", ex.getResponseBodyAsString());
-        return payload;
     }
 
     /** Monta a URL canônica do callback backend para auditoria request/response. */
@@ -286,16 +279,28 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
     }
 
     /** Executa a requisição HTTP para a Responses API. */
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> responseBody(String url, Map<String, Object> requestBody, String apiKey) {
-        Map<?, ?> response = restClient.post()
+    private String responseBody(String url, String rawRequestBody, String apiKey) {
+        return restClient.post()
                 .uri(URI.create(url))
                 .header("Authorization", "Bearer " + apiKey)
                 .header("Content-Type", "application/json")
-                .body(requestBody)
+                .body(rawRequestBody)
                 .retrieve()
-                .body(Map.class);
-        return response == null ? null : (Map<String, Object>) response;
+                .body(String.class);
+    }
+
+    /** Converte a resposta bruta da OpenAI para mapa apenas depois da auditoria crua. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseOpenAiResponse(String rawResponseBody) {
+        if (rawResponseBody == null || rawResponseBody.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(rawResponseBody, MAP_TYPE);
+        } catch (JsonProcessingException ex) {
+            log.warn("Falha ao interpretar resposta bruta OpenAI para métricas/extração.", ex);
+            return null;
+        }
     }
 
     /** Registra detalhes HTTP quando a OpenAI responde com erro. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
@@ -14,12 +14,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
@@ -35,11 +37,17 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 {\"candidatePersonas\":[{\"name\":\"p1\"},{\"name\":\"p2\"},{\"name\":\"p3\"}],\"personaSummary\":\"p1;p2;p3\"}
                 """.trim();
         String response = new ObjectMapper().writeValueAsString(Map.of("output_text", modelJson));
+        AtomicReference<String> backendRequestAudit = new AtomicReference<>();
+        AtomicReference<String> openAiRequest = new AtomicReference<>();
         server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-1/recebeRequest")))
                 .andExpect(jsonPath("$.plataforma").value("OPENAI_RESPONSES_API"))
                 .andExpect(jsonPath("$.request").exists())
                 .andExpect(jsonPath("$.prompt").exists())
                 .andExpect(jsonPath("$.schema").exists())
+                .andExpect(req -> backendRequestAudit.set(new ObjectMapper()
+                        .readTree(((MockClientHttpRequest) req).getBodyAsString())
+                        .get("request")
+                        .asText()))
                 .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
                 .andExpect(jsonPath("$.model").value("gpt-test"))
@@ -47,9 +55,10 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 .andExpect(jsonPath("$.text.format.type").value("json_schema"))
                 .andExpect(jsonPath("$.text.format.strict").value(true))
                 .andExpect(jsonPath("$.text.format.schema.required[6]").value("candidatePersonas"))
+                .andExpect(req -> openAiRequest.set(((MockClientHttpRequest) req).getBodyAsString()))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
         server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-1/recebeResponse")))
-                .andExpect(jsonPath("$.response").exists())
+                .andExpect(jsonPath("$.response").value(response))
                 .andExpect(jsonPath("$.modelo").value("gpt-test"))
                 .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         OpenAiPersonaCandidateGenerationClient client = new OpenAiPersonaCandidateGenerationClient(
@@ -68,6 +77,7 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 Map.of("cnaeCode", "4781400")));
 
         assertThat((List<?>) output.get("candidatePersonas")).hasSize(3);
+        assertThat(backendRequestAudit.get()).isEqualTo(openAiRequest.get());
         assertThat(logs.getOut())
                 .contains("Request OpenAI persona-candidate-generator")
                 .contains("Response OpenAI persona-candidate-generator")
@@ -118,7 +128,7 @@ class OpenAiPersonaCandidateGenerationClientTest {
                         .body(errorBody));
         server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-err/recebeResponse")))
                 .andExpect(jsonPath("$.descricaoErro").exists())
-                .andExpect(jsonPath("$.response").exists())
+                .andExpect(jsonPath("$.response").value(errorBody))
                 .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
         OpenAiPersonaCandidateGenerationClient client = new OpenAiPersonaCandidateGenerationClient(
                 builder.build(),


### PR DESCRIPTION
### Motivation

- Garantir que as etapas que usam OpenAI no pipeline `nichocnae.v3` persistam exatamente o request enviado ao provedor e o response recebido para auditoria e diagnóstico de causa-raiz. 
- Evitar perda de contexto ou contaminação ao enviar ao backend somente payloads transformados, facilitando investigação de falhas e contagem de tokens/custos.

### Description

- Serializa uma única vez o corpo enviado à OpenAI e reutiliza exatamente essa string para auditar o callback `recebeRequest` no backend (arquivo modificado: `oprm-coletor-mei/src/main/java/.../OpenAiPersonaCandidateGenerationClient.java`).
- Envia ao backend o corpo bruto retornado pela OpenAI (incluindo corpos de erro HTTP) no callback `recebeResponse` antes de qualquer parsing, e realiza o parsing somente depois para extração de métricas (`parseOpenAiResponse` adicionado).
- Ajusta a execução HTTP para enviar a string serializada ao endpoint da OpenAI e para receber a resposta como `String`, preservando paridade entre o request auditado e o request real.
- Atualiza o teste unitário `OpenAiPersonaCandidateGenerationClientTest` para validar que o campo `request` gravado no backend é idêntico ao body enviado à OpenAI e que o `recebeResponse` contém o corpo bruto do provedor; também registra a mudança em `docs/registros/oprm1.md`.

### Testing

- Executado `mvn -q -Dtest=OpenAiPersonaCandidateGenerationClientTest test` no módulo `oprm-coletor-mei`, que passou com sucesso.
- Executado `mvn -q test` no mesmo módulo para validação adicional da suíte de testes, que também passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40707b7c008321b51f1b1183d8198d)