### PR TITLE
[codex] Audita publicações do GeraSalesPage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
      1. Tema: Experimentos, registre em /docs/registros/experimentos.md
      2. Tema: Módulos Mois, registre em /docs/registros/mois1.md
      3. Tema: Módulos OPRM, regsitre em /docs/registros/oprm1.md
+- **Fechamento do dia (registro de negócio)**: quando o usuário pedir literalmente `feche o dia`, registrar em `/docs/registros/diario.md` um resumo do que foi realizado no dia em termos de negócio, marketing e operação comercial. O registro deve priorizar campanhas publicadas, experimentos criados ou avançados, produtos/ofertas estruturados, validações comerciais, aprendizados, métricas relevantes, decisões tomadas e próximos passos. Não transformar esse fechamento em changelog técnico de sistema, PRs, classes, endpoints ou detalhes internos, salvo quando algum ajuste técnico tiver impacto direto de negócio.
 
 ## 3. Orientações Práticas:
 

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/GeraSalesPagePublicationAudit.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/GeraSalesPagePublicationAudit.java
@@ -1,0 +1,66 @@
+package com.marketinghub.gerasalespage.v1;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Responsabilidade: preservar o snapshot historico de uma pagina de venda publicada pelo GeraSalesPage v1. */
+@Entity
+@Table(name = "gera_sales_page_publication_audit")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeraSalesPagePublicationAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "experiment_id", nullable = false)
+    private Long experimentId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false, insertable = false, updatable = false)
+    private Experiment experiment;
+
+    @Column(name = "publication_job_id", nullable = false, length = 36)
+    private String publicationJobId;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "publication_job_id", nullable = false, insertable = false, updatable = false)
+    private GeraSalesPageStageExecution publicationJob;
+
+    @Column(name = "published_at", nullable = false)
+    private Instant publishedAt;
+
+    @Column(name = "sales_page_url", length = 1024)
+    private String salesPageUrl;
+
+    @Column(name = "checkout_url", length = 1024)
+    private String checkoutUrl;
+
+    @Column(name = "html", columnDefinition = "LONGTEXT")
+    private String html;
+
+    @Column(name = "publication_package_json", columnDefinition = "LONGTEXT")
+    private String publicationPackageJson;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/GeraSalesPagePublicationStageAudit.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/GeraSalesPagePublicationStageAudit.java
@@ -1,0 +1,93 @@
+package com.marketinghub.gerasalespage.v1;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Responsabilidade: preservar os dados de uma etapa usada em uma publicacao historica do GeraSalesPage v1. */
+@Entity
+@Table(name = "gera_sales_page_publication_stage_audit")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeraSalesPagePublicationStageAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "publication_audit_id", nullable = false)
+    private Long publicationAuditId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "publication_audit_id", nullable = false, insertable = false, updatable = false)
+    private GeraSalesPagePublicationAudit publicationAudit;
+
+    @Column(name = "stage_order", nullable = false)
+    private Integer stageOrder;
+
+    @Column(name = "id_job", nullable = false, length = 36)
+    private String idJob;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_job", nullable = false, insertable = false, updatable = false)
+    private GeraSalesPageStageExecution stageExecution;
+
+    @Column(name = "stage_code", nullable = false, length = 100)
+    private String stageCode;
+
+    @Column(name = "status", nullable = false, length = 50)
+    private String status;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "prompt_template_key", length = 191)
+    private String promptTemplateKey;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "prompt_markdown_content", columnDefinition = "LONGTEXT")
+    private String promptMarkdownContent;
+
+    @Column(name = "schema_json", columnDefinition = "LONGTEXT")
+    private String schemaJson;
+
+    @Column(name = "openai_model", length = 120)
+    private String openAiModel;
+
+    @Column(name = "openai_request_body", columnDefinition = "LONGTEXT")
+    private String openAiRequestBody;
+
+    @Column(name = "model_response", columnDefinition = "LONGTEXT")
+    private String modelResponse;
+
+    @Column(name = "raw_response", columnDefinition = "LONGTEXT")
+    private String rawResponse;
+
+    @Column(name = "input_tokens")
+    private Integer inputTokens;
+
+    @Column(name = "output_tokens")
+    private Integer outputTokens;
+
+    @Column(name = "cost_usd", precision = 12, scale = 6)
+    private BigDecimal costUsd;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -1,0 +1,209 @@
+package com.marketinghub.gerasalespage.v1.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationStageAudit;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationStageAuditRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: criar e consultar snapshots historicos das paginas publicadas pelo GeraSalesPage v1. */
+@Service
+public class GeraSalesPagePublicationAuditService {
+    private static final Logger log = LoggerFactory.getLogger(GeraSalesPagePublicationAuditService.class);
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+
+    private final ExperimentRepository experimentRepository;
+    private final GeraSalesPageStageExecutionRepository executionRepository;
+    private final GeraSalesPagePublicationAuditRepository publicationRepository;
+    private final GeraSalesPagePublicationStageAuditRepository publicationStageRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o service com repositorios e serializador usados nos snapshots. */
+    public GeraSalesPagePublicationAuditService(
+            ExperimentRepository experimentRepository,
+            GeraSalesPageStageExecutionRepository executionRepository,
+            GeraSalesPagePublicationAuditRepository publicationRepository,
+            GeraSalesPagePublicationStageAuditRepository publicationStageRepository,
+            ObjectMapper objectMapper) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
+        this.publicationRepository = publicationRepository;
+        this.publicationStageRepository = publicationStageRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Cria snapshot da publicacao final quando a etapa de pacote termina com sucesso. */
+    @Transactional
+    public void snapshotPublication(GeraSalesPageStageExecution publicationExecution) {
+        if (!isCompletedPublication(publicationExecution)
+                || publicationRepository.existsByPublicationJobId(publicationExecution.getIdJob())) {
+            return;
+        }
+        Experiment experiment = experimentRepository.findById(publicationExecution.getExperimentId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Experiment not found: " + publicationExecution.getExperimentId()));
+        saveAudit(experiment, publicationExecution);
+    }
+
+    /** Lista publicacoes historicas e faz backfill quando houver execucao final antiga sem snapshot. */
+    @Transactional
+    public List<GeraSalesPagePublicationResponse> listPublications(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        backfillMissingSnapshots(experiment);
+        return publicationRepository.findByExperimentIdOrderByPublishedAtDesc(experimentId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /** Cria snapshots para publicacoes antigas que ainda possuem execucoes auditaveis no banco. */
+    private void backfillMissingSnapshots(Experiment experiment) {
+        executionRepository.findByExperimentIdAndStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        experiment.getId(), GeraSalesPageStageCode.PUBLICATION_PACKAGE.code(), STATUS_COMPLETED)
+                .stream()
+                .filter(execution -> !publicationRepository.existsByPublicationJobId(execution.getIdJob()))
+                .forEach(execution -> saveAudit(experiment, execution));
+    }
+
+    /** Salva uma publicação e suas etapas auditadas em tabelas normalizadas. */
+    private void saveAudit(
+            Experiment experiment,
+            GeraSalesPageStageExecution publicationExecution) {
+        List<GeraSalesPageStageExecution> stageExecutions =
+                executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(experiment.getId()).stream()
+                        .filter(execution -> GeraSalesPageStageCode.contains(execution.getStageCode()))
+                        .filter(execution -> STATUS_COMPLETED.equals(execution.getStatus()))
+                        .filter(execution -> !execution.getExecutionRequestedAt()
+                                .isAfter(publicationExecution.getExecutionRequestedAt()))
+                        .toList();
+        String packageJson = publicationExecution.getModelResponse();
+        Map<String, Object> packagePayload = parseObject(packageJson);
+        String html = stringValue(packagePayload.get("html"));
+        String checkoutUrl = stringValue(packagePayload.get("checkoutUrl"));
+        Instant publishedAt = publicationExecution.getCompletedAt() != null
+                ? publicationExecution.getCompletedAt()
+                : Instant.now();
+        GeraSalesPagePublicationAudit audit = publicationRepository.save(GeraSalesPagePublicationAudit.builder()
+                .experimentId(experiment.getId())
+                .publicationJobId(publicationExecution.getIdJob())
+                .publishedAt(publishedAt)
+                .salesPageUrl(experiment.getFollowUpActionUrl())
+                .checkoutUrl(StringUtils.hasText(checkoutUrl) ? checkoutUrl : experiment.getFollowUpActionUrl())
+                .html(html)
+                .publicationPackageJson(packageJson)
+                .createdAt(Instant.now())
+                .build());
+        publicationStageRepository.saveAll(toStageAudits(audit.getId(), stageExecutions));
+    }
+
+    /** Converte execuções concluídas em linhas auditáveis da publicação. */
+    private List<GeraSalesPagePublicationStageAudit> toStageAudits(
+            Long publicationAuditId,
+            List<GeraSalesPageStageExecution> executions) {
+        return java.util.stream.IntStream.range(0, executions.size())
+                .mapToObj(index -> toStageAudit(publicationAuditId, executions.get(index), index + 1))
+                .toList();
+    }
+
+    /** Converte uma execução de etapa em snapshot normalizado. */
+    private GeraSalesPagePublicationStageAudit toStageAudit(
+            Long publicationAuditId,
+            GeraSalesPageStageExecution execution,
+            int stageOrder) {
+        return GeraSalesPagePublicationStageAudit.builder()
+                .publicationAuditId(publicationAuditId)
+                .stageOrder(stageOrder)
+                .idJob(execution.getIdJob())
+                .stageCode(execution.getStageCode())
+                .status(execution.getStatus())
+                .completedAt(execution.getCompletedAt())
+                .promptTemplateKey(execution.getPromptTemplateKey())
+                .prompt(execution.getPrompt())
+                .promptMarkdownContent(execution.getPromptMarkdownContent())
+                .schemaJson(execution.getSchemaJson())
+                .openAiModel(execution.getOpenAiModel())
+                .openAiRequestBody(execution.getOpenAiRequestBody())
+                .modelResponse(execution.getModelResponse())
+                .rawResponse(execution.getRawResponse())
+                .inputTokens(execution.getInputTokens())
+                .outputTokens(execution.getOutputTokens())
+                .costUsd(execution.getCostUsd())
+                .build();
+    }
+
+    /** Converte entidade persistida em resposta usada pelo frontend. */
+    private GeraSalesPagePublicationResponse toResponse(GeraSalesPagePublicationAudit audit) {
+        return new GeraSalesPagePublicationResponse(
+                audit.getId(),
+                audit.getExperimentId(),
+                audit.getPublicationJobId(),
+                audit.getPublishedAt(),
+                audit.getSalesPageUrl(),
+                audit.getCheckoutUrl(),
+                audit.getHtml(),
+                audit.getPublicationPackageJson(),
+                publicationStageRepository.findByPublicationAuditIdOrderByStageOrderAsc(audit.getId()).stream()
+                        .map(this::toStageResponse)
+                        .toList());
+    }
+
+    /** Converte snapshot normalizado de etapa em contrato de leitura. */
+    private GeraSalesPagePublicationStageResponse toStageResponse(GeraSalesPagePublicationStageAudit stage) {
+        return new GeraSalesPagePublicationStageResponse(
+                stage.getIdJob(),
+                stage.getStageCode(),
+                stage.getStatus(),
+                stage.getCompletedAt(),
+                stage.getPromptTemplateKey(),
+                stage.getPrompt(),
+                stage.getPromptMarkdownContent(),
+                stage.getSchemaJson(),
+                stage.getOpenAiModel(),
+                stage.getOpenAiRequestBody(),
+                stage.getModelResponse(),
+                stage.getRawResponse(),
+                stage.getInputTokens(),
+                stage.getOutputTokens(),
+                stage.getCostUsd());
+    }
+
+    /** Indica se a execução é a etapa final concluída. */
+    private boolean isCompletedPublication(GeraSalesPageStageExecution execution) {
+        return execution != null
+                && GeraSalesPageStageCode.PUBLICATION_PACKAGE.code().equals(execution.getStageCode())
+                && STATUS_COMPLETED.equals(execution.getStatus());
+    }
+
+    /** Converte JSON textual em mapa quando possível. */
+    private Map<String, Object> parseObject(String json) {
+        if (!StringUtils.hasText(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception ex) {
+            log.debug("Pacote de publicacao do GeraSalesPage v1 nao estava em JSON.", ex);
+            return Map.of();
+        }
+    }
+
+    /** Extrai string de campo opcional do pacote final. */
+    private String stringValue(Object value) {
+        return value instanceof String text ? text : null;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationResponse.java
@@ -1,0 +1,16 @@
+package com.marketinghub.gerasalespage.v1.service;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Resposta publica com a auditoria historica de uma pagina de venda gerada pelo pipeline. */
+public record GeraSalesPagePublicationResponse(
+        Long id,
+        Long experimentId,
+        String publicationJobId,
+        Instant publishedAt,
+        String salesPageUrl,
+        String checkoutUrl,
+        String html,
+        String publicationPackageJson,
+        List<GeraSalesPagePublicationStageResponse> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationStageResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationStageResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.gerasalespage.v1.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Snapshot de uma etapa usada para criar uma versao publicada da pagina de venda. */
+public record GeraSalesPagePublicationStageResponse(
+        String idJob,
+        String stageCode,
+        String status,
+        Instant completedAt,
+        String promptTemplateKey,
+        String prompt,
+        String promptMarkdownContent,
+        String schemaJson,
+        String openAiModel,
+        String openAiRequestBody,
+        String modelResponse,
+        String rawResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -38,6 +38,7 @@ public class GeraSalesPageStageService {
     private final ExperimentRepository experimentRepository;
     private final GeraSalesPageStageExecutionRepository executionRepository;
     private final GeraSalesPagePromptSchemaTemplateRepository templateRepository;
+    private final GeraSalesPagePublicationAuditService publicationAuditService;
     private final ObjectMapper objectMapper;
 
     /** Inicializa o service com repositórios e serializador usados pelos contratos internos. */
@@ -45,10 +46,12 @@ public class GeraSalesPageStageService {
             ExperimentRepository experimentRepository,
             GeraSalesPageStageExecutionRepository executionRepository,
             GeraSalesPagePromptSchemaTemplateRepository templateRepository,
+            GeraSalesPagePublicationAuditService publicationAuditService,
             ObjectMapper objectMapper) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.templateRepository = templateRepository;
+        this.publicationAuditService = publicationAuditService;
         this.objectMapper = objectMapper;
     }
 
@@ -132,6 +135,7 @@ public class GeraSalesPageStageService {
             execution.setCostUsd(payload.costUsd());
             execution.setOpenAiJobId(payload.openAiJobId());
             execution.setCompletedAt(Instant.now());
+            publicationAuditService.snapshotPublication(execution);
             GeraSalesPageStageCode.nextAfter(execution.getStageCode())
                     .ifPresent(nextStage -> enqueue(execution.getExperimentId(), nextStage));
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/web/GeraSalesPageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/web/GeraSalesPageController.java
@@ -1,5 +1,7 @@
 package com.marketinghub.gerasalespage.v1.web;
 
+import com.marketinghub.gerasalespage.v1.service.GeraSalesPagePublicationAuditService;
+import com.marketinghub.gerasalespage.v1.service.GeraSalesPagePublicationResponse;
 import com.marketinghub.gerasalespage.v1.service.GeraSalesPagePendingResponse;
 import com.marketinghub.gerasalespage.v1.service.GeraSalesPagePromptRequest;
 import com.marketinghub.gerasalespage.v1.service.GeraSalesPageResultRequest;
@@ -20,10 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class GeraSalesPageController {
     private final GeraSalesPageStageService service;
+    private final GeraSalesPagePublicationAuditService publicationAuditService;
 
     /** Inicializa o controller com o service do GeraSalesPage v1. */
-    public GeraSalesPageController(GeraSalesPageStageService service) {
+    public GeraSalesPageController(
+            GeraSalesPageStageService service,
+            GeraSalesPagePublicationAuditService publicationAuditService) {
         this.service = service;
+        this.publicationAuditService = publicationAuditService;
     }
 
     /** Inicia o GeraSalesPage v1 para um experimento com checkout real. */
@@ -36,6 +42,12 @@ public class GeraSalesPageController {
     @PostMapping("/experiments/{experimentId}/gerasalespage/v1/rebuild")
     public ResponseEntity<GeraSalesPageStartResponse> rebuild(@PathVariable Long experimentId) {
         return ResponseEntity.accepted().body(service.rebuild(experimentId));
+    }
+
+    /** Lista as versões publicadas da página com prompts e schemas usados em cada versão. */
+    @GetMapping("/experiments/{experimentId}/gerasalespage/v1/publications")
+    public List<GeraSalesPagePublicationResponse> publications(@PathVariable Long experimentId) {
+        return publicationAuditService.listPublications(experimentId);
     }
 
     /** Lista jobs pendentes de uma etapa para consumo canônico pelo AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPagePublicationAuditRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPagePublicationAuditRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.gerasalespage.v1;
+
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: consultar snapshots historicos de paginas de venda do GeraSalesPage v1. */
+public interface GeraSalesPagePublicationAuditRepository
+        extends JpaRepository<GeraSalesPagePublicationAudit, Long> {
+    /** Verifica se um job final de publicacao ja possui snapshot historico. */
+    boolean existsByPublicationJobId(String publicationJobId);
+
+    /** Lista snapshots de publicacao de um experimento do mais recente para o mais antigo. */
+    List<GeraSalesPagePublicationAudit> findByExperimentIdOrderByPublishedAtDesc(Long experimentId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPagePublicationStageAuditRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPagePublicationStageAuditRepository.java
@@ -1,0 +1,12 @@
+package com.marketinghub.repository.jpa.gerasalespage.v1;
+
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationStageAudit;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: consultar snapshots de etapas usadas por uma pagina de venda publicada. */
+public interface GeraSalesPagePublicationStageAuditRepository
+        extends JpaRepository<GeraSalesPagePublicationStageAudit, Long> {
+    /** Lista etapas auditadas de uma publicacao na ordem do pipeline. */
+    List<GeraSalesPagePublicationStageAudit> findByPublicationAuditIdOrderByStageOrderAsc(Long publicationAuditId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPageStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/gerasalespage/v1/GeraSalesPageStageExecutionRepository.java
@@ -18,6 +18,10 @@ public interface GeraSalesPageStageExecutionRepository extends JpaRepository<Ger
     /** Lista todas as execuções de um experimento para rebuild auditável do pipeline. */
     List<GeraSalesPageStageExecution> findByExperimentIdOrderByExecutionRequestedAtAsc(Long experimentId);
 
+    /** Lista execuções concluídas de uma etapa para backfill de snapshots de publicação. */
+    List<GeraSalesPageStageExecution> findByExperimentIdAndStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+            Long experimentId, String stageCode, String status);
+
     /** Lista pendências de uma etapa com experimento, nicho e hipótese carregados para montar o contrato do worker. */
     @EntityGraph(attributePaths = {"experiment", "experiment.niche", "experiment.hypothesisRef"})
     List<GeraSalesPageStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-01-gera-sales-page-publication-audit.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-01-gera-sales-page-publication-audit.yaml
@@ -1,0 +1,173 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-01-gera-sales-page-publication-audit-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: gera_sales_page_publication_audit
+      changes:
+        - createTable:
+            tableName: gera_sales_page_publication_audit
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: publication_job_id
+                  type: VARCHAR(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: published_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sales_page_url
+                  type: VARCHAR(1024)
+              - column:
+                  name: checkout_url
+                  type: VARCHAR(1024)
+              - column:
+                  name: html
+                  type: LONGTEXT
+              - column:
+                  name: publication_package_json
+                  type: LONGTEXT
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_audit
+            baseColumnNames: experiment_id
+            constraintName: fk_gera_sales_page_publication_audit_experiment
+            referencedTableName: experiment
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_audit
+            baseColumnNames: publication_job_id
+            constraintName: fk_gera_sales_page_publication_audit_job
+            referencedTableName: gera_sales_page_stage_execution
+            referencedColumnNames: id_job
+        - createIndex:
+            tableName: gera_sales_page_publication_audit
+            indexName: idx_gera_sales_page_publication_experiment
+            columns:
+              - column:
+                  name: experiment_id
+              - column:
+                  name: published_at
+        - createIndex:
+            tableName: gera_sales_page_publication_audit
+            indexName: uk_gera_sales_page_publication_job
+            unique: true
+            columns:
+              - column:
+                  name: publication_job_id
+        - createTable:
+            tableName: gera_sales_page_publication_stage_audit
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: publication_audit_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: id_job
+                  type: VARCHAR(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: completed_at
+                  type: TIMESTAMP
+              - column:
+                  name: prompt_template_key
+                  type: VARCHAR(191)
+              - column:
+                  name: prompt
+                  type: LONGTEXT
+              - column:
+                  name: prompt_markdown_content
+                  type: LONGTEXT
+              - column:
+                  name: schema_json
+                  type: LONGTEXT
+              - column:
+                  name: openai_model
+                  type: VARCHAR(120)
+              - column:
+                  name: openai_request_body
+                  type: LONGTEXT
+              - column:
+                  name: model_response
+                  type: LONGTEXT
+              - column:
+                  name: raw_response
+                  type: LONGTEXT
+              - column:
+                  name: input_tokens
+                  type: INT
+              - column:
+                  name: output_tokens
+                  type: INT
+              - column:
+                  name: cost_usd
+                  type: DECIMAL(12,6)
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_stage_audit
+            baseColumnNames: publication_audit_id
+            constraintName: fk_gera_sales_page_publication_stage_audit_publication
+            referencedTableName: gera_sales_page_publication_audit
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_stage_audit
+            baseColumnNames: id_job
+            constraintName: fk_gera_sales_page_publication_stage_audit_job
+            referencedTableName: gera_sales_page_stage_execution
+            referencedColumnNames: id_job
+        - createIndex:
+            tableName: gera_sales_page_publication_stage_audit
+            indexName: idx_gera_sales_page_publication_stage_audit
+            columns:
+              - column:
+                  name: publication_audit_id
+              - column:
+                  name: stage_order

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-01-gera-sales-page-publication-audit.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-30-gera-sales-page-v1-recovery.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
@@ -1,0 +1,112 @@
+package com.marketinghub.gerasalespage.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationStageAudit;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationStageAuditRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida o snapshot historico de publicacoes do GeraSalesPage v1. */
+@ExtendWith(MockitoExtension.class)
+class GeraSalesPagePublicationAuditServiceTest {
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private GeraSalesPageStageExecutionRepository executionRepository;
+    @Mock
+    private GeraSalesPagePublicationAuditRepository publicationRepository;
+    @Mock
+    private GeraSalesPagePublicationStageAuditRepository publicationStageRepository;
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+    @InjectMocks
+    private GeraSalesPagePublicationAuditService service;
+
+    /** Deve salvar a pagina final junto dos prompts e schemas usados pelas etapas. */
+    @Test
+    void shouldSnapshotPublicationWithStagePromptsAndSchemas() {
+        Experiment experiment = new Experiment();
+        experiment.setId(53L);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp53.html");
+        GeraSalesPageStageExecution offer = execution(
+                "job-offer",
+                GeraSalesPageStageCode.OFFER_BRIEF.code(),
+                "{\"summary\":\"oferta\"}",
+                Instant.parse("2026-07-01T10:00:00Z"));
+        GeraSalesPageStageExecution publication = execution(
+                "job-publication",
+                GeraSalesPageStageCode.PUBLICATION_PACKAGE.code(),
+                "{\"html\":\"<html>Venda</html>\",\"checkoutUrl\":\"https://mp.test/checkout\"}",
+                Instant.parse("2026-07-01T10:10:00Z"));
+
+        when(publicationRepository.existsByPublicationJobId("job-publication")).thenReturn(false);
+        when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L))
+                .thenReturn(List.of(offer, publication));
+        when(publicationRepository.save(any(GeraSalesPagePublicationAudit.class)))
+                .thenAnswer(invocation -> {
+                    GeraSalesPagePublicationAudit audit = invocation.getArgument(0);
+                    audit.setId(10L);
+                    return audit;
+                });
+
+        service.snapshotPublication(publication);
+
+        ArgumentCaptor<GeraSalesPagePublicationAudit> audit =
+                ArgumentCaptor.forClass(GeraSalesPagePublicationAudit.class);
+        verify(publicationRepository).save(audit.capture());
+        ArgumentCaptor<List<GeraSalesPagePublicationStageAudit>> stages = ArgumentCaptor.forClass(List.class);
+        verify(publicationStageRepository).saveAll(stages.capture());
+        assertThat(audit.getValue().getPublicationJobId()).isEqualTo("job-publication");
+        assertThat(audit.getValue().getSalesPageUrl()).isEqualTo("https://pagamentopalf.site/sales-page-exp53.html");
+        assertThat(audit.getValue().getCheckoutUrl()).isEqualTo("https://mp.test/checkout");
+        assertThat(audit.getValue().getHtml()).contains("Venda");
+        assertThat(stages.getValue()).hasSize(2);
+        assertThat(stages.getValue().getFirst().getPublicationAuditId()).isEqualTo(10L);
+        assertThat(stages.getValue().getFirst().getStageCode()).isEqualTo("sales-page-offer-brief");
+        assertThat(stages.getValue().getFirst().getPrompt()).isEqualTo("prompt job-offer");
+        assertThat(stages.getValue().getFirst().getSchemaJson()).isEqualTo("{\"type\":\"object\"}");
+    }
+
+    /** Cria execução concluída mínima para snapshot de teste. */
+    private GeraSalesPageStageExecution execution(String idJob, String stageCode, String response, Instant requestedAt) {
+        return GeraSalesPageStageExecution.builder()
+                .idJob(idJob)
+                .experimentId(53L)
+                .stageCode(stageCode)
+                .status("CONCLUIDO")
+                .executionRequestedAt(requestedAt)
+                .completedAt(requestedAt.plusSeconds(5))
+                .promptTemplateKey("template-" + stageCode)
+                .prompt("prompt " + idJob)
+                .promptMarkdownContent("# Prompt " + idJob)
+                .schemaJson("{\"type\":\"object\"}")
+                .openAiModel("gpt-test")
+                .openAiRequestBody("{\"model\":\"gpt-test\"}")
+                .modelResponse(response)
+                .rawResponse("{\"raw\":true}")
+                .inputTokens(10)
+                .outputTokens(5)
+                .build();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -34,6 +34,8 @@ class GeraSalesPageStageServiceTest {
     @Mock
     private GeraSalesPagePromptSchemaTemplateRepository templateRepository;
     @Mock
+    private GeraSalesPagePublicationAuditService publicationAuditService;
+    @Mock
     private ObjectMapper objectMapper;
 
     @InjectMocks

--- a/docs/canonical/gerasalespage-arquitetura-canon.v1.md
+++ b/docs/canonical/gerasalespage-arquitetura-canon.v1.md
@@ -27,6 +27,8 @@ O GeraSalesPage v1 é um pipeline independente para gerar página de vendas dire
 - Experimento `LOW_TICKET_PRODUCT` só pode ser liberado para campanha quando a etapa final `sales-page-publication-package` estiver `CONCLUIDO`; URL de página preenchida manualmente não substitui a conclusão do pipeline.
 - O GeraSalesPage v1 usa `service_tier=default` por padrão, porque página de venda é artefato comercial crítico e deve priorizar estabilidade sobre economia de Flex.
 - Quando uma página precisar ser refeita, o rebuild canônico deve marcar execuções anteriores como `SUBSTITUIDO` e enfileirar nova execução a partir de `sales-page-offer-brief`.
+- Cada página de venda publicada deve gerar um snapshot histórico em banco, associando a versão da página ao job final, HTML/pacote final, prompts renderizados, prompt markdown base, schema JSON, modelo OpenAI, request enviado e resposta bruta de cada etapa usada naquela versão.
+- A troca futura de prompt, schema ou modelo não pode sobrescrever a auditoria das páginas já publicadas; o frontend deve conseguir consultar as versões publicadas e seus prompts/schemas originais por experimento.
 
 ## Sugestões incorporadas
 

--- a/docs/registros/diario.md
+++ b/docs/registros/diario.md
@@ -1,0 +1,7 @@
+# Diario de negocio
+
+Este arquivo registra o fechamento de cada dia quando o usuario pedir `feche o dia`.
+
+O foco do registro e negocio, marketing e operacao comercial: campanhas publicadas, experimentos criados ou avancados, produtos/ofertas estruturados, validacoes comerciais, aprendizados, metricas relevantes, decisoes tomadas e proximos passos.
+
+Nao usar este diario como changelog tecnico de sistema. Detalhes tecnicos devem aparecer apenas quando explicarem impacto direto no negocio.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5536,3 +5536,11 @@
 - Correção aplicada: a prontidão e a liberação para Facebook bloqueiam low-ticket sem GeraSalesPage concluído; foi criado rebuild canônico para substituir execuções antigas e gerar a página novamente pelo pipeline.
 - Decisão OpenAI: o GeraSalesPage v1 passa a usar `service_tier=default` por padrão, aceitando custo maior para reduzir falhas na criação de páginas de venda.
 - Prevenção de recorrência: testes cobrem bloqueio de campanha low-ticket sem publicação do GeraSalesPage, liberação após etapa final concluída, rebuild com status `SUBSTITUIDO` e custo Standard conforme service tier.
+
+## 2026-07-01 — Auditoria histórica de páginas GeraSalesPage
+
+- Decisão: cada página de venda publicada pelo GeraSalesPage v1 precisa manter no banco a associação com os prompts, schemas, modelo, request e respostas usados para criar aquela versão.
+- Causa-raiz: sem snapshot por publicação, uma alteração futura de prompt/schema deixaria difícil entender por que uma página antiga foi gerada daquele jeito.
+- Correção aplicada: criada auditoria de publicação por experimento, com snapshot da etapa final e das etapas concluídas usadas na página.
+- Consulta: o frontend passa a acessar as versões publicadas em `/api/experiments/{id}/gerasalespage/v1/publications` e exibe o card “Auditoria da página de venda” para experimentos low-ticket.
+- Prevenção de recorrência: o cânone do GeraSalesPage agora exige snapshot histórico por página publicada.

--- a/frontend/src/api/experiment/useGeraSalesPagePublications.ts
+++ b/frontend/src/api/experiment/useGeraSalesPagePublications.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface GeraSalesPagePublicationStage {
+  idJob: string;
+  stageCode: string;
+  status: string;
+  completedAt?: string | null;
+  promptTemplateKey?: string | null;
+  prompt?: string | null;
+  promptMarkdownContent?: string | null;
+  schemaJson?: string | null;
+  openAiModel?: string | null;
+  openAiRequestBody?: string | null;
+  modelResponse?: string | null;
+  rawResponse?: string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  costUsd?: number | null;
+}
+
+export interface GeraSalesPagePublication {
+  id: number;
+  experimentId: number;
+  publicationJobId: string;
+  publishedAt: string;
+  salesPageUrl?: string | null;
+  checkoutUrl?: string | null;
+  html?: string | null;
+  publicationPackageJson?: string | null;
+  stages: GeraSalesPagePublicationStage[];
+}
+
+export function useGeraSalesPagePublications(experimentId?: string | number) {
+  return useQuery({
+    queryKey: ["experiments", experimentId, "gerasalespage-publications"],
+    enabled: Boolean(experimentId),
+    queryFn: async () => {
+      const { data } = await axios.get<GeraSalesPagePublication[]>(
+        `/api/experiments/${experimentId}/gerasalespage/v1/publications`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -43,6 +43,7 @@ import {
   type GeraLandingStageModel,
 } from "../../api/pipeline/useGeraLandingStageModels";
 import { useExperimentCompleteMarkdownReport } from "../../api/experiment/useExperimentCompleteMarkdownReport";
+import { useGeraSalesPagePublications } from "../../api/experiment/useGeraSalesPagePublications";
 
 function formatPipelineStageModel(stageModel?: GeraLandingStageModel) {
   const name = stageModel?.openAiModelName?.trim();
@@ -286,6 +287,7 @@ export default function ExperimentDetailPage() {
   const expId = id as string;
   const navigate = useNavigate();
   const { data, isLoading } = useExperiment(expId);
+  const geraSalesPagePublications = useGeraSalesPagePublications(expId);
   const { data: geraLandingStageModels, isLoading: isLoadingStageModels } =
     useGeraLandingStageModels();
   const {
@@ -1919,6 +1921,8 @@ export default function ExperimentDetailPage() {
       action: () => window.scrollTo({ top: 0, behavior: "smooth" }),
     },
   ];
+  const salesPagePublications = geraSalesPagePublications.data ?? [];
+  const latestSalesPagePublication = salesPagePublications[0];
   const diagnosticsVariant: Record<string, string> = {
     ERROR: "danger",
     WARNING: "warning",
@@ -2316,6 +2320,163 @@ export default function ExperimentDetailPage() {
               Página de obrigado premium e ZIP de entrega ainda dependem de
               validação operacional fora deste contrato persistido do backend.
             </div>
+          </div>
+        </div>
+      ) : null}
+      {isLowTicketProduct ? (
+        <div className="card border-0 shadow-sm rounded-3 mt-3">
+          <div className="card-body">
+            <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+              <div>
+                <h5 className="card-title mb-1">
+                  Auditoria da página de venda
+                </h5>
+                <p className="text-muted small mb-0">
+                  Versões publicadas pelo GeraSalesPage v1 com prompts, schemas,
+                  modelo e request usados em cada etapa.
+                </p>
+              </div>
+              <span className="badge text-bg-light border text-body">
+                {geraSalesPagePublications.isLoading
+                  ? "Carregando"
+                  : `${salesPagePublications.length} versão(ões)`}
+              </span>
+            </div>
+            {geraSalesPagePublications.isLoading ? (
+              <div className="text-muted small mt-3">
+                Carregando auditoria da página...
+              </div>
+            ) : latestSalesPagePublication ? (
+              <div className="mt-3">
+                <div className="row g-3">
+                  <div className="col-12 col-lg-4">
+                    <div className="border rounded-3 p-3 h-100">
+                      <div className="text-muted small">Última publicação</div>
+                      <div className="fw-semibold">
+                        {formatDateTimeValue(
+                          latestSalesPagePublication.publishedAt,
+                        )}
+                      </div>
+                      <div className="text-muted small mt-2">Job final</div>
+                      <code className="small text-break">
+                        {latestSalesPagePublication.publicationJobId}
+                      </code>
+                    </div>
+                  </div>
+                  <div className="col-12 col-lg-4">
+                    <div className="border rounded-3 p-3 h-100">
+                      <div className="text-muted small">Página de venda</div>
+                      {latestSalesPagePublication.salesPageUrl ? (
+                        <a
+                          href={latestSalesPagePublication.salesPageUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="small text-break"
+                        >
+                          {latestSalesPagePublication.salesPageUrl}
+                        </a>
+                      ) : (
+                        <span className="text-muted small">Não registrada</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="col-12 col-lg-4">
+                    <div className="border rounded-3 p-3 h-100">
+                      <div className="text-muted small">Checkout usado</div>
+                      {latestSalesPagePublication.checkoutUrl ? (
+                        <a
+                          href={latestSalesPagePublication.checkoutUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="small text-break"
+                        >
+                          {latestSalesPagePublication.checkoutUrl}
+                        </a>
+                      ) : (
+                        <span className="text-muted small">Não registrado</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="accordion mt-3" id="gera-sales-page-audit">
+                  {latestSalesPagePublication.stages.map((stage, index) => (
+                    <div className="accordion-item" key={stage.idJob}>
+                      <h2
+                        className="accordion-header"
+                        id={`audit-stage-${stage.idJob}`}
+                      >
+                        <button
+                          className={`accordion-button ${index === 0 ? "" : "collapsed"}`}
+                          type="button"
+                          data-bs-toggle="collapse"
+                          data-bs-target={`#audit-stage-body-${stage.idJob}`}
+                          aria-expanded={index === 0}
+                          aria-controls={`audit-stage-body-${stage.idJob}`}
+                        >
+                          <span className="fw-semibold me-2">
+                            {stage.stageCode}
+                          </span>
+                          <span className="badge text-bg-light border text-body me-2">
+                            {stage.openAiModel || "modelo não registrado"}
+                          </span>
+                          <span className="text-muted small">
+                            {stage.completedAt
+                              ? formatDateTimeValue(stage.completedAt)
+                              : "sem data"}
+                          </span>
+                        </button>
+                      </h2>
+                      <div
+                        id={`audit-stage-body-${stage.idJob}`}
+                        className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
+                        aria-labelledby={`audit-stage-${stage.idJob}`}
+                      >
+                        <div className="accordion-body">
+                          <div className="row g-3">
+                            <div className="col-12 col-xl-6">
+                              <h6>Prompt renderizado</h6>
+                              <CollapsibleJsonViewer
+                                content={stage.prompt}
+                                parseAsJson={false}
+                                initiallyCollapsed
+                              />
+                            </div>
+                            <div className="col-12 col-xl-6">
+                              <h6>Schema JSON</h6>
+                              <CollapsibleJsonViewer
+                                content={stage.schemaJson}
+                                initiallyCollapsed
+                              />
+                            </div>
+                            <div className="col-12 col-xl-6">
+                              <h6>Prompt markdown base</h6>
+                              <CollapsibleJsonViewer
+                                content={stage.promptMarkdownContent}
+                                parseAsJson={false}
+                                initiallyCollapsed
+                              />
+                            </div>
+                            <div className="col-12 col-xl-6">
+                              <h6>Request enviado</h6>
+                              <CollapsibleJsonViewer
+                                content={stage.openAiRequestBody}
+                                initiallyCollapsed
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="alert alert-light border small text-muted mt-3 mb-0">
+                Ainda não existe página publicada pelo GeraSalesPage v1 com
+                snapshot de prompts e schemas. Execute ou refaça o pipeline para
+                registrar a auditoria.
+              </div>
+            )}
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## O que mudou

- Cria auditoria historica de paginas de venda publicadas pelo GeraSalesPage v1.
- Cada publicacao agora fica associada no banco ao job final, HTML/pacote final, checkout, prompts renderizados, prompt markdown base, schema JSON, modelo, request OpenAI e respostas das etapas usadas naquela versao.
- Exposto endpoint de consulta: `GET /api/experiments/{id}/gerasalespage/v1/publications`.
- Adicionado card no detalhe do experimento low-ticket: `Auditoria da pagina de venda`.
- Registrada a nova regra no canon do GeraSalesPage e em `docs/registros/experimentos.md`.
- Adicionada a regra operacional `feche o dia` no `AGENTS.md` e criado `docs/registros/diario.md` para fechamento diario de negocio.

## Por que

Sem snapshot historico por pagina publicada, uma mudanca futura de prompt/schema/modelo dificultaria entender por que uma pagina antiga foi gerada daquele jeito. Para venda low-ticket, a pagina e artefato comercial critico e precisa manter rastreabilidade de negocio e IA.

## Validacao

- `mvn -Dtest=GeraSalesPageStageServiceTest,GeraSalesPagePublicationAuditServiceTest test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Changelog mestre conferido sem `include` relativo sem `relativeToChangelogFile: true`.

## Observacoes

- A auditoria de etapas foi normalizada em tabela filha, evitando JSON agregado com JSON interno e facilitando consulta futura pelo frontend.