### PR TITLE
source-searcher: add short query variants, rejection reasons and auditing

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1679,3 +1679,10 @@
 - Correção: `persona-tournament` passou a ler aliases reais da IA, normalizar `dailyTasks` para downstream, pontuar melhor dono-operador/MEI/autônomo e penalizar cargos CLT/retaguarda; `routine-query-planner` passou a ler os mesmos aliases e reforçar MEI/autônomo/dono-operador nas queries.
 - Ajuste de IA: o prompt da etapa `persona-candidate-generator` agora proíbe escolher funcionário CLT/estoquista/retaguarda como persona central e pede nomes com sinal claro de autonomia.
 - Prevenção: adicionados testes cobrindo priorização de dono-operador sobre cargo interno e geração de queries a partir dos aliases reais da IA.
+
+## 2026-06-28 — NichoCNAE v3: diagnóstico e destravamento da etapa 5 por busca curta
+
+- Diagnóstico: a execução do CNAE 4781400 chegou à etapa `source-searcher` com 8 queries planejadas, cada uma retornando resultados brutos, mas todas as fontes foram descartadas antes de formar `foundSources`/`selectedSources`.
+- Causa-raiz: as queries da etapa 5 estavam longas e ruidosas demais para busca pública, e o relatório persistido não mostrava o motivo de descarte de cada fonte, deixando o bloqueio correto sem diagnóstico acionável.
+- Correção: `source-searcher` agora gera variações curtas de busca a partir da query planejada, mantém a busca Brasil/MEI/autônomo, registra `queryVariants`, preserva fontes rejeitadas com `rejectionReason` e continua bloqueando fontes sem URL, duplicadas, comerciais/solução ou com evidência insuficiente.
+- Prevenção: adicionados testes cobrindo busca com query simplificada e auditoria de fontes rejeitadas com motivo explícito.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -5,18 +5,25 @@ import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageProcessor;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
 import java.net.URI;
