### PR TITLE
Fix NichoCNAE v3 source search inputs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1671,3 +1671,11 @@
 - Ajustado o prompt da etapa `persona-candidate-generator` para orientar a OpenAI a produzir uma fotografia neutra do dia a dia da persona, sem antecipar dor, oferta, produto, mecanismo, solução ou linguagem comercial.
 - Ajustado o schema da etapa para trocar campos de interpretação comercial por campos operacionais: contexto de atuação, fluxo do dia, tarefas recorrentes, interações, ferramentas/registros, decisões pequenas e variações de rotina.
 - Prevenção: o builder e o teste funcional da etapa foram alinhados para manter a etapa 2 restrita ao entendimento da rotina antes das etapas posteriores de análise de dor/oportunidade.
+
+## 2026-06-28 — NichoCNAE v3: etapas anteriores alimentando busca de fontes
+
+- Diagnóstico: a execução 4781400 chegou ao `source-searcher` com persona vencedora do tipo cargo interno/CLT (`Estoquista / responsável por recebimento e reposição`) e com campos da IA (`recurringTasks`, `toolsAndRecords`) que as etapas seguintes não liam como `dailyTasks`, `operationalPains` e `buyingSignals`.
+- Causa-raiz: desalinhamento de contrato entre a saída real da etapa de IA `persona-candidate-generator` e as etapas determinísticas `persona-tournament`/`routine-query-planner`; isso priorizava cargo de retaguarda e gerava queries fracas para encontrar fonte pública de MEI/autônomo.
+- Correção: `persona-tournament` passou a ler aliases reais da IA, normalizar `dailyTasks` para downstream, pontuar melhor dono-operador/MEI/autônomo e penalizar cargos CLT/retaguarda; `routine-query-planner` passou a ler os mesmos aliases e reforçar MEI/autônomo/dono-operador nas queries.
+- Ajuste de IA: o prompt da etapa `persona-candidate-generator` agora proíbe escolher funcionário CLT/estoquista/retaguarda como persona central e pede nomes com sinal claro de autonomia.
+- Prevenção: adicionados testes cobrindo priorização de dono-operador sobre cargo interno e geração de queries a partir dos aliases reais da IA.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
@@ -67,16 +67,78 @@ public final class PersonaTournamentProcessor implements StageProcessor {
                 .toList();
     }
 
