### PR TITLE
[codex] Generaliza rotas de obrigado dos experimentos

### DIFF
--- a/lead-portal-payments-service/nginx.conf
+++ b/lead-portal-payments-service/nginx.conf
@@ -129,7 +129,7 @@ server {
         try_files $uri =404;
     }
 
-    location ^~ /obrigado-exp51- {
+    location ^~ /obrigado-exp {
         root /usr/share/nginx/html;
         try_files $uri =404;
     }


### PR DESCRIPTION
## O que mudou

- Generaliza a regra do Nginx de `/obrigado-exp51-` para `/obrigado-exp` no `lead-portal-payments-service`.

## Por que mudou

A correção operacional aplicada no VPS mostrou que novos experimentos, como o 52, podem publicar páginas premium de pós-compra no padrão `obrigado-exp*.html`. Com a regra fixa no experimento 51, o arquivo existia no servidor, mas a URL pública caía no backend e retornava `404`.

## Impacto

- Novos experimentos publicados pelo Marketing Hub passam a ter página de obrigado servida pelo proxy sem exigir ajuste Nginx específico por experimento.
- Reduz o risco de regressão no próximo deploy do `lead-portal-payments-service`.

## Validação

- `git diff --check`
- Validação pública atual:
  - `https://pagamentopalf.site/obrigado-exp51-mapa-recorrencia-7d.html?experimentId=51&status=success` retornou `200`
  - `https://pagamentopalf.site/obrigado-exp52-protocolo-manutencao-segura-7d.html?experimentId=52&status=success` retornou `200`

## Limitação

Não rodei `nginx -t` localmente porque este ambiente não possui Nginx instalado.