### PR TITLE
Corrige materialização final do NichoCNAE v3

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1633,3 +1633,10 @@
 - Causa-raiz: o backend persistia o envelope bruto da OpenAI em `pipeline_nichocnae.response`, o que deixava a tela de auditoria dependente de JSON técnico para encontrar o conteúdo funcional em `content[].text`.
 - Correção: adicionada a coluna `pipeline_nichocnae.resposta_final` e normalização compartilhada no callback de response v3 para gravar, em todas as etapas, o texto limpo retornado pela OpenAI quando o envelope trouxer `output[].content[].text` ou `content[].text`.
 - Prevenção: teste unitário cobre extração do envelope da Responses API, extração de mensagem direta e fallback para response original quando não houver texto extraível.
+
+## 2026-06-28 — NichoCNAE v3: verificação de objetivos das etapas
+
+- Verificação: revisado o executor `oprm-coletor-mei` em `com.marketinghub.pipelines.nichocnae.v3` contra o objetivo funcional de cada etapa do pipeline.
+- Causa-raiz encontrada: a etapa final `persona-routine-materializer` ainda concluía com payload técnico mínimo, sem materializar persona, rotina, dores, evidências e candidato funcional para persistência canônica no backend.
+- Correção: `persona-routine-materializer` agora exige aprovação do `quality-gate`, `winnerPersona` e `dailyTasks`, e entrega `materializedProfile`, `marketNicheCandidate` e prontidão explícita para o backend persistir `market_niche` e `market_niche_enrichment_profile`.
+- Prevenção de recorrência: adicionado teste unitário cobrindo materialização aprovada e bloqueio quando o `quality-gate` não aprovou.

--- a/oprm-coletor-mei/README.md
+++ b/oprm-coletor-mei/README.md
@@ -34,12 +34,18 @@ A referência oficial do módulo OPRM é o pipeline de importação por snapshot
 
 ## Pipeline NichoCNAE v3
 
-O módulo também executa o pipeline `com.marketinghub.pipelines.nichocnae.v3` para pesquisa de rotina por CNAE. As etapas 6 a 9 devem gerar saídas funcionais compatíveis com seus objetivos:
+O módulo também executa o pipeline `com.marketinghub.pipelines.nichocnae.v3` para pesquisa de rotina por CNAE. Todas as etapas devem gerar saídas funcionais compatíveis com seus objetivos, sem criar oferta, campanha ou landing page antes da etapa canônica apropriada:
 
+1. `cnae-intake`: qualifica o CNAE e delimita o público como MEI/profissional autônomo não CLT.
+2. `persona-candidate-generator`: gera personas operacionais candidatas com OpenAI, prompt/schema versionados e auditoria de request/response no backend.
+3. `persona-tournament`: prioriza a persona com maior evidência de dor, tarefas e sinais de compra.
+4. `routine-query-planner`: transforma a persona vencedora em plano de busca acionável para validar rotina real.
+5. `source-searcher`: só libera avanço quando recebe fontes reais auditáveis; sem fontes, bloqueia com causa persistível.
 6. `source-fetcher`: transforma fontes selecionadas em `sourceSnapshots` auditáveis, com URL, título, trecho de evidência e relevância de rotina.
 7. `routine-signal-extractor`: extrai `routineSignals` com tarefa, dor operacional, sinal de compra e referência do snapshot.
 8. `daily-tasks-synthesizer`: consolida `dailyTasks` com dor, evidência, fonte e alavanca de facilidade.
 9. `quality-gate`: decide avanço por critérios persistíveis de evidência e informa causa/correção quando bloquear.