-    /** Calcula pontuação simples baseada em dor, tarefas diárias e sinais de compra disponíveis. */
+    /** Calcula pontuação baseada em rotina autônoma, usando aliases reais emitidos pela etapa de IA anterior. */
     private Map<String, Object> withScore(Map<String, Object> persona) {
-        int painCount = listSize(persona.get("operationalPains"));
-        int taskCount = listSize(persona.get("dailyTasks"));
-        int signalCount = listSize(persona.get("buyingSignals"));
-        int score = painCount * 3 + taskCount * 2 + signalCount;
+        int painCount = listSize(firstExisting(persona, "operationalPains", "pains"));
+        int taskCount = listSize(firstExisting(persona, "dailyTasks", "recurringTasks", "dailyFlow"));
+        int signalCount = listSize(firstExisting(persona, "buyingSignals", "toolsAndRecords", "routineDecisions"));
+        int autonomousScore = autonomousOwnerScore(persona);
+        int employeePenalty = employeeRolePenalty(persona);
+        int score = painCount * 3 + taskCount * 2 + signalCount + autonomousScore - employeePenalty;
         Map<String, Object> scored = new LinkedHashMap<>(persona);
+        scored.putIfAbsent("dailyTasks", texts(firstExisting(persona, "dailyTasks", "recurringTasks", "dailyFlow")));
+        scored.putIfAbsent("operationalPains", texts(firstExisting(persona, "operationalPains", "pains", "validationNeed")));
+        scored.putIfAbsent("buyingSignals", texts(firstExisting(persona, "buyingSignals", "toolsAndRecords", "routineDecisions")));
         scored.put("tournamentScore", score);
-        scored.put("scoreBreakdown", Map.of("operationalPains", painCount, "dailyTasks", taskCount, "buyingSignals", signalCount));
+        scored.put("scoreBreakdown", Map.of(
+                "operationalPains", painCount,
+                "dailyTasks", taskCount,
+                "buyingSignals", signalCount,
+                "autonomousOwnerScore", autonomousScore,
+                "employeeRolePenalty", employeePenalty));
         return scored;
+    }
+
+    /** Lê o primeiro campo preenchido dentre aliases compatíveis com saídas anteriores do pipeline. */
+    private Object firstExisting(Map<String, Object> persona, String... keys) {
+        for (String key : keys) {
+            Object value = persona.get(key);
+            if (value instanceof List<?> list && !list.isEmpty()) {
+                return value;
+            }
+            if (value != null && !text(value).isBlank()) {
+                return value;
+            }
+        }
+        return List.of();
+    }
+
+    /** Pontua melhor personas de dono-operador, MEI, autônomo ou familiar por aderirem ao recorte do pipeline. */
+    private int autonomousOwnerScore(Map<String, Object> persona) {
+        String combined = combinedText(persona);
+        int score = 0;
+        if (containsAny(combined, List.of("dono", "propriet", "mei", "autônom", "autonom", "por conta própria", "conta propria", "familiar"))) {
+            score += 8;
+        }
+        if (containsAny(combined, List.of("balcão", "balcao", "whatsapp", "instagram", "cliente", "fornecedor", "caixa", "estoque"))) {
+            score += 4;
+        }
+        return score;
+    }
+
+    /** Penaliza cargos CLT/retaguarda que travam buscas públicas de rotina de MEI/autônomo. */
+    private int employeeRolePenalty(Map<String, Object> persona) {
+        String combined = combinedText(persona);
+        return containsAny(combined, List.of("estoquista", "funcionário", "funcionario", "empregado", "clt", "contratado", "retaguarda", "auxiliar", "gerente contratado")) ? 18 : 0;
+    }
+
+    /** Junta campos textuais relevantes da persona para classificação simples. */
+    private String combinedText(Map<String, Object> persona) {
+        return persona.values().stream().map(this::text).reduce("", (left, right) -> left + " " + right).toLowerCase();
+    }
+
+    /** Verifica se algum termo aparece no texto normalizado. */
+    private boolean containsAny(String text, List<String> terms) {
+        return terms.stream().anyMatch(text::contains);
+    }
+
+    /** Converte valor textual ou lista em lista de textos para manter contrato downstream. */
+    private List<String> texts(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::text).filter(item -> !item.isBlank()).toList();
+        }
+        String item = text(value);
+        return item.isBlank() ? List.of() : List.of(item);
     }
 
     /** Monta justificativa objetiva para exibir ao usuário por que a persona venceu. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
@@ -19,9 +19,9 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
     public StageResult process(StageContext context) {
         Map<String, Object> winnerPersona = winnerPersona(context.input());
         String personaName = firstNonBlank(text(context.input().get("winningPersonaName")), text(winnerPersona.get("name")), "persona operacional priorizada");
-        List<String> dailyTasks = texts(winnerPersona.get("dailyTasks"));
-        List<String> operationalPains = texts(winnerPersona.get("operationalPains"));
-        List<String> buyingSignals = texts(winnerPersona.get("buyingSignals"));
+        List<String> dailyTasks = texts(firstExisting(winnerPersona, "dailyTasks", "recurringTasks", "dailyFlow"));
+        List<String> operationalPains = texts(firstExisting(winnerPersona, "operationalPains", "pains", "validationNeed"));
+        List<String> buyingSignals = texts(firstExisting(winnerPersona, "buyingSignals", "toolsAndRecords", "routineDecisions"));
         List<Map<String, Object>> plannedQueries = plannedQueries(personaName, dailyTasks, operationalPains, buyingSignals);
 
         Map<String, Object> output = new LinkedHashMap<>();
@@ -60,7 +60,7 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
         addQueries(queries, personaName, operationalPains, "DOR_OPERACIONAL", "Confirmar dor, esforço manual e consequência prática");
         addQueries(queries, personaName, buyingSignals, "SINAL_DE_COMPRA", "Encontrar evidência de busca por solução, planilha, sistema, consultoria ou modelo pronto");
         if (queries.isEmpty()) {
-            queries.add(queryItem(personaName + " rotina diária tarefas problemas", "ROTINA_BASE", "Validar rotina e problemas recorrentes quando a persona não trouxe sinais detalhados", 1));
+            queries.add(queryItem(personaName + " MEI autônomo dono operador rotina diária tarefas problemas", "ROTINA_BASE", "Validar rotina e problemas recorrentes quando a persona não trouxe sinais detalhados", 1));
         }
         return queries.stream().limit(MAX_QUERY_ITEMS).toList();
     }
@@ -68,7 +68,7 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
     /** Adiciona consultas mantendo prioridade de acordo com a ordem da evidência recebida. */
     private void addQueries(List<Map<String, Object>> queries, String personaName, List<String> evidences, String intent, String objective) {
         for (String evidence : evidences) {
-            queries.add(queryItem(personaName + " " + evidence + " rotina problema frequência", intent, objective, queries.size() + 1));
+            queries.add(queryItem(personaName + " MEI autônomo dono operador " + evidence + " rotina problema frequência", intent, objective, queries.size() + 1));
         }
     }
 
