### PR TITLE
fix: destrava republicação Facebook com métrica de campanha

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-30-experiment-campaign-objective-sales.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-30-experiment-campaign-objective-sales.yaml
@@ -39,3 +39,76 @@ databaseChangeLog:
             sql: >
               ALTER TABLE experiment
               MODIFY campaign_objective ENUM('LEADS','TRAFFIC') NOT NULL
+
+  - changeSet:
+      id: 2026-07-02-experiment-campaign-metric-cascade-campaign
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_campaign_metric
+        - tableExists:
+            tableName: facebook_ads_campaign
+        - columnExists:
+            tableName: experiment_campaign_metric
+            columnName: campaign_id
+        - sqlCheck:
+            expectedResult: 1
+            sql: >
+              SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END
+              FROM information_schema.KEY_COLUMN_USAGE k
+              JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+                ON rc.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+               AND rc.CONSTRAINT_NAME = k.CONSTRAINT_NAME
+               AND rc.TABLE_NAME = k.TABLE_NAME
+              WHERE k.TABLE_SCHEMA = DATABASE()
+                AND k.TABLE_NAME = 'experiment_campaign_metric'
+                AND k.COLUMN_NAME = 'campaign_id'
+                AND k.REFERENCED_TABLE_NAME = 'facebook_ads_campaign'
+                AND rc.DELETE_RULE <> 'CASCADE'
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              SET @experiment_campaign_metric_fk := (
+                SELECT k.CONSTRAINT_NAME
+                FROM information_schema.KEY_COLUMN_USAGE k
+                JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+                  ON rc.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+                 AND rc.CONSTRAINT_NAME = k.CONSTRAINT_NAME
+                 AND rc.TABLE_NAME = k.TABLE_NAME
+                WHERE k.TABLE_SCHEMA = DATABASE()
+                  AND k.TABLE_NAME = 'experiment_campaign_metric'
+                  AND k.COLUMN_NAME = 'campaign_id'
+                  AND k.REFERENCED_TABLE_NAME = 'facebook_ads_campaign'
+                  AND rc.DELETE_RULE <> 'CASCADE'
+                LIMIT 1
+              );
+              SET @experiment_campaign_metric_drop_fk_sql := IF(
+                @experiment_campaign_metric_fk IS NULL,
+                'SELECT 1',
+                CONCAT('ALTER TABLE experiment_campaign_metric DROP FOREIGN KEY `', @experiment_campaign_metric_fk, '`')
+              );
+              PREPARE experiment_campaign_metric_drop_fk_stmt FROM @experiment_campaign_metric_drop_fk_sql;
+              EXECUTE experiment_campaign_metric_drop_fk_stmt;
+              DEALLOCATE PREPARE experiment_campaign_metric_drop_fk_stmt;
+              ALTER TABLE experiment_campaign_metric
+                ADD CONSTRAINT fk_experiment_campaign_metric_campaign_cascade
+                FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id)
+                ON DELETE CASCADE;
+      rollback:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_campaign_metric
+                DROP FOREIGN KEY fk_experiment_campaign_metric_campaign_cascade;
+              ALTER TABLE experiment_campaign_metric
+                ADD CONSTRAINT fk_experiment_campaign_metric_campaign
+                FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id);

--- a/docs/registros/facebook-ads-release-metric-cleanup-2026-07-02.md
+++ b/docs/registros/facebook-ads-release-metric-cleanup-2026-07-02.md
@@ -1,0 +1,21 @@
+# 2026-07-02 — Hotfix de republicacao Facebook Ads
+
+## Contexto
+
+Ao tentar republicar o experimento 53 pelo endpoint `POST /api/experiments/{id}/facebook-release`, o backend falhou porque a campanha antiga possuia metrica agregada em `experiment_campaign_metric`.
+
+## Causa-raiz
+
+A campanha antiga em `facebook_ads_campaign` era referenciada por `experiment_campaign_metric.campaign_id`. A FK nao tinha `ON DELETE CASCADE`, entao a limpeza da campanha antiga travava antes de recolocar o experimento na fila do Facebook Ads Worker.
+
+## Correcao aplicada
+
+Foi adicionado hotfix Liquibase para trocar a FK de `experiment_campaign_metric.campaign_id` para `ON DELETE CASCADE`, somente quando a FK existente ainda nao estiver em cascade.
+
+## Impacto esperado
+
+A republicacao de experimento pode remover a campanha antiga sem falhar por metrica agregada dependente. Isso destrava a publicacao correta do experimento 53 como campanha low-ticket de venda.
+
+## Prevencao
+
+Fluxos de republicacao Facebook precisam limpar ou permitir cascade para dados dependentes de campanha antes de remover `facebook_ads_campaign`, especialmente metricas agregadas usadas no funil.


### PR DESCRIPTION
## Resumo

- Ajusta a FK de `experiment_campaign_metric.campaign_id` para `ON DELETE CASCADE`.
- Evita falha no `POST /api/experiments/{id}/facebook-release` quando existe métrica agregada da campanha anterior.
- Registra o hotfix em `docs/registros/facebook-ads-release-metric-cleanup-2026-07-02.md`.

## Validação local

- `mvn -Dtest=ExperimentServiceTest#releaseForFacebookResetsFunnelAndTimestamp test`
- `git diff --check`

## Contexto operacional

O experimento 53 não pôde ser republicado porque a campanha antiga `OUTCOME_LEADS` tinha registro em `experiment_campaign_metric`, bloqueando a exclusão da campanha por FK. Depois do merge/deploy deste hotfix, o release do 53 deve conseguir limpar a publicação antiga e reenfileirar a campanha correta de venda.