### PR TITLE
[codex] Gate low-ticket campaigns on GeraSalesPage pipeline

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiCostEstimator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiCostEstimator.java
@@ -19,24 +19,31 @@ public class OpenAiCostEstimator {
 
     /** Estima o custo usando o modelo efetivo do request e os preços batch/flex cadastrados no banco. */
     public BigDecimal estimate(String model, Integer inputTokens, Integer outputTokens) {
+        return estimate(model, inputTokens, outputTokens, "flex");
+    }
+
+    /** Estima o custo usando o modo de preço correspondente ao service tier da etapa. */
+    public BigDecimal estimate(String model, Integer inputTokens, Integer outputTokens, String serviceTier) {
         OpenAiModelPricingCatalogClient.OpenAiModelPricing pricing = pricingCatalogClient.findByCode(model)
                 .orElseThrow(() -> new StageWorkerException(
                         "Modelo OpenAI não encontrado no catálogo persistido para cálculo de custo: " + model));
-        return estimateWithPricing(pricing, inputTokens, outputTokens);
+        return estimateWithPricing(pricing, inputTokens, outputTokens, serviceTier);
     }
 
     /** Aplica a tarifa por milhão de tokens aos totais de entrada e saída retornados pela OpenAI. */
     private BigDecimal estimateWithPricing(
             OpenAiModelPricingCatalogClient.OpenAiModelPricing pricing,
             Integer inputTokens,
-            Integer outputTokens
+            Integer outputTokens,
+            String serviceTier
     ) {
+        boolean standard = "default".equalsIgnoreCase(serviceTier) || "standard".equalsIgnoreCase(serviceTier);
         BigDecimal input = BigDecimal.valueOf(inputTokens == null ? 0 : inputTokens)
-                .multiply(nullToZero(pricing.priceInputBatch()))
+                .multiply(nullToZero(standard ? pricing.priceInputStandard() : pricing.priceInputBatch()))
                 .divide(ONE_MILLION, 8, RoundingMode.HALF_UP);
 
         BigDecimal output = BigDecimal.valueOf(outputTokens == null ? 0 : outputTokens)
-                .multiply(nullToZero(pricing.priceOutputBatch()))
+                .multiply(nullToZero(standard ? pricing.priceOutputStandard() : pricing.priceOutputBatch()))
                 .divide(ONE_MILLION, 8, RoundingMode.HALF_UP);
 
         return input.add(output).setScale(8, RoundingMode.HALF_UP);

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiModelPricingCatalogClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiModelPricingCatalogClient.java
@@ -90,9 +90,11 @@ public class OpenAiModelPricingCatalogClient {
         return modelCode.trim().toLowerCase(Locale.ROOT);
     }
 
-    /** DTO mínimo do catálogo backend com preços batch/flex por milhão de tokens. */
+    /** DTO mínimo do catálogo backend com preços standard e batch/flex por milhão de tokens. */
     public record OpenAiModelPricing(
             String code,
+            BigDecimal priceInputStandard,
+            BigDecimal priceOutputStandard,
             BigDecimal priceInputBatch,
             BigDecimal priceOutputBatch
     ) {}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -89,7 +89,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     modelResponse,
                     inputTokens,
                     outputTokens,
-                    costEstimator.estimate(request.model(), inputTokens, outputTokens)
+                    costEstimator.estimate(request.model(), inputTokens, outputTokens, request.serviceTier())
             );
 
             if (openAiJobId != null) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
@@ -26,17 +26,20 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
     private final GeraSalesPageResponseValidator responseValidator;
     private final GeraSalesPageBackendClient backendClient;
     private final PromptTemplateResolver promptTemplateResolver;
+    private final String serviceTier;
 
     /** Inicializa o processor com dependências de OpenAI, validação e auditoria no backend. */
     public GeraSalesPageProcessor(
             ObjectMapper objectMapper,
             OpenAiClientPort openAiClient,
             GeraSalesPageResponseValidator responseValidator,
-            GeraSalesPageBackendClient backendClient) {
+            GeraSalesPageBackendClient backendClient,
+            String serviceTier) {
         this.objectMapper = objectMapper;
         this.openAiClient = openAiClient;
         this.responseValidator = responseValidator;
         this.backendClient = backendClient;
+        this.serviceTier = normalizeServiceTier(serviceTier);
         this.promptTemplateResolver = new PromptTemplateResolver(path -> "", this::toJsonOrText);
     }
 
@@ -103,7 +106,7 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
                         "experimentId", context.execution().aggregateId()),
-                "flex");
+                serviceTier);
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
@@ -121,7 +124,7 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
             body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
-            body.put("service_tier", "flex");
+            body.put("service_tier", serviceTier);
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
             log.error("Could not build OpenAI request for GeraSalesPage v1. schemaName={}", schemaName, ex);
@@ -143,5 +146,14 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
             log.warn("Could not serialize GeraSalesPage prompt value; using toString fallback.", ex);
             return value.toString();
         }
