### PR TITLE
Allow SALES in experiment.campaign_objective enum (fix low-ticket experiment create)

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-30-experiment-campaign-objective-sales.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-30-experiment-campaign-objective-sales.yaml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-30-experiment-campaign-objective-sales
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment
+        - columnExists:
+            tableName: experiment
+            columnName: campaign_objective
+        - sqlCheck:
+            expectedResult: 1
+            sql: >
+              SELECT CASE
+                WHEN COLUMN_TYPE LIKE '%SALES%' THEN 0
+                ELSE 1
+              END
+              FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'experiment'
+                AND COLUMN_NAME = 'campaign_objective'
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: >
+              ALTER TABLE experiment
+              MODIFY campaign_objective ENUM('LEADS','TRAFFIC','SALES') NOT NULL
+      rollback:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: >
+              ALTER TABLE experiment
+              MODIFY campaign_objective ENUM('LEADS','TRAFFIC') NOT NULL

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-30-experiment-campaign-objective-sales.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-29-experiment-type-low-ticket.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5498,3 +5498,10 @@
 - Solicitação: retirar da aba Conteúdo do experimento o card “Contexto do framework da hipótese”, que ocupava espaço e repetia os resumos de Dor, Resultado, Mecanismo, Prova e Oferta.
 - Ajuste aplicado: o frontend deixou de renderizar esse card na aba de geração de conteúdo, mantendo o botão de relatório consolidado e os painéis operacionais da tela.
 - Prevenção de recorrência: removida também a montagem local dos cards, evitando manter lógica visual sem uso na tela.
+
+## 2026-06-30 — Correção da criação de experimento low ticket
+
+- solicitação: investigar erro `500 Internal Server Error` ao criar experimento do tipo low ticket pela tela `/experiments/new`.
+- causa-raiz confirmada: o backend resolvia experimento `LOW_TICKET_PRODUCT` para `campaignObjective=SALES`, mas o schema real da coluna `experiment.campaign_objective` ainda aceitava apenas `LEADS` e `TRAFFIC`, causando falha de persistência no `POST /api/experiments`.
+- correção aplicada: criado changelog incremental para ampliar o enum MySQL da coluna `campaign_objective` e aceitar `SALES`, mantendo o contrato Java já existente.
+- prevenção de recorrência: o changelog valida a coluna no `INFORMATION_SCHEMA` antes da alteração e fica incluído no master com `relativeToChangelogFile: true`.


### PR DESCRIPTION
### Motivation
- Creating a `LOW_TICKET_PRODUCT` experiment failed with a 500 because Java resolves `campaignObjective=SALES` while the MySQL `experiment.campaign_objective` enum schema only allowed `LEADS` and `TRAFFIC`.
- The change ensures database enum matches the Java contract to prevent persistence errors when creating low-ticket experiments.

### Description
- Added a Liquibase changeset `changesets/2026-06-30-experiment-campaign-objective-sales.yaml` that alters `experiment.campaign_objective` to `ENUM('LEADS','TRAFFIC','SALES') NOT NULL` with a guarded `sqlCheck` precondition.
- Included the new changeset in `db.changelog-master.yaml` with `relativeToChangelogFile: true` to follow Liquibase include conventions.
- Documented the investigation, root cause and mitigation in `docs/registros/experimentos.md`.

### Testing
- Ran `ExperimentServiceTest` (`backend/ads-service`) and all tests passed: 22 tests, 0 failures (BUILD SUCCESS). 
- Verified `db.changelog-master.yaml` includes the new changeset and each `include` has `relativeToChangelogFile: true` (custom validation passed). 
- Ran `git diff --check` with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a430c75f1908321828476c53a5b138f)