### PR TITLE
Persist clean OpenAI text as `resposta_final` in dossieproduto pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.dossiersynthesis.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
@@ -109,6 +110,7 @@ public class DossierDossierSynthesisService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service.pending.DossierIntakePendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service.pending.DossierIntakePendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service.pending.DossierIntakePendingResponse;
@@ -109,6 +110,7 @@ public class DossierIntakeService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.investigationanchorbuilder.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
@@ -109,6 +110,7 @@ public class DossierInvestigationAnchorBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
@@ -109,6 +110,7 @@ public class DossierProductUnderstandingService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractor.java
@@ -1,0 +1,65 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+
+/** Utilitário responsável por extrair a resposta funcional limpa dos envelopes OpenAI do dossiê de produto. */
+public final class DossierOpenAiTextResponseExtractor {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /** Impede instanciação porque o extrator não mantém estado por execução. */
+    private DossierOpenAiTextResponseExtractor() {}
+
+    /** Retorna o campo text do response OpenAI quando existir; caso contrário preserva o response bruto. */
+    public static String extract(String rawResponse) {
+        if (!StringUtils.hasText(rawResponse)) {
+            return rawResponse;
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(rawResponse);
+            String extracted = extractFromRoot(root);
+            return StringUtils.hasText(extracted) ? extracted : rawResponse;
+        } catch (JsonProcessingException ex) {
+            return rawResponse;
+        }
+    }
+
+    /** Busca o texto funcional nos formatos raiz usados pela Responses API e por mensagens diretas. */
+    private static String extractFromRoot(JsonNode root) {
+        String directOutput = extractFromOutput(root.path("output"));
+        if (StringUtils.hasText(directOutput)) {
+            return directOutput;
+        }
+        return extractFromContent(root.path("content"));
+    }
+
+    /** Varre a lista output da OpenAI procurando o primeiro conteúdo textual da mensagem. */
+    private static String extractFromOutput(JsonNode output) {
+        if (!output.isArray()) {
+            return null;
+        }
+        for (JsonNode outputItem : output) {
+            String text = extractFromContent(outputItem.path("content"));
+            if (StringUtils.hasText(text)) {
+                return text;
+            }
+        }
+        return null;
+    }
+
+    /** Varre a lista content da OpenAI procurando o primeiro campo text preenchido. */
+    private static String extractFromContent(JsonNode content) {
+        if (!content.isArray()) {
+            return null;
+        }
+        for (JsonNode contentItem : content) {
+            JsonNode textNode = contentItem.path("text");
+            if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
+                return textNode.asText();
+            }
+        }
+        return null;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
@@ -45,6 +45,7 @@ public class DossierSituacaoService {
                 pipeline.getJobId(),
                 pipeline.getRequest(),
                 pipeline.getResponse(),
+                pipeline.getRespostaFinal(),
                 pipeline.getQuantidadeTokenEntrada(),
                 pipeline.getQuantidadeTokenSaida(),
                 pipeline.getModelo(),

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/situacao/DossierSituacaoItem.java
@@ -13,6 +13,7 @@ public record DossierSituacaoItem(
         String jobId,
         String request,
         String response,
+        String respostaFinal,
         Long quantidadeTokenEntrada,
         Long quantidadeTokenSaida,
         String modelo,

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.sourceproductmatch.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
@@ -109,6 +110,7 @@ public class DossierSourceProductMatchService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupmapbuilder.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
@@ -109,6 +110,7 @@ public class DossierWarmupMapBuilderService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupresourcediscovery.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
@@ -109,6 +110,7 @@ public class DossierWarmupResourceDiscoveryService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupsignalextraction.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared.DossierOpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
@@ -109,6 +110,7 @@ public class DossierWarmupSignalExtractionService {
         PipelineDossieProduto pipeline = new PipelineDossieProduto();
         pipeline.setIdExterno(productKey);
         pipeline.setResponse(request.response());
+        pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setStatus(status);
         pipeline.setDataHora(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
@@ -30,6 +30,9 @@ public class PipelineDossieProduto {
     @Column(name = "response", columnDefinition = "LONGTEXT")
     private String response;
 
+    @Column(name = "resposta_final", columnDefinition = "LONGTEXT")
+    private String respostaFinal;
+
     @Column(name = "codigo_etapa", length = 120)
     private String codigoEtapa;
 

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-dossieproduto-resposta-final.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-dossieproduto-resposta-final.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-28-01-pipeline-dossieproduto-resposta-final
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_dossieproduto
+        - not:
+            - columnExists:
+                tableName: pipeline_dossieproduto
+                columnName: resposta_final
+      changes:
+        - addColumn:
+            tableName: pipeline_dossieproduto
+            columns:
+              - column:
+                  name: resposta_final
+                  type: LONGTEXT

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,10 +1,17 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-28-pipeline-dossieproduto-resposta-final.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-28-pipeline-nichocnae-resposta-final.yaml
       relativeToChangelogFile: true
   - include:
       file: changesets/2026-06-27-pipeline-dossieproduto-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-27-pipeline-geracaoanuncios-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-27-pipeline-nichocnae-status.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractorTest.java
@@ -1,0 +1,43 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Testa a limpeza dos envelopes OpenAI persistidos pelo pipeline de dossiê de produto. */
+class DossierOpenAiTextResponseExtractorTest {
+    /** Extrai o campo text quando a resposta vem no envelope padrão da Responses API. */
+    @Test
+    void extractsTextFromResponsesApiOutputEnvelope() {
+        String raw = """
+                {
+                  "id": "resp_123",
+                  "output": [
+                    {
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "{\\\"produto\\\":\\\"limpo\\\"}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String extracted = DossierOpenAiTextResponseExtractor.extract(raw);
+
+        assertThat(extracted).isEqualTo("{\"produto\":\"limpo\"}");
+    }
+
+    /** Mantém o response original quando não existe campo text extraível. */
+    @Test
+    void keepsOriginalResponseWhenTextCannotBeExtracted() {
+        String raw = "resposta direta";
+
+        String extracted = DossierOpenAiTextResponseExtractor.extract(raw);
+
+        assertThat(extracted).isEqualTo(raw);
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1912,3 +1912,9 @@ Arquivos principais:
 - documentos lidos para tratar a situação:
   - AGENTS.md
   - mois-sales-library-worker/AGENTS.md
+
+## 2026-06-28 — Resposta final limpa no pipeline dossieproduto.v1
+
+- Adicionado o campo `resposta_final` em `pipeline_dossieproduto` para guardar o texto funcional extraído do envelope OpenAI, preservando `response` como payload bruto de auditoria.
+- Todas as etapas do backend `moissaleslibraryworker.dossieproduto.v1` passaram a preencher `resposta_final` ao receber o callback de resposta.
+- Criado extrator compartilhado para localizar o campo `text` nos formatos de resposta da OpenAI e manter fallback seguro para respostas diretas.

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -846,6 +846,9 @@ components:
         jobId: { type: string }
         request: { type: string }
         response: { type: string }
+        respostaFinal:
+          type: string
+          description: Texto funcional limpo extraído do campo text do envelope OpenAI, mantendo response como auditoria bruta.
         quantidadeTokenEntrada:
           type: integer
           format: int64


### PR DESCRIPTION
### Motivation

- Garantir que, quando a resposta do OpenAI vier no envelope JSON, o campo funcional `text` seja extraído e persistido para uso funcional sem perder o payload bruto de auditoria.
- Aplicar essa extração em todas as etapas do pipeline `dossieproduto.v1` para facilitar consultas, relatórios e evitar JSON dentro de JSON em contratos finais.
- Manter `response` como registro bruto e adicionar `resposta_final` como campo dedicado com propósito claro de saída limpa.

### Description

- Adiciona changelog Liquibase `changesets/2026-06-28-pipeline-dossieproduto-resposta-final.yaml` para criar a coluna `resposta_final` na tabela `pipeline_dossieproduto` e registra o include no `db.changelog-master.yaml`.
- Expande a entidade JPA `PipelineDossieProduto` com o campo `respostaFinal` mapeado para `resposta_final` em banco (`LONGTEXT`).
- Cria o utilitário compartilhado `DossierOpenAiTextResponseExtractor` para extrair com segurança o primeiro `text` válido dos formatos de resposta OpenAI (`output[].content[].text` ou `content[].text`) com fallback para o payload bruto.
- Atualiza todas as etapas do pipeline `dossieproduto.v1` (`intake`, `product-understanding`, `investigation-anchor-builder`, `source-product-match`, `warmup-map-builder`, `warmup-resource-discovery`, `warmup-signal-extraction`, `dossier-synthesis`) para preencher `pipeline.setRespostaFinal(DossierOpenAiTextResponseExtractor.extract(request.response()))` ao receber `recebeResponse`.
- Expõe `respostaFinal` na consulta de situação alterando `DossierSituacaoItem` e `DossierSituacaoService`, e atualiza o Swagger (`docs/swagger/mois-dossie-v1-swagger.yaml`) e o registro operacional (`docs/registros/mois1.md`).
- Adiciona teste unitário `DossierOpenAiTextResponseExtractorTest` cobrindo extração de `text` do envelope Responses API e fallback para resposta direta.

### Testing

- Executado o teste unitário `DossierOpenAiTextResponseExtractorTest` com `../mvnw -Dtest=DossierOpenAiTextResponseExtractorTest test` no módulo `ads-service`, que passou (`Tests run: 2, Failures: 0`).
- Rodado `git diff --check` e verificação de status do repositório sem conflitos detectados; commit preparado com as alterações de código e changelog.
- Tentativa de rodar `../mvnw spotless:apply` falhou porque o plugin `spotless` não está configurado/disponível no projeto `ads-service`, o que não afeta a lógica implementada nem os testes unitários executados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40742ea0708321b5f5bae02cc767f7)