### PR TITLE
Show request with response in MOIS dossier audit

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoService.java
@@ -6,7 +6,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.situac
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Consulta a situação auditada das etapas do pipeline de dossiê de produto MOIS v1. */
@@ -28,8 +30,10 @@ public class DossierSituacaoService {
                 .filter(valor -> valor != null && !valor.isBlank())
                 .map(String::trim)
                 .toList();
-        List<DossierSituacaoItem> registros = buscarRegistrosDoFluxoAtual(codigoEtapa, idExterno, status).stream()
-                .map(this::toItem)
+        List<PipelineDossieProduto> auditorias = buscarRegistrosDoFluxoAtual(codigoEtapa, idExterno, status);
+        Map<String, String> requestsPorJob = mapearRequestsPorJob(auditorias);
+        List<DossierSituacaoItem> registros = auditorias.stream()
+                .map(pipeline -> toItem(pipeline, requestsPorJob.get(chaveJob(pipeline))))
                 .toList();
         return new DossierSituacaoResponse(idExterno, codigoEtapa, status, registros);
     }
@@ -53,8 +57,33 @@ public class DossierSituacaoService {
                 idExterno, codigoEtapa, status, fluxoAtualIniciadoEm);
     }
 
+    /** Mapeia o último request auditado por job para exibir request e response juntos na tela. */
+    private Map<String, String> mapearRequestsPorJob(List<PipelineDossieProduto> auditorias) {
+        Map<String, String> requestsPorJob = new HashMap<>();
+        for (PipelineDossieProduto auditoria : auditorias) {
+            String request = auditoria.getRequest();
+            if (request != null && !request.isBlank()) {
+                requestsPorJob.putIfAbsent(chaveJob(auditoria), request);
+            }
+        }
+        return requestsPorJob;
+    }
+
+    /** Gera a chave de correlação entre registros separados de request e response do mesmo job/etapa. */
+    private String chaveJob(PipelineDossieProduto pipeline) {
+        return String.join("|",
+                valorChave(pipeline.getIdExterno()),
+                valorChave(pipeline.getCodigoEtapa()),
+                valorChave(pipeline.getJobId()));
+    }
+
+    /** Normaliza valores nulos usados na chave de correlação de auditoria. */
+    private String valorChave(String valor) {
+        return valor == null ? "" : valor;
+    }
+
     /** Converte a entidade de auditoria para o contrato de consulta de situação. */
