### PR TITLE
Persist OpenAI request `input` in pipeline_nichocnae and show it in OPRM v3 UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
@@ -26,6 +26,9 @@ public class PipelineNichoCnae {
     @Column(name = "request", columnDefinition = "LONGTEXT")
     private String request;
 
+    @Column(name = "request_input", columnDefinition = "LONGTEXT")
+    private String requestInput;
+
     @Column(name = "response", columnDefinition = "LONGTEXT")
     private String response;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiRequestInputExtractor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiRequestInputExtractor.java
@@ -1,0 +1,35 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+
+/** Extrai o campo input de requests brutos da OpenAI para persistência limpa no NichoCNAE v3. */
+final class OpenAiRequestInputExtractor {
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o extrator com o mapper JSON compartilhado pelo service da etapa. */
+    OpenAiRequestInputExtractor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /** Retorna o campo input do request da OpenAI quando existir ou mantém nulo quando não houver input. */
+    String extract(String rawRequest) {
+        if (!StringUtils.hasText(rawRequest)) {
+            return null;
+        }
+        try {
+            JsonNode input = objectMapper.readTree(rawRequest).path("input");
+            if (input.isTextual() && StringUtils.hasText(input.asText())) {
+                return input.asText();
+            }
+            if (!input.isMissingNode() && !input.isNull()) {
+                return objectMapper.writeValueAsString(input);
+            }
+            return null;
+        } catch (JsonProcessingException ex) {
+            return null;
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -46,6 +46,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     private final String stageCode;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final OpenAiTextResponseExtractor responseExtractor = new OpenAiTextResponseExtractor(objectMapper);
+    private final OpenAiRequestInputExtractor requestInputExtractor = new OpenAiRequestInputExtractor(objectMapper);
 
     /** Inicializa o suporte com repository canônico e código da etapa. */
     protected OprmNichoCnaeV3StageServiceSupport(
@@ -99,7 +100,9 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
         PipelineNichoCnae pipeline = new PipelineNichoCnae();
         pipeline.setIdExterno(cnaeCode);
-        pipeline.setRequest(request == null ? null : request.request());
+        String rawRequest = request == null ? null : request.request();
+        pipeline.setRequest(rawRequest);
+        pipeline.setRequestInput(requestInputExtractor.extract(rawRequest));
         pipeline.setCodigoEtapa(stageCode);
         pipeline.setDataHora(now);
         pipeline.setStatus(STATUS_WAITING_MODULE);

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoService.java
@@ -58,6 +58,7 @@ public class BackendNichoCnaeV3PipelineSituacaoService {
                 pipeline.getDataHora(),
                 pipeline.getJobId(),
                 pipeline.getRequest(),
+                pipeline.getRequestInput(),
                 pipeline.getResponse(),
                 pipeline.getRespostaFinal(),
                 pipeline.getQuantidadeTokenEntrada(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/searchPipelineSituacao/NichoCnaeV3PipelineSituacaoResponse.java
@@ -11,6 +11,7 @@ public record NichoCnaeV3PipelineSituacaoResponse(
         Instant dataHora,
         String jobId,
         String request,
+        String requestInput,
         String response,
         String respostaFinal,
         Long quantidadeTokenEntrada,

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-nichocnae-request-input.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-28-pipeline-nichocnae-request-input.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-28-01-pipeline-nichocnae-request-input
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_nichocnae
+        - not:
+            - columnExists:
+                tableName: pipeline_nichocnae
+                columnName: request_input
+      changes:
+        - addColumn:
+            tableName: pipeline_nichocnae
+            columns:
+              - column:
+                  name: request_input
+                  type: LONGTEXT
+                  afterColumn: request

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-28-pipeline-nichocnae-request-input.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-28-pipeline-nichocnae-append-only-audit.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiRequestInputExtractorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OpenAiRequestInputExtractorTest.java
@@ -1,0 +1,38 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/** Valida a extração do campo input em requests OpenAI auditados no NichoCNAE v3. */
+class OpenAiRequestInputExtractorTest {
+    private final OpenAiRequestInputExtractor extractor = new OpenAiRequestInputExtractor(new ObjectMapper());
+
+    /** Deve extrair input textual simples da Responses API. */
+    @Test
+    void extractShouldReturnTextualInput() {
+        String rawRequest = "{\"model\":\"gpt-5.2\",\"input\":\"# Prompt operacional\",\"service_tier\":\"flex\"}";
+
+        String extracted = extractor.extract(rawRequest);
+
+        assertThat(extracted).isEqualTo("# Prompt operacional");
+    }
+
+    /** Deve serializar input estruturado quando o request usar lista ou objeto. */
+    @Test
+    void extractShouldReturnStructuredInputAsJson() {
+        String rawRequest = "{\"input\":[{\"role\":\"user\",\"content\":\"texto\"}]}";
+
+        String extracted = extractor.extract(rawRequest);
+
+        assertThat(extracted).isEqualTo("[{\"role\":\"user\",\"content\":\"texto\"}]");
+    }
+
+    /** Deve retornar nulo quando o payload não tiver input extraível. */
+    @Test
+    void extractShouldReturnNullWhenInputIsMissing() {
+        assertThat(extractor.extract("{\"model\":\"gpt-5.2\"}")).isNull();
+        assertThat(extractor.extract("texto sem json")).isNull();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/situacao/service/BackendNichoCnaeV3PipelineSituacaoServiceTest.java
@@ -34,6 +34,7 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         record.setStatus("CONCLUIDO");
         record.setDataHora(Instant.parse("2026-06-27T10:00:00Z"));
         record.setJobId("job-1");
+        record.setRequestInput("prompt operacional");
         record.setRespostaFinal("{\"persona\":\"dono de loja\"}");
         when(repository.findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
                         "source-searcher", "4781400", List.of("CONCLUIDO", "FALHA")))
@@ -45,6 +46,7 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         assertThat(response.getFirst().idExterno()).isEqualTo("4781400");
         assertThat(response.getFirst().codigoEtapa()).isEqualTo("source-searcher");
         assertThat(response.getFirst().status()).isEqualTo("CONCLUIDO");
+        assertThat(response.getFirst().requestInput()).isEqualTo("prompt operacional");
         assertThat(response.getFirst().respostaFinal()).isEqualTo("{\"persona\":\"dono de loja\"}");
         ArgumentCaptor<List<String>> statusCaptor = ArgumentCaptor.forClass(List.class);
         verify(repository).findByCodigoEtapaAndIdExternoAndStatusInOrderByDataHoraDesc(
@@ -65,6 +67,7 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         requestRecord.setDataHora(Instant.parse("2026-06-27T10:00:00Z"));
         requestRecord.setJobId("job-1");
         requestRecord.setRequest("{\"model\":\"gpt-5.2\",\"service_tier\":\"flex\"}");
+        requestRecord.setRequestInput("# prompt enviado");
         PipelineNichoCnae responseRecord = new PipelineNichoCnae();
         responseRecord.setId(2L);
         responseRecord.setIdExterno("4781400");
@@ -82,5 +85,6 @@ class BackendNichoCnaeV3PipelineSituacaoServiceTest {
         assertThat(response).hasSize(2);
         assertThat(response.get(0).response()).isEqualTo("{\"status\":\"completed\"}");
         assertThat(response.get(1).request()).isEqualTo("{\"model\":\"gpt-5.2\",\"service_tier\":\"flex\"}");
+        assertThat(response.get(1).requestInput()).isEqualTo("# prompt enviado");
     }
 }

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-28 — OPRM NichoCNAE v3: input do request OpenAI separado na auditoria
+
+- Separado o campo `input` do request bruto da OpenAI em `pipeline_nichocnae.request_input`, mantendo o request completo para auditoria e oferecendo leitura direta do prompt enviado.
+- A tela do pipeline v3 agora exibe o input extraído em bloco próprio, alinhado ao bloco de texto extraído do response.
+- Prevenção de recorrência: teste unitário cobre extração de `input` textual, `input` estruturado e ausência de campo no request.
+
 ## 2026-06-27 — OPRM NichoCNAE v3: etapa 1 qualifica o CNAE antes da geração de personas
 
 - Corrigida a causa-raiz da entrada da etapa `persona-candidate-generator`: a etapa `cnae-intake` agora nasce com `cnaeCode` e `cnaeDescription` vindos da dimensão canônica de CNAE e devolve esses campos na própria saída funcional.

--- a/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
@@ -300,6 +300,10 @@ components:
         request:
           type: string
           nullable: true
+        requestInput:
+          type: string
+          nullable: true
+          description: Campo input extraído do request bruto da OpenAI para leitura direta do prompt enviado.
         response:
           type: string
           nullable: true

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Situacao.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Situacao.ts
@@ -8,6 +8,7 @@ export interface OprmNichoCnaeV3Situacao {
   dataHora: string;
   jobId: string | null;
   request: string | null;
+  requestInput: string | null;
   response: string | null;
   respostaFinal: string | null;
   quantidadeTokenEntrada: number | null;

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -159,6 +159,7 @@ function pickSituacaoForJob(
   return {
     ...responseRecord,
     request: requestRecord?.request ?? responseRecord.request,
+    requestInput: requestRecord?.requestInput ?? responseRecord.requestInput,
     prompt: requestRecord?.prompt ?? responseRecord.prompt,
     schema: requestRecord?.schema ?? responseRecord.schema,
     plataforma: requestRecord?.plataforma ?? responseRecord.plataforma,
@@ -592,6 +593,15 @@ export default function OprmNichoCnaeV3PipelinePage() {
                           <PayloadSummary
                             label="request"
                             payload={requestPayload}
+                          />
+                        </div>
+                        <div>
+                          <div className="small fw-semibold mb-1">
+                            Input extraído do request
+                          </div>
+                          <PayloadSummary
+                            label="input extraído"
+                            payload={situacao?.requestInput}
                           />
                         </div>
                         {errorMessage ? (


### PR DESCRIPTION
### Motivation
- Separate and persist the OpenAI `input` field (the prompt) alongside the full raw request for clearer auditability and direct UI consumption. 
- Mirror the existing extraction of response text so the frontend can display the prompt/input in its own block for OpenAI integrations and reduce manual JSON-in-JSON parsing on the UI.

### Description
- Added a Liquibase changeset `changesets/2026-06-28-pipeline-nichocnae-request-input.yaml` to add `request_input` (LONGTEXT) to `pipeline_nichocnae` and ensured it is included in `db.changelog-master.yaml` with `relativeToChangelogFile: true`.
- Added `requestInput` to the JPA entity `PipelineNichoCnae`, created `OpenAiRequestInputExtractor` to extract/serialize the `input` field from raw OpenAI requests, and wired extraction/persistence in `OprmNichoCnaeV3StageServiceSupport` when receiving requests.
- Exposed `requestInput` in the backend response record `NichoCnaeV3PipelineSituacaoResponse`, updated the service mapper, updated the Swagger contract `docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml`, and updated the frontend TypeScript interface and UI to show a separate "Input extraído do request" block below the raw request.
- Added unit tests: `OpenAiRequestInputExtractorTest` (covers textual, structured and missing input) and updated `BackendNichoCnaeV3PipelineSituacaoServiceTest` to validate preservation and exposure of `requestInput`.

### Testing
- Ran the backend unit tests with `./mvnw -Dtest=OpenAiRequestInputExtractorTest,BackendNichoCnaeV3PipelineSituacaoServiceTest test`, which executed the two test classes (5 tests total) and completed with `BUILD SUCCESS` (all tests passed).
- Verified changelog includes use `relativeToChangelogFile: true` via a quick script check (no missing relative includes found). 
- Attempted frontend typecheck with `npm run typecheck`, which failed due to missing `node_modules` in the environment (type errors from missing `vite/client`, `vitest/globals` and `@testing-library/jest-dom`), so frontend static checks were not fully validated in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a412017e7188321a139709e1dd6f9a6)