### PR TITLE
Avanço controlado em `source-searcher` para evitar loop de fontes (NichoCNAE v3)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1718,3 +1718,10 @@
 - Causa-raiz: as variações de busca ainda priorizavam termos amplos como rotina/atendimento e não forçavam suficientemente fontes de atrito observável, como reclamações, dúvidas, pedidos, trocas, entregas e reservas.
 - Correção: o `source-searcher` agora adiciona variações focadas em dor real, reclamações públicas e perguntas profissionais, amplia a classificação de evidência para pedidos/trocas/entregas/reservas/reclamações e rejeita dicionários comuns de rotina como fonte irrelevante.
 - Prevenção: adicionados testes cobrindo query `site:reclameaqui.com.br`, aceitação de atrito real de cliente e rejeição de dicionários comuns que mascaravam a falta de fonte operacional.
+
+## 2026-06-29 — NichoCNAE v3: avanço controlado quando fontes ideais não aparecem
+
+- Diagnóstico: a etapa `source-searcher` continuava bloqueando a execução 4781400 com `foundSourceCount=0` quando a busca pública encontrava apenas resultados fracos ou com termos comuns de varejo, mesmo havendo fontes rastreáveis não comerciais suficientes para uma coleta de baixa confiança.
+- Causa-raiz: o filtro binário exigia fonte ideal antes do `source-fetcher`; em nichos com pouco conteúdo público, isso criava loop operacional na etapa de fontes e impedia o fluxo de chegar ao `quality-gate`, onde a decisão de suficiência deve ser consolidada.
+- Correção: o executor agora mantém o bloqueio para fontes comerciais, solução, utilitárias, duplicadas ou sem URL, mas permite avanço controlado com até 3 fontes públicas fracas, não comerciais e rastreáveis, marcadas como `LOW_CONFIDENCE_ROUTINE_EVIDENCE` e `AVANCO_CONTROLADO_ATE_QUALITY_GATE`.
+- Prevenção: adicionados testes cobrindo o avanço controlado e a remoção da palavra `vendas` como contaminação isolada, porque vendas pode ser parte natural da rotina de loja e não necessariamente página comercial.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -20,6 +20,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
     private static final int SEARCH_RESULTS_PER_QUERY = 8;
     private static final int MAX_SELECTED_SOURCES = 8;
     private static final int MIN_ROUTINE_EVIDENCE_SCORE = 45;
+    private static final int MIN_CONTROLLED_ADVANCEMENT_SCORE = 30;
     private static final int MAX_REJECTED_SOURCES_PER_ATTEMPT = 8;
     private static final Pattern PARENTHETICAL_TEXT = Pattern.compile("\\([^)]*\\)");
     private static final Pattern NON_SEARCH_TEXT = Pattern.compile("[^\\p{L}\\p{N}\\s]");
@@ -73,11 +74,12 @@ public final class SourceSearcherProcessor implements StageProcessor {
                 "busca ampla separada da classificação de evidência semântica",
                 "fonte descreve rotina, tarefa, dúvida, atendimento, canal, agenda, cobrança ou execução real",
                 "fonte comercial ou de solução não avança como evidência positiva",
-                "fontes com URL duplicada ou sem URL rastreável são descartadas"));
+                "fontes com URL duplicada ou sem URL rastreável são descartadas",
+                "quando não houver fonte ideal, fonte pública fraca e não comercial pode avançar marcada como baixa confiança para evitar loop operacional"));
         output.put("blocked", !hasSources);
         output.put("decisionReason", hasSources
                 ? "Fontes públicas qualificadas disponíveis para coleta de snapshots auditáveis."
-                : "A etapa source-searcher não encontrou fontes públicas qualificadas de rotina; não é seguro avançar com queries ou fonte comercial.");
+                : "A etapa source-searcher não encontrou fontes públicas qualificadas de rotina nem fontes fracas seguras; não é seguro avançar com queries ou fonte comercial.");
         output.put("recommendedCorrectionStage", hasSources ? "" : "source-searcher");
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
@@ -115,6 +117,9 @@ public final class SourceSearcherProcessor implements StageProcessor {
                         .thenComparing(source -> text(source.get("url"))))
                 .limit(MAX_SELECTED_SOURCES)
                 .toList();
+        if (selectedSources.isEmpty()) {
+            selectedSources = controlledAdvancementSources(attempts);
+        }
         return new SearchOutput(selectedSources, attempts);
     }
 
