### PR TITLE
Update test assertions to match revised experiment prompt guidance

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -121,7 +121,11 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("Prompt de anuncio");
         assertThat(userPrompt).contains(readPromptTemplateBody("prompts/experiment/ad-copy.md"));
         assertThat(userPrompt).contains("CONTRATO_PROMESSA_UNICA");
-        assertThat(userPrompt).contains("Todas as variações devem convidar para a mesma recompensa gratuita");
+        assertThat(userPrompt)
+                .contains("campaignObjective")
+                .contains("LEADS")
+                .contains("mesma recompensa gratuita")
+                .contains("não alternar entre diagnóstico, prévia, material, sistema completo ou outra entrega");
         assertThat(userPrompt).doesNotContain("template_id:");
         assertThat(userPrompt).doesNotContain("proofSummary,");
     }


### PR DESCRIPTION
### Motivation
- Align the unit test expectations with updated experiment prompt guidance which now includes campaign objective metadata and explicit instructions about output types.

### Description
- Update `ExperimentPipelineOpenAiClientTest` assertions to verify the generated prompt contains `campaignObjective`, `LEADS`, the phrase "mesma recompensa gratuita", and the new instruction "não alternar entre diagnóstico, prévia, material, sistema completo ou outra entrega", while preserving checks that `template_id:` and `proofSummary,` are not present.

### Testing
- Ran the unit test `ExperimentPipelineOpenAiClientTest` and the project's test suite; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a431a788b60832188ac2ef5122cf90e)