### PR TITLE
Audit raw OpenAI payloads in MOIS dossier v1

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1904,3 +1904,11 @@ Arquivos principais:
 - Criado endpoint interno `POST /api/internal/moissaleslibraryworker/dossieproduto/v1/{etapa}/stage-executions/{idExterno}/situacao` para consultar auditorias existentes por etapa, identificador externo e lista de status.
 - Adicionada coluna `status` em `pipeline_dossieproduto`, com preenchimento nas novas auditorias e backfill dos registros existentes por request/response/erro.
 - Atualizado o Swagger canônico do pipeline MOIS dossiê v1 com o contrato de entrada e resposta da consulta.
+
+## 2026-06-27 21:56:47 UTC-3
+- ajustado o pipeline `dossieproduto.v1` do `mois-sales-library-worker` para transportar auditoria bruta de chamadas OpenAI no resultado da etapa.
+- causa-raiz tratada: o runner só enviava ao backend o input da etapa e a saída funcional consolidada, então uma etapa futura com ChatGPT poderia perder o request exato enviado à OpenAI e a resposta exata recebida.
+- registro do que foi feito: `StageResult` agora aceita `OpenAiInteraction`; quando existir interação OpenAI, o runner chama `recebeRequest` com o request bruto e `recebeResponse` com a response bruta, preservando tokens, custo, modelo e erro.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - mois-sales-library-worker/AGENTS.md

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClient.java
@@ -2,6 +2,7 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.pipelines.dossie.v1.StageContext;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
+import com.marketinghub.pipelines.dossie.v1.StageResult.OpenAiInteraction;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,17 @@ public class DossierV1BackendClient {
         /** Cria a resposta de sucesso a partir do resultado da etapa. */
         public static DossierRecebeResponseRequest success(String response) {
             return new DossierRecebeResponseRequest(response, null, null, null, "mois-dossie-v1-local", null);
+        }
+
+        /** Cria a resposta bruta de uma interação OpenAI preservando tokens, custo, modelo e erro informados pela etapa. */
+        public static DossierRecebeResponseRequest openAi(OpenAiInteraction interaction) {
+            return new DossierRecebeResponseRequest(
+                    interaction.rawResponseReceived(),
+                    interaction.quantidadeTokenEntrada(),
+                    interaction.quantidadeTokenSaida(),
+                    interaction.custo(),
+                    interaction.modelo(),
+                    interaction.descricaoErro());
         }
 
         /** Cria a resposta de falha operacional persistível. */

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1Runner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1Runner.java
@@ -57,8 +57,12 @@ public class DossierV1Runner {
             backendClient.recebeRequest(stageName, job.idExterno(), job.jobId(),
                     new DossierRecebeRequestRequest(String.valueOf(job.input()), "mois-sales-library-worker", null, null));
             StageResult result = pipelineWorker.execute(job.toStageContext());
-            backendClient.recebeResponse(stageName, job.idExterno(), job.jobId(),
-                    DossierRecebeResponseRequest.success(backendClient.responseFrom(result)));
+            if (result.hasOpenAiInteractions()) {
+                registrarInteracoesOpenAi(stageName, job, result);
+            } else {
+                backendClient.recebeResponse(stageName, job.idExterno(), job.jobId(),
+                        DossierRecebeResponseRequest.success(backendClient.responseFrom(result)));
+            }
             log.info("MOIS dossie v1 job completed. stageName={}, idExterno={}, jobId={}, status={}",
                     stageName, job.idExterno(), job.jobId(), result.status());
         } catch (RuntimeException ex) {
@@ -66,6 +70,16 @@ public class DossierV1Runner {
                     stageName, job.idExterno(), job.jobId(), ex.getClass().getName(), ex.getMessage(), ex);
             backendClient.recebeResponse(stageName, job.idExterno(), job.jobId(),
                     DossierRecebeResponseRequest.failure(ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage()));
+        }
+    }
+
+    /** Envia ao backend exatamente o request e a response brutos usados em chamadas OpenAI da etapa. */
+    private void registrarInteracoesOpenAi(String stageName, DossierPendingJob job, StageResult result) {
+        for (StageResult.OpenAiInteraction interaction : result.openAiInteractions()) {
+            backendClient.recebeRequest(stageName, job.idExterno(), job.jobId(),
+                    new DossierRecebeRequestRequest(interaction.rawRequestSent(), "openai", null, null));
+            backendClient.recebeResponse(stageName, job.idExterno(), job.jobId(),
+                    DossierRecebeResponseRequest.openAi(interaction));
         }
     }
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/StageResult.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/StageResult.java
@@ -1,12 +1,56 @@
 package com.marketinghub.pipelines.dossie.v1;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
 /** Descreve a saída estruturada de uma etapa executada pelo pipeline de dossiê MOIS v1. */
