### PR TITLE
feat: audit OpenAI calls in product-understanding (worker + UI)

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1937,3 +1937,9 @@ Arquivos principais:
 - Diagnosticado na página 400 que o reprocessamento iniciado em `28/06/2026 03:27` era exibido junto de auditorias históricas das etapas.
 - Causa-raiz tratada: os endpoints de leitura da tela consultavam registros por página/etapa/status sem fronteira da execução atual.
 - Ajuste aplicado: a situação das etapas e o resumo público do pipeline agora consideram apenas registros a partir do último `intake` iniciado, preservando histórico no banco sem contaminar os cards do fluxo atual.
+
+## 2026-06-28 — Auditoria OpenAI na etapa product-understanding do dossiê MOIS v1
+
+- Ajustada a etapa `product-understanding` do worker de biblioteca de páginas MOIS para chamar OpenAI Responses Flex quando houver chave configurada, preservando request bruto, response bruto, texto final extraído, modelo e tokens no contrato de auditoria enviado ao backend.
+- Ajustada a tela do dossiê para exibir request enviado à OpenAI, response recebido da OpenAI em JSON colapsável, texto final extraído e métricas de modelo/tokens.
+- Causa-raiz: a etapa ainda podia executar em modo local sem gerar interação OpenAI, então a auditoria técnica não recebia os dados exigidos para diagnóstico e rastreabilidade comercial.

--- a/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
@@ -216,6 +216,29 @@ function getDossierStageMetricClassName(stage: DossierStageView) {
   return "border rounded-3 bg-white px-3 py-2";
 }
 
