### PR TITLE
Show business result for persona-tournament on NichoCNAE v3 pipeline page

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1524,7 +1524,6 @@
 - Correção operacional: a etapa `persona-candidate-generator` do executor OPRM passou a registrar em log o payload enviado à OpenAI e a resposta bruta recebida, com `jobId`, `stageExecutionId`, `cnaeCode` e endpoint, sem expor a chave de autenticação.
 - Motivo: permitir diagnosticar a causa real de falhas da OpenAI no NichoCNAE v3 sem depender apenas da mensagem genérica persistida na tela.
 
-
 ## 2026-06-26 — OPRM Coletor MEI: URL correta de logs no MCP
 
 - Diagnóstico: o workflow atual publica o `oprm-coletor-mei` em `191.252.120.96`, mas o default do MCP ainda apontava o alias legado `oprm-coletor-receita` para `177.153.62.107:8094`.
@@ -1647,6 +1646,7 @@
 - Ajustada a etapa `persona-candidate-generator` para serializar uma única vez o body enviado à OpenAI e reutilizar exatamente esse conteúdo no callback `recebeRequest`.
 - Ajustado o callback `recebeResponse` para enviar exatamente o corpo bruto retornado pela OpenAI, incluindo respostas HTTP de erro, antes de qualquer extração ou transformação operacional.
 - Prevenção de recorrência: teste da etapa valida que o request auditado no backend é idêntico ao body enviado para a OpenAI e que o response auditado é o corpo bruto recebido do provedor.
+
 ## 2026-06-28 — NichoCNAE v3: resposta final limpa da OpenAI no backend
 
 - Causa-raiz: o backend persistia o envelope bruto da OpenAI em `pipeline_nichocnae.response`, o que deixava a tela de auditoria dependente de JSON técnico para encontrar o conteúdo funcional em `content[].text`.
@@ -1671,3 +1671,9 @@
 - Ajustado o prompt da etapa `persona-candidate-generator` para orientar a OpenAI a produzir uma fotografia neutra do dia a dia da persona, sem antecipar dor, oferta, produto, mecanismo, solução ou linguagem comercial.
 - Ajustado o schema da etapa para trocar campos de interpretação comercial por campos operacionais: contexto de atuação, fluxo do dia, tarefas recorrentes, interações, ferramentas/registros, decisões pequenas e variações de rotina.
 - Prevenção: o builder e o teste funcional da etapa foram alinhados para manter a etapa 2 restrita ao entendimento da rotina antes das etapas posteriores de análise de dor/oportunidade.
+
+## 2026-06-28 — NichoCNAE v3: resultado visível em etapa sem IA
+
+- Ajustada a tela do pipeline v3 para mostrar um bloco de resultado de negócio na etapa `persona-tournament`, mesmo sem integração com modelo de IA.
+- O usuário passa a ver diretamente persona vencedora, pontuação, justificativa, quantidade de personas comparadas e próxima etapa, sem depender de abrir o JSON técnico.
+- Prevenção: a apresentação continua usando somente o payload persistido pelo backend/executor, mantendo a tela como exibição da verdade registrada e não como inferência local.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -25,6 +25,24 @@ type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asText(value: unknown) {
+  if (value === null || value === undefined || value === "") return "-";
+  return String(value);
+}
+
+function parsePayloadRecord(payload: string | null | undefined) {
+  return asRecord(parsePayload(payload));
+}
+
 function formatJsonPrimitive(value: JsonValue) {
   if (value === null) return "null";
   if (typeof value === "string") return JSON.stringify(value);
@@ -164,6 +182,52 @@ function pickSituacaoForJob(
     schema: requestRecord?.schema ?? responseRecord.schema,
     plataforma: requestRecord?.plataforma ?? responseRecord.plataforma,
   };
+}
+
+function StageBusinessResult({
+  stageCode,
+  payload,
+}: {
+  stageCode: string;
+  payload: string | null | undefined;
+}) {
+  const parsed = parsePayloadRecord(payload);
+
+  if (!parsed || stageCode !== "persona-tournament") {
+    return null;
+  }
+
+  const winner = asRecord(parsed.winnerPersona);
+  const ranking = asList(parsed.personaRanking);
+  const scoreBreakdown = asRecord(winner?.scoreBreakdown);
+
+  return (
+    <div className="alert alert-success-subtle border border-success-subtle py-2 px-3 mb-0">
+      <div className="small fw-semibold mb-2">Resultado para o usuário</div>
+      <div className="small">
+        <strong>Persona vencedora:</strong>{" "}
+        {asText(parsed.winningPersonaName ?? winner?.name)}
+      </div>
+      <div className="small">
+        <strong>Pontuação:</strong> {asText(winner?.tournamentScore)}
+        {scoreBreakdown ? (
+          <span className="text-muted">
+            {" "}
+            (dores: {asText(scoreBreakdown.operationalPains)}, tarefas:{" "}
+            {asText(scoreBreakdown.dailyTasks)}, sinais de compra:{" "}
+            {asText(scoreBreakdown.buyingSignals)})
+          </span>
+        ) : null}
+      </div>
+      <div className="small">
+        <strong>Justificativa:</strong> {asText(parsed.selectionRationale)}
+      </div>
+      <div className="small text-muted">
+        {ranking.length} persona(s) comparada(s). Próxima etapa:{" "}
+        {asText(parsed.nextStageCode)}.
+      </div>
+    </div>
+  );
 }
 
 function StageMetric({ label, value }: { label: string; value: string }) {
@@ -617,6 +681,10 @@ export default function OprmNichoCnaeV3PipelinePage() {
                             </div>
                           </div>
                         ) : null}
+                        <StageBusinessResult
+                          stageCode={stage.code}
+                          payload={responsePayload}
+                        />
                         <div>
                           <div className="small fw-semibold mb-1">
                             Response recebido


### PR DESCRIPTION
### Motivation
- Provide a clear, user-facing summary for the `persona-tournament` stage even when the step does not call any AI model, so the user doesn't need to open raw JSON to see the business result.
- Keep the UI strictly faithful to the backend-exposed payload so the screen remains a view of persisted truth, not a local inference.

### Description
- Add a small renderer `StageBusinessResult` (and light helpers: `asRecord`, `asList`, `asText`, `parsePayloadRecord`) to format and surface winner persona, tournament score, selection rationale, number of compared personas and next stage. 
- Render the business block in `frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx` above the existing response JSON view only when the stage code is `persona-tournament` and the backend payload contains the expected fields. 
- Ensure the component reads only the persisted `response`/`respostaFinal` payload returned by the backend and does not synthesize or infer new data. 
- Record the change in `docs/registros/oprm1.md` documenting the UX improvement.

### Testing
- Ran formatting with `npx prettier --write frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx docs/registros/oprm1.md` which completed successfully. 
- Installed frontend dependencies with `npm --prefix frontend ci` which completed successfully. 
- Ran TypeScript typecheck with `npm --prefix frontend run typecheck` after install which succeeded. 
- Ran unit tests with Vitest using `npm --prefix frontend test -- --run src/__tests__/OprmNavigation.test.tsx` and the suite passed (1 file, 9 tests passed). 
- One test command using an incorrect path (`npm --prefix frontend test -- --run frontend/src/__tests__/OprmNavigation.test.tsx`) failed due to the test path filter, not due to code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415d99da148321b382f3d7d4015b52)