### PR TITLE
Separar texto gerado (OpenAI) da auditoria técnica e adicionar dossiê final na UI

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1997,3 +1997,9 @@ Arquivos principais:
 - Causa-raiz tratada: a validação da síntese final rejeitava qualquer resposta que também contivesse metadados técnicos de auditoria (`auditDecision`, `inputKeys`, `stageExecutionId`), anulando evidências comerciais reais presentes no mesmo payload.
 - Ajuste aplicado: a síntese final passa a bloquear somente quando não houver marcadores comerciais suficientes, mantendo os metadados técnicos como auditoria sem contaminar a decisão funcional.
 - Prevenção de recorrência: adicionado teste de regressão com evidências comerciais misturadas a metadados técnicos.
+
+## 2026-06-29 — Leitura limpa do dossiê de produto na tela MOIS
+
+- Ajustada a tela do dossiê de produto para separar o texto gerado pela OpenAI do response técnico em cada etapa.
+- O response técnico agora mantém visão JSON com collapse sem despejar o campo textual longo dentro do card de auditoria.
+- Adicionado quadro de dossiê final do produto com a síntese limpa da etapa `dossier-synthesis`, facilitando decisão comercial sem misturar metadados de auditoria.

--- a/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageDossierPage.tsx
@@ -318,6 +318,59 @@ function extractOpenAiOutputText(value?: string | null) {
   return undefined;
 }
 
+function prettyPrintJsonText(value: string) {
+  const trimmed = value.trim();
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return trimmed;
+  }
+}
+
+function removeOpenAiTextFields(value?: string | null) {
+  if (!value) return value;
+  try {
+    const root = JSON.parse(value) as {
+      output_text?: unknown;
+      output?: Array<{ content?: Array<{ text?: unknown }> }>;
+    };
+    let removed = false;
+    if (typeof root.output_text === "string" && root.output_text.trim()) {
+      root.output_text =
+        "Texto removido da auditoria técnica e exibido no quadro separado abaixo.";
+      removed = true;
+    }
+    for (const item of root.output || []) {
+      for (const content of item.content || []) {
+        if (typeof content.text === "string" && content.text.trim()) {
+          content.text =
+            "Texto removido da auditoria técnica e exibido no quadro separado abaixo.";
+          removed = true;
+        }
+      }
+    }
+    return removed ? JSON.stringify(root, null, 2) : value;
+  } catch {
+    return value;
+  }
+}
+
+function generatedStageText(stage: DossierStageView) {
+  const text = extractOpenAiOutputText(stage.latest?.response);
+  return text ? prettyPrintJsonText(text) : undefined;
+}
+
+function finalDossierText(stages: DossierStageView[]) {
+  const finalStage = stages.find(
+    (stage) =>
+      (
+        stage.code === "dossier-synthesis" &&
+        stage.latest?.status === "CONCLUIDO"
+      ),
+  );
+  return finalStage ? generatedStageText(finalStage) : undefined;
+}
+
 function hasUsefulPayload(value?: string | null) {
   return Boolean(value && value.trim() && value.trim() !== "{}");
 }
@@ -412,6 +465,7 @@ export default function MoisSalesPageDossierPage() {
   const currentDossierStageView = dossierPipelineStages.find(
     (stage) => stage.code === dossierStage,
   );
+  const cleanFinalDossier = finalDossierText(dossierPipelineStages);
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -530,6 +584,26 @@ export default function MoisSalesPageDossierPage() {
           ) : null}
         </div>
       </section>
+
+      {cleanFinalDossier ? (
+        <section className="card border-success shadow-sm">
+          <div className="card-body d-flex flex-column gap-3">
+            <div>
+              <h2 className="h5 mb-1">Dossiê final do produto</h2>
+              <p className="text-secondary mb-0">
+                Texto final limpo gerado pela síntese do pipeline, separado da
+                auditoria técnica.
+              </p>
+            </div>
+            <pre
+              className="bg-body-tertiary border rounded p-3 mb-0"
+              style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}
+            >
+              {cleanFinalDossier}
+            </pre>
+          </div>
+        </section>
+      ) : null}
 
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
@@ -688,21 +762,24 @@ export default function MoisSalesPageDossierPage() {
                                 {responseLabel(stage)}
                               </h4>
                               <TechnicalPayloadReader
-                                content={stage.latest.response}
+                                content={removeOpenAiTextFields(
+                                  stage.latest.response,
+                                )}
                               />
                             </div>
                           </div>
-                          {isOpenAiAudit(stage) &&
-                          extractOpenAiOutputText(stage.latest.response) ? (
+                          {isOpenAiAudit(stage) && generatedStageText(stage) ? (
                             <div className="col-12">
                               <div className="border rounded p-3 h-100 bg-white text-body">
                                 <h4 className="h6 mb-2">
-                                  Texto final da OpenAI
+                                  Texto gerado pela etapa
                                 </h4>
+                                <p className="small text-secondary mb-2">
+                                  Conteúdo textual separado do response técnico,
+                                  com visão JSON e collapse quando aplicável.
+                                </p>
                                 <CollapsibleJsonViewer
-                                  content={extractOpenAiOutputText(
-                                    stage.latest.response,
-                                  )}
+                                  content={generatedStageText(stage)}
                                   initiallyCollapsed
                                 />
                               </div>


### PR DESCRIPTION
### Motivation
- Evitar que campos textuais longos gerados por IA contaminem a visão técnica de auditoria e melhorar a leitura comercial do dossiê; o objetivo é separar metadados técnicos da saída textual final. 
- Fornecer um quadro limpo com a síntese final do pipeline (`dossier-synthesis`) para decisão comercial sem expor artefatos técnicos dentro do mesmo payload. 

### Description
- Extrai e isola o texto gerado pela OpenAI do campo técnico do `response` e substitui o campo textual dentro da auditoria por um aviso com `removeOpenAiTextFields`, preservando a visão JSON colapsável para a auditoria técnica. 
- Adiciona componentes utilitários `prettyPrintJsonText`, `generatedStageText` e `finalDossierText` para formatar e expor o texto gerado pelas etapas quando aplicável. 
- Insere um novo quadro `Dossiê final do produto` que exibe a síntese limpa da etapa `dossier-synthesis` separada do response técnico, e adiciona um bloco "Texto gerado pela etapa" em cada card quando houver conteúdo textual útil. 
- Atualiza o registro operacional em `docs/registros/mois1.md` documentando a mudança de leitura do dossiê e alterações na UI. 

### Testing
- Executado `npm --prefix frontend run typecheck` e o comando completou com sucesso (sem erros de TypeScript). 
- Executado `npm --prefix frontend run build` e a build de produção do frontend foi gerada com sucesso. 
- Não houve falhas automáticas reportadas durante os passos de `typecheck` e `build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a429a99f0a483218eb71400c38d686b)