### PR TITLE
Melhora tela de dossiê MOIS: coluna única e visualizador JSON aprimorado

### DIFF
--- a/frontend/src/components/CollapsibleJsonViewer.tsx
+++ b/frontend/src/components/CollapsibleJsonViewer.tsx
@@ -25,7 +25,11 @@ function parseJson(content?: string | null): JsonValue | null {
 }
 
 function decodeEscapedText(value: string): string {
-  if (!value.includes("\\n") && !value.includes("\\r") && !value.includes("\\t")) {
+  if (
+    !value.includes("\\n") &&
+    !value.includes("\\r") &&
+    !value.includes("\\t")
+  ) {
     return value;
   }
 
@@ -34,6 +38,13 @@ function decodeEscapedText(value: string): string {
     .replace(/\\n/g, "\n")
     .replace(/\\r/g, "\n")
     .replace(/\\t/g, "\t");
+}
+
+function formatJsonPrimitive(value: JsonValue) {
+  if (value === null) return "null";
+  if (typeof value === "string")
+    return JSON.stringify(decodeEscapedText(value));
+  return String(value);
 }
 
 function JsonNode({
@@ -47,24 +58,15 @@ function JsonNode({
   depth?: number;
   initiallyCollapsed?: boolean;
 }) {
-  const spacing = { marginLeft: depth === 0 ? 0 : 12 };
+  const fieldLabel = label ? (
+    <span className="text-primary">{label}: </span>
+  ) : null;
 
   if (value === null || typeof value !== "object") {
-    const isString = typeof value === "string";
-
     return (
-      <div style={spacing} className="small">
-        {label ? <strong>{label}: </strong> : null}
-        {isString ? (
-          <pre
-            className="mb-0 d-inline"
-            style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
-          >
-            {decodeEscapedText(value)}
-          </pre>
-        ) : (
-          <code>{JSON.stringify(value)}</code>
-        )}
+      <div className="font-monospace small py-1">
+        {fieldLabel}
+        <span className="text-break">{formatJsonPrimitive(value)}</span>
       </div>
     );
   }
@@ -73,20 +75,29 @@ function JsonNode({
   const entries = isArray
     ? value.map((item, index) => [String(index), item] as const)
     : Object.entries(value);
+  const itemLabel = isArray
+    ? `${entries.length} item(ns)`
+    : `${entries.length} campo(s)`;
+  const bracketOpen = isArray ? "[" : "{";
+  const bracketClose = isArray ? "]" : "}";
 
   return (
-    <details open={initiallyCollapsed ? depth > 0 : depth < 1} style={spacing}>
-      <summary className="small" style={{ cursor: "pointer" }}>
-        {label ? (
-          <strong>{label}</strong>
-        ) : (
-          <strong>{isArray ? "Array" : "Object"}</strong>
-        )}{" "}
-        ({entries.length})
+    <details
+      className="json-tree-node"
+      open={initiallyCollapsed ? depth > 0 : depth < 2}
+    >
+      <summary
+        className="font-monospace small py-1"
+        style={{ cursor: "pointer" }}
+      >
+        {fieldLabel}
+        <span>{bracketOpen}</span>
+        <span className="text-muted ms-1">{itemLabel}</span>
+        <span className="ms-1">{bracketClose}</span>
       </summary>
-      <div className="mt-1 d-flex flex-column gap-1">
+      <div className="border-start ps-3 ms-2">
         {entries.length === 0 ? (
-          <div className="small text-muted">{isArray ? "[]" : "{}"}</div>
+          <div className="text-muted small py-1">Sem conteúdo.</div>
         ) : (
           entries.map(([key, child]) => (
             <JsonNode
@@ -109,7 +120,10 @@ export default function CollapsibleJsonViewer({
   initiallyCollapsed = false,
   parseAsJson = true,
 }: CollapsibleJsonViewerProps) {
-  const parsed = useMemo(() => (parseAsJson ? parseJson(content) : null), [content, parseAsJson]);
+  const parsed = useMemo(
+    () => (parseAsJson ? parseJson(content) : null),
+    [content, parseAsJson],
+  );
 
   if (!content) {
     return <p className="text-muted small mb-0">{emptyMessage}</p>;
@@ -119,7 +133,11 @@ export default function CollapsibleJsonViewer({
     return (
       <pre
         className="bg-body-tertiary p-3 rounded small mb-0"
-        style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", wordBreak: "break-word" }}
+        style={{
+          whiteSpace: "pre-wrap",
+          overflowWrap: "anywhere",
+          wordBreak: "break-word",
+        }}
       >
         {decodeEscapedText(content)}
       </pre>
@@ -127,7 +145,10 @@ export default function CollapsibleJsonViewer({
   }
 
   return (
-    <div className="bg-body-tertiary rounded p-2" style={{ overflowX: "auto" }}>
+    <div
+      className="bg-body-tertiary border rounded p-2"
+      style={{ maxHeight: "28rem", overflow: "auto" }}
+    >
       <JsonNode value={parsed} initiallyCollapsed={initiallyCollapsed} />
     </div>
   );

--- a/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
@@ -420,7 +420,7 @@ export default function MoisSalesPageDossierPage() {
 
           <div className="row g-3">
             {dossierPipelineStages.map((stage) => (
-              <article className="col-12 col-xl-6" key={stage.code}>
+              <article className="col-12" key={stage.code}>
                 <div className={getDossierStageCardClassName(stage)}>
                   <div className="card-body d-flex flex-column gap-3">
                     <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
@@ -480,7 +480,9 @@ export default function MoisSalesPageDossierPage() {
                     {stage.latest ? (
                       <div className="row g-2">
                         <div className="col-sm-6">
-                          <div className={getDossierStageMetricClassName(stage)}>
+                          <div
+                            className={getDossierStageMetricClassName(stage)}
+                          >
                             <span
                               className={`d-block small ${getDossierStageTextClassName(stage)}`}
                             >
@@ -490,7 +492,9 @@ export default function MoisSalesPageDossierPage() {
                           </div>
                         </div>
                         <div className="col-sm-6">
-                          <div className={getDossierStageMetricClassName(stage)}>
+                          <div
+                            className={getDossierStageMetricClassName(stage)}
+                          >
                             <span
                               className={`d-block small ${getDossierStageTextClassName(stage)}`}
                             >
@@ -500,7 +504,9 @@ export default function MoisSalesPageDossierPage() {
                           </div>
                         </div>
                         <div className="col-12">
-                          <div className={getDossierStageMetricClassName(stage)}>
+                          <div
+                            className={getDossierStageMetricClassName(stage)}
+                          >
                             <span
                               className={`d-block small ${getDossierStageTextClassName(stage)}`}
                             >
@@ -527,7 +533,7 @@ export default function MoisSalesPageDossierPage() {
                           Ver auditoria técnica
                         </summary>
                         <div className="row g-3 mt-2">
-                          <div className="col-lg-6">
+                          <div className="col-12">
                             <div className="border rounded p-3 h-100 bg-white text-body">
                               <h4 className="h6 mb-2">Request da etapa</h4>
                               <CollapsibleJsonViewer
@@ -536,7 +542,7 @@ export default function MoisSalesPageDossierPage() {
                               />
                             </div>
                           </div>
-                          <div className="col-lg-6">
+                          <div className="col-12">
                             <div className="border rounded p-3 h-100 bg-white text-body">
                               <h4 className="h6 mb-2">Response da etapa</h4>
                               <CollapsibleJsonViewer
@@ -546,7 +552,7 @@ export default function MoisSalesPageDossierPage() {
                             </div>
                           </div>
                           {hasUsefulPayload(stage.latest.prompt) ? (
-                            <div className="col-lg-6">
+                            <div className="col-12">
                               <div className="border rounded p-3 h-100 bg-white text-body">
                                 <h4 className="h6 mb-2">Prompt usado</h4>
                                 <CollapsibleJsonViewer
@@ -557,7 +563,7 @@ export default function MoisSalesPageDossierPage() {
                             </div>
                           ) : null}
                           {hasUsefulPayload(stage.latest.schema) ? (
-                            <div className="col-lg-6">
+                            <div className="col-12">
                               <div className="border rounded p-3 h-100 bg-white text-body">
                                 <h4 className="h6 mb-2">Schema usado</h4>
                                 <CollapsibleJsonViewer


### PR DESCRIPTION
### Motivation
- Tornar a leitura dos cards das etapas do dossiê mais sequencial e legível exibindo-os em uma única coluna, seguindo o padrão visual usado no pipeline Nicho CNAE.
- Exibir payloads JSON com formatação em árvore e apresentação mais clara para facilitar inspeção técnica e auditoria.
- Evitar JSON comprimido em colunas pequenas e melhorar a usabilidade das seções de auditoria (request/response/prompt/schema).

### Description
- Ajusta layout de etapas em `frontend/src/pages/mois/MoisSalesPageDossierPage.tsx` para renderizar cada card como coluna única (`<article className="col-12">`) e força os blocos de auditoria (request/response/prompt/schema) a ocuparem largura total (`col-12`).
- Substitui/atualiza o visual do componente `CollapsibleJsonViewer` em `frontend/src/components/CollapsibleJsonViewer.tsx` para apresentar JSON como árvore: adiciona `formatJsonPrimitive`, melhora `JsonNode` (labels, contagem de campos/itens, colchetes indicativos), decodificação de escapes (`\n`, `\t`), estilo monospace e limite de altura com rolagem e borda para facilitar leitura longa.
- Pequenas melhorias nas classes de layout/metric containers para preservar espaçamento e responsividade quando o conteúdo técnico ocupa toda a largura do card.

### Testing
- Rodei `cd frontend && npm run typecheck` e o `tsc --noEmit` finalizou com sucesso após instalar dependências (typecheck: succeeded).
- Tentei rodar testes unitários específicos com `cd frontend && npm test -- --run src/pages/mois/MoisSalesPageDossierPage.test.tsx`, mas o runner retornou que não há arquivo de teste correspondente (vitest exit com "No test files found").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4165bb85848321b032538704470850)