### PR TITLE
Require collected product context for MOIS dossier and include it in product-understanding pending

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -9,6 +9,7 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service.receberesponse.DossierIntakeRecebeResponseRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.intake.service.receberesponse.DossierIntakeRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import com.marketinghub.repository.jpa.mois.dossieproduto.DossierProductContextGateway;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
 import java.time.Instant;
@@ -22,13 +23,16 @@ import org.springframework.stereotype.Service;
 public class DossierIntakeService {
     private final MoisSalesPageRepository salesPageRepository;
     private final PipelineDossieProdutoRepository pipelineDossieProdutoRepository;
+    private final DossierProductContextGateway productContextGateway;
 
     /** Cria o service da etapa com acesso aos repositórios canônicos da página/produto e da auditoria do pipeline. */
     public DossierIntakeService(
             MoisSalesPageRepository salesPageRepository,
-            PipelineDossieProdutoRepository pipelineDossieProdutoRepository) {
+            PipelineDossieProdutoRepository pipelineDossieProdutoRepository,
+            DossierProductContextGateway productContextGateway) {
         this.salesPageRepository = salesPageRepository;
         this.pipelineDossieProdutoRepository = pipelineDossieProdutoRepository;
+        this.productContextGateway = productContextGateway;
     }
 
     private static final String STAGE_CODE = "intake";
@@ -45,6 +49,9 @@ public class DossierIntakeService {
         String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        if (!productContextGateway.hasCollectedProductContext(pageId)) {
+            throw new IllegalStateException("Dossiê de produto exige HTML, descrição ou resumo coletado antes do início: " + productKey);
+        }
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
         page.setDossieProdutoUpdatedAt(now);

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -9,6 +9,7 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.produc
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import com.marketinghub.repository.jpa.mois.dossieproduto.DossierProductContextGateway;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
 import java.time.Instant;
@@ -22,13 +23,16 @@ import org.springframework.stereotype.Service;
 public class DossierProductUnderstandingService {
     private final MoisSalesPageRepository salesPageRepository;
     private final PipelineDossieProdutoRepository pipelineDossieProdutoRepository;
+    private final DossierProductContextGateway productContextGateway;
 
     /** Cria o service da etapa com acesso aos repositórios canônicos da página/produto e da auditoria do pipeline. */
     public DossierProductUnderstandingService(
             MoisSalesPageRepository salesPageRepository,
-            PipelineDossieProdutoRepository pipelineDossieProdutoRepository) {
+            PipelineDossieProdutoRepository pipelineDossieProdutoRepository,
+            DossierProductContextGateway productContextGateway) {
         this.salesPageRepository = salesPageRepository;
         this.pipelineDossieProdutoRepository = pipelineDossieProdutoRepository;
+        this.productContextGateway = productContextGateway;
     }
 
     private static final String STAGE_CODE = "product-understanding";
@@ -144,19 +148,22 @@ public class DossierProductUnderstandingService {
                 .stream()
                 .map(page -> {
                     String jobId = resolveJobId(String.valueOf(page.getId()));
+                    Map<String, Object> input = new java.util.LinkedHashMap<>(productContextGateway.findContext(page.getId())
+                            .map(DossierProductContextGateway.DossierProductContext::toInputMap)
+                            .orElseGet(Map::of));
+                    input.put("jobId", jobId);
+                    input.put("productKey", String.valueOf(page.getId()));
+                    input.put("pageId", page.getId());
+                    input.put("stageCode", STAGE_CODE);
+                    input.put("status", STATUS_STARTED);
+                    input.put("nextStageCode", NEXT_STAGE);
                     return new DossierProductUnderstandingPendingJob(
                         jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
-                        Map.of(
-                                "jobId", jobId,
-                                "productKey", String.valueOf(page.getId()),
-                                "pageId", page.getId(),
-                                "stageCode", STAGE_CODE,
-                                "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE));
+                        input);
                 })
                 .toList();
         return new DossierProductUnderstandingPendingResponse(!jobs.isEmpty(), jobs);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/DossierProductContextGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/DossierProductContextGateway.java
@@ -1,0 +1,123 @@
+package com.marketinghub.repository.jpa.mois.dossieproduto;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** Lê o contexto coletado da página/produto MOIS para alimentar o pipeline de dossiê. */
+@Repository
+public class DossierProductContextGateway {
+    private final JdbcTemplate jdbcTemplate;
+
+    /** Cria o gateway com acesso JDBC canônico centralizado no pacote de repositórios. */
+    public DossierProductContextGateway(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /** Busca HTML bruto, descrições e resumos já coletados/analisados para uma página de venda. */
+    public Optional<DossierProductContext> findContext(long pageId) {
+        return jdbcTemplate.query("""
+                SELECT p.id AS page_id, p.workspace_id, p.source, p.url_canonical, p.title, p.product_name,
+                       COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name,
+                       COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price,
+                       COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature,
+                       COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer,
+                       COALESCE(cr_direct.hotmart_description, cr_url.hotmart_description) AS hotmart_description,
+                       p.url_final, p.http_status, p.html_sha256, p.html_bytes, p.score_total,
+                       p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       cap.raw_html AS raw_html
+                FROM mois_sales_page p
+                LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
+                LEFT JOIN (
+                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    FROM mois_collected_reference
+                    WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
+                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
+                LEFT JOIN mois_sales_page_capture cap ON cap.id = (
+                    SELECT MAX(cap2.id)
+                    FROM mois_sales_page_capture cap2
+                    WHERE cap2.sales_page_id = p.id
+                      AND cap2.status = 'CAPTURED'
+                      AND COALESCE(cap2.raw_html_bytes, 0) > 0
+                )
+                WHERE p.id = ?
+                LIMIT 1
+                """, rs -> {
+                    if (!rs.next()) return Optional.<DossierProductContext>empty();
+                    return Optional.of(new DossierProductContext(
+                            rs.getLong("page_id"), rs.getString("workspace_id"), rs.getString("source"),
+                            rs.getString("url_canonical"), rs.getString("title"), rs.getString("product_name"),
+                            rs.getString("producer_name"), rs.getString("hotmart_price"), rs.getString("hotmart_temperature"),
+                            rs.getString("hotmart_producer"), rs.getString("hotmart_description"), rs.getString("url_final"),
+                            (Integer) rs.getObject("http_status"), rs.getString("html_sha256"), rs.getLong("html_bytes"),
+                            rs.getString("score_total"), rs.getString("offer_summary"), rs.getString("mechanism_summary"),
+                            rs.getString("promise_summary"), rs.getString("proof_summary"), rs.getString("raw_html")));
+                }, pageId);
+    }
+
+    /** Indica se existe material coletado mínimo para permitir iniciar o dossiê. */
+    public boolean hasCollectedProductContext(long pageId) {
+        return findContext(pageId).map(DossierProductContext::hasCollectedPayload).orElse(false);
+    }
+
+    /** Representa o material coletado/analisado que deve entrar no prompt de entendimento do produto. */
+    public record DossierProductContext(
+            long pageId, String workspaceId, String source, String urlCanonical, String title, String productName,
+            String producerName, String hotmartPrice, String hotmartTemperature, String hotmartProducer,
+            String hotmartDescription, String finalUrl, Integer httpStatus, String htmlSha256, long htmlBytes,
+            String scoreTotal, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary,
+            String rawHtml) {
+
+        /** Verifica se há HTML ou descrições/resumos suficientes para o dossiê trabalhar com evidência real. */
+        public boolean hasCollectedPayload() {
+            return htmlBytes > 0 || hasText(rawHtml) || hasText(hotmartDescription) || hasText(offerSummary)
+                    || hasText(mechanismSummary) || hasText(promiseSummary) || hasText(proofSummary);
+        }
+
+        /** Converte o contexto para Map estável usado no contrato pending entregue ao executor. */
+        public Map<String, Object> toInputMap() {
+            Map<String, Object> values = new LinkedHashMap<>();
+            put(values, "pageId", pageId);
+            put(values, "workspaceId", workspaceId);
+            put(values, "source", source);
+            put(values, "urlCanonical", urlCanonical);
+            put(values, "title", title);
+            put(values, "productName", productName);
+            put(values, "producerName", producerName);
+            put(values, "hotmartPrice", hotmartPrice);
+            put(values, "hotmartTemperature", hotmartTemperature);
+            put(values, "hotmartProducer", hotmartProducer);
+            put(values, "hotmartDescription", hotmartDescription);
+            put(values, "finalUrl", finalUrl);
+            put(values, "httpStatus", httpStatus);
+            put(values, "htmlSha256", htmlSha256);
+            put(values, "htmlBytes", htmlBytes);
+            put(values, "scoreTotal", scoreTotal);
+            put(values, "offerSummary", offerSummary);
+            put(values, "mechanismSummary", mechanismSummary);
+            put(values, "promiseSummary", promiseSummary);
+            put(values, "proofSummary", proofSummary);
+            put(values, "rawHtml", rawHtml);
+            return values;
+        }
+
+        /** Adiciona valor textual ou numérico no mapa preservando apenas campos com conteúdo útil. */
+        private static void put(Map<String, Object> values, String key, Object value) {
+            if (value instanceof String text) {
+                if (StringUtils.hasText(text)) values.put(key, text);
+            } else if (value != null) {
+                values.put(key, value);
+            }
+        }
+
+        /** Verifica texto útil para validar existência de material coletado. */
+        private static boolean hasText(String value) {
+            return StringUtils.hasText(value);
+        }
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1964,3 +1964,9 @@ Arquivos principais:
 - Reorganizado `docs/marketing/pipeline_dossieproduto_v1.md` para que cada etapa do pipeline funcione como capítulo com exemplo real dentro do próprio capítulo.
 - Os exemplos foram distribuídos entre `intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder` e `dossier-synthesis`, usando registros reais pesquisados no banco.
 - Objetivo: facilitar a leitura operacional e comercial de cada etapa, deixando claro o que cada capítulo deve produzir e como interpretar evidência forte, evidência fraca ou bloqueio.
+
+## 2026-06-29 — Contexto coletado obrigatório no dossiê MOIS v1
+
+- Corrigida a entrada do dossiê de produto para impedir início quando a página não possui HTML, descrição ou resumo coletado.
+- A etapa `product-understanding` agora recebe no `pending` o material real do produto: HTML bruto capturado, descrição Hotmart, URL, título, produtor, preço e resumos comerciais já analisados.
+- A tela do dossiê desabilita o botão de reprocessamento quando não existe HTML coletado, evitando gerar análise sem evidência do produto.

--- a/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
@@ -263,14 +263,23 @@ export default function MoisSalesPageDossierPage() {
     "AGUARDANDO",
     "AGUARDANDO_RETORNO_MODULO",
   ].includes(dossierStatus);
+  const hasCollectedProductPayload = Boolean(
+    (pageQuery.data?.htmlBytes ?? 0) > 0 ||
+      cleanText(pageQuery.data?.offerSummary) ||
+      cleanText(pageQuery.data?.mechanismSummary) ||
+      cleanText(pageQuery.data?.promiseSummary) ||
+      cleanText(pageQuery.data?.proofSummary),
+  );
   const isCommercialAnalysisDone = ["DONE", "ANALYZED"].includes(
     pageQuery.data?.analysisStatus || pageQuery.data?.currentStatus || "",
   );
   const dossierRequestBlockReason = hasActiveDossierRequest
     ? "Esta página já possui dossiê em fila ou em processamento; aguarde o backend concluir antes de reprocessar."
-    : !isCommercialAnalysisDone
-      ? "O dossiê só pode iniciar depois que a análise comercial da página estiver concluída."
-      : undefined;
+    : !hasCollectedProductPayload
+      ? "O dossiê só pode iniciar quando existir HTML ou conteúdo coletado do produto."
+      : !isCommercialAnalysisDone
+        ? "O dossiê só pode iniciar depois que a análise comercial da página estiver concluída."
+        : undefined;
   const isDossierRequestDisabled =
     !validPageId ||
     requestDossierMutation.isPending ||
@@ -369,6 +378,12 @@ export default function MoisSalesPageDossierPage() {
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Dossiê v1</div>
                 <strong>{labelStatus(dossierStatus)}</strong>
+              </div>
+            </div>
+            <div className="col-md-3">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">HTML coletado</div>
+                <strong>{pageQuery.data?.htmlBytes ?? 0} bytes</strong>
               </div>
             </div>
             <div className="col-md-3">


### PR DESCRIPTION
### Motivation
- Prevent running the product dossier pipeline when there is no real evidence (HTML, descriptions or summaries) for the product, because the worker prompt must receive actual product material to generate valid analysis. 
- Ensure the `product-understanding` step receives the full collected product context (HTML, Hotmart description, title, URL, producer, price, summaries) instead of only operational metadata so the OpenAI prompt is grounded in evidence.

### Description
- Added `DossierProductContextGateway` (`backend/.../DossierProductContextGateway.java`) to read HTML, collected reference data and summarized fields and expose a `toInputMap()` and `hasCollectedPayload()` helper. 
- Blocked pipeline start in `DossierIntakeService.start` when `productContextGateway.hasCollectedProductContext(pageId)` is false, returning an explicit `IllegalStateException`. 
- Modified `DossierProductUnderstandingService.pending` to include the collected context map into the pending job `input` (so the worker prompt can replace `{{context}}` with real product data). 
- Frontend `MoisSalesPageDossierPage.tsx` now computes `hasCollectedProductPayload`, shows `HTML coletado` bytes, and disables the Reprocess button with a clearer block reason when no collected material exists. 
- Registered the change in `docs/registros/mois1.md` describing the behavioral and documentation updates.

### Testing
- Ran backend unit tests with `../mvnw -Dtest=DossierSituacaoServiceTest,DossierOpenAiTextResponseExtractorTest test` and the tests passed (`Tests run: 4, Failures: 0, Errors: 0`).
- Built the frontend with `npm install` and `npm run build` and the build completed successfully (Vite build produced `dist/` without errors).
- No failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41c9da06ac83219286d01db8ac20bf)