### PR TITLE
Corrige bloqueio do source-searcher NichoCNAE v3 (WhatsApp e resultados utilitários)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-29 — OPRM NichoCNAE v3: diagnóstico do bloqueio no source-searcher
+
+- Diagnóstico do CNAE `4781400`: o job `0a58f188-e5be-445b-bbe4-bdb87c470f6a` não teve falha técnica; ele parou com bloqueio funcional na etapa `source-searcher`, porque nenhuma fonte pública qualificada foi encontrada para sustentar a rotina da persona antes do snapshot.
+- Causa-raiz comprovada: queries derivadas de validações longas como “Validar volume de pedidos...” geravam buscas genéricas e traziam resultados irrelevantes, como calculadoras e dicionários; além disso, a heurística de risco comercial tratava `WhatsApp` como se contivesse o termo isolado `app`, contaminando evidências reais de rotina por canal de atendimento.
+- Correção: o `source-searcher` passou a extrair termos operacionais de comércio por WhatsApp/pedidos/trocas/devoluções, deixou de tratar `app` dentro de `WhatsApp` como risco de solução e passou a marcar resultados utilitários irrelevantes com risco próprio.
+
 ## 2026-06-28 — OPRM NichoCNAE v3: input do request OpenAI separado na auditoria
 
 - Separado o campo `input` do request bruto da OpenAI em `pipeline_nichocnae.request_input`, mantendo o request completo para auditoria e oferecendo leitura direta do prompt enviado.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -187,11 +187,12 @@ public final class SourceSearcherProcessor implements StageProcessor {
         String combined = (title + " " + snippet + " " + url).toLowerCase();
         int routineEvidenceScore = routineEvidenceScore(combined);
         int brazilRelevanceScore = brazilRelevanceScore(url, combined);
-        boolean solutionLanguageRisk = containsAny(combined, List.of("software", "sistema", "app", "aplicativo", "plataforma", "automação", "automacao", "curso", "mentoria", "funil", "landing page", "tráfego pago", "trafego pago", "crm"));
+        boolean solutionLanguageRisk = containsAny(combined, List.of("software", "sistema", "aplicativo", "plataforma", "automação", "automacao", "curso", "mentoria", "funil", "landing page", "tráfego pago", "trafego pago", "crm"));
         boolean commercialPageRisk = containsAny(combined, List.of("preço", "preco", "planos", "contrate", "comprar", "teste grátis", "teste gratis", "demonstração", "demonstracao", "vendas", "marketing digital", "anúncio", "anuncio"));
         boolean structuredBusinessDriftRisk = containsAny(combined, List.of("empresa", "indústria", "industria", "corporativo", "franquia", "grande porte", "gestão empresarial"));
-        int qualityScore = routineEvidenceScore + brazilRelevanceScore - (solutionLanguageRisk ? 35 : 0) - (commercialPageRisk ? 20 : 0) - (structuredBusinessDriftRisk ? 15 : 0);
-        String sourceIntent = sourceIntent(solutionLanguageRisk, commercialPageRisk, combined);
+        boolean irrelevantUtilityRisk = irrelevantUtilityRisk(url, combined);
+        int qualityScore = routineEvidenceScore + brazilRelevanceScore - (solutionLanguageRisk ? 35 : 0) - (commercialPageRisk ? 20 : 0) - (structuredBusinessDriftRisk ? 15 : 0) - (irrelevantUtilityRisk ? 100 : 0);
+        String sourceIntent = sourceIntent(solutionLanguageRisk, commercialPageRisk, irrelevantUtilityRisk, combined);
 
         qualified.put("url", url);
         qualified.put("title", title);
@@ -207,6 +208,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
         qualified.put("commercialPageRisk", commercialPageRisk);
         qualified.put("solutionLanguageRisk", solutionLanguageRisk);
         qualified.put("structuredBusinessDriftRisk", structuredBusinessDriftRisk);
+        qualified.put("irrelevantUtilityRisk", irrelevantUtilityRisk);
         qualified.put("qualityScore", Math.max(0, qualityScore));
         qualified.putIfAbsent("matchedQuery", text(plannedQuery.get("query")));
         qualified.putIfAbsent("queryIntent", text(plannedQuery.get("intent")));
@@ -259,7 +261,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
     /** Mantém termos de operação diária mais fortes para uma variação de busca objetiva. */
     private String operationalQuery(String query) {
         String normalized = normalize(query);
-        List<String> terms = List.of("atendimento", "provador", "estoque", "reposicao", "reposição", "mercadoria", "vitrine", "araras", "etiquetas", "caixa", "loja", "roupas", "acessorios", "acessórios");
+        List<String> terms = List.of("atendimento", "provador", "estoque", "reposicao", "reposição", "mercadoria", "vitrine", "araras", "etiquetas", "caixa", "loja", "roupas", "acessorios", "acessórios", "pagamentos", "comprovantes", "pedidos", "reservas", "trocas", "devolucoes", "devoluções", "entregas", "whatsapp", "instagram");
         StringBuilder builder = new StringBuilder();
         for (String term : terms) {
             if (normalized.contains(normalize(term)) && !builder.toString().contains(term)) {
@@ -342,7 +344,10 @@ public final class SourceSearcherProcessor implements StageProcessor {
     }
 
     /** Classifica semanticamente a fonte separando evidência real de contaminação comercial. */
-    private String sourceIntent(boolean solutionLanguageRisk, boolean commercialPageRisk, String text) {
+    private String sourceIntent(boolean solutionLanguageRisk, boolean commercialPageRisk, boolean irrelevantUtilityRisk, String text) {
+        if (irrelevantUtilityRisk) {
+            return "IRRELEVANT_UTILITY_RISK";
+        }
         if (solutionLanguageRisk || commercialPageRisk) {
             return "CONTAMINATION_RISK";
         }
@@ -353,6 +358,12 @@ public final class SourceSearcherProcessor implements StageProcessor {
             return "ROUTINE_EVIDENCE";
         }
         return "GENERIC_SECTOR_SOURCE";
+    }
+
+    /** Identifica resultados utilitários ou dicionários fora da rotina real do CNAE. */
+    private boolean irrelevantUtilityRisk(String url, String text) {
+        String domain = domain(url);
+        return containsAny(domain + " " + text, List.of("calculator", "calculadora", "dicionario", "dicionário", "sinonimos", "sinônimos", "infopedia", "lexico", "desmos", "app store"));
     }
 
     /** Classifica o tipo operacional da fonte. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
@@ -103,6 +103,52 @@ class SourceSearcherProcessorTest {
                 assertThat(String.valueOf(query)).startsWith("atendimento"));
     }
 
+    /** Usa termos operacionais de pedidos e trocas para evitar buscas genéricas que retornam calculadoras/dicionários. */
+    @Test
+    void shouldSearchOperationalCommerceTermsFromValidationQuery() {
+        SourceSearchClient searchClient = (query, limit) -> List.of(new SourceSearchResult(
+                "Rotina de MEI no Brasil com atendimento por WhatsApp",
+                "https://varejo.example.com.br/whatsapp-pedidos",
+                "MEI relata pedidos, reservas, trocas, clientes, atendimento por WhatsApp e controle manual de estoque.",
+                "TEST_PROVIDER",
+                "<item />"));
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of(
+                        "query", "dificuldade de Validar o volume típico de pedidos dia como a persona controla reservas e trocas devoluções à distância e quais canais digitais predominam WhatsApp Instagram Brasil",
+                        "intent", "DOR_OPERACIONAL",
+                        "objective", "Confirmar dor, esforço manual e consequência prática")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        List<?> attempts = (List<?>) result.output().get("searchAttempts");
+        Map<?, ?> attempt = (Map<?, ?>) attempts.getFirst();
+        assertThat((List<?>) attempt.get("queryVariants")).anySatisfy(query ->
+                assertThat(String.valueOf(query)).startsWith("pedidos reservas trocas"));
+    }
+
+    /** Rejeita resultados utilitários irrelevantes que aparecem em buscas ruidosas de cobrança ou pagamento. */
+    @Test
+    void shouldRejectIrrelevantUtilityResults() {
+        SourceSearchClient searchClient = (query, limit) -> List.of(new SourceSearchResult(
+                "Calculator.net: Free Online Calculators",
+                "https://www.calculator.net/",
+                "Online calculator for quick calculations, finance and math.",
+                "TEST_PROVIDER",
+                "<item />"));
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "pagamentos comprovantes cobrança")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_NAO_COLETADAS");
+        List<?> attempts = (List<?>) result.output().get("searchAttempts");
+        Map<?, ?> attempt = (Map<?, ?>) attempts.getFirst();
+        assertThat((List<?>) attempt.get("rejectedSources")).anySatisfy(rejected -> {
+            Map<?, ?> source = (Map<?, ?>) rejected;
+            assertThat(source.get("sourceIntent")).isEqualTo("IRRELEVANT_UTILITY_RISK");
+            assertThat(source.get("irrelevantUtilityRisk")).isEqualTo(true);
+        });
+    }
+
     /** Registra fontes rejeitadas com motivo para diagnosticar bloqueios sem depender apenas do log técnico. */
     @Test
     void shouldAuditRejectedSourcesWithReason() {


### PR DESCRIPTION
### Motivation
- O pipeline NichoCNAE v3 para o CNAE `4781400` parou em bloqueio funcional na etapa `source-searcher` porque buscas ruidosas não retornavam fontes públicas qualificadas; a heurística atual tratava "WhatsApp" como risco por conter o token `app` e resultados utilitários (p.ex. calculadoras) mascaravam a ausência de evidência real. 

### Description
- Ajusta a heurística de risco para não identificar `app` dentro de `WhatsApp` como `solutionLanguageRisk` e evita contaminação de evidências por canal. 
- Introduz `irrelevantUtilityRisk` para detectar e penalizar resultados utilitários/dicionários (calculadoras, dicionários, app stores) e mapeia esse risco para `sourceIntent = IRRELEVANT_UTILITY_RISK`. 
- Alarga a lista de termos operacionais usados nas variações de busca (`operationalQuery`) para incluir `pedidos`, `reservas`, `trocas`, `devoluções`, `pagamentos`, `whatsapp`, `instagram` entre outros, melhorando a geração de `queryVariants`. 
- Adiciona testes unitários cobrindo o caso de consultas longas com termos de comércio/WhatsApp e rejeição explícita de resultados utilitários, e registra o diagnóstico operacional em `docs/registros/oprm1.md`.

### Testing
- Rodei `mvn test -Dtest=SourceSearcherProcessorTest` e o caso específico do `SourceSearcherProcessorTest` passou sem falhas. 
- Rodei `mvn test` no módulo `oprm-coletor-mei` e todos os testes do módulo (49 testes executados) passaram com sucesso. 
- Os testes automatizados agora cobrem geração de `queryVariants`, qualificação/rejeição de fontes e classificação `IRRELEVANT_UTILITY_RISK`, e foram validados localmente com resultados verdes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41cb1031648321a1cbb1c7ad481b9c)