+10. `persona-routine-materializer`: materializa o perfil aprovado com persona, rotina, dores, evidências e candidato funcional para o backend persistir em `market_niche` e `market_niche_enrichment_profile`.
 
 A etapa `persona-candidate-generator`, quando chama OpenAI, audita o request pelo endpoint backend `recebeRequest` antes do envio ao provedor e audita o retorno pelo `recebeResponse` tanto em sucesso quanto em erro HTTP da OpenAI.
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
@@ -8,20 +8,117 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Processa a etapa persona-routine-materializer do pipeline NichoCNAE v3. */
+/** Processa a etapa final persona-routine-materializer materializando o perfil funcional aprovado. */
 public final class PersonaRoutineMaterializerProcessor implements StageProcessor {
-    /** Executa a etapa persona-routine-materializer produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "PERFIL_MATERIALIZAVEL";
+
+    /** Executa a etapa persona-routine-materializer consolidando persona, rotina, dores, evidências e prontidão para persistência final. */
     @Override
     public StageResult process(StageContext context) {
+        if (!Boolean.TRUE.equals(context.input().get("approved"))) {
+            throw new IllegalStateException("Entrada de persona-routine-materializer exige quality-gate aprovado antes da materialização.");
+        }
+        Map<String, Object> winnerPersona = map(context.input().get("winnerPersona"));
+        List<Map<String, Object>> dailyTasks = maps(context.input().get("dailyTasks"));
+        if (winnerPersona.isEmpty() || dailyTasks.isEmpty()) {
+            throw new IllegalStateException("Entrada de persona-routine-materializer exige winnerPersona e dailyTasks para materializar o perfil.");
+        }
+
+        Map<String, Object> materializedProfile = materializedProfile(context.input(), winnerPersona, dailyTasks);
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "persona-routine-materializer");
-        output.put("status", "PERFIL_MATERIALIZAVEL");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("cnaeCode", text(context.input().get("cnaeCode")));
+        output.put("cnaeDescription", text(context.input().get("cnaeDescription")));
+        output.put("materializedProfile", materializedProfile);
+        output.put("marketNicheCandidate", marketNicheCandidate(context.input(), materializedProfile));
+        output.put("materializationReadiness", "PRONTO_PARA_BACKEND_PERSISTIR_MARKET_NICHE_E_PROFILE");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "");
-        return new StageResult("PERFIL_MATERIALIZAVEL", output, List.of(new StageArtifact("PERFIL_MATERIALIZAVEL", "inline://nichocnae-v3/persona-routine-materializer", "Etapa persona-routine-materializer concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/persona-routine-materializer", "Perfil final materializado com persona, rotina, dores e evidências para persistência backend.")));
+    }
+
+    /** Monta o perfil final sem inserir metadado técnico no artefato funcional. */
+    private Map<String, Object> materializedProfile(Map<String, Object> input, Map<String, Object> winnerPersona, List<Map<String, Object>> dailyTasks) {
+        Map<String, Object> profile = new LinkedHashMap<>();
+        profile.put("personaName", firstNonBlank(text(input.get("winningPersonaName")), text(winnerPersona.get("name")), "persona operacional priorizada"));
+        profile.put("personaDescription", text(winnerPersona.get("description")));
+        profile.put("routineSummary", routineSummary(profile.get("personaName"), dailyTasks));
+        profile.put("dailyTasks", dailyTasks);
+        profile.put("topOperationalPains", dailyTasks.stream().map(task -> text(task.get("pain"))).filter(pain -> !pain.isBlank()).distinct().toList());
+        profile.put("buyingSignals", dailyTasks.stream().map(task -> text(task.get("buyingSignal"))).filter(signal -> !signal.isBlank()).distinct().toList());
+        profile.put("evidenceSources", dailyTasks.stream().map(this::evidenceSource).filter(source -> !source.isEmpty()).toList());
+        profile.put("easeLevers", dailyTasks.stream().map(task -> text(task.get("easeLever"))).filter(lever -> !lever.isBlank()).distinct().toList());
+        profile.put("approvedByQualityGate", true);
+        return profile;
+    }
+
+    /** Cria um candidato de nicho com campos funcionais para o backend materializar nas tabelas canônicas. */
+    private Map<String, Object> marketNicheCandidate(Map<String, Object> input, Map<String, Object> materializedProfile) {
+        Map<String, Object> candidate = new LinkedHashMap<>();
+        candidate.put("sourcePipeline", "nichocnae.v3");
+        candidate.put("cnaeCode", text(input.get("cnaeCode")));
+        candidate.put("cnaeDescription", text(input.get("cnaeDescription")));
+        candidate.put("title", materializedProfile.get("personaName"));
+        candidate.put("summary", materializedProfile.get("routineSummary"));
+        candidate.put("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
+        candidate.put("profilePayload", materializedProfile);
+        return candidate;
+    }
+
+    /** Gera resumo funcional curto da rotina validada. */
+    private String routineSummary(Object personaName, List<Map<String, Object>> dailyTasks) {
+        String firstTask = dailyTasks.stream().map(task -> text(task.get("task"))).filter(task -> !task.isBlank()).findFirst().orElse("tarefas operacionais recorrentes");
+        return personaName + " executa " + firstTask + " e apresenta dores recorrentes mapeadas com evidência pública.";
+    }
+
+    /** Extrai a fonte auditável de uma tarefa diária. */
+    private Map<String, Object> evidenceSource(Map<String, Object> task) {
+        String sourceUrl = text(task.get("sourceUrl"));
+        String evidenceText = text(task.get("evidenceText"));
+        if (sourceUrl.isBlank() && evidenceText.isBlank()) {
+            return Map.of();
+        }
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("sourceUrl", sourceUrl);
+        source.put("evidenceText", evidenceText);
+        return source;
+    }
+
+    /** Normaliza objeto de entrada em mapa textual. */
+    private Map<String, Object> map(Object value) {
+        if (!(value instanceof Map<?, ?> raw)) {
+            return Map.of();
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        raw.forEach((key, val) -> normalized.put(String.valueOf(key), val));
+        return normalized;
+    }
+
+    /** Normaliza lista de mapas preservando apenas itens estruturados. */
+    private List<Map<String, Object>> maps(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().filter(Map.class::isInstance).map(this::map).toList();
+    }
+
+    /** Escolhe o primeiro texto preenchido. */
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (!value.isBlank()) {
+                return value;
+            }
+        }
+        return "persona operacional priorizada";
+    }
+
+    /** Converte valor opcional em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessorTest.java
@@ -1,0 +1,62 @@
+package com.marketinghub.pipelines.nichocnae.v3.personaroutinematerializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a materialização final do perfil persona-rotina no pipeline NichoCNAE v3. */
+class PersonaRoutineMaterializerProcessorTest {
+    /** Garante que a etapa final entregue perfil funcional completo para persistência canônica no backend. */
+    @Test
+    void shouldMaterializeApprovedPersonaRoutineProfile() {
+        PersonaRoutineMaterializerProcessor processor = new PersonaRoutineMaterializerProcessor();
+        StageResult result = processor.process(new StageContext("job-1", "10", Map.of(
+                "approved", true,
+                "cnaeCode", "4781400",
+                "cnaeDescription", "Comércio varejista de artigos do vestuário",
+                "winningPersonaName", "lojista MEI de moda",
+                "winnerPersona", Map.of("name", "lojista MEI de moda", "description", "Dono operador de loja pequena"),
+                "dailyTasks", List.of(
+                        Map.of(
+                                "task", "controlar estoque de peças",
+                                "pain", "CONTROLE_OPERACIONAL_MANUAL",
+                                "buyingSignal", "PROCURA_FERRAMENTA_OU_MODELO",
+                                "sourceUrl", "https://fonte.example/rotina",
+                                "evidenceText", "relato público sobre controle de estoque",
+                                "easeLever", "simplificar controle operacional"),
+                        Map.of(
+                                "task", "responder clientes no WhatsApp",
+                                "pain", "PERDA_DE_TEMPO",
+                                "buyingSignal", "SINAL_DE_COMPRA_A_VALIDAR",
+                                "sourceUrl", "https://fonte.example/atendimento",
+                                "evidenceText", "relato público sobre atendimento diário",
+                                "easeLever", "economizar tempo em tarefa recorrente")))));
+
+        assertThat(result.status()).isEqualTo("PERFIL_MATERIALIZAVEL");
+        assertThat(result.output()).containsEntry("nextStageCode", "").containsEntry("materializationReadiness", "PRONTO_PARA_BACKEND_PERSISTIR_MARKET_NICHE_E_PROFILE");
+        assertThat(result.output().get("materializedProfile")).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> profile = (Map<String, Object>) result.output().get("materializedProfile");
+        assertThat(profile)
+                .containsEntry("personaName", "lojista MEI de moda")
+                .containsEntry("approvedByQualityGate", true);
+        assertThat(profile.get("dailyTasks")).asList().hasSize(2);
+        assertThat(profile.get("evidenceSources")).asList().hasSize(2);
+        assertThat(result.output().get("marketNicheCandidate")).isInstanceOf(Map.class);
+    }
+
+    /** Impede materialização quando o quality-gate ainda não aprovou a rotina. */
+    @Test
+    void shouldBlockWhenQualityGateIsNotApproved() {
+        PersonaRoutineMaterializerProcessor processor = new PersonaRoutineMaterializerProcessor();
+
+        assertThatThrownBy(() -> processor.process(new StageContext("job-1", "10", Map.of("approved", false))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("quality-gate aprovado");
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantir que o pipeline `nichocnae.v3` cumpra seus objetivos funcionais em todas as etapas e que a etapa final entregue artefatos prontos para persistência canônica no backend. 
- Corrigir a lacuna onde `persona-routine-materializer` encerrava com payload técnico mínimo em vez de materializar persona, rotina, dores, evidências e candidato funcional.

### Description
- Atualiza `PersonaRoutineMaterializerProcessor` para exigir `approved` pelo `quality-gate`, presença de `winnerPersona` e `dailyTasks`, e para produzir `materializedProfile`, `marketNicheCandidate`, `cnaeCode`/`cnaeDescription` e `materializationReadiness` antes de concluir. 
- Centraliza `STATUS = "PERFIL_MATERIALIZAVEL"` e usa `StageArtifact`/`StageResult` consistentes com saída funcional pronta para persistência. 
- Adiciona `PersonaRoutineMaterializerProcessorTest` com dois cenários: materialização aprovada (valida campos do profile e candidate) e bloqueio quando `quality-gate` não aprovou. 
- Documenta os objetivos das 10 etapas do pipeline em `oprm-coletor-mei/README.md` e registra a verificação/correção em `docs/registros/oprm1.md`.

### Testing
- Executed `mvn -q test` in the `oprm-coletor-mei` module and the unit tests completed successfully. 
- Ran `mvn -q spotless:check` in `oprm-coletor-mei` which failed because the Spotless plugin is not configured for this module. 
- Attempted `mvn -q -pl oprm-coletor-mei test` from the repository root which failed because the module was not resolved in the reactor, so module-scoped test command should be run from the module directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407375a4d08321b43b4849192ea058)