### PR TITLE
Melhora pipeline dossieproduto.v1: evidências comerciais, prompts versionados e orientação por etapa

### DIFF
--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/DossierStageSupport.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/DossierStageSupport.java
@@ -19,8 +19,79 @@ public final class DossierStageSupport {
         evidence.put("workspaceId", context.workspaceId());
         evidence.put("inputKeys", context.input() == null ? java.util.List.of() : context.input().keySet().stream().sorted().toList());
         evidence.put("inputAvailable", context.input() != null && !context.input().isEmpty());
+        evidence.put("commercialContextQuality", commercialContextQuality(context));
+        evidence.put("commercialSignalsFound", commercialSignalsFound(context));
+        evidence.put("stageGuidance", stageGuidance(stageName));
         evidence.put("auditDecision", "Registrar saída estruturada suficiente para o backend persistir relatório e avançar a próxima etapa.");
         return Map.copyOf(evidence);
+    }
+
+    /** Classifica a riqueza comercial do contexto recebido para evitar conclusões fortes com matéria-prima fraca. */
+    private static String commercialContextQuality(StageContext context) {
+        int signals = commercialSignalsFound(context);
+        if (signals >= 5) {
+            return "RICA";
+        }
+        if (signals >= 2) {
+            return "PARCIAL";
+        }
+        return "INSUFICIENTE";
+    }
+
+    /** Conta sinais comerciais presentes no contexto operacional enviado pelo backend. */
+    private static int commercialSignalsFound(StageContext context) {
+        if (context.input() == null || context.input().isEmpty()) {
+            return 0;
+        }
+        String flattened = context.input().toString().toLowerCase(java.util.Locale.ROOT);
+        return (int) java.util.List.of(
+                        "headline",
+                        "promessa",
+                        "produto",
+                        "produtor",
+                        "marca",
+                        "preço",
+                        "preco",
+                        "garantia",
+                        "cta",
+                        "depoimento",
+                        "fonte",
+                        "prova",
+                        "mecanismo",
+                        "obje",
+                        "review")
+                .stream()
+                .filter(flattened::contains)
+                .count();
+    }
+
+    /** Expõe critérios de negócio específicos da etapa para orientar relatório, auditoria e próximos passos. */
+    public static Map<String, Object> stageGuidance(String stageName) {
+        return switch (stageName) {
+            case "intake" -> Map.of(
+                    "expectedDecision", "Triar a página como RICA, PARCIAL ou INSUFICIENTE antes de avançar.",
+                    "mustPreserve", java.util.List.of("headline", "promessa", "preço", "garantia", "CTA", "produtor", "provas", "links externos"));
+            case "investigation-anchor-builder" -> Map.of(
+                    "expectedDecision", "Gerar âncoras por intenção de investigação e priorizar vínculo real com produto/produtor/marca.",
+                    "anchorTypes", java.util.List.of("produto exato", "produtor", "marca", "reviews", "reclamações", "lives", "afiliados", "mecanismo proprietário"));
+            case "warmup-resource-discovery" -> Map.of(
+                    "expectedDecision", "Mapear canais que aquecem a decisão, não apenas links com palavra parecida.",
+                    "commercialRoles", java.util.List.of("descoberta", "educação", "autoridade", "prova social", "objeção", "demonstração", "oferta direta"));
+            case "source-product-match" -> Map.of(
+                    "expectedDecision", "Separar evidência direta, provável, indireta, nicho apenas e descartada.",
+                    "matchCriteria", java.util.List.of("nome exato", "domínio", "produtor", "marca", "CTA", "checkout", "depoimento", "promessa específica"));
+            case "warmup-signal-extraction" -> Map.of(
+                    "expectedDecision", "Extrair sinais de persuasão conectados à fonte que sustenta cada conclusão.",
+                    "signalGroups", java.util.List.of("dor", "promessa", "mecanismo", "prova", "autoridade", "objeções", "distribuição", "linguagem do público"));
+            case "warmup-map-builder" -> Map.of(
+                    "expectedDecision", "Transformar sinais em jornada de aquecimento e matriz de força comercial.",
+                    "scoreDimensions", java.util.List.of("demanda", "clareza da promessa", "mecanismo", "prova", "distribuição", "objeções", "facilidade de compra"));
+            case "dossier-synthesis" -> Map.of(
+                    "expectedDecision", "Concluir como FORTE, PROMISSOR_COM_LACUNAS ou FRACO_OU_INSUFICIENTE com evidências e próximos testes.",
+                    "mustSeparate", java.util.List.of("sucesso observado", "hipóteses pendentes", "o que adaptar", "o que não copiar"));
+            default -> Map.of(
+                    "expectedDecision", "Aplicar Dor → Resultado → Mecanismo → Prova → Oferta com evidência rastreável.");
+        };
     }
 
     /** Cria artefato auditável do objetivo executado sem contaminar o artefato final publicável. */

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class DossierDossierSynthesisProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "dossier-synthesis";
-    private static final String OBJECTIVE = "Consolidar conclusão de negócio, evidências, recursos de aquecimento, recomendação final e próximos passos comerciais para exibição na tela.";
+    private static final String OBJECTIVE = "Consolidar relatório executivo com recomendação final com classificação FORTE, PROMISSOR_COM_LACUNAS ou FRACO_OU_INSUFICIENTE, separando evidências, hipóteses pendentes, oportunidades acionáveis, riscos e próximos testes comerciais.";
     private static final String INSUFFICIENT_CONTEXT_ERROR = "Dossiê final bloqueado: as etapas anteriores não entregaram evidências comerciais suficientes para gerar conclusão, recomendação e próximos passos úteis.";
 
     /** Informa o nome canônico da etapa síntese final do dossiê. */

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/intake/DossierIntakeProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/intake/DossierIntakeProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierIntakeProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "intake";
-    private static final String OBJECTIVE = "Validar se a página possui contexto mínimo para iniciar o dossiê de produto, preservando o texto da página, produto, produtor, promessa, marca e sinais públicos recebidos do backend.";
+    private static final String OBJECTIVE = "Validar contexto mínimo e triar comercialmente a página, classificando a matéria-prima como RICA, PARCIAL ou INSUFICIENTE e preservar headline, promessa, preço, garantia, CTA, produtor, domínio, provas, links e sinais públicos para as próximas etapas.";
 
     /** Informa o nome canônico da etapa entrada inicial. */
     @Override

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/investigationanchorbuilder/DossierInvestigationAnchorBuilderProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/investigationanchorbuilder/DossierInvestigationAnchorBuilderProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierInvestigationAnchorBuilderProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "investigation-anchor-builder";
-    private static final String OBJECTIVE = "Gerar âncoras confiáveis de investigação pública a partir de produto, produtor, domínio, marca, promessa e termos proprietários.";
+    private static final String OBJECTIVE = "Gerar âncoras confiáveis por intenção de investigação — produto exato, produtor, marca, reviews, reclamações, afiliados, lives, anúncios, comunidades e mecanismo proprietário — priorizando vínculo real com o ecossistema da oferta.";
 
     /** Informa o nome canônico da etapa geração de âncoras de investigação. */
     @Override

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
@@ -8,10 +8,13 @@ import com.marketinghub.pipelines.dossie.v1.StageContext;
 import com.marketinghub.pipelines.dossie.v1.StageProcessor;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
 import com.marketinghub.pipelines.dossie.v1.StageResult.OpenAiInteraction;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
