### PR TITLE
[codex] Ajusta funil low-ticket e tracking de checkout

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 /** Responsabilidade: executar uma etapa do GeraSalesPage v1 usando prompt/schema vindos do backend. */
 public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput, GeraSalesPageOutput> {
     private static final Logger log = LoggerFactory.getLogger(GeraSalesPageProcessor.class);
+    private static final String PUBLICATION_PACKAGE_STAGE = "sales-page-publication-package";
     private final ObjectMapper objectMapper;
     private final OpenAiClientPort openAiClient;
     private final GeraSalesPageResponseValidator responseValidator;
@@ -61,6 +62,8 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
                 context.execution().stageCode(),
                 rawResult.rawResponse());
         GeraSalesPageOutput output = responseValidator.validateAndParse(rawResult.modelResponse());
+        OpenAiResult<String> effectiveRawResult = enrichFinalSalesPageResponse(context, rawResult, output);
+        GeraSalesPageOutput effectiveOutput = responseValidator.validateAndParse(effectiveRawResult.modelResponse());
         StageArtifact requestArtifact = context.artifactStore().save(
                 "OPENAI_REQUEST",
                 context.execution().stageCode() + "-request.json",
@@ -71,20 +74,99 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
                 "OPENAI_RESPONSE",
                 context.execution().stageCode() + "-response.json",
                 "application/json",
-                rawResult.rawResponse(),
+                effectiveRawResult.rawResponse(),
                 Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
         return new StageResult<>(
-                output,
+                effectiveOutput,
                 List.of(requestArtifact, responseArtifact),
                 Map.of(
                         "openAiResult",
-                        rawResult,
+                        effectiveRawResult,
                         "openAiJobId",
-                        rawResult.openAiJobId() == null ? "" : rawResult.openAiJobId(),
+                        effectiveRawResult.openAiJobId() == null ? "" : effectiveRawResult.openAiJobId(),
                         "inputTokens",
-                        rawResult.inputTokens() == null ? 0 : rawResult.inputTokens(),
+                        effectiveRawResult.inputTokens() == null ? 0 : effectiveRawResult.inputTokens(),
                         "outputTokens",
-                        rawResult.outputTokens() == null ? 0 : rawResult.outputTokens()));
+                        effectiveRawResult.outputTokens() == null ? 0 : effectiveRawResult.outputTokens()));
+    }
+
+    /** Injeta tracking de clique no checkout no HTML final publicado pelo GeraSalesPage v1. */
+    private OpenAiResult<String> enrichFinalSalesPageResponse(
+            StageContext<GeraSalesPageInput> context,
+            OpenAiResult<String> rawResult,
+            GeraSalesPageOutput output) {
+        if (!PUBLICATION_PACKAGE_STAGE.equals(context.execution().stageCode())) {
+            return rawResult;
+        }
+        Object htmlValue = output.payload().get("html");
+        if (!(htmlValue instanceof String html) || html.isBlank() || html.contains("checkout_click")) {
+            return rawResult;
+        }
+        Map<String, Object> enrichedPayload = new LinkedHashMap<>(output.payload());
+        enrichedPayload.put("html", injectCheckoutClickTracking(html));
+        try {
+            String enrichedModelResponse = objectMapper.writeValueAsString(enrichedPayload);
+            return new OpenAiResult<>(
+                    rawResult.openAiJobId(),
+                    rawResult.rawResponse(),
+                    enrichedModelResponse,
+                    enrichedModelResponse,
+                    rawResult.inputTokens(),
+                    rawResult.outputTokens(),
+                    rawResult.costUsd());
+        } catch (JsonProcessingException ex) {
+            log.error("Falha ao injetar tracking de checkout no GeraSalesPage v1. jobId={}",
+                    context.execution().idJob(), ex);
+            throw new StageWorkerException("Falha ao injetar tracking de checkout no GeraSalesPage v1", ex);
+        }
+    }
+
+    /** Adiciona script pequeno de analytics para registrar clique em links de checkout. */
+    private String injectCheckoutClickTracking(String html) {
+        String script = """
+                <script>
+                (function(){
+                  function uid(prefix){return prefix+'-'+Date.now().toString(36)+'-'+Math.random().toString(36).slice(2,10);}
+                  function storageGet(key){try{return localStorage.getItem(key);}catch(e){return null;}}
+                  function storageSet(key,value){try{localStorage.setItem(key,value);}catch(e){}}
+                  var visitorKey='mhub_visitor_id';
+                  var visitorId=storageGet(visitorKey)||uid('visitor');
+                  storageSet(visitorKey,visitorId);
+                  var sessionId=storageGet('mhub_session_id')||uid('session');
+                  storageSet('mhub_session_id',sessionId);
+                  var slug=(location.pathname.split('/').pop()||'').replace(/\\.html$/,'');
+                  function sendCheckoutClick(){
+                    if(!slug){return;}
+                    var payload={
+                      eventId:uid('checkout-click'),
+                      eventType:'checkout_click',
+                      visitorId:visitorId,
+                      sessionId:sessionId,
+                      pageUrl:location.href,
+                      occurredAt:new Date().toISOString(),
+                      userAgent:navigator.userAgent,
+                      deviceType:window.innerWidth<768?'mobile':'desktop',
+                      operatingSystem:navigator.platform||''
+                    };
+                    try{
+                      navigator.sendBeacon('/api/public/lead-portal/flows/'+encodeURIComponent(slug)+'/page-analytics', new Blob([JSON.stringify(payload)], {type:'application/json'}));
+                    }catch(e){
+                      fetch('/api/public/lead-portal/flows/'+encodeURIComponent(slug)+'/page-analytics',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload),keepalive:true}).catch(function(){});
+                    }
+                  }
+                  document.addEventListener('click',function(event){
+                    var link=event.target&&event.target.closest?event.target.closest('a[href]'):null;
+                    if(!link){return;}
+                    var href=link.getAttribute('href')||'';
+                    if(/mercadopago|checkout|pref_id/i.test(href)){sendCheckoutClick();}
+                  },true);
+                })();
+                </script>
+                """;
+        if (html.toLowerCase().contains("</body>")) {
+            return html.replaceFirst("(?i)</body>", java.util.regex.Matcher.quoteReplacement(script) + "</body>");
+        }
+        return html + script;
     }
 
     /** Monta o request da Responses API usando prompt e schema entregues pelo backend. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
@@ -1,0 +1,41 @@
+package com.marketinghub.worker.pipeline.gerasalespagev1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar enriquecimentos técnicos aplicados pelo processor do GeraSalesPage v1. */
+class GeraSalesPageProcessorTest {
+
+    /** Garante que o HTML final registre clique real no checkout para métricas de low-ticket. */
+    @Test
+    void injectsCheckoutClickTrackingIntoFinalHtml() throws Exception {
+        GeraSalesPageProcessor processor = processor();
+        Method method = GeraSalesPageProcessor.class.getDeclaredMethod("injectCheckoutClickTracking", String.class);
+        method.setAccessible(true);
+
+        String html = (String) method.invoke(processor,
+                "<!doctype html><html><body><a href=\"https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc\">Comprar</a></body></html>");
+
+        assertThat(html)
+                .contains("checkout_click")
+                .contains("/api/public/lead-portal/flows/")
+                .contains("sendBeacon")
+                .contains("</body>");
+    }
+
+    /** Cria processor mínimo para exercitar métodos puros por reflexão. */
+    private GeraSalesPageProcessor processor() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return new GeraSalesPageProcessor(
+                objectMapper,
+                mock(OpenAiClientPort.class),
+                new GeraSalesPageResponseValidator(objectMapper),
+                mock(GeraSalesPageBackendClient.class),
+                "default");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
@@ -29,11 +29,33 @@ public class ExperimentFunnelDiagnosticConfig {
             new ConversionRuleSpec(ExperimentFunnelStage.ACESSO_CHECKOUT, ExperimentFunnelStage.COMPRA, 0.03)
     );
 
+    private static final List<ConversionRuleSpec> LOW_TICKET_PRIORITIZED_RULES = List.of(
+            new ConversionRuleSpec(
+                    ExperimentFunnelStage.VISUALIZACAO_ANUNCIO,
+                    ExperimentFunnelStage.ACESSO_FORM_LEAD,
+                    0.015
+            ),
+            new ConversionRuleSpec(
+                    ExperimentFunnelStage.VISUALIZACAO_FORM,
+                    ExperimentFunnelStage.ACESSO_CHECKOUT,
+                    0.03,
+                    List.of(0.02, 0.01)
+            ),
+            new ConversionRuleSpec(ExperimentFunnelStage.ACESSO_CHECKOUT, ExperimentFunnelStage.COMPRA, 0.03)
+    );
+
     /**
      * Retorna as transições do funil que devem ser diagnosticadas pelo backend.
      */
     public List<ConversionRuleSpec> prioritizedRules() {
         return PRIORITIZED_RULES;
+    }
+
+    /**
+     * Retorna as transições de venda direta low-ticket, sem etapas de formulário.
+     */
+    public List<ConversionRuleSpec> lowTicketPrioritizedRules() {
+        return LOW_TICKET_PRIORITIZED_RULES;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
@@ -1,11 +1,14 @@
 package com.marketinghub.experiment.funnel;
 
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDiagnosticDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticReasonCode;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
 import com.marketinghub.experiment.funnel.dto.FunnelThresholdCheckDto;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -22,25 +25,29 @@ public class ExperimentFunnelDiagnosticService {
 
     private final ExperimentFunnelService funnelService;
     private final ExperimentFunnelDiagnosticConfig config;
+    private final ExperimentRepository experimentRepository;
 
     /**
      * Cria o serviço com a fonte de métricas do funil e a configuração canônica dos limites.
      */
     public ExperimentFunnelDiagnosticService(ExperimentFunnelService funnelService,
-                                             ExperimentFunnelDiagnosticConfig config) {
+                                             ExperimentFunnelDiagnosticConfig config,
+                                             ExperimentRepository experimentRepository) {
         this.funnelService = funnelService;
         this.config = config;
+        this.experimentRepository = experimentRepository;
     }
 
     /**
      * Diagnostica as transições prioritárias do funil para um experimento.
      */
     public ExperimentFunnelDiagnosticsResponseDto diagnose(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
         List<ExperimentFunnelStageDto> stages = funnelService.summarize(experimentId);
         Map<ExperimentFunnelStage, ExperimentFunnelStageDto> byStage = stages.stream()
                 .collect(Collectors.toMap(ExperimentFunnelStageDto::getStage, stage -> stage));
 
-        List<ExperimentFunnelStageDiagnosticDto> diagnostics = config.prioritizedRules().stream()
+        List<ExperimentFunnelStageDiagnosticDto> diagnostics = rulesFor(experiment).stream()
                 .map(rule -> diagnoseRule(byStage, rule))
                 .sorted(Comparator.comparing(dto -> dto.stageKey().getOrder()))
                 .toList();
@@ -53,6 +60,16 @@ public class ExperimentFunnelDiagnosticService {
                 : null;
 
         return new ExperimentFunnelDiagnosticsResponseDto(diagnostics, contextualAlert);
+    }
+
+    /**
+     * Seleciona as transições estatísticas compatíveis com o tipo comercial do experimento.
+     */
+    private List<ExperimentFunnelDiagnosticConfig.ConversionRuleSpec> rulesFor(Experiment experiment) {
+        if (experiment != null && experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT) {
+            return config.lowTicketPrioritizedRules();
+        }
+        return config.prioritizedRules();
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.funnel;
 
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
@@ -81,9 +82,11 @@ public class ExperimentFunnelService {
 
         applyManualEvents(experiment.getId(), baseline, stages);
         applyAutomaticMetrics(experiment.getId(), baseline, stages);
+        adaptStagesForExperimentType(experiment, stages);
         fillDefaultSourceWhenMissing(stages);
 
         return stages.values().stream()
+                .filter(stage -> shouldExposeStage(experiment, stage.getStage()))
                 .sorted(Comparator.comparingInt(ExperimentFunnelStageDto::getOrder))
                 .toList();
     }
@@ -396,7 +399,7 @@ public class ExperimentFunnelService {
                 request.userAgent(),
                 normalizeLandingAnalyticsDeviceType(request.deviceType(), request.userAgent()));
 
-        ExperimentFunnelStage stage = resolveStageForLandingAnalyticsEvent(eventType);
+        ExperimentFunnelStage stage = resolveStageForLandingAnalyticsEvent(experiment, eventType);
         if (stage != null) {
             ExperimentFunnelEvent event = ExperimentFunnelEvent.builder()
                     .experiment(experiment)
@@ -437,6 +440,10 @@ public class ExperimentFunnelService {
         if ("page_load_metric".equalsIgnoreCase(eventType)) {
             validateRequiredLandingAnalyticsField(request.sessionId(), "sessionId é obrigatório para page_load_metric");
             validateRequiredLandingAnalyticsField(request.pageUrl(), "pageUrl é obrigatório para page_load_metric");
+        }
+        if ("checkout_click".equalsIgnoreCase(eventType)) {
+            validateRequiredLandingAnalyticsField(request.sessionId(), "sessionId é obrigatório para checkout_click");
+            validateRequiredLandingAnalyticsField(request.pageUrl(), "pageUrl é obrigatório para checkout_click");
         }
     }
 
@@ -547,7 +554,7 @@ public class ExperimentFunnelService {
     /**
      * Mapeia eventos de analytics da landing para a etapa consolidada do funil.
      */
-    private ExperimentFunnelStage resolveStageForLandingAnalyticsEvent(String eventType) {
+    private ExperimentFunnelStage resolveStageForLandingAnalyticsEvent(Experiment experiment, String eventType) {
         if ("page_view".equalsIgnoreCase(eventType)) {
             return ExperimentFunnelStage.VISUALIZACAO_FORM;
         }
@@ -556,6 +563,9 @@ public class ExperimentFunnelService {
         }
         if ("page_load_metric".equalsIgnoreCase(eventType)) {
             return ExperimentFunnelStage.VISUALIZACAO_FORM;
+        }
+        if ("checkout_click".equalsIgnoreCase(eventType) && isLowTicketProduct(experiment)) {
+            return ExperimentFunnelStage.ACESSO_CHECKOUT;
         }
         return null;
     }
@@ -744,16 +754,27 @@ public class ExperimentFunnelService {
         mergeMetric(stages, ExperimentFunnelStage.ACESSO_CHECKOUT,
                 fetchSingleMetric("""
                         SELECT COUNT(*) AS total,
-                               COUNT(DISTINCT p.submission_id) AS unique_count,
-                               MAX(p.checkout_accessed_at) AS last_event
-                        FROM lead_portal_purchase p
-                        JOIN flow_submissions s ON s.id = p.submission_id
-                        JOIN lead_portal_flow f ON f.slug = s.flow_slug
-                        WHERE %s
-                          AND p.checkout_accessed_at IS NOT NULL
-                          AND (? IS NULL OR p.checkout_accessed_at > ?)
-                        """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
-                "Acessos ao checkout registrados via tracking público (lead_portal_purchase.checkout_accessed_at)");
+                               NULL AS unique_count,
+                               MAX(event_at) AS last_event
+                        FROM (
+                            SELECT p.checkout_accessed_at AS event_at
+                            FROM lead_portal_purchase p
+                            JOIN flow_submissions s ON s.id = p.submission_id
+                            JOIN lead_portal_flow f ON f.slug = s.flow_slug
+                            WHERE %s
+                              AND p.checkout_accessed_at IS NOT NULL
+                            UNION ALL
+                            SELECT efe.occurred_at AS event_at
+                            FROM experiment_funnel_event efe
+                            WHERE efe.experiment_id = ?
+                              AND efe.stage = 'ACESSO_CHECKOUT'
+                              AND efe.source = ?
+                              AND efe.payload LIKE '%%eventType=checkout_click%%'
+                        ) checkout_access
+                        WHERE (? IS NULL OR event_at > ?)
+                        """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, experimentId,
+                        ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, baseline, baseline),
+                "Acessos ao checkout registrados via tracking público e clique real no checkout (checkout_click)");
 
         mergeMetric(stages, ExperimentFunnelStage.COMPRA,
                 fetchSingleMetric("""
@@ -820,6 +841,62 @@ public class ExperimentFunnelService {
         dto.setUniqueCount(sum(dto.getUniqueCount(), metric.uniqueCount()));
         dto.setLastEventAt(max(dto.getLastEventAt(), metric.lastEvent()));
         dto.setSource(source);
+    }
+
+    /**
+     * Adapta nomes e fontes do funil quando o experimento é venda direta low-ticket, sem alterar chaves históricas.
+     */
+    private void adaptStagesForExperimentType(Experiment experiment,
+                                              Map<ExperimentFunnelStage, ExperimentFunnelStageDto> stages) {
+        if (!isLowTicketProduct(experiment)) {
+            return;
+        }
+        renameStage(stages, ExperimentFunnelStage.ACESSO_FORM_LEAD,
+                "Clique para a página de venda",
+                "Cliques do anúncio para a página de venda (experiment_campaign_metric)");
+        renameStage(stages, ExperimentFunnelStage.VISUALIZACAO_FORM,
+                "Visualização da página de venda",
+                "Visualizações da página de venda publicadas pelo GeraSalesPage (page_view)");
+        renameStage(stages, ExperimentFunnelStage.ACESSO_CHECKOUT,
+                "Clique no checkout",
+                "Cliques reais no checkout da página de venda (checkout_click)");
+    }
+
+    /**
+     * Troca label e fonte da etapa quando a métrica já foi consolidada para outro tipo comercial.
+     */
+    private void renameStage(Map<ExperimentFunnelStage, ExperimentFunnelStageDto> stages,
+                             ExperimentFunnelStage stage,
+                             String label,
+                             String source) {
+        ExperimentFunnelStageDto dto = stages.get(stage);
+        if (dto == null) {
+            return;
+        }
+        dto.setLabel(label);
+        dto.setSource(source);
+    }
+
+    /**
+     * Decide quais etapas aparecem para o tipo comercial do experimento.
+     */
+    private boolean shouldExposeStage(Experiment experiment, ExperimentFunnelStage stage) {
+        if (!isLowTicketProduct(experiment)) {
+            return true;
+        }
+        return stage == ExperimentFunnelStage.VISUALIZACAO_ANUNCIO
+                || stage == ExperimentFunnelStage.ACESSO_FORM_LEAD
+                || stage == ExperimentFunnelStage.VISUALIZACAO_FORM
+                || stage == ExperimentFunnelStage.ACESSO_CHECKOUT
+                || stage == ExperimentFunnelStage.COMPRA
+                || stage == ExperimentFunnelStage.DOWNLOAD_MATERIAL_PAGO;
+    }
+
+    /**
+     * Identifica se o experimento segue o fluxo comercial de venda direta low-ticket.
+     */
+    private boolean isLowTicketProduct(Experiment experiment) {
+        return experiment != null && experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT;
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
@@ -1,5 +1,7 @@
 package com.marketinghub.experiment.funnel;
 
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
@@ -8,11 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /** Testa os diagnósticos estatísticos das transições do funil de experimentos. */
@@ -21,12 +26,18 @@ class ExperimentFunnelDiagnosticServiceTest {
 
     @Mock
     private ExperimentFunnelService funnelService;
+    @Mock
+    private ExperimentRepository experimentRepository;
 
     private ExperimentFunnelDiagnosticService service;
 
     @BeforeEach
     void setUp() {
-        service = new ExperimentFunnelDiagnosticService(funnelService, new ExperimentFunnelDiagnosticConfig());
+        service = new ExperimentFunnelDiagnosticService(funnelService, new ExperimentFunnelDiagnosticConfig(), experimentRepository);
+        lenient().when(experimentRepository.findById(10L)).thenReturn(Optional.of(Experiment.builder().id(10L).build()));
+        lenient().when(experimentRepository.findById(20L)).thenReturn(Optional.of(Experiment.builder().id(20L).build()));
+        lenient().when(experimentRepository.findById(30L)).thenReturn(Optional.of(Experiment.builder().id(30L).build()));
+        lenient().when(experimentRepository.findById(40L)).thenReturn(Optional.of(Experiment.builder().id(40L).build()));
     }
 
     @Test
@@ -110,6 +121,32 @@ class ExperimentFunnelDiagnosticServiceTest {
                         assertThat(item.upper95RateIfZero()).isLessThanOrEqualTo(item.minAcceptableRate());
                     }
                 });
+    }
+
+    /** Garante que venda low-ticket diagnostica página de venda e checkout, sem formulário. */
+    @Test
+    void usesDirectSalesRulesForLowTicketProduct() {
+        when(experimentRepository.findById(50L)).thenReturn(Optional.of(Experiment.builder()
+                .id(50L)
+                .experimentType(ExperimentType.LOW_TICKET_PRODUCT)
+                .build()));
+        when(funnelService.summarize(50L)).thenReturn(stageList(
+                stage(ExperimentFunnelStage.VISUALIZACAO_ANUNCIO, 1000),
+                stage(ExperimentFunnelStage.ACESSO_FORM_LEAD, 50),
+                stage(ExperimentFunnelStage.VISUALIZACAO_FORM, 40),
+                stage(ExperimentFunnelStage.ACESSO_CHECKOUT, 0),
+                stage(ExperimentFunnelStage.COMPRA, 0)
+        ));
+
+        ExperimentFunnelDiagnosticsResponseDto response = service.diagnose(50L);
+
+        assertThat(response.diagnostics())
+                .extracting(item -> item.stageKey())
+                .containsExactly(
+                        ExperimentFunnelStage.ACESSO_FORM_LEAD,
+                        ExperimentFunnelStage.ACESSO_CHECKOUT,
+                        ExperimentFunnelStage.COMPRA)
+                .doesNotContain(ExperimentFunnelStage.ENVIO_FORM);
     }
 
     private List<ExperimentFunnelStageDto> stageList(ExperimentFunnelStageDto... stages) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.funnel;
 
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
@@ -147,6 +148,47 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(ExperimentFunnelStage.VISUALIZACAO_FORM, saved.getStage());
         assertEquals(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, saved.getSource());
         assertEquals(Instant.parse("2026-06-04T21:00:00Z"), saved.getOccurredAt());
+    }
+
+    /**
+     * Valida que venda low-ticket registra clique real no checkout sem depender de formulário.
+     */
+    @Test
+    void registerLandingPageAnalyticsSavesCheckoutClickForLowTicketProduct() {
+        Experiment experiment = Experiment.builder()
+                .id(52L)
+                .experimentType(ExperimentType.LOW_TICKET_PRODUCT)
+                .build();
+        when(experimentRepository.findFirstByLeadPortalFlowSlug("sales-page-exp52"))
+                .thenReturn(Optional.empty());
+        when(experimentRepository.findFirstByFollowUpActionUrlFlowSlug("sales-page-exp52"))
+                .thenReturn(Optional.of(experiment));
+        when(eventRepository.save(any(ExperimentFunnelEvent.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.registerLandingPageAnalyticsEvent("sales-page-exp52",
+                new RegisterLandingPageAnalyticsEventRequest(
+                        "checkout-event-1",
+                        "checkout_click",
+                        "visitor-1",
+                        "session-1",
+                        null,
+                        null,
+                        null,
+                        "https://pagamentopalf.site/sales-page-exp52.html",
+                        Instant.parse("2026-07-01T21:00:00Z"),
+                        "JUnit",
+                        "desktop",
+                        "other",
+                        1366,
+                        768));
+
+        ArgumentCaptor<ExperimentFunnelEvent> eventCaptor = ArgumentCaptor.forClass(ExperimentFunnelEvent.class);
+        verify(eventRepository).save(eventCaptor.capture());
+
+        ExperimentFunnelEvent saved = eventCaptor.getValue();
+        assertEquals(experiment, saved.getExperiment());
+        assertEquals(ExperimentFunnelStage.ACESSO_CHECKOUT, saved.getStage());
+        assertEquals(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, saved.getSource());
     }
 
 

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1975,9 +1975,7 @@ export default function ExperimentDetailPage() {
       value: data.singlePain || "—",
     },
     {
-      label: isLowTicketProduct
-        ? "Prova/preview da oferta"
-        : "Isca digital",
+      label: isLowTicketProduct ? "Prova/preview da oferta" : "Isca digital",
       value:
         data.freeReward ||
         (isLowTicketProduct ? "Sem prova/preview informada" : "—"),
@@ -2268,9 +2266,8 @@ export default function ExperimentDetailPage() {
               </div>
               <span className="badge text-bg-light border text-body">
                 {
-                  lowTicketSalePreparationChecklist.filter(
-                    (item) => item.isMet,
-                  ).length
+                  lowTicketSalePreparationChecklist.filter((item) => item.isMet)
+                    .length
                 }
                 /{lowTicketSalePreparationChecklist.length} concluídos
               </span>
@@ -2607,6 +2604,7 @@ export default function ExperimentDetailPage() {
           <Tabs.Content value="funnel" asChild>
             <ExperimentFunnelTab
               experimentId={expId}
+              experimentType={data?.experimentType}
               totalSpend={data?.campaignMetric?.spend}
               spendLastSyncedAt={data?.campaignMetric?.lastSyncedAt}
               alterationLocked={alterationLocked}

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -201,4 +201,34 @@ describe("ExperimentFunnelTab", () => {
     const secondStageCells = within(secondStageRow).getAllByRole("cell");
     expect(secondStageCells[3]).toHaveTextContent("—");
   });
+
+  it("explains the direct-sales funnel for low-ticket products without form steps", () => {
+    (useExperimentFunnel as unknown as Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+    (useExperimentFunnelDiagnostics as unknown as Mock).mockReturnValue({
+      data: { diagnostics: [], contextualAlert: null },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithClient(
+      <ExperimentFunnelTab
+        experimentId="52"
+        experimentType="LOW_TICKET_PRODUCT"
+        totalSpend={0}
+      />,
+    );
+
+    expect(screen.getByText(/Venda direta low-ticket/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Clique para a página de venda").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Clique no checkout").length).toBeGreaterThan(0);
+    expect(
+      screen.queryByText("Acesso ao formulário de lead"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -5,6 +5,7 @@ import {
   useExperimentFunnel,
   type ExperimentFunnelStageSummary,
 } from "../../api/experiment/useExperimentFunnel";
+import type { ExperimentType } from "../../api/experiment/useExperiments";
 import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
 import {
@@ -26,6 +27,7 @@ function formatPercentage(value: number) {
 
 interface ExperimentFunnelTabProps {
   experimentId: string;
+  experimentType?: ExperimentType | null;
   totalSpend?: number | null;
   spendLastSyncedAt?: string | null;
   alterationLocked?: boolean;
@@ -50,16 +52,18 @@ function formatDate(value?: string | null) {
 
 export default function ExperimentFunnelTab({
   experimentId,
+  experimentType,
   totalSpend,
   spendLastSyncedAt,
   alterationLocked = false,
 }: ExperimentFunnelTabProps) {
+  const isLowTicketProduct = experimentType === "LOW_TICKET_PRODUCT";
   const { data, isLoading, isError } = useExperimentFunnel(experimentId);
   const diagnosticsQuery = useExperimentFunnelDiagnostics(experimentId);
   const stages = (data ?? []).slice().sort((a, b) => a.order - b.order);
   const normalizedTotalSpend = normalizeSpend(totalSpend);
   const canResetFunnelMetrics = normalizedTotalSpend === 0;
-  const fallbackStages: ExperimentFunnelStageSummary[] = [
+  const leadFunnelFallbackStages: ExperimentFunnelStageSummary[] = [
     {
       stage: "VISUALIZACAO_ANUNCIO",
       label: "Visualização do anúncio",
@@ -160,6 +164,77 @@ export default function ExperimentFunnelTab({
       source: null,
     },
   ];
+  const lowTicketFallbackStages: ExperimentFunnelStageSummary[] = [
+    {
+      stage: "VISUALIZACAO_ANUNCIO",
+      label: "Visualização do anúncio",
+      order: 1,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+    {
+      stage: "ACESSO_FORM_LEAD",
+      label: "Clique para a página de venda",
+      order: 2,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+    {
+      stage: "VISUALIZACAO_FORM",
+      label: "Visualização da página de venda",
+      order: 3,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+    {
+      stage: "ACESSO_CHECKOUT",
+      label: "Clique no checkout",
+      order: 6,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+    {
+      stage: "COMPRA",
+      label: "Compra",
+      order: 7,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+    {
+      stage: "DOWNLOAD_MATERIAL_PAGO",
+      label: "Download do material pago",
+      order: 9,
+      autoCount: 0,
+      manualCount: 0,
+      totalCount: 0,
+      uniqueCount: null,
+      lastEventAt: null,
+      source: null,
+    },
+  ];
+  const fallbackStages = isLowTicketProduct
+    ? lowTicketFallbackStages
+    : leadFunnelFallbackStages;
   const selectableStages = stages.length > 0 ? stages : fallbackStages;
   const outcomeQuantities = selectableStages.map((stage) => ({
     label: stage.label,
@@ -231,9 +306,9 @@ export default function ExperimentFunnelTab({
           <div>
             <h5 className="card-title mb-1">Funil de vendas do experimento</h5>
             <p className="text-muted small mb-0">
-              Cada etapa consolida os eventos da jornada (anúncios, Lead Portal
-              e e-mails) para dar visibilidade ao avanço das leads no
-              experimento.
+              {isLowTicketProduct
+                ? "Venda direta low-ticket: anúncio, página de venda, clique no checkout, compra e entrega paga."
+                : "Cada etapa consolida os eventos da jornada (anúncios, Lead Portal e e-mails) para dar visibilidade ao avanço das leads no experimento."}
             </p>
           </div>
           {canResetFunnelMetrics ? (
@@ -556,20 +631,31 @@ export default function ExperimentFunnelTab({
 
         <div className="alert alert-info mb-0 mt-4" role="alert">
           <div className="fw-semibold mb-1">O que cada etapa representa</div>
-          <ul className="mb-0 small ps-3">
-            <li>1) Impressões do anúncio.</li>
-            <li>2) Cliques que levaram ao formulário do experimento.</li>
-            <li>
-              3) Renderizações completas do formulário (evento
-              lead-portal-render-complete).
-            </li>
-            <li>4) Envios de formulário (lead_portal_submission).</li>
-            <li>5) Abertura do e-mail de amostra.</li>
-            <li>6) Acessos ao checkout no Mercado Pago.</li>
-            <li>7) Compras aprovadas.</li>
-            <li>8) Abertura do e-mail de entrega da compra.</li>
-            <li>9) Visualização/download do material pago.</li>
-          </ul>
+          {isLowTicketProduct ? (
+            <ul className="mb-0 small ps-3">
+              <li>1) Impressões do anúncio.</li>
+              <li>2) Cliques que levaram para a página de venda.</li>
+              <li>3) Visualizações reais da página de venda.</li>
+              <li>4) Cliques reais no checkout.</li>
+              <li>5) Compras aprovadas.</li>
+              <li>6) Visualização/download do material pago.</li>
+            </ul>
+          ) : (
+            <ul className="mb-0 small ps-3">
+              <li>1) Impressões do anúncio.</li>
+              <li>2) Cliques que levaram ao formulário do experimento.</li>
+              <li>
+                3) Renderizações completas do formulário (evento
+                lead-portal-render-complete).
+              </li>
+              <li>4) Envios de formulário (lead_portal_submission).</li>
+              <li>5) Abertura do e-mail de amostra.</li>
+              <li>6) Acessos ao checkout no Mercado Pago.</li>
+              <li>7) Compras aprovadas.</li>
+              <li>8) Abertura do e-mail de entrega da compra.</li>
+              <li>9) Visualização/download do material pago.</li>
+            </ul>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## O que mudou

- Corrige o funil de experimentos `LOW_TICKET_PRODUCT` para venda direta: anúncio -> página de venda -> checkout -> compra -> entrega.
- Remove etapas de formulário da resposta/explicação da tela para low-ticket.
- Ajusta diagnóstico estatístico low-ticket para avaliar página de venda, clique no checkout e compra.
- Injeta tracking `checkout_click` no HTML final publicado pelo GeraSalesPage v1.
- Adiciona testes backend, AI Worker e frontend para prevenir regressão.

## Por quê

O fluxo low-ticket não tem formulário. A tela e o diagnóstico herdavam nomenclatura e etapas de lead/form, deixando as métricas reais confusas para decisão de campanha.

## Validação

- `mvn -Dtest=ExperimentFunnelDiagnosticServiceTest,ExperimentFunnelServiceRenderCompleteTest test` em `backend/ads-service`
- `mvn -Dtest=GeraSalesPageProcessorTest,GeraSalesPageResponseValidatorTest test` em `ai-worker`
- `npm run typecheck` em `frontend`
- `npm run build` em `frontend`
- `NODE_ENV=test npm test -- ExperimentFunnelTab.test.tsx --run` em `frontend`
- `git diff --check`

Observação: o primeiro `npm test` sem `NODE_ENV=test` falhou porque o ambiente estava carregando React em modo production; com `NODE_ENV=test`, os 7 testes da aba passaram.