### PR TITLE
Expose `respostaFinal` in NichoCNAE v3 pipeline situacao responses and UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
@@ -59,6 +59,7 @@ public class BackendNichoCnaeV3PipelineSituacaoService {
                 pipeline.getJobId(),
                 pipeline.getRequest(),
                 pipeline.getResponse(),
+                pipeline.getRespostaFinal(),
                 pipeline.getQuantidadeTokenEntrada(),
                 pipeline.getQuantidadeTokenSaida(),
                 pipeline.getModelo(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
@@ -12,6 +12,7 @@ public record NichoCnaeV3PipelineSituacaoResponse(
         String jobId,
         String request,
         String response,
+        String respostaFinal,
         Long quantidadeTokenEntrada,
         Long quantidadeTokenSaida,
         String modelo,

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
@@ -33,6 +33,7 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         record.setStatus("CONCLUIDO");
         record.setDataHora(Instant.parse("2026-06-27T10:00:00Z"));
         record.setJobId("job-1");
+        record.setRespostaFinal("{\"persona\":\"dono de loja\"}");
         when(repository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
                         "source-searcher", "4781400", List.of("CONCLUIDO", "FALHA")))
                 .thenReturn(List.of(record));
@@ -43,6 +44,7 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         assertThat(response.getFirst().idExterno()).isEqualTo("4781400");
         assertThat(response.getFirst().codigoEtapa()).isEqualTo("source-searcher");
         assertThat(response.getFirst().status()).isEqualTo("CONCLUIDO");
+        assertThat(response.getFirst().respostaFinal()).isEqualTo("{\"persona\":\"dono de loja\"}");
         ArgumentCaptor<List<String>> statusCaptor = ArgumentCaptor.forClass(List.class);
         verify(repository).findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
                 org.mockito.ArgumentMatchers.eq("source-searcher"),

--- a/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
@@ -303,6 +303,10 @@ components:
         response:
           type: string
           nullable: true
+        respostaFinal:
+          type: string
+          nullable: true
+          description: Texto funcional extraído do campo text do response bruto da IA.
         quantidadeTokenEntrada:
           type: integer
           format: int64

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Situacao.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Situacao.ts
@@ -9,6 +9,7 @@ export interface OprmNichoCnaeV3Situacao {
   jobId: string | null;
   request: string | null;
   response: string | null;
+  respostaFinal: string | null;
   quantidadeTokenEntrada: number | null;
   quantidadeTokenSaida: number | null;
   modelo: string | null;

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -547,6 +547,15 @@ export default function OprmNichoCnaeV3PipelinePage() {
                             payload={responsePayload}
                           />
                         </div>
+                        <div>
+                          <div className="small fw-semibold mb-1">
+                            Texto extraído do response
+                          </div>
+                          <PayloadSummary
+                            label="texto extraído"
+                            payload={situacao?.respostaFinal}
+                          />
+                        </div>
                         {situacao?.prompt || situacao?.schema ? (
                           <details className="small">
                             <summary className="fw-semibold">


### PR DESCRIPTION
### Motivation

- Surface a functional text extracted from the raw IA response so consumers and UI can show the simplified result (`respostaFinal`).
- Keep the public API, backend mapping and frontend types in sync to avoid missing data in responses and UI.

### Description

- Added `respostaFinal` to the backend response mapping by including `pipeline.getRespostaFinal()` in `BackendNichoCnaeV3PipelineSituacaoService.toResponse` and adding the field to the response record `NichoCnaeV3PipelineSituacaoResponse`.
- Updated the OpenAPI spec `docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml` to include the `respostaFinal` property with a description.
- Extended the frontend TypeScript contract in `useOprmNichoCnaeV3Situacao.ts` to include `respostaFinal` and added a UI block in `OprmNichoCnaeV3PipelinePage.tsx` to display the extracted text.
- Adjusted the unit test `BackendNichoCnaeV3PipelineSituacaoServiceTest` to set and assert the new `respostaFinal` value.

### Testing

- Ran the unit test `BackendNichoCnaeV3PipelineSituacaoServiceTest` which was updated to assert `respostaFinal`, and it passed.
- No other automated tests were changed or reported failing as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407a259e44832193d16314626fab6a)