### PR TITLE
fix: require pixel for low-ticket sales campaigns

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -163,6 +163,9 @@ public class ExperimentReadinessService {
         if (isLowTicketProduct(experiment) && !hasCompletedGeraSalesPagePipeline(experiment != null ? experiment.getId() : null)) {
             missing.add("geraSalesPagePipeline");
         }
+        if (isLowTicketProduct(experiment) && !hasFacebookPixel(experiment)) {
+            missing.add("facebookPixel");
+        }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("approvedTargetingPackage");
         }
@@ -228,6 +231,14 @@ public class ExperimentReadinessService {
         return experiment != null
                 && experiment.getFollowUpActionUrl() != null
                 && !experiment.getFollowUpActionUrl().isBlank();
+    }
+
+    /** Verifica se o nicho do experimento já possui pixel da Meta para otimização de compra. */
+    private boolean hasFacebookPixel(Experiment experiment) {
+        return experiment != null
+                && experiment.getNiche() != null
+                && experiment.getNiche().getFacebookPixelId() != null
+                && !experiment.getNiche().getFacebookPixelId().isBlank();
     }
 
     /** Identifica experimento de venda direta low-ticket. */

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -394,7 +394,10 @@ public class FacebookAdsCampaignController {
         adSet.setDailyBudgetMinor(parseLong(adSetReq.dailyBudget()));
         adSet.setLifetimeBudgetMinor(parseLong(adSetReq.lifetimeBudget()));
         adSet.setBidAmountMinor(parseLong(adSetReq.bidAmount()));
-        adSet.setPromotedObjectJson(buildPromotedObjectJson(adSetReq.pageId()));
+        adSet.setPromotedObjectJson(buildPromotedObjectJson(
+                adSetReq.pageId(),
+                adSetReq.pixelId(),
+                adSetReq.customEventType()));
         adSet.setTargetingJson(buildTargetingJson(adSetReq.targetCountry(), adSetReq.targetingJson(), adSetReq.savedAudienceId()));
         return adSet;
     }
@@ -492,12 +495,20 @@ public class FacebookAdsCampaignController {
     }
 
     // Executa a operação buildPromotedObjectJson da integração Facebook Ads.
