### PR TITLE
Corrige bloqueio indevido da síntese do dossiê MOIS

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1990,3 +1990,10 @@ Arquivos principais:
 - Causa-raiz tratada: o gateway de contexto do dossiê consultava a tabela legada/inexistente `mois_sales_page_capture`; o modelo operacional atual grava captura em `mois_sales_page_job_execution`.
 - Ajuste aplicado: o start do dossiê passa a buscar HTML bruto na tabela operacional canônica de jobs, filtrando etapa `CAPTURE`, status `CAPTURED`/`DUPLICATE` e bytes positivos.
 - Prevenção de recorrência: adicionado teste de regressão garantindo que o gateway não volte a usar a tabela antiga.
+
+## 2026-06-29 — Correção do bloqueio indevido da síntese final do dossiê MOIS v1
+
+- Diagnosticado no produto 288 que a etapa `dossier-synthesis` falhou mesmo recebendo respostas anteriores com sinais comerciais.
+- Causa-raiz tratada: a validação da síntese final rejeitava qualquer resposta que também contivesse metadados técnicos de auditoria (`auditDecision`, `inputKeys`, `stageExecutionId`), anulando evidências comerciais reais presentes no mesmo payload.
+- Ajuste aplicado: a síntese final passa a bloquear somente quando não houver marcadores comerciais suficientes, mantendo os metadados técnicos como auditoria sem contaminar a decisão funcional.
+- Prevenção de recorrência: adicionado teste de regressão com evidências comerciais misturadas a metadados técnicos.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
@@ -91,7 +91,6 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
             return false;
         }
         String joined = String.join(" ", stageResponses).toLowerCase();
-        boolean hasOnlyOperationalMarkers = joined.contains("auditdecision") && joined.contains("inputkeys") && joined.contains("stageexecutionid");
         boolean hasBusinessMarkers = joined.contains("promessa")
                 || joined.contains("público")
                 || joined.contains("publico")
@@ -101,7 +100,7 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
                 || joined.contains("recomendacao")
                 || joined.contains("risco")
                 || joined.contains("prova");
-        return hasBusinessMarkers && !hasOnlyOperationalMarkers;
+        return hasBusinessMarkers;
     }
 
     /** Cria o artefato final separado dos metadados técnicos de auditoria. */

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/pipelines/dossie/v1/PipelineWorkerTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/pipelines/dossie/v1/PipelineWorkerTest.java
@@ -61,6 +61,24 @@ class PipelineWorkerTest {
         assertThat(String.valueOf(result.output())).contains("BLOCKED_INSUFFICIENT_CONTEXT");
     }
 
+
+    /** Garante que metadados de auditoria não anulam evidências comerciais reais recebidas das etapas anteriores. */
+    @Test
+    void deveAprovarSinteseFinalComEvidenciasComerciaisEAuditoriaTecnica() {
+        PipelineWorker worker = new PipelineWorker(processorsCanonicos());
+        StageContext context = new StageContext(10L, 20L, "workspace-mois", "dossier-synthesis", Map.of(
+                "previousStageResponses", List.of(
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, promessa=resultado claro para o público}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, evidência=prova social e autoridade}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, recomendação=avançar com risco controlado}")));
+
+        StageResult result = worker.execute(context);
+
+        assertThat(result.status()).isEqualTo("DONE");
+        assertThat(result.errorMessage()).isNull();
+        assertThat(String.valueOf(result.output())).contains("OBJECTIVE_FULFILLED");
+    }
+
     /** Garante bloqueio explícito quando o backend enviar etapa sem processor registrado no executor. */
     @Test
     void deveBloquearEtapaSemProcessorRegistrado() {


### PR DESCRIPTION
### Motivation

- A etapa `dossier-synthesis` estava bloqueando conclusões quando o payload continha metadados de auditoria (`auditDecision`, `inputKeys`, `stageExecutionId`), mesmo havendo evidências comerciais úteis no mesmo conteúdo. 
- É necessário que a regra de aceitação da síntese final permita evidências comerciais reais mesmo quando misturadas com metadados técnicos de auditoria para evitar falsos negativos operacionais.

### Description

- Altere a validação em `mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java` removendo a condição que rejeitava respostas contendo apenas marcadores operacionais e passando a aceitar quaisquer respostas que contenham marcadores comerciais (`promessa`, `público`, `evidência`, `recomendação`, `risco`, `prova`).
- Adicionado teste de regressão em `mois-sales-library-worker/src/test/java/com/marketinghub/pipelines/dossie/v1/PipelineWorkerTest.java` verificando que evidências comerciais misturadas com `auditDecision`/`inputKeys`/`stageExecutionId` aprovam a síntese final.
- Atualizado registro de investigação em `docs/registros/mois1.md` com diagnóstico, causa-raiz e prevenção de recorrência do problema.

### Testing

- Executado `mvn test -Dtest=PipelineWorkerTest` no módulo `mois-sales-library-worker` com resultado de sucesso (`Tests run: 4, Failures: 0, Errors: 0`).
- Tentativa de `./mvnw test -Dtest=PipelineWorkerTest` não foi executada porque o wrapper `mvnw` não existe no módulo, portanto os testes foram rodados com `mvn` do ambiente e passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42294ae8708321a55446c57de9bb3d)