@@ -108,12 +108,27 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
                 "fonte sem relação clara com a persona vencedora");
     }
 
-    /** Converte uma lista opcional em textos limpos. */
-    private List<String> texts(Object value) {
-        if (!(value instanceof List<?> list)) {
-            return List.of();
+    /** Lê o primeiro campo preenchido dentre aliases compatíveis com saídas anteriores do pipeline. */
+    private Object firstExisting(Map<String, Object> source, String... keys) {
+        for (String key : keys) {
+            Object value = source.get(key);
+            if (value instanceof List<?> list && !list.isEmpty()) {
+                return value;
+            }
+            if (value != null && !text(value).isBlank()) {
+                return value;
+            }
         }
-        return list.stream().map(this::text).filter(item -> !item.isBlank()).toList();
+        return List.of();
+    }
+
+    /** Converte uma lista ou texto opcional em textos limpos. */
+    private List<String> texts(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::text).filter(item -> !item.isBlank()).toList();
+        }
+        String item = text(value);
+        return item.isBlank() ? List.of() : List.of(item);
     }
 
     /** Escolhe o primeiro texto preenchido de uma lista de candidatos. */

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
@@ -11,8 +11,10 @@ Regras obrigatórias:
 1. Não crie nem antecipe dor, oferta, campanha, promessa, preço, checkout, landing page, produto, mecanismo, solução, automação ou recomendação comercial.
 2. Não use linguagem de venda, persuasão ou diagnóstico comercial.
 3. Descreva personas por rotina observável, contexto de trabalho e tarefas executadas, não por potencial de compra.
-4. Evite personas genéricas demais. Em vez de apenas “dono de loja”, diferencie perfis operacionais quando o cotidiano for diferente, por exemplo: dono que atende no balcão, responsável por estoque, vendedor de WhatsApp, operador familiar ou auxiliar administrativo.
-5. Para cada persona candidata, descreva:
+4. Evite personas genéricas demais. Em vez de apenas “dono de loja”, diferencie perfis operacionais quando o cotidiano for diferente, por exemplo: dono que atende no balcão, vendedor de WhatsApp, operador familiar ou auxiliar administrativo.
+5. O recorte obrigatório é MEI, autônomo ou dono-operador. Não escolha funcionário CLT, empregado contratado, estoquista de retaguarda, auxiliar interno ou gerente contratado como persona central; se aparecerem na rotina, trate apenas como interação ou variação, não como candidato vencedor.
+6. Escreva o nome de cada persona com sinal claro de autonomia quando aplicável, como “dono-operador”, “MEI”, “autônomo” ou “profissional por conta própria”, para orientar as buscas públicas posteriores.
+7. Para cada persona candidata, descreva:
    - contexto de atuação;
    - como o dia normalmente começa, se desenvolve e termina;
    - tarefas recorrentes;
@@ -21,5 +23,5 @@ Regras obrigatórias:
    - pequenas decisões operacionais tomadas na rotina;
    - variações de rotina que podem existir dentro do mesmo CNAE;
    - incertezas ou pontos que precisam de validação futura.