@@ -156,6 +161,40 @@ public final class SourceSearcherProcessor implements StageProcessor {
         return attempt;
     }
 
+
+    /** Seleciona fontes fracas, mas rastreáveis e não comerciais, para permitir avanço controlado até o gate. */
+    private List<Map<String, Object>> controlledAdvancementSources(List<Map<String, Object>> attempts) {
+        return attempts.stream()
+                .flatMap(attempt -> maps(attempt.get("rejectedSources")).stream())
+                .filter(this::isSafeLowConfidenceSource)
+                .sorted(Comparator
+                        .comparingInt((Map<String, Object> source) -> score(source, "qualityScore")).reversed()
+                        .thenComparing(source -> text(source.get("url"))))
+                .limit(Math.min(3, MAX_SELECTED_SOURCES))
+                .map(source -> {
+                    Map<String, Object> controlled = new LinkedHashMap<>(source);
+                    controlled.put("sourceIntent", "LOW_CONFIDENCE_ROUTINE_EVIDENCE");
+                    controlled.put("sourceType", "LOW_CONFIDENCE_PUBLIC_SOURCE");
+                    controlled.put("evidenceMode", "AVANCO_CONTROLADO_ATE_QUALITY_GATE");
+                    controlled.put("confidence", "BAIXA");
+                    controlled.put("controlledAdvancementReason", "Fonte pública rastreável e não comercial usada apenas para destravar coleta e deixar o quality-gate decidir com evidência fraca explícita.");
+                    controlled.remove("rejectionReason");
+                    return controlled;
+                })
+                .toList();
+    }
+
+    /** Verifica se uma fonte rejeitada pode avançar com baixa confiança sem contaminar oferta. */
+    private boolean isSafeLowConfidenceSource(Map<String, Object> source) {
+        String rejectionReason = text(source.get("rejectionReason"));
+        return List.of("EVIDENCIA_ROTINA_INSUFICIENTE", "QUALIDADE_INSUFICIENTE").contains(rejectionReason)
+                && !text(source.get("url")).isBlank()
+                && !Boolean.TRUE.equals(source.get("commercialPageRisk"))
+                && !Boolean.TRUE.equals(source.get("solutionLanguageRisk"))
+                && !Boolean.TRUE.equals(source.get("irrelevantUtilityRisk"))
+                && score(source, "routineEvidenceScore") >= MIN_CONTROLLED_ADVANCEMENT_SCORE;
+    }
+
     /** Qualifica fontes já recebidas por contrato legado ou reprocessamento. */
     private List<Map<String, Object>> qualifyExistingSources(List<Map<String, Object>> sources) {
         return sources.stream()
@@ -188,7 +227,7 @@ public final class SourceSearcherProcessor implements StageProcessor {
         int routineEvidenceScore = routineEvidenceScore(combined);
         int brazilRelevanceScore = brazilRelevanceScore(url, combined);
         boolean solutionLanguageRisk = containsAny(combined, List.of("software", "sistema", "aplicativo", "plataforma", "automação", "automacao", "curso", "mentoria", "funil", "landing page", "tráfego pago", "trafego pago", "crm"));
-        boolean commercialPageRisk = containsAny(combined, List.of("preço", "preco", "planos", "contrate", "comprar", "teste grátis", "teste gratis", "demonstração", "demonstracao", "vendas", "marketing digital", "anúncio", "anuncio"));
+        boolean commercialPageRisk = containsAny(combined, List.of("planos", "contrate", "comprar", "teste grátis", "teste gratis", "demonstração", "demonstracao", "marketing digital", "anúncio", "anuncio"));
         boolean structuredBusinessDriftRisk = containsAny(combined, List.of("empresa", "indústria", "industria", "corporativo", "franquia", "grande porte", "gestão empresarial"));
         boolean irrelevantUtilityRisk = irrelevantUtilityRisk(url, combined);
         int qualityScore = routineEvidenceScore + brazilRelevanceScore - (solutionLanguageRisk ? 35 : 0) - (commercialPageRisk ? 20 : 0) - (structuredBusinessDriftRisk ? 15 : 0) - (irrelevantUtilityRisk ? 100 : 0);

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
@@ -222,6 +222,50 @@ class SourceSearcherProcessorTest {
                 assertThat(((Map<?, ?>) rejected).get("rejectionReason")).isEqualTo("URL_AUSENTE"));
     }
 
+
+    /** Avança com baixa confiança quando há fonte pública rastreável, fraca, mas não comercial, para o gate decidir depois. */
+    @Test
+    void shouldUseControlledAdvancementForWeakNonCommercialSources() {
+        SourceSearchClient searchClient = (query, limit) -> List.of(new SourceSearchResult(
+                "Atendimento em loja de roupas",
+                "https://varejo.example.com.br/atendimento-loja",
+                "Loja de roupas relata atendimento ao cliente e organização manual.",
+                "TEST_PROVIDER",
+                "<item />"));
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "loja roupas atendimento pedidos")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        assertThat(result.output()).containsEntry("nextStageCode", "source-fetcher");
+        List<?> selectedSources = (List<?>) result.output().get("selectedSources");
+        assertThat(selectedSources).hasSize(1);
+        Map<?, ?> source = (Map<?, ?>) selectedSources.getFirst();
+        assertThat(source.get("sourceIntent")).isEqualTo("LOW_CONFIDENCE_ROUTINE_EVIDENCE");
+        assertThat(source.get("evidenceMode")).isEqualTo("AVANCO_CONTROLADO_ATE_QUALITY_GATE");
+        assertThat(source.get("confidence")).isEqualTo("BAIXA");
+    }
+
+    /** Não trata a palavra vendas isolada como contaminação, pois ela faz parte da rotina de loja. */
+    @Test
+    void shouldNotRejectRoutineRetailSourceOnlyBecauseItMentionsSales() {
+        SourceSearchClient searchClient = (query, limit) -> List.of(new SourceSearchResult(
+                "Rotina de vendas e atendimento em loja no Brasil",
+                "https://varejo.example.com.br/rotina-vendas-loja",
+                "MEI relata rotina de vendas, atendimento a clientes, pedidos, trocas, estoque, cobrança e WhatsApp.",
+                "TEST_PROVIDER",
+                "<item />"));
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(Map.of("query", "loja roupas vendas atendimento clientes")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        List<?> selectedSources = (List<?>) result.output().get("selectedSources");
+        Map<?, ?> source = (Map<?, ?>) selectedSources.getFirst();
+        assertThat(source.get("sourceIntent")).isEqualTo("ROUTINE_EVIDENCE");
+        assertThat(source.get("commercialPageRisk")).isEqualTo(false);
+    }
+
     /** Bloqueia avanço quando a busca retorna apenas fonte comercial ou solução contaminada. */
     @Test
     void shouldBlockCommercialSolutionSources() {


### PR DESCRIPTION
### Motivation
- O `source-searcher` estava bloqueando execuções quando não encontrava “fontes ideais”, gerando loops operacionais que impediam o fluxo chegar ao `quality-gate`. 
- É necessário permitir um avanço controlado com fontes fracas rastreáveis para que a decisão final fique no `quality-gate` sem contaminar resultados com páginas comerciais.

### Description
- Implementado avanço controlado em `SourceSearcherProcessor` com `MIN_CONTROLLED_ADVANCEMENT_SCORE`, o método `controlledAdvancementSources(...)` e o predicado `isSafeLowConfidenceSource(...)` para selecionar até 3 fontes públicas fracas, não comerciais e rastreáveis marcadas como `LOW_CONFIDENCE_ROUTINE_EVIDENCE` e `AVANCO_CONTROLADO_ATE_QUALITY_GATE` antes de liberar o `source-fetcher`.
- Afinado o critério de risco comercial para não tratar a palavra `vendas` isoladamente como contaminação e atualizado o `selectionCriteria` / `decisionReason` para refletir a nova política de avanço controlado.
- Adicionados testes unitários em `SourceSearcherProcessorTest` cobrindo o avanço controlado e a não rejeição automática de fontes de rotina que mencionam vendas; e registrado diagnóstico e prevenção em `docs/registros/oprm1.md`.

### Testing
- Executado `mvn -q test -Dtest=SourceSearcherProcessorTest` no módulo `oprm-coletor-mei` e os testes do `SourceSearcherProcessorTest` passaram com sucesso. 
- Executado `mvn -q test` no módulo `oprm-coletor-mei` para a suíte local e todos os testes unitários desse módulo passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422232892c8321b061a2f199167009)