-public record StageResult(String status, Map<String, Object> output, List<StageArtifact> artifacts, String errorMessage) {
+public record StageResult(
+        String status,
+        Map<String, Object> output,
+        List<StageArtifact> artifacts,
+        String errorMessage,
+        List<OpenAiInteraction> openAiInteractions) {
     /** Cria um resultado concluído com saída funcional e artefatos auditáveis. */
     public static StageResult done(Map<String, Object> output, List<StageArtifact> artifacts) {
-        return new StageResult("DONE", output, artifacts, null);
+        return new StageResult("DONE", output, artifacts, null, List.of());
+    }
+
+    /** Cria um resultado concluído com saída funcional, artefatos e auditoria bruta da OpenAI. */
+    public static StageResult doneWithOpenAiInteractions(
+            Map<String, Object> output,
+            List<StageArtifact> artifacts,
+            List<OpenAiInteraction> openAiInteractions) {
+        return new StageResult("DONE", output, artifacts, null, safeInteractions(openAiInteractions));
+    }
+
+    /** Normaliza interações nulas para lista vazia e evita checks defensivos no runner. */
+    public StageResult {
+        openAiInteractions = safeInteractions(openAiInteractions);
+    }
+
+    /** Indica se a etapa executada acessou OpenAI e gerou payloads brutos para auditoria no backend. */
+    public boolean hasOpenAiInteractions() {
+        return !openAiInteractions.isEmpty();
+    }
+
+    /** Normaliza uma lista opcional de interações OpenAI para contrato imutável não nulo. */
+    private static List<OpenAiInteraction> safeInteractions(List<OpenAiInteraction> interactions) {
+        return interactions == null ? List.of() : List.copyOf(interactions);
+    }
+
+    /** Representa exatamente uma chamada feita à OpenAI por uma etapa do dossiê v1. */
+    public record OpenAiInteraction(
+            String rawRequestSent,
+            String rawResponseReceived,
+            Integer quantidadeTokenEntrada,
+            Integer quantidadeTokenSaida,
+            BigDecimal custo,
+            String modelo,
+            String descricaoErro) {
+        /** Cria uma interação de sucesso preservando request e response brutos da OpenAI. */
+        public static OpenAiInteraction success(String rawRequestSent, String rawResponseReceived, String modelo) {
+            return new OpenAiInteraction(rawRequestSent, rawResponseReceived, null, null, null, modelo, null);
+        }
     }
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1RunnerTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1RunnerTest.java
@@ -1,0 +1,78 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config.WorkerProperties;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierPendingJob;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierPendingRequest;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierPendingResponse;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierRecebeRequestRequest;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierRecebeResponseRequest;
+import com.marketinghub.pipelines.dossie.v1.PipelineWorker;
+import com.marketinghub.pipelines.dossie.v1.StageContext;
+import com.marketinghub.pipelines.dossie.v1.StageResult;
+import com.marketinghub.pipelines.dossie.v1.StageResult.OpenAiInteraction;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+/** Valida o runner operacional do pipeline dossieproduto.v1 no worker MOIS. */
+class DossierV1RunnerTest {
+
+    /** Garante que etapas com ChatGPT enviem ao backend o request e response exatos da OpenAI. */
+    @Test
+    void deveRegistrarPayloadsBrutosDaOpenAiNosCallbacksCanonicos() {
+        DossierV1BackendClient backendClient = org.mockito.Mockito.mock(DossierV1BackendClient.class);
+        PipelineWorker pipelineWorker = org.mockito.Mockito.mock(PipelineWorker.class);
+        WorkerProperties properties = new WorkerProperties(null, "workspace-mois", null, null, null, null, 0L, 0L, 0L, null, null, false, 0L, null, null, null, null, 10);
+        DossierV1Runner runner = new DossierV1Runner(backendClient, pipelineWorker, properties);
+        DossierPendingJob job = new DossierPendingJob(
+                "job-openai", 11L, 22L, "workspace-mois", "product-understanding", Map.of("productKey", "produto-1"));
+        String rawRequest = "{\"model\":\"gpt-5.2\",\"input\":\"prompt exato\"}";
+        String rawResponse = "{\"id\":\"resp_1\",\"output_text\":\"resposta exata\"}";
+        StageResult result = StageResult.doneWithOpenAiInteractions(
+                Map.of("product-understanding", Map.of("status", "DONE")),
+                List.of(),
+                List.of(new OpenAiInteraction(rawRequest, rawResponse, 10, 20, new BigDecimal("0.01"), "gpt-5.2", null)));
+
+        stubSemPendencia(backendClient, "intake");
+        when(backendClient.pending(eq("product-understanding"), any(DossierPendingRequest.class)))
+                .thenReturn(new DossierPendingResponse(true, List.of(job)));
+        stubSemPendencia(backendClient, "source-product-match");
+        stubSemPendencia(backendClient, "investigation-anchor-builder");
+        stubSemPendencia(backendClient, "warmup-resource-discovery");
+        stubSemPendencia(backendClient, "warmup-signal-extraction");
+        stubSemPendencia(backendClient, "warmup-map-builder");
+        stubSemPendencia(backendClient, "dossier-synthesis");
+        when(pipelineWorker.execute(any(StageContext.class))).thenReturn(result);
+
+        runner.runDossierV1Cycle();
+
+        InOrder order = inOrder(backendClient, pipelineWorker);
+        order.verify(backendClient).recebeRequest(eq("product-understanding"), eq("produto-1"), eq("job-openai"), any(DossierRecebeRequestRequest.class));
+        order.verify(pipelineWorker).execute(any(StageContext.class));
+        ArgumentCaptor<DossierRecebeRequestRequest> openAiRequestCaptor = ArgumentCaptor.forClass(DossierRecebeRequestRequest.class);
+        order.verify(backendClient).recebeRequest(eq("product-understanding"), eq("produto-1"), eq("job-openai"), openAiRequestCaptor.capture());
+        ArgumentCaptor<DossierRecebeResponseRequest> openAiResponseCaptor = ArgumentCaptor.forClass(DossierRecebeResponseRequest.class);
+        order.verify(backendClient).recebeResponse(eq("product-understanding"), eq("produto-1"), eq("job-openai"), openAiResponseCaptor.capture());
+
+        org.assertj.core.api.Assertions.assertThat(openAiRequestCaptor.getValue().request()).isEqualTo(rawRequest);
+        org.assertj.core.api.Assertions.assertThat(openAiRequestCaptor.getValue().plataforma()).isEqualTo("openai");
+        org.assertj.core.api.Assertions.assertThat(openAiResponseCaptor.getValue().response()).isEqualTo(rawResponse);
+        org.assertj.core.api.Assertions.assertThat(openAiResponseCaptor.getValue().quantidadeTokenEntrada()).isEqualTo(10);
+        org.assertj.core.api.Assertions.assertThat(openAiResponseCaptor.getValue().quantidadeTokenSaida()).isEqualTo(20);
+        org.assertj.core.api.Assertions.assertThat(openAiResponseCaptor.getValue().modelo()).isEqualTo("gpt-5.2");
+    }
+
+    /** Configura uma etapa do backend fake sem jobs pendentes. */
+    private void stubSemPendencia(DossierV1BackendClient backendClient, String stageName) {
+        when(backendClient.pending(eq(stageName), any(DossierPendingRequest.class)))
+                .thenReturn(new DossierPendingResponse(false, List.of()));
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure any dossieproduto.v1 stage that calls ChatGPT/OpenAI preserves and forwards the exact raw request and raw response to the backend for auditability and root-cause investigation.
- Comply with module operational contracts that require storing request/response raw payloads, tokens, cost and model metadata for steps that use OpenAI.

### Description
- Added `OpenAiInteraction` support to `StageResult` and new constructors `doneWithOpenAiInteractions` plus normalization helpers to carry raw OpenAI request/response and metadata. (`mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/StageResult.java`)
- Updated `DossierV1Runner` to call the canonical backend callbacks: when `StageResult` contains OpenAI interactions the runner now posts the exact `rawRequestSent` to `recebeRequest` and the exact `rawResponseReceived` (with tokens/cost/model/error) to `recebeResponse`. (`DossierV1Runner.java`)
- Extended `DossierV1BackendClient` with an `openAi` factory for `DossierRecebeResponseRequest` to map interaction fields into the backend contract. (`DossierV1BackendClient.java`)
- Added a unit test `DossierV1RunnerTest` that verifies the runner sends the exact raw OpenAI request and response to the backend callbacks, and recorded the operational change in `docs/registros/mois1.md`.

### Testing
- Ran `mvn test` in `mois-sales-library-worker`, which executed the module unit tests including the new `DossierV1RunnerTest`; all tests passed (`Tests run: 25, Failures: 0, Errors: 0, Skipped: 0`) and build succeeded. 
- Verified logging and behavior in the runner by executing the test scenario that simulates a job with an `OpenAiInteraction` and asserting the backend callbacks received the exact raw payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407068c29883219de976382ab69731)