@@ -22,7 +25,8 @@ import org.springframework.web.client.RestClient;
 public class DossierProductUnderstandingProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "product-understanding";
-    private static final String OBJECTIVE = "Estruturar produto, público, dor, promessa, mecanismo, formato, oferta e prova antes da pesquisa externa.";
+    private static final String OBJECTIVE = "Estruturar produto, público, dores, promessa, mecanismo, oferta, prova, objeções, urgência e hipótese de sucesso antes da pesquisa externa.";
+    private static final String PROMPT_PATH = "prompts/dossieproduto/v1/product-understanding/prompt.md";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestClient openAiClient;
     private final OpenAiProperties openAiProperties;
@@ -102,10 +106,7 @@ public class DossierProductUnderstandingProcessor implements StageProcessor {
 
     /** Monta o request Responses Flex enviado diretamente à OpenAI para entender o produto. */
     private String buildOpenAiRequest(StageContext context) throws Exception {
-        String prompt = "Entenda o produto para orientar a investigação comercial do dossiê MOIS. "
-                + "Responda em JSON válido com: produto, publico, dor, promessa, mecanismo, formato, oferta, prova, resumo_final. "
-                + "Use Dor → Resultado → Mecanismo → Prova → Oferta. Não invente dados externos; use apenas o contexto recebido. Contexto: "
-                + objectMapper.writeValueAsString(context.input());
+        String prompt = loadPrompt().replace("{{context}}", objectMapper.writeValueAsString(context.input()));
         return objectMapper.writeValueAsString(Map.of(
                 "model", openAiProperties.normalizedModel(),
                 "service_tier", "flex",
@@ -114,9 +115,14 @@ public class DossierProductUnderstandingProcessor implements StageProcessor {
                         "stage_execution_id", Long.toString(context.stageExecutionId()),
                         "dossier_id", Long.toString(context.dossierId())),
                 "input", List.of(
-                        Map.of("role", "system", "content", "Você estrutura entendimento comercial de produto e responde exclusivamente JSON válido sem markdown."),
+                        Map.of("role", "system", "content", "Você estrutura entendimento comercial de produto, protege o dossiê contra inferência sem evidência e responde exclusivamente JSON válido sem markdown."),
                         Map.of("role", "user", "content", prompt)),
                 "text", Map.of("format", Map.of("type", "json_object"))));
+    }
+
+    /** Carrega o prompt versionado da etapa para evitar contrato hardcoded na classe Java. */
+    private String loadPrompt() throws IOException {
+        return new ClassPathResource(PROMPT_PATH).getContentAsString(StandardCharsets.UTF_8);
     }
 
     /** Extrai o texto final retornado pelo endpoint Responses da OpenAI. */

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/sourceproductmatch/DossierSourceProductMatchProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/sourceproductmatch/DossierSourceProductMatchProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierSourceProductMatchProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "source-product-match";
-    private static final String OBJECTIVE = "Classificar se cada fonte externa pertence ao produto, produtor, marca ou recurso de aquecimento antes de virar evidência do dossiê.";
+    private static final String OBJECTIVE = "Classificar cada fonte externa por força de vínculo com produto, produtor, marca, promessa, mecanismo ou checkout, separando DIRETO, PROVAVEL, INDIRETO, NICHO_APENAS e DESCARTADO antes de virar evidência.";
 
     /** Informa o nome canônico da etapa validação de relação fonte-produto. */
     @Override

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupmapbuilder/DossierWarmupMapBuilderProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupmapbuilder/DossierWarmupMapBuilderProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierWarmupMapBuilderProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "warmup-map-builder";
-    private static final String OBJECTIVE = "Organizar os recursos externos por papel no aquecimento do público e indicar lacunas que precisam de nova evidência.";
+    private static final String OBJECTIVE = "Organizar os recursos externos por papel no aquecimento do público e transformar sinais em jornada de aquecimento e matriz de força comercial, avaliando demanda, clareza da promessa, credibilidade do mecanismo, prova, distribuição, objeções, facilidade de compra e lacunas para adaptação.";
 
     /** Informa o nome canônico da etapa montagem do mapa de aquecimento. */
     @Override

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupresourcediscovery/DossierWarmupResourceDiscoveryProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupresourcediscovery/DossierWarmupResourceDiscoveryProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierWarmupResourceDiscoveryProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "warmup-resource-discovery";
-    private static final String OBJECTIVE = "Planejar a descoberta de canais, comunidades, aulas, lives, reviews, afiliados, matérias, páginas auxiliares e provas sociais que aquecem o público.";
+    private static final String OBJECTIVE = "Mapear canais, comunidades, aulas, lives, reviews, afiliados, matérias, páginas auxiliares e provas sociais que aquecem o público, classificando recursos externos por papel comercial no aquecimento — descoberta, educação, autoridade, comunidade, prova social, comparação, objeção, demonstração, captura, oferta direta e remarketing provável.";
 
     /** Informa o nome canônico da etapa descoberta de recursos de aquecimento. */
     @Override

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupsignalextraction/DossierWarmupSignalExtractionProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/warmupsignalextraction/DossierWarmupSignalExtractionProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class DossierWarmupSignalExtractionProcessor implements StageProcessor {
 
     private static final String STAGE_NAME = "warmup-signal-extraction";
-    private static final String OBJECTIVE = "Extrair sinais de autoridade, prova social, educação pré-venda, comunidade, distribuição, objeções e intensidade de aquecimento das fontes qualificadas.";
+    private static final String OBJECTIVE = "Extrair sinais de autoridade, prova social, educação pré-venda, comunidade, distribuição e objeções como sinais de persuasão conectados às fontes: dor explorada, promessa repetida, mecanismo explicado, prova social, autoridade, demonstração, comunidade, objeções, risco, urgência, distribuição e linguagem do público.";
 
     /** Informa o nome canônico da etapa extração de sinais de aquecimento. */
     @Override

--- a/mois-sales-library-worker/src/main/resources/prompts/dossieproduto/v1/product-understanding/prompt.md
+++ b/mois-sales-library-worker/src/main/resources/prompts/dossieproduto/v1/product-understanding/prompt.md
@@ -1,0 +1,34 @@
+Entenda o produto para orientar a investigação comercial do dossiê MOIS.
+
+Use exclusivamente o contexto recebido. Não invente dados externos.
+
+Organize a análise pelo eixo Dor → Resultado → Mecanismo → Prova → Oferta e responda em JSON válido com os campos:
+- produto
+- publico
+- dor_superficie
+- dor_raiz
+- dor_emocional_social
+- ganho_desejado
+- promessa
+- mecanismo
+- formato
+- arquitetura_oferta
+- prova
+- objecao_principal
+- custo_de_nao_agir
+- nivel_consciencia_publico
+- maturidade_dor
+- urgencia
+- desejo_dominante
+- angulo_central
+- porque_agora
+- hipotese_sucesso
+- lacunas
+- resumo_final
+
+A hipótese de sucesso deve seguir o formato: "o produto ganha força porque combina [dor forte] + [resultado desejado] + [mecanismo crível] + [prova/autoridade] + [oferta fácil de comprar]".
+
+Se o contexto não sustentar algum campo, informe claramente "não informado no contexto" e registre a lacuna. Não transforme metadados operacionais em conclusão comercial.
+
+Contexto:
+{{context}}

--- a/mois-sales-library-worker/src/main/resources/prompts/dossieproduto/v1/product-understanding/schema.json
+++ b/mois-sales-library-worker/src/main/resources/prompts/dossieproduto/v1/product-understanding/schema.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "required": ["produto", "publico", "promessa", "mecanismo", "prova", "lacunas", "resumo_final"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
### Motivation

- Evitar conclusões comerciais frágeis quando o backend entrega apenas metadados operacionais e aumentar a auditabilidade das decisões do pipeline dossieproduto.v1.
- Fornecer orientação operacional por etapa para que o worker e o backend preservem sinais comerciais relevantes e tomem decisões de avanço com critério.
- Externalizar e versionar o prompt da etapa `product-understanding` para facilitar iterações do contrato de IA sem hardcode em Java.

### Description

- Adiciona na evidência auditável por etapa a classificação da qualidade do contexto (`commercialContextQuality`), contagem de sinais comerciais (`commercialSignalsFound`) e `stageGuidance` com instruções de negócio (arquivo `DossierStageSupport.java`).
- Torna o `intake` uma triagem comercial explícita que classifica a matéria-prima como `RICA`, `PARCIAL` ou `INSUFICIENTE` e preserva campos essenciais para as próximas etapas (`DossierIntakeProcessor.java`).
- Atualiza os `OBJECTIVE` das etapas intermediárias (`product-understanding`, `investigation-anchor-builder`, `warmup-*`, `source-product-match`, `warmup-map-builder`, `dossier-synthesis`) para mensagens orientadas ao negócio e maior precisão técnica.
- Passa o `product-understanding` a carregar um prompt versionado do classpath (`prompts/dossieproduto/v1/product-understanding/prompt.md`) e adiciona o `schema.json` de validação; a classe Java apenas monta a requisição e registra auditoria (`DossierProductUnderstandingProcessor.java` + novos arquivos de prompt/schema).
- Ajusta a síntese final para produzir classificação final do dossiê (`FORTE`, `PROMISSOR_COM_LACUNAS`, `FRACO_OU_INSUFICIENTE`) e manter o gate que bloqueia conclusões sem evidência (`DossierDossierSynthesisProcessor.java`).

### Testing

- Rodei os testes unitários do módulo `mois-sales-library-worker` com `mvn test -q` e a suíte unitária (incluindo `PipelineWorkerTest`) foi executada com sucesso.
- Não foram alterados testes de outros módulos; validação focada no worker responsável pelas etapas do dossiê.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41c4b0220c83219ff4aaecc5382416)