### PR TITLE
Persist clean OpenAI text into pipeline_nichocnae.resposta_final

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
@@ -23,6 +23,9 @@ public class PipelineNichoCnae {
     @Column(name = "response", columnDefinition = "LONGTEXT")
     private String response;
 
+    @Column(name = "resposta_final", columnDefinition = "LONGTEXT")
+    private String respostaFinal;
+
     @Column(name = "codigo_etapa", length = 96)
     private String codigoEtapa;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiTextResponseExtractor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiTextResponseExtractor.java
@@ -1,0 +1,67 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+
+/** Extrai o texto funcional de responses brutos da OpenAI para persistência limpa no NichoCNAE v3. */
+final class OpenAiTextResponseExtractor {
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o extrator com o mapper JSON compartilhado pelo service da etapa. */
+    OpenAiTextResponseExtractor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /** Retorna o texto funcional da OpenAI quando existir ou mantém o response original como fallback auditável. */
+    String extract(String rawResponse) {
+        if (!StringUtils.hasText(rawResponse)) {
+            return rawResponse;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(rawResponse);
+            String extracted = extractFromRoot(root);
+            return StringUtils.hasText(extracted) ? extracted : rawResponse;
+        } catch (JsonProcessingException ex) {
+            return rawResponse;
+        }
+    }
+
+    /** Busca o primeiro campo text dentro dos formatos de response da OpenAI usados pelo executor. */
+    private String extractFromRoot(JsonNode root) {
+        String directOutput = extractFromOutput(root.path("output"));
+        if (StringUtils.hasText(directOutput)) {
+            return directOutput;
+        }
+        return extractFromContent(root.path("content"));
+    }
+
+    /** Varre a lista output da OpenAI procurando mensagens com content textual. */
+    private String extractFromOutput(JsonNode output) {
+        if (!output.isArray()) {
+            return null;
+        }
+        for (JsonNode outputItem : output) {
+            String text = extractFromContent(outputItem.path("content"));
+            if (StringUtils.hasText(text)) {
+                return text;
+            }
+        }
+        return null;
+    }
+
+    /** Varre a lista content da OpenAI procurando itens do tipo output_text com campo text. */
+    private String extractFromContent(JsonNode content) {
+        if (!content.isArray()) {
+            return null;
+        }
+        for (JsonNode contentItem : content) {
+            JsonNode textNode = contentItem.path("text");
+            if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
+                return textNode.asText();
+            }
+        }
+        return null;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -45,6 +45,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     private final PipelineNichoCnaeRepository pipelineNichoCnaeRepository;
     private final String stageCode;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OpenAiTextResponseExtractor responseExtractor = new OpenAiTextResponseExtractor(objectMapper);
 
     /** Inicializa o suporte com repository canônico e código da etapa. */
     protected OprmNichoCnaeV3StageServiceSupport(
@@ -129,7 +130,9 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
         PipelineNichoCnae pipeline = new PipelineNichoCnae();
         pipeline.setIdExterno(cnaeCode);
-        pipeline.setResponse(request == null ? null : request.response());
+        String rawResponse = request == null ? null : request.response();
+        pipeline.setResponse(rawResponse);
+        pipeline.setRespostaFinal(responseExtractor.extract(rawResponse));
         pipeline.setCodigoEtapa(stageCode);
         pipeline.setDataHora(now);
         pipeline.setStatus(hasFailure ? STATUS_FAILED : STATUS_COMPLETED);

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-nichocnae-resposta-final.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-nichocnae-resposta-final.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-28-01-pipeline-nichocnae-resposta-final
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_nichocnae
+        - not:
+            - columnExists:
+                tableName: pipeline_nichocnae
+                columnName: resposta_final
+      changes:
+        - addColumn:
+            tableName: pipeline_nichocnae
+            columns:
+              - column:
+                  name: resposta_final
+                  type: LONGTEXT

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-28-pipeline-nichocnae-resposta-final.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-27-pipeline-dossieproduto-status.yaml
       file: changesets/2026-06-27-pipeline-geracaoanuncios-status.yaml
       file: changesets/2026-06-27-pipeline-nichocnae-status.yaml

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -76,6 +78,38 @@ class BackendCnaeIntakeServiceTest {
         verify(repository).save(executionCaptor.capture());
         assertThat(executionCaptor.getValue().getStageCode()).isEqualTo("cnae-intake");
         assertThat(executionCaptor.getValue().getInputPayload()).contains("\"cnaeDescription\":\"Comércio varejista de artigos do vestuário\"");
+    }
+
+    /** Garante que o callback de response grava a resposta final limpa da OpenAI na auditoria. */
+    @Test
+    void recebeResponseStoresCleanFinalResponse() {
+        OprmCnpjCnaeDim cnae = cnae();
+        when(cnaeRepository.findById("4781400")).thenReturn(Optional.of(cnae));
+        when(pipelineNichoCnaeRepository.save(any(PipelineNichoCnae.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        String rawResponse = """
+                {
+                  "output": [
+                    {
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "resposta funcional limpa"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        service.recebeResponse(
+                "4781400",
+                "job-4781400",
+                new OprmNichoCnaeV3RecebeResponseRequest(rawResponse, null, 10L, 20L, null, "gpt"));
+
+        ArgumentCaptor<PipelineNichoCnae> pipelineCaptor = ArgumentCaptor.forClass(PipelineNichoCnae.class);
+        verify(pipelineNichoCnaeRepository).save(pipelineCaptor.capture());
+        assertThat(pipelineCaptor.getValue().getResponse()).isEqualTo(rawResponse);
+        assertThat(pipelineCaptor.getValue().getRespostaFinal()).isEqualTo("resposta funcional limpa");
     }
 
     /** Monta uma execução pendente da etapa inicial. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiTextResponseExtractorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiTextResponseExtractorTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/** Testa a limpeza do response bruto da OpenAI para gravação funcional no NichoCNAE v3. */
+class OpenAiTextResponseExtractorTest {
+    private final OpenAiTextResponseExtractor extractor = new OpenAiTextResponseExtractor(new ObjectMapper());
+
+    /** Extrai o campo text quando o response vem no envelope padrão da Responses API. */
+    @Test
+    void extractsTextFromResponsesApiOutputEnvelope() {
+        String raw = """
+                {
+                  "id": "resp_123",
+                  "output": [
+                    {
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "{\\"stage\\":\\"persona-candidate-generator\\",\\"status\\":\\"PERSONAS_CANDIDATAS\\"}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String extracted = extractor.extract(raw);
+
+        assertThat(extracted).isEqualTo("{\"stage\":\"persona-candidate-generator\",\"status\":\"PERSONAS_CANDIDATAS\"}");
+    }
+
+    /** Extrai o campo text quando o worker envia diretamente uma mensagem da OpenAI. */
+    @Test
+    void extractsTextFromDirectMessageContentEnvelope() {
+        String raw = """
+                {
+                  "type": "message",
+                  "content": [
+                    {
+                      "type": "output_text",
+                      "text": "resposta limpa"
+                    }
+                  ]
+                }
+                """;
+
+        String extracted = extractor.extract(raw);
+
+        assertThat(extracted).isEqualTo("resposta limpa");
+    }
+
+    /** Mantém o response original quando não existe envelope JSON da OpenAI. */
+    @Test
+    void keepsOriginalResponseWhenTextCannotBeExtracted() {
+        String raw = "resposta direta sem envelope";
+
+        String extracted = extractor.extract(raw);
+
+        assertThat(extracted).isEqualTo(raw);
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1622,3 +1622,9 @@
 - Causa-raiz: contrato incompleto entre `source-searcher` e `source-fetcher`; o pipeline avançava com queries planejadas como se fossem fontes reais.
 - Correção: `source-searcher` agora só libera `nextStageCode=source-fetcher` quando recebe fontes reais auditáveis; sem fontes, conclui bloqueado com `FONTES_NAO_COLETADAS`, motivo persistível e etapa recomendada de correção.
 - Prevenção: adicionado teste unitário cobrindo bloqueio sem fontes e avanço apenas com `foundSources` reais.
+
+## 2026-06-28 — NichoCNAE v3: resposta final limpa da OpenAI no backend
+
+- Causa-raiz: o backend persistia o envelope bruto da OpenAI em `pipeline_nichocnae.response`, o que deixava a tela de auditoria dependente de JSON técnico para encontrar o conteúdo funcional em `content[].text`.
+- Correção: adicionada a coluna `pipeline_nichocnae.resposta_final` e normalização compartilhada no callback de response v3 para gravar, em todas as etapas, o texto limpo retornado pela OpenAI quando o envelope trouxer `output[].content[].text` ou `content[].text`.
+- Prevenção: teste unitário cobre extração do envelope da Responses API, extração de mensagem direta e fallback para response original quando não houver texto extraível.


### PR DESCRIPTION
### Motivation
- The backend was persisting the raw OpenAI envelope in `pipeline_nichocnae.response`, forcing downstream consumers to parse JSON-in-JSON to find the functional text; this change centralizes extraction of the useful `text` and stores it separately to simplify UI/audit and avoid JSON nesting in final artifacts.
- The goal is to apply the normalization in the shared response callback so every NichoCNAE stage records a cleaned, application-ready response in `resposta_final` while keeping the raw payload for audit.

### Description
- Added a new `resposta_final` field to the JPA entity `PipelineNichoCnae` (`backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java`).
- Created a Liquibase changelog `changesets/2026-06-28-pipeline-nichocnae-resposta-final.yaml` and added it to `db.changelog-master.yaml` to add the `resposta_final` `LONGTEXT` column to `pipeline_nichocnae` at runtime.
- Implemented `OpenAiTextResponseExtractor` (`backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiTextResponseExtractor.java`) to extract the first usable `text` from OpenAI envelopes (`output[].content[].text` or `content[].text`) with safe fallback to the raw response.
- Hooked the extractor into the shared callback by updating `OprmNichoCnaeV3StageServiceSupport.doRecebeResponse` to set `pipeline.setRespostaFinal(...)` alongside `pipeline.setResponse(...)` so all stages persist the cleaned text (`backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java`).
- Added unit tests: `OpenAiTextResponseExtractorTest` to validate extraction from typical OpenAI envelopes and direct messages, and an updated `BackendCnaeIntakeServiceTest` case to assert `resposta_final` persistence; and recorded the change in `docs/registros/oprm1.md`.

### Testing
- Ran the module tests with `../mvnw -Dtest=OpenAiTextResponseExtractorTest,BackendCnaeIntakeServiceTest test` in `backend/ads-service` and the targeted tests passed (build success, tests ran with zero failures). 
- Verified the new Liquibase include entry in `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` and confirmed `relativeToChangelogFile: true` is present for included changesets. 
- Verified `git diff --check` returned no problems and unit tests covering extraction and persistence succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a406f00cab88321a17694097e0a3946)