### PR TITLE
NichoCNAE v3: make persona-candidate-generator prompt routine-focused and update schema/tests

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1665,3 +1665,9 @@
 - Causa-raiz confirmada: o `oprm-coletor-mei` mantinha a rotina agendada de importação OPRM CNPJ/CNAE ativa por padrão (`OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true`), concorrendo com o executor NichoCNAE v3 no mesmo módulo.
 - Correção: o padrão da rotina foi alterado para desativado (`false`) e a finalização automática de runs antigas passou a respeitar a mesma flag.
 - Prevenção de recorrência: adicionado teste de configuração para garantir que a rotina antiga não volte a iniciar automaticamente por padrão e ajustado o Surefire do módulo para executar testes JUnit 5.
+
+## 2026-06-28 — NichoCNAE v3: prompt da etapa 2 focado em rotina neutra
+
+- Ajustado o prompt da etapa `persona-candidate-generator` para orientar a OpenAI a produzir uma fotografia neutra do dia a dia da persona, sem antecipar dor, oferta, produto, mecanismo, solução ou linguagem comercial.
+- Ajustado o schema da etapa para trocar campos de interpretação comercial por campos operacionais: contexto de atuação, fluxo do dia, tarefas recorrentes, interações, ferramentas/registros, decisões pequenas e variações de rotina.
+- Prevenção: o builder e o teste funcional da etapa foram alinhados para manter a etapa 2 restrita ao entendimento da rotina antes das etapas posteriores de análise de dor/oportunidade.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/PersonaCandidatePromptBuilder.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/PersonaCandidatePromptBuilder.java
@@ -20,7 +20,7 @@ public class PersonaCandidatePromptBuilder {
                 + "cnaeCode: " + request.cnaeCode() + "\n"
                 + "cnaeDescription: " + request.cnaeDescription() + "\n"
                 + "inputKeys: " + request.input().keySet() + "\n"
-                + "\nRetorne somente JSON aderente ao schema. Gere 4 personas candidatas operacionais, com dores, tarefas diárias e sinais de compra, sem criar oferta, campanha, promessa, preço, checkout ou landing page.";
+                + "\nRetorne somente JSON aderente ao schema. Gere 4 personas candidatas operacionais, descrevendo contexto de atuação, fluxo do dia, tarefas recorrentes, interações, ferramentas, registros, decisões pequenas e variações de rotina, sem criar dor, oferta, campanha, promessa, preço, checkout, landing page, produto ou solução.";
     }
 
     /** Lê o prompt operacional do recurso versionado. */

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator-schema.json
@@ -15,15 +15,19 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "name", "priorityScore", "description", "operationalPains", "dailyTasks", "buyingSignals", "validationNeed"],
+        "required": ["id", "name", "priorityScore", "description", "routineContext", "dailyFlow", "recurringTasks", "interactions", "toolsAndRecords", "routineDecisions", "routineVariations", "validationNeed"],
         "properties": {
           "id": { "type": "string" },
           "name": { "type": "string" },
           "priorityScore": { "type": "integer", "minimum": 0, "maximum": 100 },
           "description": { "type": "string" },
-          "operationalPains": { "type": "array", "items": { "type": "string" } },
-          "dailyTasks": { "type": "array", "items": { "type": "string" } },
-          "buyingSignals": { "type": "array", "items": { "type": "string" } },
+          "routineContext": { "type": "string" },
+          "dailyFlow": { "type": "array", "items": { "type": "string" } },
+          "recurringTasks": { "type": "array", "items": { "type": "string" } },
+          "interactions": { "type": "array", "items": { "type": "string" } },
+          "toolsAndRecords": { "type": "array", "items": { "type": "string" } },
+          "routineDecisions": { "type": "array", "items": { "type": "string" } },
+          "routineVariations": { "type": "array", "items": { "type": "string" } },
           "validationNeed": { "type": "string" }
         }
       }

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
@@ -2,6 +2,24 @@
 
 Você executa a etapa persona-candidate-generator do pipeline OPRM NichoCNAE v3.
 
-Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+Objetivo: produzir uma fotografia neutra e operacional do dia a dia de personas candidatas dentro de um CNAE. A etapa existe para entender quem são as pessoas, como trabalham, quais rotinas repetem e quais contextos práticos aparecem antes de qualquer análise de dor, oportunidade, oferta ou produto.
 
-Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.
+Use apenas o contexto persistido enviado pelo backend. Não invente dados externos e preserve limites, incertezas e diferenças entre perfis quando o contexto não permitir concluir com segurança.
+
+Regras obrigatórias:
+
+1. Não crie nem antecipe dor, oferta, campanha, promessa, preço, checkout, landing page, produto, mecanismo, solução, automação ou recomendação comercial.
+2. Não use linguagem de venda, persuasão ou diagnóstico comercial.
+3. Descreva personas por rotina observável, contexto de trabalho e tarefas executadas, não por potencial de compra.
+4. Evite personas genéricas demais. Em vez de apenas “dono de loja”, diferencie perfis operacionais quando o cotidiano for diferente, por exemplo: dono que atende no balcão, responsável por estoque, vendedor de WhatsApp, operador familiar ou auxiliar administrativo.
+5. Para cada persona candidata, descreva:
+   - contexto de atuação;
+   - como o dia normalmente começa, se desenvolve e termina;
+   - tarefas recorrentes;
+   - interações com clientes, fornecedores, equipe, família ou sistemas;
+   - ferramentas, canais, controles, documentos ou registros usados;
+   - pequenas decisões operacionais tomadas na rotina;
+   - variações de rotina que podem existir dentro do mesmo CNAE;
+   - incertezas ou pontos que precisam de validação futura.
+6. Mantenha tom factual, simples e operacional.
+7. Retorne somente JSON aderente ao schema.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/PersonaCandidateGeneratorProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/PersonaCandidateGeneratorProcessorTest.java
@@ -63,9 +63,9 @@ class PersonaCandidateGeneratorProcessorTest {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("personaSummary", "Dono operador; vendedor digital; operação familiar");
         payload.put("candidatePersonas", List.of(
-                Map.of("name", "Dono operador de loja de vestuário", "operationalPains", List.of("falta de tempo"), "dailyTasks", List.of("atender clientes"), "buyingSignals", List.of("procura atalhos")),
-                Map.of("name", "Vendedor digital de vestuário", "operationalPains", List.of("mensagens repetidas"), "dailyTasks", List.of("responder dúvidas"), "buyingSignals", List.of("busca modelo pronto")),
-                Map.of("name", "Operação familiar de vestuário", "operationalPains", List.of("delegação informal"), "dailyTasks", List.of("conferir estoque"), "buyingSignals", List.of("quer previsibilidade"))));
+                Map.of("name", "Dono operador de loja de vestuário", "routineContext", "atua no balcão e acompanha a loja", "recurringTasks", List.of("atender clientes"), "interactions", List.of("clientes e fornecedores")),
+                Map.of("name", "Vendedor digital de vestuário", "routineContext", "atende pedidos por mensagens", "recurringTasks", List.of("responder dúvidas"), "interactions", List.of("clientes no WhatsApp")),
+                Map.of("name", "Operação familiar de vestuário", "routineContext", "divide tarefas entre familiares", "recurringTasks", List.of("conferir estoque"), "interactions", List.of("familiares e clientes"))));
         return payload;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure the `persona-candidate-generator` step produces a neutral, operational snapshot of daily routines rather than commercial or solution-oriented outputs.
- Align the step's contract so downstream stages receive routine-focused fields instead of commercial interpretation fields.

### Description

- Changed the prompt builder `PersonaCandidatePromptBuilder` to instruct the model to return routine-focused personas and to ban generation of commercial content in the injected prompt string.  
- Rewrote the versioned prompt `persona-candidate-generator.md` to define mandatory rules for producing factual, routine-based persona descriptions and to require JSON conforming to the schema.  
- Replaced commercial-oriented fields with operational fields in the schema `persona-candidate-generator-schema.json` (e.g., `operationalPains`/`dailyTasks`/`buyingSignals` -> `routineContext`/`dailyFlow`/`recurringTasks`/`interactions`/`toolsAndRecords`/`routineDecisions`/`routineVariations`).  
- Updated the unit test `PersonaCandidateGeneratorProcessorTest` to use the new schema field names in its fake payload and to assert compatibility with the updated behavior.  
- Added documentation notes in `docs/registros/oprm1.md` describing the prompt/schema/test alignment and the behavioral intent of the change.

### Testing

- Ran the module unit test `PersonaCandidateGeneratorProcessorTest` which executes the `personaPayload()` scenario and the test suite completed successfully.  
- Executed unit test run for the `oprm-coletor-mei` module and the tests passed (including schema-conforming payload checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4154c1e5e883219758ab1b2146f96a)