### PR TITLE
[codex] Corrige auditoria GeraSalesPage no MySQL 5.7

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-01-gera-sales-page-publication-audit.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-01-gera-sales-page-publication-audit.yaml
@@ -33,7 +33,8 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: published_at
-                  type: TIMESTAMP
+                  type: DATETIME(6)
+                  defaultValueComputed: CURRENT_TIMESTAMP(6)
                   constraints:
                     nullable: false
               - column:
@@ -50,7 +51,8 @@ databaseChangeLog:
                   type: LONGTEXT
               - column:
                   name: created_at
-                  type: TIMESTAMP
+                  type: DATETIME(6)
+                  defaultValueComputed: CURRENT_TIMESTAMP(6)
                   constraints:
                     nullable: false
         - addForeignKeyConstraint:
@@ -117,7 +119,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: completed_at
-                  type: TIMESTAMP
+                  type: DATETIME(6)
               - column:
                   name: prompt_template_key
                   type: VARCHAR(191)

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,12 +1,12 @@
 databaseChangeLog:
   - include:
-      file: changesets/2026-07-01-gera-sales-page-publication-audit.yaml
-      relativeToChangelogFile: true
-  - include:
       file: changesets/2026-06-30-gera-sales-page-v1-recovery.yaml
       relativeToChangelogFile: true
   - include:
       file: changesets/2026-06-30-gera-sales-page-v1.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-07-01-gera-sales-page-publication-audit.yaml
       relativeToChangelogFile: true
   - include:
       file: changesets/2026-06-30-experiment-campaign-objective-sales.yaml

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5544,3 +5544,10 @@
 - Correção aplicada: criada auditoria de publicação por experimento, com snapshot da etapa final e das etapas concluídas usadas na página.
 - Consulta: o frontend passa a acessar as versões publicadas em `/api/experiments/{id}/gerasalespage/v1/publications` e exibe o card “Auditoria da página de venda” para experimentos low-ticket.
 - Prevenção de recorrência: o cânone do GeraSalesPage agora exige snapshot histórico por página publicada.
+
+## 2026-07-01 — Hotfix MySQL 5.7 da auditoria GeraSalesPage
+
+- Problema: o backend não subiu em produção porque o changelog de auditoria do GeraSalesPage criava colunas `TIMESTAMP NOT NULL` sem valor padrão, gerando `Invalid default value for 'created_at'` no MySQL 5.7.
+- Causa-raiz: o changelog não seguiu o padrão seguro do projeto para datas em MySQL 5.7 e ainda estava incluído antes das tabelas base do GeraSalesPage.
+- Correção aplicada: `published_at` e `created_at` passaram para `DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`, `completed_at` passou para `DATETIME(6)` e o include da auditoria foi movido para depois dos changelogs base do GeraSalesPage.
+- Prevenção de recorrência: o diff foi revisado contra as regras de Liquibase/MySQL 5.7, mantendo `relativeToChangelogFile: true` no changelog mestre.


### PR DESCRIPTION
## O que mudou

- Corrige o changelog `2026-07-01-gera-sales-page-publication-audit.yaml` para MySQL 5.7.
- Troca `TIMESTAMP NOT NULL` sem default por `DATETIME(6)` com `DEFAULT CURRENT_TIMESTAMP(6)` em `published_at` e `created_at`.
- Mantém `completed_at` como `DATETIME(6)` nullable.
- Move o include da auditoria para depois dos changelogs base do GeraSalesPage.
- Registra a causa-raiz em `docs/registros/experimentos.md`.

## Causa-raiz

O backend não subia porque o Liquibase tentava criar a tabela `gera_sales_page_publication_audit` com `TIMESTAMP NOT NULL` sem valor padrão. No MySQL 5.7 isso falha com `Invalid default value for 'created_at'`. Além disso, a auditoria estava incluída antes das tabelas base do GeraSalesPage, o que deixava a migração frágil para as FKs.

## Validação

- `mvn -Dtest=GeraSalesPagePublicationAuditServiceTest,GeraSalesPageStageServiceTest test`
- `git diff --check`
- validação do changelog mestre: nenhum include relativo `changesets/...` ficou sem `relativeToChangelogFile: true`.

## Impacto

Após merge e novo deploy do backend, a migration deve rodar sem bloquear o bootstrap do `ads-service`.