-6. Mantenha tom factual, simples e operacional.
-7. Retorne somente JSON aderente ao schema.
+8. Mantenha tom factual, simples e operacional.
+9. Retorne somente JSON aderente ao schema.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
@@ -25,7 +25,22 @@ class PersonaTournamentProcessorTest {
         assertThat(result.output()).containsEntry("winningPersonaName", "Dono operador de loja");
         assertThat(result.output()).containsKeys("winnerPersona", "selectionRationale", "personaRanking");
         Map<?, ?> winner = (Map<?, ?>) result.output().get("winnerPersona");
-        assertThat(winner.get("tournamentScore")).isEqualTo(14);
+        assertThat(winner.get("tournamentScore")).isEqualTo(26);
+    }
+
+    /** Prioriza dono-operador MEI quando a IA também retorna cargo CLT com muitas tarefas, evitando travar a busca de fontes. */
+    @Test
+    void shouldPreferAutonomousOwnerOverEmployeeRoleFromAiOutputAliases() {
+        PersonaTournamentProcessor processor = new PersonaTournamentProcessor();
+
+        StageResult result = processor.process(new StageContext("job-4781400", "73", Map.of("candidatePersonas", List.of(
+                Map.of("name", "Estoquista / responsável por recebimento e reposição (retaguarda)", "recurringTasks", List.of("conferir mercadoria", "repor araras", "organizar estoque", "avisar divergência", "separar troca"), "toolsAndRecords", List.of("sistema interno", "planilha")),
+                Map.of("name", "Dono-operador MEI de loja de roupas", "recurringTasks", List.of("atender cliente", "responder WhatsApp", "controlar estoque", "comprar peças"), "toolsAndRecords", List.of("caderno", "WhatsApp", "Instagram"))))));
+
+        assertThat(result.output()).containsEntry("winningPersonaName", "Dono-operador MEI de loja de roupas");
+        Map<?, ?> winner = (Map<?, ?>) result.output().get("winnerPersona");
+        assertThat((List<String>) winner.get("dailyTasks")).contains("atender cliente", "responder WhatsApp");
+        assertThat(((Map<?, ?>) winner.get("scoreBreakdown")).get("employeeRolePenalty")).isEqualTo(0);
     }
 
     /** Bloqueia avanço quando a etapa anterior não forneceu candidatos para o torneio. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
@@ -37,6 +37,22 @@ class RoutineQueryPlannerProcessorTest {
         assertThat(firstQuery).containsKeys("query", "objective", "expectedEvidence", "priority");
     }
 
+    /** Usa aliases vindos da IA e reforça MEI/autônomo nas queries que alimentarão a busca de fontes. */
+    @Test
+    void shouldPlanQueriesFromAiAliasesWithAutonomousContext() {
+        RoutineQueryPlannerProcessor processor = new RoutineQueryPlannerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-4781400", "137", Map.of(
+                "winnerPersona", Map.of(
+                        "name", "Dono-operador MEI de loja de roupas",
+                        "recurringTasks", List.of("responder clientes no WhatsApp"),
+                        "toolsAndRecords", List.of("caderno de estoque")))));
+
+        List<?> plannedQueries = (List<?>) result.output().get("plannedQueries");
+        assertThat(plannedQueries).hasSize(2);
+        assertThat(plannedQueries.getFirst()).asString().contains("MEI autônomo dono operador", "responder clientes no WhatsApp");
+    }
+
     /** Bloqueia uma saída genérica quando a etapa anterior não trouxe a persona vencedora. */
     @Test
     void shouldFailWithoutWinnerPersona() {


### PR DESCRIPTION
### Motivation
- Corrigir bloqueio no pipeline onde `source-searcher` recebia queries em vez de fontes reais por desalinhamento entre saída da IA e etapas determinísticas. 
- Garantir que as etapas anteriores entreguem insumo auditável (fontes ou `selectedSources`) e que o fluxo priorize MEI/dono-operador em vez de cargos CLT que comprometem busca pública.

### Description
- `persona-tournament` agora consome aliases reais da IA (`recurringTasks`, `toolsAndRecords`, `pains`, `routineDecisions`), normaliza campos downstream e altera a pontuação com `autonomousOwnerScore` e `employeeRolePenalty` para favorecer MEI/dono-operador e penalizar cargos CLT/retaguarda.
- `routine-query-planner` passou a ler os mesmos aliases e a reforçar o contexto `MEI autônomo dono operador` nas queries geradas para aumentar chance de fontes públicas qualificadas.
- Prompt da etapa `persona-candidate-generator` ajustado para proibir escolha de funcionário CLT/estoquista como persona central e orientar nomes com sinal de autonomia.
- Adicionados/ajustados helpers (`firstExisting`, `texts`) e normalizações para compatibilizar contratos entre etapas; incluídos testes de regressão que cobrem priorização de dono-operador e geração de queries a partir de aliases da IA.
- Atualização de registro operacional em `docs/registros/oprm1.md` explicando diagnóstico, causa-raiz e prevenção.

### Testing
- Executado `mvn test -Dtest='PersonaTournamentProcessorTest,RoutineQueryPlannerProcessorTest,SourceSearcherProcessorTest'` no módulo `oprm-coletor-mei` e corrigidos erros detectados; os testes unitários específicos passaram após ajustes.
- Executado `mvn test` no módulo `oprm-coletor-mei` com suíte completa; todos os testes do módulo passaram (build success, testes unitários e de integração relacionados à pipeline v3 verdes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a415e5236a883218b89348de0bf2000)