+    }
+
+    /** Normaliza o tier OpenAI aceito pela Responses API. */
+    private String normalizeServiceTier(String value) {
+        if (value == null || value.isBlank()) {
+            return "default";
+        }
+        String normalized = value.trim().toLowerCase();
+        return "standard".equals(normalized) ? "default" : normalized;
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerConfiguration.java
@@ -57,8 +57,9 @@ public class GeraSalesPageWorkerConfiguration {
             ObjectMapper objectMapper,
             OpenAiClientPort openAiClient,
             GeraSalesPageResponseValidator responseValidator,
-            GeraSalesPageBackendClient backendClient) {
-        return new GeraSalesPageProcessor(objectMapper, openAiClient, responseValidator, backendClient);
+            GeraSalesPageBackendClient backendClient,
+            GeraSalesPageWorkerProperties properties) {
+        return new GeraSalesPageProcessor(objectMapper, openAiClient, responseValidator, backendClient, properties.serviceTier());
     }
 
     /** Compõe o worker genérico com o adapter e processor do GeraSalesPage v1. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerProperties.java
@@ -17,7 +17,8 @@ public record GeraSalesPageWorkerProperties(
         @NotBlank String backendBaseUrl,
         String apiPrefix,
         @NotNull List<String> stageCodes,
-        @NotNull Duration timeout
+        @NotNull Duration timeout,
+        String serviceTier
 ) {
     /** Normaliza valores opcionais usados pelo ciclo operacional do GeraSalesPage v1. */
     public GeraSalesPageWorkerProperties {
@@ -39,5 +40,15 @@ public record GeraSalesPageWorkerProperties(
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);
         }
+        serviceTier = normalizeServiceTier(serviceTier);
+    }
+
+    /** Normaliza o tier OpenAI do GeraSalesPage, que usa Standard por decisão comercial. */
+    private static String normalizeServiceTier(String value) {
+        if (value == null || value.isBlank()) {
+            return "default";
+        }
+        String normalized = value.trim().toLowerCase();
+        return "standard".equals(normalized) ? "default" : normalized;
     }
 }

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -136,6 +136,7 @@ gerasalespage.worker.backend-base-url=${GERASALESPAGE_WORKER_BACKEND_BASE_URL:${
 gerasalespage.worker.api-prefix=${GERASALESPAGE_WORKER_API_PREFIX:${backend.api-prefix}}
 gerasalespage.worker.stage-codes=${GERASALESPAGE_WORKER_STAGE_CODES:sales-page-offer-brief,sales-page-wireframe,sales-page-copy,sales-page-visual-plan,sales-page-html,sales-page-checkout-quality-review,sales-page-publication-package}
 gerasalespage.worker.timeout=${GERASALESPAGE_WORKER_TIMEOUT:PT30M}
+gerasalespage.worker.service-tier=${GERASALESPAGE_WORKER_SERVICE_TIER:default}
 hypothesis-pain.worker.enabled=${HYPOTHESIS_PAIN_WORKER_ENABLED:true}
 hypothesis-pain.worker.pending-limit=${HYPOTHESIS_PAIN_WORKER_PENDING_LIMIT:5}
 hypothesis-pain.worker.backend-base-url=${HYPOTHESIS_PAIN_WORKER_BACKEND_BASE_URL:${backend.base-url}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -117,7 +117,7 @@ class ResponsesApiOpenAiClientTest {
                           "usage": {"input_tokens": 10, "output_tokens": 5}
                         }
                         """));
-        enqueuePricingCatalog("gpt-test", "1.00", "4.00");
+        enqueuePricingCatalog("gpt-test", "2.00", "8.00", "1.00", "4.00");
         ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
                 WebClient.builder(),
                 new ObjectMapper(),
@@ -133,6 +133,7 @@ class ResponsesApiOpenAiClientTest {
                 "default");
 
         var dispatch = client.dispatch(request);
+        var result = client.awaitResult(dispatch);
 
         Map<String, Object> sentPayload = new ObjectMapper().readValue(
                 server.takeRequest().getBody().readUtf8(),
@@ -145,6 +146,7 @@ class ResponsesApiOpenAiClientTest {
                 dispatch.requestBodyJson(),
                 new TypeReference<>() {});
         assertThat(dispatchPayload).containsEntry("service_tier", "default");
+        assertThat(result.costUsd()).isEqualByComparingTo(new BigDecimal("0.00006000"));
     }
 
     /** Deve estimar custo em modo flex pelo modelo do request quando a configuração não informa tarifa explícita. */
@@ -167,7 +169,7 @@ class ResponsesApiOpenAiClientTest {
                           "usage": {"input_tokens": 1000000, "output_tokens": 1000000}
                         }
                         """));
-        enqueuePricingCatalog("gpt-5.4", "1.25", "7.50");
+        enqueuePricingCatalog("gpt-5.4", "2.50", "15.00", "1.25", "7.50");
         ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
                 WebClient.builder(),
                 new ObjectMapper(),
@@ -202,7 +204,7 @@ class ResponsesApiOpenAiClientTest {
                           "usage": {"input_tokens": 1000, "output_tokens": 2000}
                         }
                         """));
-        enqueuePricingCatalog("gpt-other", "10", "20");
+        enqueuePricingCatalog("gpt-other", "20", "40", "10", "20");
         ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
                 WebClient.builder(),
                 new ObjectMapper(),
@@ -236,7 +238,12 @@ class ResponsesApiOpenAiClientTest {
     }
 
     /** Simula o endpoint backend que lista os modelos persistidos na tabela openai_model. */
-    private void enqueuePricingCatalog(String code, String inputBatchPrice, String outputBatchPrice) {
+    private void enqueuePricingCatalog(
+            String code,
+            String inputStandardPrice,
+            String outputStandardPrice,
+            String inputBatchPrice,
+            String outputBatchPrice) {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
@@ -244,11 +251,13 @@ class ResponsesApiOpenAiClientTest {
                         [
                           {
                             "code": "%s",
+                            "priceInputStandard": %s,
+                            "priceOutputStandard": %s,
                             "priceInputBatch": %s,
                             "priceOutputBatch": %s
                           }
                         ]
-                        """.formatted(code, inputBatchPrice, outputBatchPrice)));
+                        """.formatted(code, inputStandardPrice, outputStandardPrice, inputBatchPrice, outputBatchPrice)));
     }
 
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerPropertiesTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageWorkerPropertiesTest.java
@@ -13,10 +13,11 @@ class GeraSalesPageWorkerPropertiesTest {
     @Test
     void shouldDefaultCanonicalStageCodes() {
         GeraSalesPageWorkerProperties properties =
-                new GeraSalesPageWorkerProperties(true, 5, "http://backend", null, null, null);
+                new GeraSalesPageWorkerProperties(true, 5, "http://backend", null, null, null, null);
 
         assertEquals("/api", properties.apiPrefix());
         assertEquals(Duration.ofMinutes(30), properties.timeout());
+        assertEquals("default", properties.serviceTier());
         assertEquals(7, properties.stageCodes().size());
         assertTrue(properties.stageCodes().contains("sales-page-checkout-quality-review"));
     }
@@ -30,8 +31,10 @@ class GeraSalesPageWorkerPropertiesTest {
                 "http://backend",
                 "/api",
                 List.of("sales-page-offer-brief"),
-                Duration.ofMinutes(5));
+                Duration.ofMinutes(5),
+                "standard");
 
         assertEquals(List.of("sales-page-offer-brief"), properties.stageCodes());
+        assertEquals("default", properties.serviceTier());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
@@ -7,5 +7,6 @@ public enum ExperimentReadinessIssueType {
     CREATIVE,
     LEAD_PORTAL_FLOW,
     TARGETING,
-    GERA_LANDING
+    GERA_LANDING,
+    GERA_SALES_PAGE
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -4,14 +4,17 @@ import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,16 +49,19 @@ public class ExperimentReadinessService {
     private static final Set<TargetingElementType> PUBLISHABLE_TARGETING_TYPE_SET = Set.copyOf(PUBLISHABLE_TARGETING_TYPES);
 
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+    private final GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
 
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
-                                      GeraLandingStageExecutionRepository geraLandingStageExecutionRepository) {
+                                      GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
+                                      GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
+        this.geraSalesPageStageExecutionRepository = geraSalesPageStageExecutionRepository;
     }
 
     /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
@@ -74,6 +80,8 @@ public class ExperimentReadinessService {
                 : PUBLISHABLE_TARGETING_TYPES;
         long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
         boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
+        boolean lowTicket = isLowTicketProduct(experiment);
+        boolean hasGeraSalesPagePipeline = hasCompletedGeraSalesPagePipeline(experimentId);
 
         List<ExperimentReadinessIssueDto> issues = new ArrayList<>();
         if (!hasCreatives) {
@@ -85,7 +93,7 @@ public class ExperimentReadinessService {
                     List.of()
             ));
         }
-        if (!hasLeadPortalFlow) {
+        if (!lowTicket && !hasLeadPortalFlow) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.LEAD_PORTAL_FLOW,
                     "Sem fluxo do portal do lead",
@@ -104,7 +112,17 @@ public class ExperimentReadinessService {
             ));
         }
 
-        if (!hasGeraLandingPipeline) {
+        if (lowTicket && !hasGeraSalesPagePipeline) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.GERA_SALES_PAGE,
+                    "Página de venda não foi criada pelo pipeline",
+                    "Experimentos low-ticket só podem ser liberados quando o GeraSalesPage v1 concluir a publicação.",
+                    "Execute ou refaça o GeraSalesPage v1 e use a página de venda gerada pelo pipeline.",
+                    List.of()
+            ));
+        }
+
+        if (!lowTicket && !hasGeraLandingPipeline) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_LANDING,
                     "GeraLanding incompleto",
@@ -141,6 +159,9 @@ public class ExperimentReadinessService {
         }
         if (!hasApprovedLandingDestination(experiment)) {
             missing.add("landingDestination");
+        }
+        if (isLowTicketProduct(experiment) && !hasCompletedGeraSalesPagePipeline(experiment != null ? experiment.getId() : null)) {
+            missing.add("geraSalesPagePipeline");
         }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("approvedTargetingPackage");
@@ -207,6 +228,24 @@ public class ExperimentReadinessService {
         return experiment != null
                 && experiment.getFollowUpActionUrl() != null
                 && !experiment.getFollowUpActionUrl().isBlank();
+    }
+
+    /** Identifica experimento de venda direta low-ticket. */
+    private boolean isLowTicketProduct(Experiment experiment) {
+        return experiment != null && experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT;
+    }
+
+    /** Verifica a conclusão da etapa final que publica a página de venda canônica. */
+    private boolean hasCompletedGeraSalesPagePipeline(Long experimentId) {
+        if (experimentId == null) {
+            return false;
+        }
+        return geraSalesPageStageExecutionRepository
+                .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experimentId, GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                .map(com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution::getStatus)
+                .map(STATUS_COMPLETED::equalsIgnoreCase)
+                .orElse(false);
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -13,6 +13,7 @@ import com.marketinghub.experiment.*;
 import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
@@ -20,6 +21,7 @@ import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyt
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
@@ -72,6 +74,7 @@ public class ExperimentService {
     private final FacebookAdsCampaignRepository facebookAdsCampaignRepository;
     private final FacebookAdsAdSetRepository facebookAdsAdSetRepository;
     private final FacebookAdsAdRepository facebookAdsAdRepository;
+    private final GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
     private final ObjectMapper objectMapper;
     private final CurrencyConversionService currencyConversionService;
 
@@ -95,6 +98,7 @@ public class ExperimentService {
                              FacebookAdsCampaignRepository facebookAdsCampaignRepository,
                              FacebookAdsAdSetRepository facebookAdsAdSetRepository,
                              FacebookAdsAdRepository facebookAdsAdRepository,
+                             GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository,
                              ObjectMapper objectMapper,
                              CurrencyConversionService currencyConversionService) {
         this.repository = repository;
@@ -117,6 +121,7 @@ public class ExperimentService {
         this.facebookAdsCampaignRepository = facebookAdsCampaignRepository;
         this.facebookAdsAdSetRepository = facebookAdsAdSetRepository;
         this.facebookAdsAdRepository = facebookAdsAdRepository;
+        this.geraSalesPageStageExecutionRepository = geraSalesPageStageExecutionRepository;
         this.objectMapper = objectMapper;
         this.currencyConversionService = currencyConversionService;
     }
@@ -851,6 +856,7 @@ public class ExperimentService {
         if (experiment.getPlatform() != ExperimentPlatform.FACEBOOK) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Experiment platform must be Facebook");
         }
+        ensureLowTicketSalesPageWasBuiltByPipeline(experiment);
         experiment.setStatus(ExperimentStatus.PLANNED);
         experiment.setFacebookReleaseRequestedAt(Instant.now());
         experiment.setFunnelResetAt(experiment.getFacebookReleaseRequestedAt());
@@ -858,6 +864,24 @@ public class ExperimentService {
         experimentLandingAnalyticsEventRepository.deleteByExperimentId(id);
         experimentFunnelEventRepository.deleteByExperimentId(id);
         return experiment;
+    }
+
+    /** Bloqueia venda low-ticket quando a página de venda não veio do GeraSalesPage v1. */
+    private void ensureLowTicketSalesPageWasBuiltByPipeline(Experiment experiment) {
+        if (experiment.getExperimentType() != ExperimentType.LOW_TICKET_PRODUCT) {
+            return;
+        }
+        boolean pipelineCompleted = geraSalesPageStageExecutionRepository
+                .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experiment.getId(), GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                .map(com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution::getStatus)
+                .map("CONCLUIDO"::equalsIgnoreCase)
+                .orElse(false);
+        if (!pipelineCompleted) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento low-ticket exige página de venda criada pelo GeraSalesPage v1 antes da campanha.");
+        }
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -33,6 +33,7 @@ public class GeraSalesPageStageService {
     private static final String STATUS_WAITING_OPENAI = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
+    private static final String STATUS_REPLACED = "SUBSTITUIDO";
 
     private final ExperimentRepository experimentRepository;
     private final GeraSalesPageStageExecutionRepository executionRepository;
@@ -56,12 +57,27 @@ public class GeraSalesPageStageService {
     public GeraSalesPageStartResponse start(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
-        if (!isRealCheckoutUrl(experiment.getFollowUpActionUrl())) {
-            throw new ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "GeraSalesPage v1 exige followUpActionUrl com URL real de checkout antes de iniciar.");
-        }
+        validateCheckoutUrl(experiment);
         GeraSalesPageStageExecution execution = enqueue(experimentId, GeraSalesPageStageCode.OFFER_BRIEF.code());
+        return new GeraSalesPageStartResponse(experimentId, execution.getStageCode(), idJobText(execution), execution.getStatus());
+    }
+
+    /** Substitui execuções anteriores e reinicia o GeraSalesPage v1 desde a primeira etapa. */
+    @Transactional
+    public GeraSalesPageStartResponse rebuild(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        validateCheckoutUrl(experiment);
+        List<GeraSalesPageStageExecution> executions =
+                executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(experimentId);
+        executions.forEach(execution -> {
+            if (!STATUS_REPLACED.equalsIgnoreCase(execution.getStatus())) {
+                execution.setStatus(STATUS_REPLACED);
+                execution.setErrorMessage("Execução substituída por rebuild manual do GeraSalesPage v1.");
+            }
+        });
+        executionRepository.saveAll(executions);
+        GeraSalesPageStageExecution execution = createNewExecution(experimentId, GeraSalesPageStageCode.OFFER_BRIEF.code());
         return new GeraSalesPageStartResponse(experimentId, execution.getStageCode(), idJobText(execution), execution.getStatus());
     }
 
@@ -126,18 +142,24 @@ public class GeraSalesPageStageService {
     private GeraSalesPageStageExecution enqueue(Long experimentId, String stageCode) {
         return executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
                 .filter(existing -> !STATUS_FAILED.equals(existing.getStatus()))
+                .filter(existing -> !STATUS_REPLACED.equals(existing.getStatus()))
                 .orElseGet(() -> {
-                    GeraSalesPagePromptSchemaTemplate template = loadTemplate(stageCode);
-                    GeraSalesPageStageExecution execution = GeraSalesPageStageExecution.builder()
-                            .idJob(UUID.randomUUID().toString())
-                            .experimentId(experimentId)
-                            .stageCode(stageCode)
-                            .status(STATUS_STARTED)
-                            .executionRequestedAt(Instant.now())
-                            .promptTemplateKey(template.getTemplateKey())
-                            .build();
-                    return executionRepository.save(execution);
+                    return createNewExecution(experimentId, stageCode);
                 });
+    }
+
+    /** Cria uma nova execução de etapa com template ativo e idJob único. */
+    private GeraSalesPageStageExecution createNewExecution(Long experimentId, String stageCode) {
+        GeraSalesPagePromptSchemaTemplate template = loadTemplate(stageCode);
+        GeraSalesPageStageExecution execution = GeraSalesPageStageExecution.builder()
+                .idJob(UUID.randomUUID().toString())
+                .experimentId(experimentId)
+                .stageCode(stageCode)
+                .status(STATUS_STARTED)
+                .executionRequestedAt(Instant.now())
+                .promptTemplateKey(template.getTemplateKey())
+                .build();
+        return executionRepository.save(execution);
     }
 
     /** Converte uma execução persistida no payload de pendência consumido pelo worker. */
@@ -225,6 +247,15 @@ public class GeraSalesPageStageService {
         return StringUtils.hasText(url)
                 && (url.startsWith("http://") || url.startsWith("https://"))
                 && !url.contains("#checkout");
+    }
+
+    /** Bloqueia início ou rebuild sem checkout real persistido no experimento. */
+    private void validateCheckoutUrl(Experiment experiment) {
+        if (!isRealCheckoutUrl(experiment.getFollowUpActionUrl())) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "GeraSalesPage v1 exige followUpActionUrl com URL real de checkout antes de iniciar.");
+        }
     }
 
     /** Converte JSON textual quando possível, preservando texto simples quando não for JSON. */

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/web/GeraSalesPageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/web/GeraSalesPageController.java
@@ -32,6 +32,12 @@ public class GeraSalesPageController {
         return ResponseEntity.accepted().body(service.start(experimentId));
     }
 
+    /** Refaz o GeraSalesPage v1 substituindo execuções antigas por uma geração limpa. */
+    @PostMapping("/experiments/{experimentId}/gerasalespage/v1/rebuild")
+    public ResponseEntity<GeraSalesPageStartResponse> rebuild(@PathVariable Long experimentId) {
+        return ResponseEntity.accepted().body(service.rebuild(experimentId));
+    }
+
     /** Lista jobs pendentes de uma etapa para consumo canônico pelo AI Worker. */
     @GetMapping("/internal/gerasalespage/v1/{stageCode}/stage-executions/pending")
     public List<GeraSalesPagePendingResponse> pending(@PathVariable String stageCode) {

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiPricingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiPricingService.java
@@ -21,9 +21,9 @@ public class OpenAiPricingService {
         this.modelRepository = modelRepository;
     }
 
-    /** Estima custo canônico de execução Flex, usando os preços standard cadastrados no catálogo OpenAI. */
+    /** Estima custo canônico de execução Flex, usando os preços batch/flex cadastrados no catálogo OpenAI. */
     public BigDecimal estimateFlexCost(String modelCode, Integer inputTokens, Integer outputTokens) {
-        return estimateStandardCost(modelCode, new OpenAiResponse.OpenAiUsage(inputTokens, outputTokens, null, null, null));
+        return estimateBatchCost(modelCode, new OpenAiResponse.OpenAiUsage(inputTokens, outputTokens, null, null, null));
     }
 
     /** Estima custo canônico de execução Standard usando o uso retornado pela OpenAI. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPageStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPageStageExecutionRepository.java
@@ -15,6 +15,9 @@ public interface GeraSalesPageStageExecutionRepository extends JpaRepository<Ger
     Optional<GeraSalesPageStageExecution> findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
             Long experimentId, String stageCode);
 
+    /** Lista todas as execuções de um experimento para rebuild auditável do pipeline. */
+    List<GeraSalesPageStageExecution> findByExperimentIdOrderByExecutionRequestedAtAsc(Long experimentId);
+
     /** Lista pendências de uma etapa com experimento, nicho e hipótese carregados para montar o contrato do worker. */
     @EntityGraph(attributePaths = {"experiment", "experiment.niche", "experiment.hypothesisRef"})
     List<GeraSalesPageStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -26,7 +26,10 @@ import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.facebookads.BudgetMode;
 import com.marketinghub.facebookads.FacebookAdStatus;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,6 +74,8 @@ class ExperimentServiceTest {
     FacebookAccountRepository facebookAccountRepository;
     @Autowired
     FacebookAdsCampaignRepository facebookAdsCampaignRepository;
+    @Autowired
+    GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
     @Autowired
     com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository leadPortalFlowRepository;
     @Autowired
@@ -791,6 +796,95 @@ class ExperimentServiceTest {
         assertThat(released.getStatus()).isEqualTo(ExperimentStatus.PLANNED);
         MarketNiche refreshed = nicheRepository.findById(niche.getId()).orElseThrow();
         assertThat(refreshed.getFacebookPixelId()).isNull();
+        assertThat(released.getFacebookReleaseRequestedAt()).isNotNull();
+    }
+
+    /** Garante que venda low-ticket não entra na fila sem página criada pelo pipeline. */
+    @Test
+    void releaseForFacebookRejectsLowTicketWithoutGeraSalesPagePipeline() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Low Ticket Release").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("ALT").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("HLT")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.TRIPWIRE)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_LOW_RELEASE")
+                .name("Lean Low Release")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp Low Release");
+        req.setHypothesis("H");
+        req.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_LOW_RELEASE");
+        req.setJourneyTemplateId(createJourneyTemplate().getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow(niche));
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        Experiment experiment = service.create(req);
+
+        assertThatThrownBy(() -> service.releaseForFacebook(experiment.getId()))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("low-ticket exige página de venda criada pelo GeraSalesPage");
+    }
+
+    /** Garante que venda low-ticket só entra na fila após a etapa final do GeraSalesPage. */
+    @Test
+    void releaseForFacebookAllowsLowTicketAfterGeraSalesPagePipeline() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Low Ticket Release Ok").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("ALTOk").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("HLTOk")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.TRIPWIRE)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_LOW_RELEASE_OK")
+                .name("Lean Low Release Ok")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp Low Release Ok");
+        req.setHypothesis("H");
+        req.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_LOW_RELEASE_OK");
+        req.setJourneyTemplateId(createJourneyTemplate().getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow(niche));
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        Experiment experiment = service.create(req);
+        geraSalesPageStageExecutionRepository.save(GeraSalesPageStageExecution.builder()
+                .idJob(java.util.UUID.randomUUID().toString())
+                .experimentId(experiment.getId())
+                .stageCode(GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                .status("CONCLUIDO")
+                .executionRequestedAt(Instant.now())
+                .build());
+
+        Experiment released = service.releaseForFacebook(experiment.getId());
+
         assertThat(released.getFacebookReleaseRequestedAt()).isNotNull();
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -4,10 +4,13 @@ import com.marketinghub.repository.jpa.creative.CreativeRepository;
 import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
@@ -17,6 +20,7 @@ import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -41,6 +45,8 @@ class ExperimentReadinessServiceTest {
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
     @Mock
     private GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+    @Mock
+    private GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
 
     @InjectMocks
     private ExperimentReadinessService service;
@@ -215,6 +221,34 @@ class ExperimentReadinessServiceTest {
         assertThat(service.isReadyForCampaign(experiment)).isFalse();
     }
 
+    @Test
+    void shouldRequireGeraSalesPagePipelineForLowTicketCampaign() {
+        Experiment experiment = buildExperiment(52L, 62L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp52.html");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(52L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(52L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("geraSalesPagePipeline");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    @Test
+    void shouldAllowLowTicketCampaignOnlyAfterGeraSalesPagePublicationPackage() {
+        Experiment experiment = buildExperiment(53L, 63L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp53.html");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(53L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(53L, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);
+        mockCompletedGeraSalesPagePublication(53L);
+
+        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
+        assertThat(service.isReadyForCampaign(experiment)).isTrue();
+    }
+
 
     /** Simula uma seleção de público aprovada e identificável pela Meta. */
     private void mockPublishableSelection(Long experimentId, TargetingCandidateType candidateType, TargetingElementType elementType) {
@@ -262,6 +296,17 @@ class ExperimentReadinessServiceTest {
                 .stageCode(stageCode)
                 .status(status)
                 .build();
+    }
+
+    /** Simula a etapa final do GeraSalesPage como concluída para low-ticket. */
+    private void mockCompletedGeraSalesPagePublication(Long experimentId) {
+        when(geraSalesPageStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                experimentId, GeraSalesPageStageCode.PUBLICATION_PACKAGE.code()))
+                .thenReturn(Optional.of(GeraSalesPageStageExecution.builder()
+                        .experimentId(experimentId)
+                        .stageCode(GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                        .status("CONCLUIDO")
+                        .build()));
     }
 
     /** Cria um experimento base para os testes de prontidão. */

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -1,0 +1,93 @@
+package com.marketinghub.gerasalespage.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePromptSchemaTemplateRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida controle de fila e rebuild do GeraSalesPage v1. */
+@ExtendWith(MockitoExtension.class)
+class GeraSalesPageStageServiceTest {
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private GeraSalesPageStageExecutionRepository executionRepository;
+    @Mock
+    private GeraSalesPagePromptSchemaTemplateRepository templateRepository;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private GeraSalesPageStageService service;
+
+    /** Deve substituir execuções antigas e criar uma primeira etapa nova. */
+    @Test
+    void rebuildShouldReplacePreviousExecutionsAndStartFreshPipeline() {
+        Experiment experiment = new Experiment();
+        experiment.setId(53L);
+        experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc");
+        GeraSalesPageStageExecution previous = GeraSalesPageStageExecution.builder()
+                .idJob("old-job")
+                .experimentId(53L)
+                .stageCode(GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                .status("CONCLUIDO")
+                .executionRequestedAt(Instant.now().minusSeconds(60))
+                .build();
+
+        when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L)).thenReturn(List.of(previous));
+        when(templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
+                "gera-sales-page-v1", GeraSalesPageStageCode.OFFER_BRIEF.code()))
+                .thenReturn(Optional.of(template(GeraSalesPageStageCode.OFFER_BRIEF.code())));
+        when(executionRepository.save(any(GeraSalesPageStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GeraSalesPageStartResponse response = service.rebuild(53L);
+
+        assertThat(previous.getStatus()).isEqualTo("SUBSTITUIDO");
+        assertThat(previous.getErrorMessage()).contains("substituída por rebuild");
+        verify(executionRepository).saveAll(List.of(previous));
+        ArgumentCaptor<GeraSalesPageStageExecution> newExecution =
+                ArgumentCaptor.forClass(GeraSalesPageStageExecution.class);
+        verify(executionRepository).save(newExecution.capture());
+        assertThat(newExecution.getValue().getStageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+        assertThat(newExecution.getValue().getStatus()).isEqualTo("INICIADO");
+        assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+    }
+
+    /** Cria template mínimo de prompt/schema para etapa de teste. */
+    private GeraSalesPagePromptSchemaTemplate template(String stageCode) {
+        return GeraSalesPagePromptSchemaTemplate.builder()
+                .templateKey("template-" + stageCode)
+                .pipelineCode("gera-sales-page-v1")
+                .stageCode(stageCode)
+                .version("v1")
+                .openAiModel("gpt-test")
+                .schemaName("schema")
+                .promptMarkdownContent("# Prompt")
+                .schemaJson("{\"type\":\"object\"}")
+                .active(true)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiPricingServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiPricingServiceTest.java
@@ -9,65 +9,59 @@ import com.marketinghub.openai.OpenAiResponse;
 import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import java.math.BigDecimal;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+/** Valida cálculo de custo OpenAI conforme o modo de preço usado. */
 class OpenAiPricingServiceTest {
 
-    @Mock
-    private OpenAiModelRepository modelRepository;
+    private final OpenAiModelRepository repository = org.mockito.Mockito.mock(OpenAiModelRepository.class);
+    private final OpenAiPricingService service = new OpenAiPricingService(repository);
 
-    private OpenAiPricingService service;
-
-    @BeforeEach
-    void setUp() {
-        service = new OpenAiPricingService(modelRepository);
-    }
-
+    /** Deve calcular Flex pelas tarifas Batch/Flex do catálogo. */
     @Test
-    void estimateStandardCostUsesPricesPerMillionTokens() {
-        OpenAiModel model = OpenAiModel.builder()
-                .code("gpt-5.3-codex")
-                .priceInputStandard(new BigDecimal("2.00000"))
-                .priceOutputStandard(new BigDecimal("10.00000"))
-                .build();
-        when(modelRepository.findByCode("gpt-5.3-codex")).thenReturn(Optional.of(model));
+    void estimateFlexCostShouldUseBatchPrices() {
+        when(repository.findByCode("gpt-test")).thenReturn(Optional.of(model()));
 
-        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(250_000, 125_000, null, null, 375_000);
-        BigDecimal cost = service.estimateStandardCost("gpt-5.3-codex", usage);
+        BigDecimal cost = service.estimateFlexCost("gpt-test", 1_000_000, 1_000_000);
 
-        assertThat(cost).isEqualByComparingTo("1.7500");
+        assertThat(cost).isEqualByComparingTo("8.7500");
     }
 
+    /** Deve calcular Standard pelas tarifas Standard do catálogo. */
     @Test
-    void estimateBatchCostUsesBatchColumnsPerMillionTokens() {
-        OpenAiModel model = OpenAiModel.builder()
-                .code("gpt-5.3-codex")
-                .priceInputBatch(new BigDecimal("1.00000"))
-                .priceOutputBatch(new BigDecimal("4.00000"))
-                .build();
-        when(modelRepository.findByCode("gpt-5.3-codex")).thenReturn(Optional.of(model));
+    void estimateStandardCostShouldUseStandardPrices() {
+        when(repository.findByCode("gpt-test")).thenReturn(Optional.of(model()));
 
-        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(300_000, 50_000, null, null, 350_000);
-        BigDecimal cost = service.estimateBatchCost("gpt-5.3-codex", usage);
+        BigDecimal cost = service.estimateStandardCost(
+                "gpt-test",
+                new OpenAiResponse.OpenAiUsage(1_000_000, 1_000_000, null, null, null));
 
-        assertThat(cost).isEqualByComparingTo("0.5000");
+        assertThat(cost).isEqualByComparingTo("17.5000");
     }
 
+    /** Deve falhar claramente quando o modelo não existe no catálogo. */
     @Test
     void estimateCostFailsWhenModelIsMissingFromCatalog() {
-        when(modelRepository.findByCode("missing-model")).thenReturn(Optional.empty());
-
-        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(1000, 1000, null, null, 2000);
+        when(repository.findByCode("missing-model")).thenReturn(Optional.empty());
 
         IllegalStateException error = assertThrows(
                 IllegalStateException.class,
-                () -> service.estimateStandardCost("missing-model", usage));
+                () -> service.estimateStandardCost(
+                        "missing-model",
+                        new OpenAiResponse.OpenAiUsage(1000, 1000, null, null, 2000)));
 
         assertThat(error.getMessage()).contains("Modelo OpenAI não encontrado no catálogo");
+    }
+
+    /** Cria modelo com preços diferentes para provar a escolha do modo. */
+    private OpenAiModel model() {
+        return OpenAiModel.builder()
+                .code("gpt-test")
+                .name("GPT Test")
+                .priceInputStandard(new BigDecimal("2.50"))
+                .priceOutputStandard(new BigDecimal("15.00"))
+                .priceInputBatch(new BigDecimal("1.25"))
+                .priceOutputBatch(new BigDecimal("7.50"))
+                .build();
     }
 }

--- a/docs/canonical/gerasalespage-arquitetura-canon.v1.md
+++ b/docs/canonical/gerasalespage-arquitetura-canon.v1.md
@@ -24,6 +24,9 @@ O GeraSalesPage v1 é um pipeline independente para gerar página de vendas dire
 - O worker não carrega prompt/schema local para este pipeline.
 - Toda chamada OpenAI deve registrar request, response bruto, modelo, tokens, custo e erro quando houver.
 - A revisão de checkout deve bloquear liberação para tráfego quando checkout, promessa, preço, garantia ou CTA estiverem incoerentes.
+- Experimento `LOW_TICKET_PRODUCT` só pode ser liberado para campanha quando a etapa final `sales-page-publication-package` estiver `CONCLUIDO`; URL de página preenchida manualmente não substitui a conclusão do pipeline.
+- O GeraSalesPage v1 usa `service_tier=default` por padrão, porque página de venda é artefato comercial crítico e deve priorizar estabilidade sobre economia de Flex.
+- Quando uma página precisar ser refeita, o rebuild canônico deve marcar execuções anteriores como `SUBSTITUIDO` e enfileirar nova execução a partir de `sales-page-offer-brief`.
 
 ## Sugestões incorporadas
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5528,3 +5528,11 @@
 - Causa-raiz: o compose de produção dependia de comportamento frágil de merge do Docker Compose; em produção, o serviço deve usar somente a imagem publicada no registry, sem herdar configuração de build local.
 - Correção aplicada: o `docker-compose.deploy.yml` passou a ser autônomo, com imagem publicada obrigatória e sem bloco `build`; o workflow de deploy passou a executar somente esse compose de produção.
 - Prevenção de recorrência: a documentação de CI/CD foi atualizada para registrar que o deploy usa `docker compose -f docker-compose.deploy.yml`, separando build local de publicação produtiva.
+
+## 2026-07-01 — Trava de pipeline para página de venda low-ticket
+
+- Decisão: experimento `LOW_TICKET_PRODUCT` não pode ser liberado para campanha apenas com URL manual de página de venda; precisa ter a etapa final `sales-page-publication-package` do GeraSalesPage v1 concluída.
+- Causa-raiz: durante o experimento 53, a indisponibilidade/rate limit da OpenAI levou a conclusão operacional por ponte controlada, mas isso enfraquece o aprendizado do pipeline de criação de páginas.
+- Correção aplicada: a prontidão e a liberação para Facebook bloqueiam low-ticket sem GeraSalesPage concluído; foi criado rebuild canônico para substituir execuções antigas e gerar a página novamente pelo pipeline.
+- Decisão OpenAI: o GeraSalesPage v1 passa a usar `service_tier=default` por padrão, aceitando custo maior para reduzir falhas na criação de páginas de venda.
+- Prevenção de recorrência: testes cobrem bloqueio de campanha low-ticket sem publicação do GeraSalesPage, liberação após etapa final concluída, rebuild com status `SUBSTITUIDO` e custo Standard conforme service tier.

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -50,8 +50,29 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
 | `LOOP-HYPOTHESIS-PIPELINE` | ALTO | Em formação | Pipeline Dor → Resultado → Mecanismo → Prova → Oferta | etapas completas + pré-requisitos + finalização separada + lease |
 | `LOOP-ARTIFACT-CONTAMINATION` | ALTO | Estabilizado com risco | Metadado técnico em artefato final | separação auditoria vs artefato publicável + whitelist de DTO final |
 | `LOOP-COST-MODEL-AUDIT` | MÉDIO | Em observação | Custos OpenAI e modelo por etapa | preço vindo do catálogo backend + modelo efetivo auditado por etapa |
+| `LOOP-LOW-TICKET-SALES-PAGE-BYPASS` | CRÍTICO | Fechado em 2026-07-01 | Low-ticket/GeraSalesPage | campanha bloqueada sem etapa final do pipeline concluída |
 
 ---
+
+## LOOP-LOW-TICKET-SALES-PAGE-BYPASS — Low-ticket sem página criada pelo pipeline
+
+- **Severidade**: CRÍTICO.
+- **Status**: fechado em 2026-07-01.
+- **Sintomas recorrentes ou risco observado**:
+  - experimento low-ticket com página publicada por ponte operacional, fora da execução completa do GeraSalesPage;
+  - liberação de campanha baseada apenas em `followUpActionUrl` preenchido;
+  - aprendizado de qualidade da página ficando fora do pipeline;
+  - risco de tráfego pago apontar para artefato não auditado pela etapa de quality review/publication package.
+- **Causa-raiz sistêmica confirmada**:
+  - a prontidão de campanha validava destino de venda como URL, não como artefato concluído pelo pipeline responsável;
+  - o GeraSalesPage usava Flex, que reduzia custo, mas aumentava indisponibilidade em artefato comercial crítico.
+- **Correção efetiva**:
+  - bloquear prontidão e liberação de campanha para `LOW_TICKET_PRODUCT` sem `sales-page-publication-package=CONCLUIDO`;
+  - adicionar rebuild canônico para substituir execuções antigas por `SUBSTITUIDO` e recriar a página pelo pipeline;
+  - usar `service_tier=default` no GeraSalesPage v1 por padrão;
+  - calcular custo OpenAI conforme o service tier usado.
+- **Regra preventiva**:
+  - nunca liberar campanha low-ticket apenas porque existe URL pública; a URL deve ser resultado auditável do GeraSalesPage v1 concluído.
 
 ## LOOP-FB-PUBLICATION — Publicação Facebook Ads
 


### PR DESCRIPTION
## O que mudou

- Bloqueia campanhas `LOW_TICKET_PRODUCT` sem a etapa final `sales-page-publication-package` do GeraSalesPage v1 concluída.
- Adiciona endpoint de rebuild do GeraSalesPage v1 para substituir execuções antigas por `SUBSTITUIDO` e recriar a página desde a primeira etapa.
- Muda o GeraSalesPage v1 para `service_tier=default` por padrão no AI Worker.
- Corrige cálculo de custo OpenAI para usar preço Standard ou Batch/Flex conforme o service tier real.
- Atualiza cânone e registros de recorrência para impedir página low-ticket fora do pipeline.

## Por quê

A causa-raiz era que a liberação de low-ticket validava URL pública, mas não validava que a página tinha sido criada e auditada pelo pipeline. Isso permitia atalhos operacionais e enfraquecia o aprendizado de qualidade das páginas de venda.

## Validação

- `./backend/mvnw -f backend/ads-service/pom.xml -Dtest=ExperimentReadinessServiceTest,GeraSalesPageStageServiceTest,OpenAiPricingServiceTest,ExperimentServiceTest test`
- `./backend/mvnw -f ai-worker/pom.xml -Dtest=GeraSalesPageWorkerPropertiesTest,ResponsesApiOpenAiClientTest test`
- `git diff --check`

## Próximo passo operacional

Depois do deploy de backend e AI Worker, chamar `POST /api/experiments/53/gerasalespage/v1/rebuild` e deixar o pipeline gerar novamente a página do experimento 53.