-    private DossierSituacaoItem toItem(PipelineDossieProduto pipeline) {
+    private DossierSituacaoItem toItem(PipelineDossieProduto pipeline, String requestCorrelacionado) {
         return new DossierSituacaoItem(
                 pipeline.getId(),
                 pipeline.getIdExterno(),
@@ -62,7 +91,7 @@ public class DossierSituacaoService {
                 pipeline.getStatus(),
                 pipeline.getDataHora(),
                 pipeline.getJobId(),
-                pipeline.getRequest(),
+                requestVisivel(pipeline.getRequest(), requestCorrelacionado),
                 pipeline.getResponse(),
                 pipeline.getRespostaFinal(),
                 pipeline.getQuantidadeTokenEntrada(),
@@ -75,5 +104,10 @@ public class DossierSituacaoService {
                 pipeline.getPrompt(),
                 pipeline.getSchema(),
                 pipeline.getVersaoPipeline());
+    }
+
+    /** Prioriza o request do próprio registro e usa o request correlacionado quando a linha atual é de response. */
+    private String requestVisivel(String requestDoRegistro, String requestCorrelacionado) {
+        return requestDoRegistro == null || requestDoRegistro.isBlank() ? requestCorrelacionado : requestDoRegistro;
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/situacao/service/DossierSituacaoServiceTest.java
@@ -47,6 +47,38 @@ class DossierSituacaoServiceTest {
                 "400", "product-understanding", List.of("CONCLUIDO"), inicioAtual);
     }
 
+    /** Garante que a linha de response exiba o request correlacionado do mesmo job para auditoria completa na tela. */
+    @Test
+    void consultarCorrelacionaRequestComResponseDoMesmoJob() {
+        DossierSituacaoService service = new DossierSituacaoService(repository);
+        Instant inicioAtual = Instant.parse("2026-06-28T03:27:06Z");
+        PipelineDossieProduto intakeAtual = registro("286", "intake", "INICIADO", inicioAtual);
+        PipelineDossieProduto response = registro("286", "product-understanding", "CONCLUIDO", Instant.parse("2026-06-28T22:44:00Z"));
+        response.setResponse("{\"output\":[]}");
+        PipelineDossieProduto request = registro("286", "product-understanding", "AGUARDANDO_RETORNO_MODULO", Instant.parse("2026-06-28T22:43:00Z"));
+        request.setRequest("{\"model\":\"gpt-5.2-2025-12-11\"}");
+
+        when(repository.findTopByIdExternoAndCodigoEtapaAndStatusOrderByDataHoraDescIdDesc(
+                        "286", "intake", "INICIADO"))
+                .thenReturn(Optional.of(intakeAtual));
+        when(repository
+                        .findByIdExternoAndCodigoEtapaAndStatusInAndDataHoraGreaterThanEqualOrderByDataHoraDescIdDesc(
+                                "286",
+                                "product-understanding",
+                                List.of("AGUARDANDO_RETORNO_MODULO", "CONCLUIDO"),
+                                inicioAtual))
+                .thenReturn(List.of(response, request));
+
+        var resultado = service.consultar(
+                "product-understanding",
+                "286",
+                new DossierSituacaoRequest(List.of("AGUARDANDO_RETORNO_MODULO", "CONCLUIDO")));
+
+        assertThat(resultado.registros()).hasSize(2);
+        assertThat(resultado.registros().getFirst().response()).isEqualTo("{\"output\":[]}");
+        assertThat(resultado.registros().getFirst().request()).isEqualTo("{\"model\":\"gpt-5.2-2025-12-11\"}");
+    }
+
     /** Monta uma auditoria mínima do pipeline para validar a fronteira de reprocessamento. */
     private PipelineDossieProduto registro(String idExterno, String etapa, String status, Instant dataHora) {
         PipelineDossieProduto registro = new PipelineDossieProduto();

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1943,3 +1943,9 @@ Arquivos principais:
 - Ajustada a etapa `product-understanding` do worker de biblioteca de páginas MOIS para chamar OpenAI Responses Flex quando houver chave configurada, preservando request bruto, response bruto, texto final extraído, modelo e tokens no contrato de auditoria enviado ao backend.
 - Ajustada a tela do dossiê para exibir request enviado à OpenAI, response recebido da OpenAI em JSON colapsável, texto final extraído e métricas de modelo/tokens.
 - Causa-raiz: a etapa ainda podia executar em modo local sem gerar interação OpenAI, então a auditoria técnica não recebia os dados exigidos para diagnóstico e rastreabilidade comercial.
+
+## 2026-06-28 — Request visível junto do response no dossiê MOIS v1
+
+- Diagnosticado que a tela mostrava a response da OpenAI, mas o card mais recente ficava sem request porque request e response são persistidos em linhas de auditoria separadas do mesmo job.
+- Causa-raiz tratada: a consulta de situação devolvia cada linha isoladamente, então a linha `CONCLUIDO` usada pela tela não herdava o request registrado antes em `AGUARDANDO_RETORNO_MODULO`.
+- Ajuste aplicado: a consulta de situação agora correlaciona registros por página, etapa e `jobId`, exibindo o request auditado junto da linha de response do mesmo job.


### PR DESCRIPTION
### Motivation
- The dossier UI displayed OpenAI `response` but sometimes the matching `request` was missing because request and response are stored in separate audit rows and the query returned rows in isolation.
- The change aims to improve traceability and debugging by making the request visible alongside the response for the same job/step in the dossier audit view.

### Description
- The backend query `DossierSituacaoService.consultar` now collects audit rows and builds a map of the last `request` per job, then correlates requests to responses when producing `DossierSituacaoItem` records by adding `mapearRequestsPorJob`, `chaveJob`, `valorChave` and `requestVisivel` helpers.
- The `toItem` function signature was adjusted to accept a correlated `request` and to prefer the row `request` when present, otherwise use the correlated one.
- Added a regression unit test `consultarCorrelacionaRequestComResponseDoMesmoJob` in `DossierSituacaoServiceTest` that asserts a `CONCLUIDO` response line exposes the `request` persisted earlier in the same job.
- Updated documentation `docs/registros/mois1.md` to register the change and rationale for the MOIS dossier audit fix.

### Testing
- Ran the unit tests for the modified service with `../mvnw -Dtest=DossierSituacaoServiceTest test` and the two tests passed (`Tests run: 2, Failures: 0`).
- Attempted to run `../mvnw spotless:apply` but the project does not have a Spotless plugin bound to that Maven prefix, so formatting step was not applied (non-blocking for functionality).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a4e0494883218c16432c46ba7b8b)