-    private String buildPromotedObjectJson(String pageId) {
-        if (!StringUtils.hasText(pageId)) {
+    private String buildPromotedObjectJson(String pageId, String pixelId, String customEventType) {
+        if (!StringUtils.hasText(pageId) && !StringUtils.hasText(pixelId) && !StringUtils.hasText(customEventType)) {
             return null;
         }
         ObjectNode node = objectMapper.createObjectNode();
-        node.put("page_id", pageId);
+        if (StringUtils.hasText(pageId)) {
+            node.put("page_id", pageId);
+        }
+        if (StringUtils.hasText(pixelId)) {
+            node.put("pixel_id", pixelId);
+        }
+        if (StringUtils.hasText(customEventType)) {
+            node.put("custom_event_type", customEventType);
+        }
         return node.toString();
     }
 
@@ -583,6 +594,7 @@ public class FacebookAdsCampaignController {
                         : null,
                 experiment.getFollowUpActionUrl(),
                 pageId,
+                experiment.getNiche() != null ? experiment.getNiche().getFacebookPixelId() : null,
                 experiment.getKpiTargetCpl(),
                 experiment.getDailyBudget(),
                 experiment.getStartDate(),
@@ -757,6 +769,7 @@ public class FacebookAdsCampaignController {
             String campaignObjective,
             String followUpActionUrl,
             String pageId,
+            String facebookPixelId,
             BigDecimal kpiTargetCpl,
             BigDecimal dailyBudget,
             LocalDate startDate,
@@ -863,6 +876,8 @@ public class FacebookAdsCampaignController {
                 String targetCountry,
                 String destinationType,
                 String pageId,
+                String pixelId,
+                String customEventType,
                 String targetingJson,
                 String savedAudienceId,
                 String savedAudienceName,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -226,6 +226,7 @@ class ExperimentReadinessServiceTest {
         Experiment experiment = buildExperiment(52L, 62L);
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
         experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp52.html");
+        experiment.getNiche().setFacebookPixelId("pixel-exp52");
 
         when(creativeRepository.existsByExperimentIdAndStatus(52L, CreativeStatus.READY)).thenReturn(true);
         mockPublishableSelection(52L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
@@ -236,10 +237,28 @@ class ExperimentReadinessServiceTest {
     }
 
     @Test
+    // Verifica que low-ticket sem pixel não entra na fila de campanha de venda.
+    void shouldRequireFacebookPixelForLowTicketCampaign() {
+        Experiment experiment = buildExperiment(54L, 64L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp54.html");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(54L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(54L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(54L);
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("facebookPixel");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    @Test
+    // Verifica que low-ticket completo com página e pixel pode ser publicado.
     void shouldAllowLowTicketCampaignOnlyAfterGeraSalesPagePublicationPackage() {
         Experiment experiment = buildExperiment(53L, 63L);
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
         experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp53.html");
+        experiment.getNiche().setFacebookPixelId("pixel-exp53");
 
         when(creativeRepository.existsByExperimentIdAndStatus(53L, CreativeStatus.READY)).thenReturn(true);
         mockPublishableSelection(53L, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -297,10 +297,16 @@ class FacebookAdsCampaignControllerTest {
     }
 
     @Test
+    // Garante que o contrato do worker recebe tipo, objetivo e pixel de low-ticket.
     void experimentsReadyIncludesExperimentTypeForLowTicketSalesCampaigns() throws Exception {
         var experiment = Experiment.builder()
                 .id(53L)
                 .name("Experimento 53")
+                .niche(MarketNiche.builder()
+                        .id(23L)
+                        .name("Vestuário")
+                        .facebookPixelId("pixel-exp53")
+                        .build())
                 .platform(ExperimentPlatform.FACEBOOK)
                 .status(ExperimentStatus.PLANNED)
                 .experimentType(ExperimentType.LOW_TICKET_PRODUCT)
@@ -341,6 +347,7 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].id").value(53))
                 .andExpect(jsonPath("$[0].experimentType").value("LOW_TICKET_PRODUCT"))
                 .andExpect(jsonPath("$[0].campaignObjective").value("SALES"))
+                .andExpect(jsonPath("$[0].facebookPixelId").value("pixel-exp53"))
                 .andExpect(jsonPath("$[0].freeReward").value("preview da ferramenta"));
     }
 

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -105,6 +105,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
   - alinhar orçamento real por Ad Set, reportando `budgetMode=ADSET`;
   - enviar `is_adset_budget_sharing_enabled=false` em campanhas sem orçamento no nível da campanha.
   - enviar `experimentType` no contrato `/api/facebook-campaigns/experiments-ready` para o worker não degradar `LOW_TICKET_PRODUCT + SALES` para campanha de leads quando existir `freeReward` secundário.
+  - exigir `facebookPixelId` para `LOW_TICKET_PRODUCT + SALES` antes de entrar na fila e publicar o ad set com `optimization_goal=OFFSITE_CONVERSIONS`, `promoted_object.pixel_id` e `custom_event_type=PURCHASE`.
 - **Módulos envolvidos**:
   - `backend/ads-service`;
   - `facebook-ads-worker`;
@@ -127,6 +128,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
   - teste garantindo que ausência de `users_lower_bound`/`users_upper_bound` em `reachestimate` é alerta, não falha automática;
   - teste garantindo orçamento por Ad Set e `is_adset_budget_sharing_enabled=false` em campanha sem orçamento.
   - teste garantindo que o contrato do backend expõe `experimentType=LOW_TICKET_PRODUCT` e que o worker publica `campaignObjective=SALES` como `OUTCOME_SALES`.
+  - teste garantindo que campanha low-ticket de venda só é considerada pronta com pixel e que o worker usa `OFFSITE_CONVERSIONS` + evento `PURCHASE`.
 - **Regra preventiva**:
   - nunca corrigir publicação Facebook apenas pelo erro atual da Meta; comparar payload esperado, payload enviado, resposta, estado do experimento, campanha persistida e job steps.
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -341,8 +341,9 @@ public class FacebookAdsService {
                 body.put("bid_amount", bidAmount);
             }
         }
-        if (request.pageId() != null && !request.pageId().isBlank()) {
-            body.put("promoted_object", Map.of("page_id", request.pageId()));
+        Map<String, Object> promotedObject = buildPromotedObject(request);
+        if (!promotedObject.isEmpty()) {
+            body.put("promoted_object", promotedObject);
         }
         body.put("access_token", requireAccessToken());
 
@@ -350,6 +351,21 @@ public class FacebookAdsService {
 
         JsonNode response = executeAdSetPost(path, body, request.name());
         return response.path("id").asText();
+    }
+
+    /** Monta o objeto promovido do ad set com página e, quando aplicável, pixel/evento de conversão. */
+    private Map<String, Object> buildPromotedObject(AdSetRequest request) {
+        Map<String, Object> promotedObject = new HashMap<>();
+        if (request.pageId() != null && !request.pageId().isBlank()) {
+            promotedObject.put("page_id", request.pageId());
+        }
+        if (request.pixelId() != null && !request.pixelId().isBlank()) {
+            promotedObject.put("pixel_id", request.pixelId());
+        }
+        if (request.customEventType() != null && !request.customEventType().isBlank()) {
+            promotedObject.put("custom_event_type", request.customEventType());
+        }
+        return promotedObject;
     }
 
     private JsonNode executeAdSetPost(String path, Map<String, Object> body, String adSetName) {
@@ -3168,6 +3184,8 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         String bidStrategy,
         String bidAmount,
         String pageId,
+        String pixelId,
+        String customEventType,
         String targetCountry,
         String targetingJson,
         List<TargetingOption> targetingOptions

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -418,9 +418,18 @@ public class FacebookCampaignService {
                 );
             }
             boolean leadCampaignRequired = requiresLeadCampaign(exp) || hasLeadFormDestination;
+            boolean salesConversionRequired = requiresPurchaseConversionCampaign(exp, leadCampaignRequired);
+            if (salesConversionRequired && !StringUtils.hasText(exp.facebookPixelId())) {
+                String reason = "low-ticket sales campaign requires facebookPixelId for Purchase optimization";
+                LOGGER.warn("Skipping experiment {} because {}", exp.id(), reason);
+                markExperimentAsFailed(exp.id(), reason);
+                return;
+            }
             String resolvedDestinationType = hasLeadFormDestination ? "ON_AD" : config.adSetDestinationType();
             String resolvedOptimizationGoal = leadCampaignRequired
                 ? "LEAD_GENERATION"
+                : salesConversionRequired
+                    ? "OFFSITE_CONVERSIONS"
                 : config.adSetOptimizationGoal();
             String resolvedCampaignObjective = resolveCampaignObjective(exp, leadCampaignRequired);
 
@@ -476,6 +485,8 @@ public class FacebookCampaignService {
                 config.adSetBidStrategy(),
                 config.adSetBidAmount(),
                 resolvedPageId,
+                salesConversionRequired ? exp.facebookPixelId() : null,
+                salesConversionRequired ? "PURCHASE" : null,
                 FacebookAdsService.BRAZIL_COUNTRY_CODE,
                 resolvedTargeting.targetingJson(),
                 resolvedTargeting.options()
@@ -563,6 +574,8 @@ public class FacebookCampaignService {
                     adSetRequest.targetCountry(),
                     adSetRequest.destinationType(),
                     adSetRequest.pageId(),
+                    adSetRequest.pixelId(),
+                    adSetRequest.customEventType(),
                     resolvedTargeting.targetingJson(),
                     null
                 ),
@@ -1109,6 +1122,15 @@ public class FacebookCampaignService {
         return "OUTCOME_TRAFFIC";
     }
 
+    /** Indica se a campanha deve ser otimizada para compra fora do site. */
+    private boolean requiresPurchaseConversionCampaign(Experiment experiment, boolean leadCampaignRequired) {
+        return !leadCampaignRequired
+                && isLowTicketProduct(experiment)
+                && experiment != null
+                && StringUtils.hasText(experiment.campaignObjective())
+                && "SALES".equalsIgnoreCase(experiment.campaignObjective().trim());
+    }
+
     public record Experiment(
         long id,
         String name,
@@ -1119,6 +1141,7 @@ public class FacebookCampaignService {
         String experimentType,
         String campaignObjective,
         String pageId,
+        String facebookPixelId,
         BigDecimal dailyBudget,
         @JsonAlias({ "page", "associatedFacebookPage", "facebookPageAssociation" })
         FacebookPage facebookPage,
@@ -1176,6 +1199,8 @@ public class FacebookCampaignService {
             String targetCountry,
             String destinationType,
             String pageId,
+            String pixelId,
+            String customEventType,
             String targetingJson,
             Long experimentAdSetId
         ) {}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -102,6 +102,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             null,
             Collections.emptyList()
@@ -147,6 +149,8 @@ class FacebookAdsServiceTest {
             "COST_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             null,
             Collections.emptyList()
@@ -156,6 +160,36 @@ class FacebookAdsServiceTest {
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         assertEquals("COST_CAP", body.get("bid_strategy").asText());
         assertEquals("200", body.get("bid_amount").asText());
+    }
+
+    @Test
+    // Garante que campanhas de compra enviam pixel e evento Purchase no promoted_object.
+    void createAdSetIncludesPixelPurchasePromotedObject() throws Exception {
+        server.enqueueResponse(new MockResponse().setBody("{\"id\":\"334\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdSetRequest request = new FacebookAdsService.AdSetRequest(
+            "Camp - Sales Ad Set",
+            "123",
+            "1500",
+            "IMPRESSIONS",
+            "OFFSITE_CONVERSIONS",
+            "WEBSITE",
+            "LOWEST_COST_WITHOUT_CAP",
+            null,
+            "42",
+            "pixel-123",
+            "PURCHASE",
+            "BR",
+            null,
+            Collections.emptyList()
+        );
+        service.createAdSet("1", request);
+        RecordedRequest recorded = takeRequest("request");
+        JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
+        assertEquals("OFFSITE_CONVERSIONS", body.get("optimization_goal").asText());
+        assertEquals("42", body.get("promoted_object").get("page_id").asText());
+        assertEquals("pixel-123", body.get("promoted_object").get("pixel_id").asText());
+        assertEquals("PURCHASE", body.get("promoted_object").get("custom_event_type").asText());
     }
 
     @Test
@@ -173,6 +207,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -206,6 +242,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -238,6 +276,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -269,6 +309,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -300,6 +342,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -334,6 +378,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             null,
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -432,6 +478,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -481,6 +529,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()
@@ -523,6 +573,8 @@ class FacebookAdsServiceTest {
             "LOWEST_COST_WITHOUT_CAP",
             "200",
             "42",
+            null,
+            null,
             "BR",
             targetingJson,
             Collections.emptyList()

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -741,8 +741,9 @@ class FacebookCampaignServiceTest {
     }
 
     @Test
+    // Garante que low-ticket com recompensa secundária continua como venda otimizada para Purchase.
     void createsSalesCampaignForLowTicketProductEvenWithSecondaryReward() throws Exception {
-        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"dailyBudget\":25.0,\"experimentType\":\"LOW_TICKET_PRODUCT\",\"freeReward\":\"ver amostra gratuita\",\"campaignObjective\":\"SALES\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
+        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"dailyBudget\":25.0,\"experimentType\":\"LOW_TICKET_PRODUCT\",\"freeReward\":\"ver amostra gratuita\",\"campaignObjective\":\"SALES\",\"facebookPixelId\":\"pixel-123\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueueResponse(new MockResponse().setBody("{\"images\":{\"uploaded\":{\"hash\":\"hash-preloaded\"}}}")
             .addHeader("Content-Type", "application/json"));
@@ -791,6 +792,9 @@ class FacebookCampaignServiceTest {
         RecordedRequest postAdSet = takeFacebookRequest("facebook ad set");
         JsonNode adSetPayload = objectMapper.readTree(postAdSet.getBody().inputStream());
         assertEquals("WEBSITE", adSetPayload.get("destination_type").asText());
+        assertEquals("OFFSITE_CONVERSIONS", adSetPayload.get("optimization_goal").asText());
+        assertEquals("pixel-123", adSetPayload.get("promoted_object").get("pixel_id").asText());
+        assertEquals("PURCHASE", adSetPayload.get("promoted_object").get("custom_event_type").asText());
     }
 
     @Test


### PR DESCRIPTION
## Resumo
- bloqueia campanha low-ticket sem pixel do nicho na prontidão do backend
- envia `facebookPixelId` no contrato do worker
- publica low-ticket `SALES` como `OUTCOME_SALES` com ad set `OFFSITE_CONVERSIONS`, `pixel_id` e evento `PURCHASE`
- persiste `pixel_id` e `custom_event_type` no promoted object do ad set
- registra o aprendizado no loop de publicação Facebook Ads

## Validação
- `mvn -Dtest=ExperimentReadinessServiceTest,FacebookAdsCampaignControllerTest test` em `backend/ads-service`
- `mvn -Dtest=FacebookCampaignServiceTest,FacebookAdsServiceTest test` em `facebook-ads-worker`
- `git diff --check`