+function extractOpenAiOutputText(value?: string | null) {
+  if (!value) return undefined;
+  try {
+    const root = JSON.parse(value) as {
+      output_text?: unknown;
+      output?: Array<{ content?: Array<{ text?: unknown }> }>;
+    };
+    if (typeof root.output_text === "string" && root.output_text.trim()) {
+      return root.output_text;
+    }
+    for (const item of root.output || []) {
+      for (const content of item.content || []) {
+        if (typeof content.text === "string" && content.text.trim()) {
+          return content.text;
+        }
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 function hasUsefulPayload(value?: string | null) {
   return Boolean(value && value.trim() && value.trim() !== "{}");
 }
@@ -498,7 +521,7 @@ export default function MoisSalesPageDossierPage() {
                             <span
                               className={`d-block small ${getDossierStageTextClassName(stage)}`}
                             >
-                              Modelo
+                              Modelo OpenAI
                             </span>
                             <strong>{displayText(stage.latest.modelo)}</strong>
                           </div>
@@ -535,7 +558,7 @@ export default function MoisSalesPageDossierPage() {
                         <div className="row g-3 mt-2">
                           <div className="col-12">
                             <div className="border rounded p-3 h-100 bg-white text-body">
-                              <h4 className="h6 mb-2">Request da etapa</h4>
+                              <h4 className="h6 mb-2">Request enviado para OpenAI</h4>
                               <CollapsibleJsonViewer
                                 content={stage.latest.request}
                                 initiallyCollapsed
@@ -544,13 +567,26 @@ export default function MoisSalesPageDossierPage() {
                           </div>
                           <div className="col-12">
                             <div className="border rounded p-3 h-100 bg-white text-body">
-                              <h4 className="h6 mb-2">Response da etapa</h4>
+                              <h4 className="h6 mb-2">Response da OpenAI</h4>
                               <CollapsibleJsonViewer
                                 content={stage.latest.response}
                                 initiallyCollapsed
                               />
                             </div>
                           </div>
+                          {extractOpenAiOutputText(stage.latest.response) ? (
+                            <div className="col-12">
+                              <div className="border rounded p-3 h-100 bg-white text-body">
+                                <h4 className="h6 mb-2">Texto final da OpenAI</h4>
+                                <CollapsibleJsonViewer
+                                  content={extractOpenAiOutputText(
+                                    stage.latest.response,
+                                  )}
+                                  initiallyCollapsed
+                                />
+                              </div>
+                            </div>
+                          ) : null}
                           {hasUsefulPayload(stage.latest.prompt) ? (
                             <div className="col-12">
                               <div className="border rounded p-3 h-100 bg-white text-body">

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1WorkerConfig.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1WorkerConfig.java
@@ -1,6 +1,8 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis.OpenAiProperties;
 import com.marketinghub.pipelines.dossie.v1.PipelineWorker;
+import org.springframework.web.client.RestClient;
 import com.marketinghub.pipelines.dossie.v1.StageProcessor;
 import com.marketinghub.pipelines.dossie.v1.dossiersynthesis.DossierDossierSynthesisProcessor;
 import com.marketinghub.pipelines.dossie.v1.intake.DossierIntakeProcessor;
@@ -19,10 +21,10 @@ import org.springframework.context.annotation.Configuration;
 public class DossierV1WorkerConfig {
     /** Expõe os processors canônicos da versão v1 do dossiê. */
     @Bean
-    List<StageProcessor> dossierV1StageProcessors() {
+    List<StageProcessor> dossierV1StageProcessors(RestClient.Builder restClientBuilder, OpenAiProperties openAiProperties) {
         return List.of(
                 new DossierIntakeProcessor(),
-                new DossierProductUnderstandingProcessor(),
+                new DossierProductUnderstandingProcessor(restClientBuilder, openAiProperties),
                 new DossierSourceProductMatchProcessor(),
                 new DossierInvestigationAnchorBuilderProcessor(),
                 new DossierWarmupResourceDiscoveryProcessor(),

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
@@ -1,17 +1,50 @@
 package com.marketinghub.pipelines.dossie.v1.productunderstanding;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis.OpenAiProperties;
 import com.marketinghub.pipelines.dossie.v1.DossierStageSupport;
 import com.marketinghub.pipelines.dossie.v1.StageContext;
 import com.marketinghub.pipelines.dossie.v1.StageProcessor;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
+import com.marketinghub.pipelines.dossie.v1.StageResult.OpenAiInteraction;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
 
 /** Executa a etapa entendimento do produto cumprindo o objetivo funcional contratado para o dossiê. */
+@Slf4j
 public class DossierProductUnderstandingProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "product-understanding";
     private static final String OBJECTIVE = "Estruturar produto, público, dor, promessa, mecanismo, formato, oferta e prova antes da pesquisa externa.";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestClient openAiClient;
+    private final OpenAiProperties openAiProperties;
+
+    /** Cria a etapa em modo local para testes e ambientes sem integração OpenAI configurada. */
+    public DossierProductUnderstandingProcessor() {
+        this.openAiClient = null;
+        this.openAiProperties = null;
+    }
+
+    /** Cria a etapa com cliente OpenAI Responses Flex para gerar auditoria bruta e saída funcional. */
+    public DossierProductUnderstandingProcessor(RestClient.Builder builder, OpenAiProperties openAiProperties) {
+        this.openAiProperties = openAiProperties;
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(30));
+        requestFactory.setReadTimeout(Duration.ofMillis(openAiProperties.normalizedRequestTimeoutMs()));
+        this.openAiClient = builder.requestFactory(requestFactory)
+                .baseUrl(openAiProperties.normalizedBaseUrl())
+                .defaultHeader("Authorization", "Bearer " + openAiProperties.resolvedApiKey())
+                .defaultHeader("OpenAI-Beta", "reasoning=1")
+                .build();
+    }
 
     /** Informa o nome canônico da etapa entendimento do produto. */
     @Override
@@ -22,6 +55,100 @@ public class DossierProductUnderstandingProcessor implements StageProcessor {
     /** Produz saída funcional auditável alinhada ao objetivo da etapa. */
     @Override
     public StageResult process(StageContext context) {
+        if (openAiClient != null && openAiProperties != null && StringUtils.hasText(openAiProperties.resolvedApiKey())) {
+            return processWithOpenAi(context);
+        }
+        return processLocally(context);
+    }
+
+    /** Executa a etapa usando OpenAI e preserva request, response, texto final, modelo e tokens para auditoria. */
+    private StageResult processWithOpenAi(StageContext context) {
+        try {
+            String rawRequest = buildOpenAiRequest(context);
+            log.info("MOIS dossie v1 product-understanding enviando request cru para OpenAI. jobId={}, requestPayload={}",
+                    context.stageExecutionId(), rawRequest);
+            String rawResponse = openAiClient.post().uri("/responses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(rawRequest)
+                    .retrieve()
+                    .body(String.class);
+            if (!StringUtils.hasText(rawResponse)) {
+                throw new IllegalStateException("OpenAI Responses Flex retornou corpo vazio em product-understanding");
+            }
+            log.info("MOIS dossie v1 product-understanding recebeu resposta crua da OpenAI. jobId={}, rawResponse={}",
+                    context.stageExecutionId(), rawResponse);
+            JsonNode root = objectMapper.readTree(rawResponse);
+            String outputText = extractOutputText(root);
+            JsonNode usage = root.path("usage");
+            Integer inputTokens = nullableInt(usage.path("input_tokens"));
+            Integer outputTokens = nullableInt(usage.path("output_tokens"));
+            String model = root.path("model").asText(openAiProperties.normalizedModel());
+            Map<String, Object> evidence = DossierStageSupport.evidenceFor(context, STAGE_NAME);
+            DossierProductUnderstandingOutput output = new DossierProductUnderstandingOutput(
+                    context.dossierId(),
+                    "OBJECTIVE_FULFILLED",
+                    outputText,
+                    evidence);
+            return StageResult.doneWithOpenAiInteractions(
+                    Map.of(STAGE_NAME, output, "openAiFinalText", outputText),
+                    List.of(DossierStageSupport.objectiveArtifact(context, STAGE_NAME, outputText, evidence)),
+                    List.of(new OpenAiInteraction(rawRequest, rawResponse, inputTokens, outputTokens, null, model, null)));
+        } catch (Exception ex) {
+            log.error("Falha na etapa product-understanding com OpenAI. stageExecutionId={}, dossierId={}",
+                    context.stageExecutionId(), context.dossierId(), ex);
+            return StageResult.failed("Falha ao entender produto via OpenAI: " + ex.getMessage(), Map.of(), List.of());
+        }
+    }
+
+    /** Monta o request Responses Flex enviado diretamente à OpenAI para entender o produto. */
+    private String buildOpenAiRequest(StageContext context) throws Exception {
+        String prompt = "Entenda o produto para orientar a investigação comercial do dossiê MOIS. "
+                + "Responda em JSON válido com: produto, publico, dor, promessa, mecanismo, formato, oferta, prova, resumo_final. "
+                + "Use Dor → Resultado → Mecanismo → Prova → Oferta. Não invente dados externos; use apenas o contexto recebido. Contexto: "
+                + objectMapper.writeValueAsString(context.input());
+        return objectMapper.writeValueAsString(Map.of(
+                "model", openAiProperties.normalizedModel(),
+                "service_tier", "flex",
+                "metadata", Map.of(
+                        "stage", STAGE_NAME,
+                        "stage_execution_id", Long.toString(context.stageExecutionId()),
+                        "dossier_id", Long.toString(context.dossierId())),
+                "input", List.of(
+                        Map.of("role", "system", "content", "Você estrutura entendimento comercial de produto e responde exclusivamente JSON válido sem markdown."),
+                        Map.of("role", "user", "content", prompt)),
+                "text", Map.of("format", Map.of("type", "json_object"))));
+    }
+
+    /** Extrai o texto final retornado pelo endpoint Responses da OpenAI. */
+    private String extractOutputText(JsonNode root) {
+        JsonNode outputText = root.path("output_text");
+        if (!outputText.isMissingNode() && StringUtils.hasText(outputText.asText())) {
+            return outputText.asText();
+        }
+        JsonNode output = root.path("output");
+        if (output.isArray()) {
+            for (JsonNode item : output) {
+                JsonNode content = item.path("content");
+                if (content.isArray()) {
+                    for (JsonNode contentItem : content) {
+                        JsonNode text = contentItem.path("text");
+                        if (!text.isMissingNode() && StringUtils.hasText(text.asText())) {
+                            return text.asText();
+                        }
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException("OpenAI Responses Flex não retornou texto final em product-understanding");
+    }
+
+    /** Lê um contador de tokens preservando nulo quando o campo não foi enviado pela OpenAI. */
+    private Integer nullableInt(JsonNode node) {
+        return node == null || node.isMissingNode() || node.isNull() ? null : node.asInt();
+    }
+
+    /** Mantém a saída local anterior quando a integração OpenAI não está configurada. */
+    private StageResult processLocally(StageContext context) {
         Map<String, Object> evidence = DossierStageSupport.evidenceFor(context, STAGE_NAME);
         DossierProductUnderstandingOutput output = new DossierProductUnderstandingOutput(
                 context.dossierId(),


### PR DESCRIPTION
### Motivation
- Ensure full auditability of OpenAI interactions for the `product-understanding` stage by recording raw request, raw response, extracted final text, model and tokens for diagnosis and traceability.
- Surface these audit fields on the dossiê UI so operators can inspect the exact request/response and the final text returned by OpenAI.

### Description
- Implemented OpenAI Responses Flex call in `product-understanding` when OpenAI is configured, preserving raw request and raw response and extracting final text, model and token counts into `StageResult.openAiInteractions` (file: `mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java`).
- Updated worker configuration to inject `RestClient.Builder` and `OpenAiProperties` into the `product-understanding` processor so the OpenAI client is available when configured (file: `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1WorkerConfig.java`).
- Updated frontend dossiê page to display: request sent to OpenAI, full response JSON (collapsible), extracted final text, and OpenAI model/tokens in the audit panel (file: `frontend/src/pages/mois/MoisSalesPageDossierPage.tsx`).
- Added a registry entry describing the change (file: `docs/registros/mois1.md`).

### Testing
- Ran unit tests for the worker: `mvn -q test -Dtest=DossierV1RunnerTest,PipelineWorkerTest` and they completed successfully (tests covering OpenAI interaction callbacks passed).
- Built frontend assets: ran `npm install` and `npm run build` and the build completed successfully.
- No automated backend integration tests were added in this PR beyond the unit tests above; existing runner test validates that raw request/response and tokens/model are forwarded to the backend and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a416ee4eaa88321b2c9797367403b55)