### PR TITLE
Implementa melhorias recomendadas no pipeline NichoCNAE v3

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1692,3 +1692,8 @@
 - Atualizado `docs/marketing/pipeline-nichocnae-v3.md` com exemplos reais da execução do CNAE `4781400` na tela `/oprm/cnaes/4781400/pipeline-v3`.
 - Registrado que a execução avançou até `source-searcher` e bloqueou com `FONTES_NAO_COLETADAS`, antes do `quality-gate` formal, porque nenhuma fonte pública qualificada de rotina foi encontrada.
 - Documentados exemplos reais de personas, tarefas planejadas e motivos de rejeição de fontes: URLs duplicadas, evidência de rotina insuficiente e risco comercial/solução.
+
+## 2026-06-28 — NichoCNAE v3: melhorias recomendadas do documento de marketing
+
+- Implementadas melhorias recomendadas em todas as etapas do executor `oprm-coletor-mei` para o pipeline NichoCNAE v3.
+- O fluxo agora reforça CNAE como ponto estatístico, pontua persona por canais e utilidade comercial futura, gera queries mais naturais Brasil-first, separa busca ampla de classificação de evidência, preserva snapshots com situação/canal, diferencia dor operacional de oportunidade futura, sintetiza blocos de rotina, endurece o quality gate por contexto comercial cotidiano e materializa um brief de público sem criar oferta prematura.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
@@ -23,7 +23,10 @@ public final class CnaeIntakeProcessor implements StageProcessor {
         output.put("cnaeCode", cnaeCode);
         output.put("cnaeDescription", cnaeDescription);
         output.put("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
-        output.put("targetAudienceDefinition", "Estamos falando de MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
+        output.put("targetAudienceDefinition", "Estamos falando de MEI, donos-operadores e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
+        output.put("cnaeRole", "CNAE_E_PONTO_DE_PARTIDA_ESTATISTICO_NAO_PUBLICO_FINAL");
+        output.put("discoveryFrame", "Este CNAE possui volume de MEIs, mas ainda é necessário descobrir qual pessoa real trabalha nele e em qual situação operacional cotidiana.");
+        output.put("researchMode", "REALIDADE_OPERACIONAL_DE_ROTINA_COM_CANAIS_DO_MEI");
         output.put("employmentBoundary", "NAO_ANALISAR_FUNCIONARIOS_CLT_CONTRATADOS_DIRETAMENTE");
         output.put("inputKeys", context.input().keySet());
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
@@ -29,6 +29,8 @@ public final class DailyTasksSynthesizerProcessor implements StageProcessor {
         output.put("inputKeys", context.input().keySet());
         output.put("dailyTaskCount", dailyTasks.size());
         output.put("dailyTasks", dailyTasks);
+        output.put("routineActionBlocks", routineActionBlocks(dailyTasks));
+        output.put("channelMap", dailyTasks.stream().map(task -> text(task.get("channelContext"))).filter(channel -> !channel.isBlank()).distinct().toList());
         output.put("commercialReading", "Mapa de rotina pronto para orientar produto futuro em facilidade, economia de esforço e redução de dor, sem gerar oferta nesta etapa.");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
@@ -56,8 +58,37 @@ public final class DailyTasksSynthesizerProcessor implements StageProcessor {
         task.put("buyingSignal", text(signal.get("buyingSignal")));
         task.put("evidenceText", text(signal.get("evidenceText")));
         task.put("sourceUrl", text(signal.get("sourceUrl")));
+        task.put("channelContext", text(signal.get("channelContext")));
+        task.put("probableFrequency", text(signal.get("probableFrequency")));
+        task.put("operationalImpact", operationalImpact(text(signal.get("painSignal")), text(signal.get("effortIntensity"))));
+        task.put("actionBlock", actionBlock(signal));
         task.put("easeLever", easeLever(text(signal.get("painSignal"))));
         return task;
+    }
+
+    /** Agrupa tarefas nos blocos que depois viram ângulos claros de criativo/produto, sem criar oferta. */
+    private Map<String, Object> routineActionBlocks(List<Map<String, Object>> tasks) {
+        Map<String, Object> blocks = new LinkedHashMap<>();
+        for (String block : List.of("CONSEGUIR_CLIENTE", "ATENDER", "EXECUTAR_SERVICO", "COBRAR", "ORGANIZAR_RETORNO", "CONTROLAR_OPERACAO")) {
+            blocks.put(block, tasks.stream().filter(task -> block.equals(task.get("actionBlock"))).toList());
+        }
+        return blocks;
+    }
+
+    /** Classifica a tarefa em bloco operacional reconhecível. */
+    private String actionBlock(Map<String, Object> signal) {
+        String combined = (text(signal.get("routineTask")) + " " + text(signal.get("channelContext")) + " " + text(signal.get("buyingSignal"))).toLowerCase();
+        if (combined.contains("cliente") || combined.contains("instagram") || combined.contains("indicação") || combined.contains("indicacao")) return "CONSEGUIR_CLIENTE";
+        if (combined.contains("atend") || combined.contains("whatsapp") || combined.contains("balcão") || combined.contains("balcao")) return "ATENDER";
+        if (combined.contains("cobr") || combined.contains("preço") || combined.contains("preco")) return "COBRAR";
+        if (combined.contains("agenda") || combined.contains("retorno") || combined.contains("recorrente")) return "ORGANIZAR_RETORNO";
+        if (combined.contains("estoque") || combined.contains("controle") || combined.contains("caixa")) return "CONTROLAR_OPERACAO";
+        return "EXECUTAR_SERVICO";
+    }
+
+    /** Resume impacto operacional provável em linguagem de negócio. */
+    private String operationalImpact(String pain, String effortIntensity) {
+        return ("ALTA".equals(effortIntensity) ? "Impacto alto" : "Impacto médio") + " associado a " + (pain.isBlank() ? "dor operacional a validar" : pain);
     }
 
     /** Traduz a dor operacional em alavanca de facilidade para uso posterior no pipeline. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
@@ -47,14 +47,32 @@ public final class PersonaRoutineMaterializerProcessor implements StageProcessor
         Map<String, Object> profile = new LinkedHashMap<>();
         profile.put("personaName", firstNonBlank(text(input.get("winningPersonaName")), text(winnerPersona.get("name")), "persona operacional priorizada"));
         profile.put("personaDescription", text(winnerPersona.get("description")));
+        profile.put("cnaeAudienceDistinction", "CNAE é volume estatístico; o público materializado é o executor MEI/autônomo observado na rotina.");
         profile.put("routineSummary", routineSummary(profile.get("personaName"), dailyTasks));
         profile.put("dailyTasks", dailyTasks);
         profile.put("topOperationalPains", dailyTasks.stream().map(task -> text(task.get("pain"))).filter(pain -> !pain.isBlank()).distinct().toList());
         profile.put("buyingSignals", dailyTasks.stream().map(task -> text(task.get("buyingSignal"))).filter(signal -> !signal.isBlank()).distinct().toList());
+        profile.put("routineActionBlocks", actionBlocks(dailyTasks));
+        profile.put("channels", dailyTasks.stream().map(task -> text(task.get("channelContext"))).filter(channel -> !channel.isBlank()).distinct().toList());
+        profile.put("recognizableVocabularyAndScenes", dailyTasks.stream().map(task -> text(task.get("evidenceText"))).filter(text -> !text.isBlank()).distinct().toList());
         profile.put("evidenceSources", dailyTasks.stream().map(this::evidenceSource).filter(source -> !source.isEmpty()).toList());
         profile.put("easeLevers", dailyTasks.stream().map(task -> text(task.get("easeLever"))).filter(lever -> !lever.isBlank()).distinct().toList());
+        profile.put("futureBriefRole", "Brief de público para fase posterior de hipótese, oferta e campanha, sem promessa comercial gerada neste pipeline.");
         profile.put("approvedByQualityGate", true);
         return profile;
+    }
+
+    /** Agrupa tarefas por blocos operacionais para formar um brief de público acionável. */
+    private Map<String, Object> actionBlocks(List<Map<String, Object>> dailyTasks) {
+        Map<String, Object> blocks = new LinkedHashMap<>();
+        dailyTasks.forEach(task -> {
+            String block = firstNonBlank(text(task.get("actionBlock")), "EXECUTAR_SERVICO");
+            blocks.computeIfAbsent(block, ignored -> new java.util.ArrayList<Map<String, Object>>());
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> blockTasks = (List<Map<String, Object>>) blocks.get(block);
+            blockTasks.add(task);
+        });
+        return blocks;
     }
 
     /** Cria um candidato de nicho com campos funcionais para o backend materializar nas tabelas canônicas. */
@@ -65,6 +83,8 @@ public final class PersonaRoutineMaterializerProcessor implements StageProcessor
         candidate.put("cnaeDescription", text(input.get("cnaeDescription")));
         candidate.put("title", materializedProfile.get("personaName"));
         candidate.put("summary", materializedProfile.get("routineSummary"));
+        candidate.put("channels", materializedProfile.get("channels"));
+        candidate.put("easeLevers", materializedProfile.get("easeLevers"));
         candidate.put("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
         candidate.put("profilePayload", materializedProfile);
         return candidate;

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
@@ -72,9 +72,12 @@ public final class PersonaTournamentProcessor implements StageProcessor {
         int painCount = listSize(firstExisting(persona, "operationalPains", "pains"));
         int taskCount = listSize(firstExisting(persona, "dailyTasks", "recurringTasks", "dailyFlow"));
         int signalCount = listSize(firstExisting(persona, "buyingSignals", "toolsAndRecords", "routineDecisions"));
+        int channelScore = channelScore(persona);
+        int commercialUseScore = commercialUseScore(persona);
         int autonomousScore = autonomousOwnerScore(persona);
         int employeePenalty = employeeRolePenalty(persona);
-        int score = painCount * 3 + taskCount * 2 + signalCount + autonomousScore - employeePenalty;
+        int narrowOrInstitutionalPenalty = narrowOrInstitutionalPenalty(persona);
+        int score = painCount * 3 + taskCount * 2 + signalCount + channelScore + commercialUseScore + autonomousScore - employeePenalty - narrowOrInstitutionalPenalty;
         Map<String, Object> scored = new LinkedHashMap<>(persona);
         scored.putIfAbsent("dailyTasks", texts(firstExisting(persona, "dailyTasks", "recurringTasks", "dailyFlow")));
         scored.putIfAbsent("operationalPains", texts(firstExisting(persona, "operationalPains", "pains", "validationNeed")));
@@ -84,8 +87,11 @@ public final class PersonaTournamentProcessor implements StageProcessor {
                 "operationalPains", painCount,
                 "dailyTasks", taskCount,
                 "buyingSignals", signalCount,
+                "channelScore", channelScore,
+                "commercialUseScore", commercialUseScore,
                 "autonomousOwnerScore", autonomousScore,
-                "employeeRolePenalty", employeePenalty));
+                "employeeRolePenalty", employeePenalty,
+                "narrowOrInstitutionalPenalty", narrowOrInstitutionalPenalty));
         return scored;
     }
 
@@ -101,6 +107,18 @@ public final class PersonaTournamentProcessor implements StageProcessor {
             }
         }
         return List.of();
+    }
+
+    /** Pontua canais reais de aquisição, atendimento e cobrança reconhecíveis em rotina de MEI. */
+    private int channelScore(Map<String, Object> persona) {
+        String combined = combinedText(persona);
+        return scoreByTerms(combined, List.of("whatsapp", "instagram", "indicação", "indicacao", "agenda", "balcão", "balcao", "delivery", "cliente", "cobrança", "cobranca"), 2);
+    }
+
+    /** Pontua utilidade futura para anúncio amplo sem gerar oferta nesta etapa. */
+    private int commercialUseScore(Map<String, Object> persona) {
+        String combined = combinedText(persona);
+        return scoreByTerms(combined, List.of("rotina", "dor", "tempo", "retrabalho", "organização", "organizacao", "controle", "agenda", "cliente", "preço", "preco"), 2);
     }
 
     /** Pontua melhor personas de dono-operador, MEI, autônomo ou familiar por aderirem ao recorte do pipeline. */
@@ -120,6 +138,23 @@ public final class PersonaTournamentProcessor implements StageProcessor {
     private int employeeRolePenalty(Map<String, Object> persona) {
         String combined = combinedText(persona);
         return containsAny(combined, List.of("estoquista", "funcionário", "funcionario", "empregado", "clt", "contratado", "retaguarda", "auxiliar", "gerente contratado")) ? 18 : 0;
+    }
+
+    /** Penaliza recortes pequenos, institucionais, B2B ou pouco reconhecíveis no feed. */
+    private int narrowOrInstitutionalPenalty(Map<String, Object> persona) {
+        String combined = combinedText(persona);
+        return containsAny(combined, List.of("institucional", "b2b", "industrial", "corporativo", "licitação", "licitacao", "órgão público", "orgao publico", "enterprise")) ? 12 : 0;
+    }
+
+    /** Calcula score por termos para decompor o ranking comercial. */
+    private int scoreByTerms(String text, List<String> terms, int points) {
+        int score = 0;
+        for (String term : terms) {
+            if (text.contains(term)) {
+                score += points;
+            }
+        }
+        return score;
     }
 
     /** Junta campos textuais relevantes da persona para classificação simples. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessor.java
@@ -14,7 +14,10 @@ public final class QualityGateProcessor implements StageProcessor {
     @Override
     public StageResult process(StageContext context) {
         List<Map<String, Object>> dailyTasks = maps(context.input().get("dailyTasks"));
-        boolean approved = dailyTasks.size() >= 2 && dailyTasks.stream().anyMatch(task -> !text(task.get("sourceUrl")).isBlank());
+        boolean hasTraceableSource = dailyTasks.stream().anyMatch(task -> !text(task.get("sourceUrl")).isBlank());
+        boolean hasCommercialRoutineContext = dailyTasks.stream().anyMatch(this::hasCommercialRoutineContext);
+        boolean hasRecognizableLanguage = dailyTasks.stream().anyMatch(task -> !text(task.get("evidenceText")).isBlank());
+        boolean approved = dailyTasks.size() >= 2 && hasTraceableSource && hasCommercialRoutineContext && hasRecognizableLanguage;
         String status = approved ? "QUALIDADE_APROVADA" : "QUALIDADE_BLOQUEADA";
 
         Map<String, Object> output = new LinkedHashMap<>();
@@ -25,13 +28,22 @@ public final class QualityGateProcessor implements StageProcessor {
         output.put("inputKeys", context.input().keySet());
         output.put("approved", approved);
         output.put("evidenceTaskCount", dailyTasks.size());
-        output.put("gateCriteria", List.of("mínimo de duas tarefas sintetizadas", "ao menos uma tarefa com fonte rastreável", "ausência de oferta/campanha/landing prematura"));
-        output.put("decisionReason", approved ? "Há sinais suficientes de rotina e fonte rastreável para materializar relatório da persona." : "Faltam tarefas suficientes ou fonte rastreável; reprocessar busca/coleta antes de avançar.");
+        output.put("hasTraceableSource", hasTraceableSource);
+        output.put("hasCommercialRoutineContext", hasCommercialRoutineContext);
+        output.put("hasRecognizableLanguage", hasRecognizableLanguage);
+        output.put("gateCriteria", List.of("mínimo de duas tarefas sintetizadas", "ao menos uma tarefa com fonte rastreável", "contexto MEI/autônomo com canal, atendimento, cobrança, agenda, recorrência ou cliente", "linguagem/evidência reconhecível do público", "ausência de oferta/campanha/landing prematura"));
+        output.put("decisionReason", approved ? "Há sinais suficientes de rotina, canal comercial cotidiano e fonte rastreável para materializar o brief de público." : "Faltam tarefas, fonte rastreável, linguagem reconhecível ou contexto comercial cotidiano; reprocessar busca/coleta antes de avançar.");
         output.put("recommendedCorrectionStage", approved ? "" : "source-searcher");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", approved ? "persona-routine-materializer" : "");
         return new StageResult(status, output, List.of(new StageArtifact(status, "inline://nichocnae-v3/quality-gate", "Gate de qualidade executado com decisão e causa persistíveis.")));
+    }
+
+    /** Verifica se a tarefa traz canal ou situação comercial cotidiana útil para a próxima fase. */
+    private boolean hasCommercialRoutineContext(Map<String, Object> task) {
+        String combined = (text(task.get("channelContext")) + " " + text(task.get("task")) + " " + text(task.get("buyingSignal"))).toLowerCase();
+        return List.of("whatsapp", "instagram", "cliente", "agenda", "cobrança", "cobranca", "balcão", "balcao", "recorr", "indicação", "indicacao", "atendimento").stream().anyMatch(combined::contains);
     }
 
     /** Normaliza a lista de tarefas sintetizadas recebida da etapa anterior. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
@@ -22,7 +22,8 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
         List<String> dailyTasks = texts(firstExisting(winnerPersona, "dailyTasks", "recurringTasks", "dailyFlow"));
         List<String> operationalPains = texts(firstExisting(winnerPersona, "operationalPains", "pains", "validationNeed"));
         List<String> buyingSignals = texts(firstExisting(winnerPersona, "buyingSignals", "toolsAndRecords", "routineDecisions"));
-        List<Map<String, Object>> plannedQueries = plannedQueries(personaName, dailyTasks, operationalPains, buyingSignals);
+        List<String> channels = texts(firstExisting(winnerPersona, "channels", "serviceChannels", "acquisitionChannels", "billingRoutine", "customerAcquisition"));
+        List<Map<String, Object>> plannedQueries = plannedQueries(personaName, dailyTasks, operationalPains, buyingSignals, channels);
 
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "routine-query-planner");
@@ -54,13 +55,14 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
     }
 
     /** Monta consultas de busca acionáveis a partir das tarefas, dores e sinais da persona. */
-    private List<Map<String, Object>> plannedQueries(String personaName, List<String> dailyTasks, List<String> operationalPains, List<String> buyingSignals) {
+    private List<Map<String, Object>> plannedQueries(String personaName, List<String> dailyTasks, List<String> operationalPains, List<String> buyingSignals, List<String> channels) {
         List<Map<String, Object>> queries = new ArrayList<>();
         addQueries(queries, personaName, dailyTasks, "TAREFA_DIARIA", "Validar tarefa recorrente e frequência operacional");
         addQueries(queries, personaName, operationalPains, "DOR_OPERACIONAL", "Confirmar dor, esforço manual e consequência prática");
-        addQueries(queries, personaName, buyingSignals, "SINAL_DE_COMPRA", "Encontrar evidência de busca por solução, planilha, sistema, consultoria ou modelo pronto");
+        addQueries(queries, personaName, buyingSignals, "SINAL_DE_COMPRA", "Encontrar evidência de busca por facilidade, organização, agenda, cobrança ou modelo pronto");
+        addQueries(queries, personaName, channels, "CANAL_ATENDIMENTO_AQUISICAO", "Validar canais reais como WhatsApp, Instagram, indicação, balcão, agenda, cobrança ou atendimento local");
         if (queries.isEmpty()) {
-            queries.add(queryItem(personaName + " MEI autônomo dono operador rotina diária tarefas problemas", "ROTINA_BASE", "Validar rotina e problemas recorrentes quando a persona não trouxe sinais detalhados", 1));
+            queries.add(queryItem("rotina de " + personaName + " pequena no Brasil atendimento cliente cobrança agenda", "ROTINA_BASE", "Validar rotina e problemas recorrentes quando a persona não trouxe sinais detalhados", 1));
         }
         return queries.stream().limit(MAX_QUERY_ITEMS).toList();
     }
@@ -68,8 +70,18 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
     /** Adiciona consultas mantendo prioridade de acordo com a ordem da evidência recebida. */
     private void addQueries(List<Map<String, Object>> queries, String personaName, List<String> evidences, String intent, String objective) {
         for (String evidence : evidences) {
-            queries.add(queryItem(personaName + " MEI autônomo dono operador " + evidence + " rotina problema frequência", intent, objective, queries.size() + 1));
+            queries.add(queryItem(naturalQuery(personaName, evidence, intent), intent, objective, queries.size() + 1));
         }
+    }
+
+    /** Monta query natural Brasil-first sem depender sempre de termos formais como dono-operador ou MEI. */
+    private String naturalQuery(String personaName, String evidence, String intent) {
+        return switch (intent) {
+            case "DOR_OPERACIONAL" -> "dificuldade de " + evidence + " na rotina de " + personaName + " Brasil";
+            case "SINAL_DE_COMPRA" -> "como organizar " + evidence + " para " + personaName + " clientes agenda cobrança";
+            case "CANAL_ATENDIMENTO_AQUISICAO" -> personaName + " usa " + evidence + " para atender conseguir cliente cobrar Brasil";
+            default -> "rotina de " + personaName + " " + evidence + " atendimento cliente Brasil";
+        };
     }
 
     /** Cria um item estruturado de consulta para a próxima etapa buscar fontes. */
@@ -79,7 +91,7 @@ public final class RoutineQueryPlannerProcessor implements StageProcessor {
         item.put("query", query);
         item.put("intent", intent);
         item.put("objective", objective);
-        item.put("expectedEvidence", List.of("relato de rotina", "tarefa concreta", "dor ou esforço", "frequência ou impacto"));
+        item.put("expectedEvidence", List.of("relato de rotina", "tarefa concreta", "dor ou esforço", "frequência ou impacto", "canal de atendimento/aquisição/cobrança"));
         return item;
     }
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinesignalextractor/RoutineSignalExtractorProcessor.java
@@ -59,8 +59,17 @@ public final class RoutineSignalExtractorProcessor implements StageProcessor {
         signal.put("routineTask", inferTask(evidence));
         signal.put("painSignal", inferPain(lower));
         signal.put("buyingSignal", inferBuyingSignal(lower));
+        signal.put("channelContext", firstNonBlank(text(snapshot.get("mentionedChannel")), inferChannel(lower)));
+        signal.put("effortIntensity", inferEffortIntensity(lower));
+        signal.put("probableFrequency", inferFrequency(lower));
+        signal.put("commercialOpportunityFuture", futureOpportunity(signal));
         signal.put("confidence", evidence.isBlank() ? "BAIXA" : "MEDIA");
         return signal;
+    }
+
+    /** Resume oportunidade futura sem transformar a evidência em oferta prematura. */
+    private String futureOpportunity(Map<String, Object> signal) {
+        return "Matéria-prima para hipótese futura: " + signal.get("painSignal") + " em " + signal.get("channelContext") + ".";
     }
 
     /** Infere uma tarefa objetiva sem inventar além do trecho recebido. */
@@ -94,6 +103,42 @@ public final class RoutineSignalExtractorProcessor implements StageProcessor {
             return "PROCURA_AJUDA_ESPECIALIZADA";
         }
         return "SINAL_DE_COMPRA_A_VALIDAR";
+    }
+
+    /** Infere canal quando ele aparece literalmente no trecho de evidência. */
+    private String inferChannel(String lowerEvidence) {
+        for (String channel : List.of("whatsapp", "instagram", "agenda", "balcão", "balcao", "delivery", "cobrança", "cobranca")) {
+            if (lowerEvidence.contains(channel)) {
+                return channel;
+            }
+        }
+        return "CANAL_A_VALIDAR";
+    }
+
+    /** Infere intensidade do esforço a partir de sinais textuais simples. */
+    private String inferEffortIntensity(String lowerEvidence) {
+        return lowerEvidence.contains("difícil") || lowerEvidence.contains("dificil") || lowerEvidence.contains("problema") || lowerEvidence.contains("retrabalho") ? "ALTA" : "MEDIA";
+    }
+
+    /** Infere frequência provável sem inventar dado não sustentado. */
+    private String inferFrequency(String lowerEvidence) {
+        if (lowerEvidence.contains("diário") || lowerEvidence.contains("diaria") || lowerEvidence.contains("todo dia")) {
+            return "DIARIA";
+        }
+        if (lowerEvidence.contains("semana") || lowerEvidence.contains("recorrente")) {
+            return "RECORRENTE";
+        }
+        return "A_VALIDAR";
+    }
+
+    /** Escolhe o primeiro texto preenchido. */
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (!value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
     }
 
     /** Converte valor opcional em texto seguro. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcefetcher/SourceFetcherProcessor.java
@@ -78,6 +78,9 @@ public final class SourceFetcherProcessor implements StageProcessor {
         snapshot.put("evidenceText", evidence);
         snapshot.put("sourceType", text(first(source, "sourceType", "type", "category")));
         snapshot.put("routineRelevance", text(first(source, "routineRelevance", "objective", "whyRelevant")));
+        snapshot.put("observedRoutineSituation", firstNonBlank(evidence, title));
+        snapshot.put("mentionedChannel", mentionedChannel(title + " " + evidence));
+        snapshot.put("usefulnessReason", text(first(source, "routineRelevance", "objective", "whyRelevant", "matchedQuery")));
         snapshot.put("sourceIntent", text(first(source, "sourceIntent")));
         snapshot.put("routineEvidenceScore", first(source, "routineEvidenceScore"));
         snapshot.put("commercialPageRisk", first(source, "commercialPageRisk"));
@@ -88,8 +91,29 @@ public final class SourceFetcherProcessor implements StageProcessor {
         snapshot.put("outdatedSourceRisk", first(source, "outdatedSourceRisk"));
         snapshot.put("structuredBusinessDriftRisk", first(source, "structuredBusinessDriftRisk"));
         snapshot.put("capturedFields", List.of("url", "title", "evidenceText", "sourceType", "routineRelevance",
-                "sourceIntent", "routineEvidenceScore", "commercialPageRisk", "solutionLanguageRisk"));
+                "sourceIntent", "routineEvidenceScore", "commercialPageRisk", "solutionLanguageRisk", "observedRoutineSituation", "mentionedChannel", "usefulnessReason"));
         return snapshot;
+    }
+
+    /** Identifica canal operacional citado no trecho da fonte. */
+    private String mentionedChannel(String text) {
+        String lower = text.toLowerCase();
+        for (String channel : List.of("whatsapp", "instagram", "agenda", "balcão", "balcao", "delivery", "indicação", "indicacao", "cobrança", "cobranca")) {
+            if (lower.contains(channel)) {
+                return channel;
+            }
+        }
+        return "CANAL_NAO_EXPLICITO";
+    }
+
+    /** Escolhe o primeiro texto preenchido para preservar evidência mínima suficiente. */
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (!value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
     }
 
     /** Retorna o primeiro campo existente no mapa de fonte. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 
 /** Processa a etapa source-searcher do pipeline NichoCNAE v3. */
 public final class SourceSearcherProcessor implements StageProcessor {
-    private static final int SEARCH_RESULTS_PER_QUERY = 5;
+    private static final int SEARCH_RESULTS_PER_QUERY = 8;
     private static final int MAX_SELECTED_SOURCES = 8;
     private static final int MIN_ROUTINE_EVIDENCE_SCORE = 45;
     private static final int MAX_REJECTED_SOURCES_PER_ATTEMPT = 8;
@@ -70,7 +70,8 @@ public final class SourceSearcherProcessor implements StageProcessor {
         output.put("searchAttempts", searchAttempts);
         output.put("selectionCriteria", List.of(
                 "fonte Brasil-first em português quando possível",
-                "fonte descreve rotina, tarefa, dúvida, atendimento, agenda, cobrança ou execução real",
+                "busca ampla separada da classificação de evidência semântica",
+                "fonte descreve rotina, tarefa, dúvida, atendimento, canal, agenda, cobrança ou execução real",
                 "fonte comercial ou de solução não avança como evidência positiva",
                 "fontes com URL duplicada ou sem URL rastreável são descartadas"));
         output.put("blocked", !hasSources);
@@ -186,17 +187,16 @@ public final class SourceSearcherProcessor implements StageProcessor {
         String combined = (title + " " + snippet + " " + url).toLowerCase();
         int routineEvidenceScore = routineEvidenceScore(combined);
         int brazilRelevanceScore = brazilRelevanceScore(url, combined);
-        boolean solutionLanguageRisk = containsAny(combined, List.of("software", "sistema", "app", "aplicativo", "plataforma", "automação", "automacao", "curso", "mentoria", "template", "funil", "landing page", "tráfego pago", "trafego pago", "crm"));
+        boolean solutionLanguageRisk = containsAny(combined, List.of("software", "sistema", "app", "aplicativo", "plataforma", "automação", "automacao", "curso", "mentoria", "funil", "landing page", "tráfego pago", "trafego pago", "crm"));
         boolean commercialPageRisk = containsAny(combined, List.of("preço", "preco", "planos", "contrate", "comprar", "teste grátis", "teste gratis", "demonstração", "demonstracao", "vendas", "marketing digital", "anúncio", "anuncio"));
         boolean structuredBusinessDriftRisk = containsAny(combined, List.of("empresa", "indústria", "industria", "corporativo", "franquia", "grande porte", "gestão empresarial"));
         int qualityScore = routineEvidenceScore + brazilRelevanceScore - (solutionLanguageRisk ? 35 : 0) - (commercialPageRisk ? 20 : 0) - (structuredBusinessDriftRisk ? 15 : 0);
-        String sourceIntent = solutionLanguageRisk || commercialPageRisk
-                ? "CONTAMINATION_RISK"
-                : "ROUTINE_EVIDENCE";
+        String sourceIntent = sourceIntent(solutionLanguageRisk, commercialPageRisk, combined);
 
         qualified.put("url", url);
         qualified.put("title", title);
         qualified.put("snippet", snippet);
+        qualified.put("semanticEvidenceClassification", sourceIntent);
         qualified.put("sourceIntent", sourceIntent);
         qualified.put("sourceType", sourceType(url, combined, sourceIntent));
         qualified.put("routineEvidenceScore", Math.max(0, Math.min(100, routineEvidenceScore)));
@@ -216,7 +216,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
 
     /** Decide se a fonte pode avançar para coleta de snapshot da rotina. */
     private boolean isQualifiedRoutineSource(Map<String, Object> source) {
-        return "ROUTINE_EVIDENCE".equals(source.get("sourceIntent"))
+        return List.of("ROUTINE_EVIDENCE", "COMMUNITY_OR_QUESTION_EVIDENCE").contains(source.get("sourceIntent"))
                 && score(source, "routineEvidenceScore") >= MIN_ROUTINE_EVIDENCE_SCORE
                 && score(source, "qualityScore") >= MIN_ROUTINE_EVIDENCE_SCORE;
     }
@@ -230,6 +230,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
         addVariant(variants, enrichBrazilFirstQuery(simplifiedQuery));
         addVariant(variants, enrichBrazilFirstQuery(operationalQuery(simplifiedQuery)));
         addVariant(variants, enrichBrazilFirstQuery(objective));
+        addVariant(variants, naturalRoutineQuery(simplifiedQuery));
         return variants;
     }
 
@@ -239,7 +240,13 @@ public final class SourceSearcherProcessor implements StageProcessor {
         if (cleanQuery.isBlank()) {
             return "";
         }
-        return cleanQuery + " Brasil rotina MEI autônomo";
+        return cleanQuery + " Brasil rotina cliente atendimento cobrança";
+    }
+
+    /** Cria variação semântica ampla para encontrar relatos e dúvidas reais. */
+    private String naturalRoutineQuery(String query) {
+        String cleanQuery = trimWords(query, 10);
+        return cleanQuery.isBlank() ? "" : "como é a rotina " + cleanQuery + " problemas clientes whatsapp instagram";
     }
 
     /** Simplifica a query planejada removendo ruído que reduz a chance de resultado rastreável. */
@@ -292,7 +299,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
         if (seenUrls.contains(url)) {
             return "URL_DUPLICADA";
         }
-        if (!"ROUTINE_EVIDENCE".equals(source.get("sourceIntent"))) {
+        if (!List.of("ROUTINE_EVIDENCE", "COMMUNITY_OR_QUESTION_EVIDENCE").contains(source.get("sourceIntent"))) {
             return "RISCO_CONTAMINACAO_SOLUCAO_OU_COMERCIAL";
         }
         if (score(source, "routineEvidenceScore") < MIN_ROUTINE_EVIDENCE_SCORE) {
@@ -306,7 +313,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
 
     /** Calcula score de evidência de rotina operacional. */
     private int routineEvidenceScore(String text) {
-        return scoreByTerms(text, List.of("rotina", "tarefa", "tarefas", "atendimento", "agenda", "cliente", "clientes", "cobrança", "cobranca", "preço", "preco", "orçamento", "orcamento", "material", "estoque", "retrabalho", "problema", "dúvida", "duvida", "pergunta", "frequência", "frequencia", "manual"), 12);
+        return scoreByTerms(text, List.of("rotina", "tarefa", "tarefas", "atendimento", "agenda", "cliente", "clientes", "cobrança", "cobranca", "preço", "preco", "orçamento", "orcamento", "material", "estoque", "retrabalho", "problema", "dúvida", "duvida", "pergunta", "frequência", "frequencia", "manual", "whatsapp", "instagram", "indicação", "indicacao", "balcão", "balcao", "delivery", "relato"), 10);
     }
 
     /** Calcula aderência ao contexto brasileiro. */
@@ -334,10 +341,27 @@ public final class SourceSearcherProcessor implements StageProcessor {
         return 45;
     }
 
+    /** Classifica semanticamente a fonte separando evidência real de contaminação comercial. */
+    private String sourceIntent(boolean solutionLanguageRisk, boolean commercialPageRisk, String text) {
+        if (solutionLanguageRisk || commercialPageRisk) {
+            return "CONTAMINATION_RISK";
+        }
+        if (containsAny(text, List.of("pergunta", "dúvida", "duvida", "relato", "comentário", "comentario", "forum", "fórum"))) {
+            return "COMMUNITY_OR_QUESTION_EVIDENCE";
+        }
+        if (containsAny(text, List.of("whatsapp", "instagram", "agenda", "cobrança", "cobranca", "cliente", "atendimento", "estoque", "balcão", "balcao"))) {
+            return "ROUTINE_EVIDENCE";
+        }
+        return "GENERIC_SECTOR_SOURCE";
+    }
+
     /** Classifica o tipo operacional da fonte. */
     private String sourceType(String url, String text, String sourceIntent) {
-        if (!"ROUTINE_EVIDENCE".equals(sourceIntent)) {
+        if ("CONTAMINATION_RISK".equals(sourceIntent)) {
             return "COMMERCIAL_OR_SOLUTION_RISK";
+        }
+        if ("COMMUNITY_OR_QUESTION_EVIDENCE".equals(sourceIntent)) {
+            return "REAL_PROFESSIONAL_QUESTION";
         }
         if (domain(url).endsWith(".gov.br")) {
             return "BRAZILIAN_OFFICIAL_SOURCE";

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
@@ -24,7 +24,7 @@ class CnaeIntakeProcessorTest {
         assertThat(result.output()).containsEntry("cnaeCode", "4781400");
         assertThat(result.output()).containsEntry("cnaeDescription", "Comércio varejista de artigos do vestuário");
         assertThat(result.output()).containsEntry("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
-        assertThat(result.output()).containsEntry("targetAudienceDefinition", "Estamos falando de MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
+        assertThat(result.output()).containsEntry("targetAudienceDefinition", "Estamos falando de MEI, donos-operadores e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
         assertThat(result.output()).containsEntry("employmentBoundary", "NAO_ANALISAR_FUNCIONARIOS_CLT_CONTRATADOS_DIRETAMENTE");
         assertThat(result.output()).containsEntry("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         assertThat(result.output()).containsEntry("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
@@ -25,7 +25,11 @@ class PersonaTournamentProcessorTest {
         assertThat(result.output()).containsEntry("winningPersonaName", "Dono operador de loja");
         assertThat(result.output()).containsKeys("winnerPersona", "selectionRationale", "personaRanking");
         Map<?, ?> winner = (Map<?, ?>) result.output().get("winnerPersona");
-        assertThat(winner.get("tournamentScore")).isEqualTo(26);
+        assertThat(winner.get("tournamentScore")).isEqualTo(28);
+        Map<?, ?> scoreBreakdown = (Map<?, ?>) winner.get("scoreBreakdown");
+        assertThat(scoreBreakdown.containsKey("channelScore")).isTrue();
+        assertThat(scoreBreakdown.containsKey("commercialUseScore")).isTrue();
+        assertThat(scoreBreakdown.containsKey("narrowOrInstitutionalPenalty")).isTrue();
     }
 
     /** Prioriza dono-operador MEI quando a IA também retorna cargo CLT com muitas tarefas, evitando travar a busca de fontes. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/qualitygate/QualityGateProcessorTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 
 /** Valida que o gate decide avanço por evidência persistível. */
 class QualityGateProcessorTest {
-    /** Garante aprovação apenas quando há volume mínimo e fonte rastreável. */
+    /** Garante aprovação quando há volume mínimo, fonte rastreável e contexto comercial cotidiano. */
     @Test
     void shouldApproveWhenTasksHaveEnoughEvidence() {
         StageResult result = new QualityGateProcessor().process(new StageContext("job", "9", Map.of("dailyTasks", List.of(
-                Map.of("task", "Conferir estoque", "sourceUrl", "https://exemplo.com/1"),
-                Map.of("task", "Acompanhar metas", "sourceUrl", "")))));
+                Map.of("task", "Conferir estoque do cliente no WhatsApp", "sourceUrl", "https://exemplo.com/1", "channelContext", "whatsapp", "evidenceText", "cliente pediu tamanho pelo WhatsApp"),
+                Map.of("task", "Acompanhar agenda de cobrança", "sourceUrl", "", "channelContext", "agenda", "evidenceText", "agenda e cobrança recorrente")))));
 
         assertThat(result.status()).isEqualTo("QUALIDADE_APROVADA");
         assertThat(result.output()).containsEntry("approved", true).containsEntry("nextStageCode", "persona-routine-materializer");

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
@@ -50,7 +50,7 @@ class RoutineQueryPlannerProcessorTest {
 
         List<?> plannedQueries = (List<?>) result.output().get("plannedQueries");
         assertThat(plannedQueries).hasSize(2);
-        assertThat(plannedQueries.getFirst()).asString().contains("MEI autônomo dono operador", "responder clientes no WhatsApp");
+        assertThat(plannedQueries.getFirst()).asString().contains("rotina de Dono-operador MEI", "responder clientes no WhatsApp", "atendimento cliente Brasil");
     }
 
     /** Bloqueia uma saída genérica quando a etapa anterior não trouxe a persona vencedora. */


### PR DESCRIPTION
### Motivation
- Aplicar as "Melhorias Recomendadas" do documento `/docs/marketing/pipeline-nichocnae-v3.md` para transformar o pipeline em um gerador de insumo de marketing mais útil sem gerar oferta prematura. 
- A intenção é aumentar a taxa de materialização útil preservando rigor: buscar evidência semântica de rotina, mapear canais e linguagem do MEI/dono-operador e entregar um brief de público estruturado para etapas posteriores. 

### Description
- Reforço do enquadramento inicial em `cnae-intake` para tratar o CNAE como ponto estatístico e acrescentar `cnaeRole`, `discoveryFrame` e `researchMode` (arquivos: `CnaeIntakeProcessor.java`).
- Melhoria da seleção de persona em `persona-tournament` adicionando `channelScore`, `commercialUseScore`, penalização de recortes institucionais e decomposição do `scoreBreakdown` (arquivo: `PersonaTournamentProcessor.java`).
- Planejamento de buscas e variantes: `routine-query-planner` gera queries Brasil-first e naturais, passa a considerar canais e o `source-searcher` aumenta resultados por query, separa busca ampla da classificação semântica e passa a aceitar evidência da comunidade; também adiciona `naturalRoutineQuery` e aumenta `SEARCH_RESULTS_PER_QUERY` (arquivos: `RoutineQueryPlannerProcessor.java`, `SourceSearcherProcessor.java`).
- Coleta e classificação de fontes/snapshots: `source-fetcher` preserva trecho/situação/canal e motivo de uso, e `source-searcher` classifica semanticamente (`ROUTINE_EVIDENCE`, `COMMUNITY_OR_QUESTION_EVIDENCE`, `CONTAMINATION_RISK`) e aprimora critérios de rejeição (arquivos: `SourceFetcherProcessor.java`, `SourceSearcherProcessor.java`).
- Extração, síntese e blocos de rotina: `routine-signal-extractor` passa a extrair `channelContext`, `effortIntensity`, `probableFrequency` e um resumo de oportunidade futura; `daily-tasks-synthesizer` cria `actionBlock`, `routineActionBlocks`, `channelMap`, `operationalImpact` e preserva alavancas de facilidade (arquivos: `RoutineSignalExtractorProcessor.java`, `DailyTasksSynthesizerProcessor.java`).
- Gate e materialização final: `quality-gate` endurece critérios (exige fonte rastreável, contexto comercial cotidiano e linguagem reconhecível) e `persona-routine-materializer` materializa um `materializedProfile`/`marketNicheCandidate` com canais, blocos de ação, vocabulário reconhecível e `futureBriefRole` sem introduzir oferta (arquivos: `QualityGateProcessor.java`, `PersonaRoutineMaterializerProcessor.java`).
- Testes e documentação: ajustes nos testes do executor OPRM para refletir os novos contratos e inclusão do registro operacional em `docs/registros/oprm1.md` mencionando as mudanças implementadas.

### Testing
- Rodei os testes automatizados do executor com `mvn test -DskipITs` dentro de `oprm-coletor-mei` e a suíte concluiu com sucesso (todas as classes de teste executadas e sem falhas). 
- Os ajustes incluíram atualização de asserts nos testes que dependiam de contratos/nomes de campos alterados, e a execução final dos testes retornou `BUILD SUCCESS` (47 testes, 0 falhas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a417a97c69083218a7eb38793d9a8d3)