+import java.text.Normalizer;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /** Processa a etapa source-searcher do pipeline NichoCNAE v3. */
 public final class SourceSearcherProcessor implements StageProcessor {
     private static final int SEARCH_RESULTS_PER_QUERY = 5;
     private static final int MAX_SELECTED_SOURCES = 8;
     private static final int MIN_ROUTINE_EVIDENCE_SCORE = 45;
+    private static final int MAX_REJECTED_SOURCES_PER_ATTEMPT = 8;
+    private static final Pattern PARENTHETICAL_TEXT = Pattern.compile("\\([^)]*\\)");
+    private static final Pattern NON_SEARCH_TEXT = Pattern.compile("[^\\p{L}\\p{N}\\s]");
+    private static final Pattern MULTIPLE_SPACES = Pattern.compile("\\s+");
     private static final SourceSearchClient EMPTY_SEARCH_CLIENT = (query, limit) -> List.of();
 
     private final SourceSearchClient searchClient;
@@ -110,25 +117,41 @@ public final class SourceSearcherProcessor implements StageProcessor {
         return new SearchOutput(selectedSources, attempts);
     }
 
-    /** Busca uma query e registra tentativa com quantidade bruta e fontes aceitas. */
+    /** Busca uma query por variações simples e registra quantidade bruta, fontes aceitas e descartes. */
     private Map<String, Object> searchOneQuery(Map<String, Object> plannedQuery, Set<String> seenUrls) {
         String originalQuery = text(plannedQuery.get("query"));
-        String query = enrichBrazilFirstQuery(originalQuery);
-        List<SourceSearchResult> rawResults = query.isBlank() ? List.of() : searchClient.search(query, SEARCH_RESULTS_PER_QUERY);
-        List<Map<String, Object>> qualifiedSources = rawResults.stream()
-                .map(result -> qualify(result, plannedQuery))
-                .filter(source -> !text(source.get("url")).isBlank())
-                .filter(source -> seenUrls.add(text(source.get("url"))))
-                .filter(this::isQualifiedRoutineSource)
+        List<String> queryVariants = queryVariants(plannedQuery);
+        List<SourceSearchResult> rawResults = queryVariants.stream()
+                .flatMap(query -> searchClient.search(query, SEARCH_RESULTS_PER_QUERY).stream())
                 .toList();
+        List<Map<String, Object>> qualifiedSources = new ArrayList<>();
+        List<Map<String, Object>> rejectedSources = new ArrayList<>();
+        for (SourceSearchResult rawResult : rawResults) {
+            Map<String, Object> source = qualify(rawResult, plannedQuery);
+            String url = text(source.get("url"));
+            String rejectionReason = rejectionReason(source, seenUrls);
+            if (rejectionReason.isBlank()) {
+                qualifiedSources.add(source);
+            } else if (rejectedSources.size() < MAX_REJECTED_SOURCES_PER_ATTEMPT) {
+                Map<String, Object> rejected = new LinkedHashMap<>(source);
+                rejected.put("rejectionReason", rejectionReason);
+                rejectedSources.add(rejected);
+            }
+            if (!url.isBlank()) {
+                seenUrls.add(url);
+            }
+        }
         Map<String, Object> attempt = new LinkedHashMap<>();
-        attempt.put("query", query);
+        attempt.put("query", queryVariants.isEmpty() ? "" : queryVariants.getFirst());
+        attempt.put("queryVariants", queryVariants);
         attempt.put("originalQuery", originalQuery);
         attempt.put("intent", text(plannedQuery.get("intent")));
         attempt.put("objective", text(plannedQuery.get("objective")));
         attempt.put("rawResultCount", rawResults.size());
         attempt.put("qualifiedSourceCount", qualifiedSources.size());
         attempt.put("qualifiedSources", qualifiedSources);
+        attempt.put("rejectedSourceCount", Math.max(0, rawResults.size() - qualifiedSources.size()));
+        attempt.put("rejectedSources", rejectedSources);
         return attempt;
     }
 
@@ -198,12 +221,87 @@ public final class SourceSearcherProcessor implements StageProcessor {
                 && score(source, "qualityScore") >= MIN_ROUTINE_EVIDENCE_SCORE;
     }
 
+    /** Gera variações curtas de busca para evitar que queries longas impeçam fontes úteis. */
+    private List<String> queryVariants(Map<String, Object> plannedQuery) {
+        String originalQuery = text(plannedQuery.get("query"));
+        String objective = text(plannedQuery.get("objective"));
+        String simplifiedQuery = simplifyQuery(originalQuery);
+        List<String> variants = new ArrayList<>();
+        addVariant(variants, enrichBrazilFirstQuery(simplifiedQuery));
+        addVariant(variants, enrichBrazilFirstQuery(operationalQuery(simplifiedQuery)));
+        addVariant(variants, enrichBrazilFirstQuery(objective));
+        return variants;
+    }
+
     /** Enriquece a consulta para priorizar Brasil e rotina real do profissional. */
     private String enrichBrazilFirstQuery(String query) {
-        if (query.isBlank()) {
+        String cleanQuery = trimWords(query, 12);
+        if (cleanQuery.isBlank()) {
             return "";
         }
-        return query + " Brasil MEI autônomo rotina problema atendimento cliente";
+        return cleanQuery + " Brasil rotina MEI autônomo";
+    }
+
+    /** Simplifica a query planejada removendo ruído que reduz a chance de resultado rastreável. */
+    private String simplifyQuery(String query) {
+        String withoutParenthetical = PARENTHETICAL_TEXT.matcher(query).replaceAll(" ");
+        String searchable = NON_SEARCH_TEXT.matcher(withoutParenthetical).replaceAll(" ");
+        return MULTIPLE_SPACES.matcher(searchable).replaceAll(" ").trim();
+    }
+
+    /** Mantém termos de operação diária mais fortes para uma variação de busca objetiva. */
+    private String operationalQuery(String query) {
+        String normalized = normalize(query);
+        List<String> terms = List.of("atendimento", "provador", "estoque", "reposicao", "reposição", "mercadoria", "vitrine", "araras", "etiquetas", "caixa", "loja", "roupas", "acessorios", "acessórios");
+        StringBuilder builder = new StringBuilder();
+        for (String term : terms) {
+            if (normalized.contains(normalize(term)) && !builder.toString().contains(term)) {
+                builder.append(term).append(' ');
+            }
+        }
+        String operational = builder.toString().trim();
+        return operational.isBlank() ? query : operational;
+    }
+
+    /** Adiciona uma variação não vazia sem duplicidade. */
+    private void addVariant(List<String> variants, String query) {
+        if (!query.isBlank() && !variants.contains(query)) {
+            variants.add(query);
+        }
+    }
+
+    /** Limita o texto aos primeiros termos relevantes para busca pública. */
+    private String trimWords(String query, int maxWords) {
+        String[] words = MULTIPLE_SPACES.matcher(query).replaceAll(" ").trim().split(" ");
+        if (words.length <= maxWords) {
+            return query.trim();
+        }
+        StringBuilder builder = new StringBuilder();
+        for (int index = 0; index < maxWords; index++) {
+            builder.append(words[index]).append(' ');
+        }
+        return builder.toString().trim();
+    }
+
+    /** Explica por que uma fonte foi recusada, preservando auditoria da decisão. */
+    private String rejectionReason(Map<String, Object> source, Set<String> seenUrls) {
+        String url = text(source.get("url"));
+        if (url.isBlank()) {
+            return "URL_AUSENTE";
+        }
+        if (seenUrls.contains(url)) {
+            return "URL_DUPLICADA";
+        }
+        if (!"ROUTINE_EVIDENCE".equals(source.get("sourceIntent"))) {
+            return "RISCO_CONTAMINACAO_SOLUCAO_OU_COMERCIAL";
+        }
+        if (score(source, "routineEvidenceScore") < MIN_ROUTINE_EVIDENCE_SCORE) {
+            return "EVIDENCIA_ROTINA_INSUFICIENTE";
+        }
+        if (score(source, "qualityScore") < MIN_ROUTINE_EVIDENCE_SCORE) {
+            return "QUALIDADE_INSUFICIENTE";
+        }
+        return "";
     }
 
     /** Calcula score de evidência de rotina operacional. */
@@ -267,6 +365,12 @@ public final class SourceSearcherProcessor implements StageProcessor {
     /** Verifica presença de qualquer termo em texto normalizado. */
     private boolean containsAny(String text, List<String> terms) {
         return terms.stream().anyMatch(text::contains);
+    }
+
+    /** Normaliza acentos para comparar termos de busca de forma estável. */
+    private String normalize(String value) {
+        return Normalizer.normalize(text(value).toLowerCase(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
     }
 
     /** Retorna o primeiro campo existente no mapa de fonte. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
@@ -75,6 +75,53 @@ class SourceSearcherProcessorTest {
         assertThat(source.containsKey("brazilRelevanceScore")).isTrue();
     }
 
+    /** Usa variações curtas para encontrar fontes mesmo quando a query planejada vem longa e ruidosa. */
+    @Test
+    void shouldSearchWithSimplifiedQueryVariants() {
+        SourceSearchClient searchClient = (query, limit) -> {
+            if (query.toLowerCase().startsWith("atendimento") && query.toLowerCase().contains("provador")) {
+                return List.of(new SourceSearchResult(
+                        "Rotina de atendimento em loja de roupas no Brasil",
+                        "https://varejo.example.com.br/rotina-loja-roupas",
+                        "Dono MEI relata rotina de atendimento, provador, clientes, estoque, caixa e reposição manual.",
+                        "TEST_PROVIDER",
+                        "<item />"));
+            }
+            return List.of();
+        };
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of(
+                        "query", "Dono-operador de loja física de roupas e acessórios (MEI/pequeno varejo) MEI autônomo dono operador Atendimento presencial e suporte no provador rotina problema frequência",
+                        "intent", "TAREFA_DIARIA",
+                        "objective", "Validar tarefa recorrente e frequência operacional")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        List<?> attempts = (List<?>) result.output().get("searchAttempts");
+        Map<?, ?> attempt = (Map<?, ?>) attempts.getFirst();
+        assertThat((List<?>) attempt.get("queryVariants")).anySatisfy(query ->
+                assertThat(String.valueOf(query)).startsWith("atendimento"));
+    }
+
+    /** Registra fontes rejeitadas com motivo para diagnosticar bloqueios sem depender apenas do log técnico. */
+    @Test
+    void shouldAuditRejectedSourcesWithReason() {
+        SourceSearchClient searchClient = (query, limit) -> List.of(new SourceSearchResult(
+                "Conteúdo genérico de moda",
+                "",
+                "Texto sem fonte rastreável para rotina operacional.",
+                "TEST_PROVIDER",
+                "<item />"));
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "loja roupas estoque")))));
+
+        List<?> attempts = (List<?>) result.output().get("searchAttempts");
+        Map<?, ?> attempt = (Map<?, ?>) attempts.getFirst();
+        assertThat((List<?>) attempt.get("rejectedSources")).anySatisfy(rejected ->
+                assertThat(((Map<?, ?>) rejected).get("rejectionReason")).isEqualTo("URL_AUSENTE"));
+    }
+
     /** Bloqueia avanço quando a busca retorna apenas fonte comercial ou solução contaminada. */
     @Test
     void shouldBlockCommercialSolutionSources() {


### PR DESCRIPTION
### Motivation

- Improve success rate of public web searches when planned queries are long or noisy by generating shorter, focused query variants. 
- Make source selection decisions auditable by preserving rejected sources with explicit rejection reasons. 
- Prevent duplicate or irrelevant sources from advancing and provide better diagnostics for pipeline failures.

### Description

- Updated `SourceSearcherProcessor` to generate `queryVariants` from the planned query using `simplifyQuery`, `operationalQuery`, `trimWords` and `enrichBrazilFirstQuery` and to execute searches over those variants. 
- Reworked search flow to accumulate raw results from variants, qualify sources, track `rejectedSources` with `rejectionReason`, and include `rejectedSourceCount`/`rejectedSources` and `queryVariants` in each search attempt. 
- Added normalization utilities (`normalize`) and regex-based cleaning (`PARENTHETICAL_TEXT`, `NON_SEARCH_TEXT`, `MULTIPLE_SPACES`) plus new thresholds/constants (`MAX_REJECTED_SOURCES_PER_ATTEMPT`), and adjusted `enrichBrazilFirstQuery` to trim and shorten queries. 
- Kept existing qualification logic but improved `seenUrls` handling to prevent duplicates and ensured only qualified `ROUTINE_EVIDENCE` sources pass downstream selection. 
- Added/updated documentation in `docs/registros/oprm1.md` describing the change and the pipeline behavior improvements. 

### Testing

- Ran unit tests in `SourceSearcherProcessorTest`, including newly added `shouldSearchWithSimplifiedQueryVariants` and `shouldAuditRejectedSourcesWithReason`, together with existing selection/blocking tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4166671cb08321b865716cddf80ce8)