### PR TITLE
fix: preserve objetivo de vendas low-ticket no Facebook Ads

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -575,6 +575,9 @@ public class FacebookAdsCampaignController {
                 experiment.getFreeReward(),
                 experiment.getFunnelPromise(),
                 experiment.getPrimaryCta(),
+                experiment.getExperimentType() != null
+                        ? experiment.getExperimentType().name()
+                        : null,
                 experiment.getCampaignObjective() != null
                         ? experiment.getCampaignObjective().name()
                         : null,
@@ -750,6 +753,7 @@ public class FacebookAdsCampaignController {
             String freeReward,
             String funnelPromise,
             String primaryCta,
+            String experimentType,
             String campaignObjective,
             String followUpActionUrl,
             String pageId,

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -11,9 +11,11 @@ import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.experiment.AdSet;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.ExperimentFunnelAutoStopService;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.hypothesis.Hypothesis;
@@ -26,10 +28,14 @@ import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.facebookads.FacebookAdsAdSet;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdStatus;
+import com.marketinghub.facebookads.service.publicationstep.FacebookCampaignPublicationJobStepService;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.creative.Creative;
 import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentMetricsDto;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentUserDto;
@@ -102,6 +108,10 @@ class FacebookAdsCampaignControllerTest {
     ExperimentTargetingSelectionRepository targetingSelectionRepository;
     @MockBean
     CreativeRepository creativeRepository;
+    @MockBean
+    GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
+    @MockBean
+    FacebookCampaignPublicationJobStepService publicationJobStepService;
 
     @MockBean
     LeadPortalMetricsService leadPortalMetricsService;
@@ -284,6 +294,54 @@ class FacebookAdsCampaignControllerTest {
         mockMvc.perform(get("/api/facebook-campaigns/experiments-ready"))
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
+    }
+
+    @Test
+    void experimentsReadyIncludesExperimentTypeForLowTicketSalesCampaigns() throws Exception {
+        var experiment = Experiment.builder()
+                .id(53L)
+                .name("Experimento 53")
+                .platform(ExperimentPlatform.FACEBOOK)
+                .status(ExperimentStatus.PLANNED)
+                .experimentType(ExperimentType.LOW_TICKET_PRODUCT)
+                .campaignObjective(ExperimentCampaignObjective.SALES)
+                .freeReward("preview da ferramenta")
+                .facebookReleaseRequestedAt(Instant.parse("2026-07-01T20:00:00Z"))
+                .followUpActionUrl("https://pagamentopalf.site/sales-page-exp53.html")
+                .creativeApproved(true)
+                .build();
+        when(experimentService.listByStatusAndPlatform(ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK))
+                .thenReturn(List.of(experiment));
+        when(campaignRepository.existsByExperimentId(53L)).thenReturn(false);
+        when(creativeRepository.existsByExperimentIdAndStatus(53L, CreativeStatus.READY)).thenReturn(true);
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(53L)).thenReturn(List.of(
+                ExperimentTargetingSelection.builder()
+                        .candidateType(TargetingCandidateType.INTEREST)
+                        .term("Loja de roupas")
+                        .targetingElement(TargetingElement.builder()
+                                .type(TargetingElementType.INTEREST)
+                                .term("Loja de roupas")
+                                .status(TargetingElementStatus.APPROVED)
+                                .metaId("meta-interest-vestuario")
+                                .build())
+                        .build()));
+        when(geraSalesPageStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                53L, GeraSalesPageStageCode.PUBLICATION_PACKAGE.code()))
+                .thenReturn(Optional.of(GeraSalesPageStageExecution.builder()
+                        .idJob("job-exp53-publication")
+                        .experimentId(53L)
+                        .stageCode(GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                        .status("CONCLUIDO")
+                        .executionRequestedAt(Instant.parse("2026-07-01T20:05:00Z"))
+                        .build()));
+        when(leadPortalMetricsService.listExperimentMetrics()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/facebook-campaigns/experiments-ready"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(53))
+                .andExpect(jsonPath("$[0].experimentType").value("LOW_TICKET_PRODUCT"))
+                .andExpect(jsonPath("$[0].campaignObjective").value("SALES"))
+                .andExpect(jsonPath("$[0].freeReward").value("preview da ferramenta"));
     }
 
     @Test

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -104,6 +104,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
   - usar destino standalone vindo de `followUpActionUrl` no worker;
   - alinhar orçamento real por Ad Set, reportando `budgetMode=ADSET`;
   - enviar `is_adset_budget_sharing_enabled=false` em campanhas sem orçamento no nível da campanha.
+  - enviar `experimentType` no contrato `/api/facebook-campaigns/experiments-ready` para o worker não degradar `LOW_TICKET_PRODUCT + SALES` para campanha de leads quando existir `freeReward` secundário.
 - **Módulos envolvidos**:
   - `backend/ads-service`;
   - `facebook-ads-worker`;
@@ -125,6 +126,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
   - teste cobrindo retry de experimento `FAILED` com targeting aprovado;
   - teste garantindo que ausência de `users_lower_bound`/`users_upper_bound` em `reachestimate` é alerta, não falha automática;
   - teste garantindo orçamento por Ad Set e `is_adset_budget_sharing_enabled=false` em campanha sem orçamento.
+  - teste garantindo que o contrato do backend expõe `experimentType=LOW_TICKET_PRODUCT` e que o worker publica `campaignObjective=SALES` como `OUTCOME_SALES`.
 - **Regra preventiva**:
   - nunca corrigir publicação Facebook apenas pelo erro atual da Meta; comparar payload esperado, payload enviado, resposta, estado do experimento, campanha persistida e job steps.
 

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -256,7 +256,10 @@ e reutiliza o identificador resolvido ao montar criativos com
 `call_to_action.value.lead_gen_form_id`, mantendo o destino `ON_AD` e o objetivo
 `OUTCOME_LEADS` conforme as regras mais recentes da Graph API. A mesma política
 de Leads também vale para experimentos com recompensa gratuita (`freeReward`),
-mesmo quando a captura usa landing própria em vez de Instant Form. Identificadores
+mesmo quando a captura usa landing própria em vez de Instant Form. A exceção
+obrigatória é `experimentType=LOW_TICKET_PRODUCT` com `campaignObjective=SALES`:
+nesse caso o worker deve preservar campanha de venda (`OUTCOME_SALES`), ainda
+que exista algum `freeReward` secundário no contrato. Identificadores
 temporários no formato `ai_form_*` são normalizados para o padrão `form_*`
 antes da publicação, e o share link é reconstruído com o identificador final
 quando disponível.


### PR DESCRIPTION
## Resumo
- adiciona `experimentType` no contrato `/api/facebook-campaigns/experiments-ready`
- garante por teste que low-ticket + SALES chega ao worker mesmo com `freeReward` secundário
- documenta a regra no Facebook Ads Worker e no registro de loops

## Validação
- `mvn -Dtest=FacebookAdsCampaignControllerTest test` em `backend/ads-service`
- `mvn -Dtest=FacebookCampaignServiceTest test` em `facebook-ads-worker`
- `git diff --check`

## Contexto operacional
Corrige a causa-raiz que fez o experimento 53 nascer como `OUTCOME_LEADS`: o worker já sabia preservar `LOW_TICKET_PRODUCT + SALES` como `OUTCOME_SALES`, mas o backend não expunha `experimentType` na fila de publicação.