### PR TITLE
[codex] Fix Sales Video job event type schema

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2037-02-15-sales-video-hardening.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2037-02-15-sales-video-hardening.yaml
@@ -140,3 +140,32 @@ databaseChangeLog:
               UPDATE sales_video_script SET created_by = COALESCE(created_by, 'system@marketinghub.io');
               UPDATE sales_video_job SET tenant_id = COALESCE(tenant_id, 'default'), retry_attempt = COALESCE(retry_attempt, 1);
               UPDATE landing_video_slot SET tenant_id = COALESCE(tenant_id, 'default');
+  - changeSet:
+      id: sales-video-hardening-007-event-type-varchar
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: sales_video_job_event
+        - columnExists:
+            tableName: sales_video_job_event
+            columnName: event_type
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE sales_video_job_event
+                MODIFY event_type VARCHAR(64) NOT NULL;
+      rollback:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE sales_video_job_event
+                MODIFY event_type VARCHAR(64) NOT NULL;

--- a/docs/diagnostics/ai-worker-jobs-log-check-2026-05-01.md
+++ b/docs/diagnostics/ai-worker-jobs-log-check-2026-05-01.md
@@ -60,3 +60,11 @@ Próxima validação recomendada:
 - comparar enum/tamanho de `event_type` no código Java vs definição da coluna no MySQL;
 - reprocessar um job de teste e confirmar se passa a aparecer no banco (eventos + estado final);
 - revisar transação/rollback no fluxo que registra evento após resposta da OpenAI.
+
+## Confirmação posterior em 2026-07-02
+
+Durante a validação pós-merge do PR 4196, o backend voltou a registrar `Data truncated for column 'event_type' at row 1` no retry automático de Sales Video.
+
+Consulta via MCP (`db_query`) confirmou a causa-raiz: no banco real, `sales_video_job_event.event_type` ainda estava como `ENUM('CREATED','CLAIMED','HEARTBEAT','PROGRESS','STATUS_CHANGED','COMPLETED','FAILED','EXPIRED')`, sem o valor `RETRIED`, enquanto o código Java atual já registra `SalesVideoJobEventType.RETRIED`.
+
+Correção preparada: changeset Liquibase `sales-video-hardening-007-event-type-varchar` para converter `event_type` em `VARCHAR(64) NOT NULL`, alinhando o banco real à entidade JPA e ao documento de modelo de dados do módulo.

--- a/docs/registros/sales-video.md
+++ b/docs/registros/sales-video.md
@@ -1,0 +1,9 @@
+# Registro operacional — Sales Video
+
+## 2026-07-02 — Correção de truncamento em evento de retry
+
+- Problema observado: backend saudável, mas logs com `Data truncated for column 'event_type' at row 1` durante `SalesVideoAutoRetryScheduler`.
+- Histórico consultado: `docs/diagnostics/ai-worker-jobs-log-check-2026-05-01.md` já apontava suspeita de incompatibilidade entre código e banco.
+- Confirmação via MCP: `sales_video_job_event.event_type` no banco real estava como `ENUM` sem o valor `RETRIED`; o código atual grava `SalesVideoJobEventType.RETRIED`.
+- Causa-raiz: schema real ficou preso em contrato antigo de enum, enquanto entidade JPA e changelog fundacional atuais esperam `VARCHAR(64)`.
+- Correção preparada: Liquibase `sales-video-hardening-007-event-type-varchar` converte `sales_video_job_event.event_type` para `VARCHAR(64) NOT NULL`, mantendo compatibilidade com eventos futuros sem precisar alterar enum físico no banco.


### PR DESCRIPTION
## O que muda

- Adiciona o changeset `sales-video-hardening-007-event-type-varchar` no changelog de Sales Video já incluído pelo master.
- Converte `sales_video_job_event.event_type` para `VARCHAR(64) NOT NULL`.
- Registra a causa-raiz confirmada em `docs/diagnostics/ai-worker-jobs-log-check-2026-05-01.md` e `docs/registros/sales-video.md`.

## Causa-raiz

O backend está saudável, mas o retry automático de Sales Video tenta gravar `SalesVideoJobEventType.RETRIED`. O MCP confirmou que o banco real ainda está com `sales_video_job_event.event_type` como `ENUM('CREATED','CLAIMED','HEARTBEAT','PROGRESS','STATUS_CHANGED','COMPLETED','FAILED','EXPIRED')`, sem `RETRIED`. Isso gera `Data truncated for column 'event_type' at row 1`.

A correção usa `VARCHAR(64)` porque esse já é o contrato atual da entidade JPA e do changelog fundacional, e evita nova quebra a cada evento operacional futuro.

## Validação

- MCP `db_query` confirmou o schema real divergente.
- `mvn -B org.liquibase:liquibase-maven-plugin:4.26.0:validate -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml -Dliquibase.url=jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false\&serverTimezone=UTC -Dliquibase.username=marketing_hub_user -Dliquibase.password=***` passou.
- `mvn -B test -Dtest=SalesVideoJobServiceTest,SalesVideoProfileServiceTest` passou.
- Verificado que não há include relativo sem `relativeToChangelogFile: true`.
- Verificado que o changeset não usa `UPDATE`/`DELETE` com subconsulta na mesma tabela alvo.

## Limitação

- `mvn -B test` completo falhou em erro não relacionado: `ExperimentControllerTest.cleanDb` tenta apagar `experiment` antes de `gera_sales_page_stage_execution`, gerando violação de FK em H2. A falha não envolve Sales Video nem este changeset.

## Observação

O PR 4196 já foi mergeado e o workflow `Build & Deploy containers` terminou com sucesso. O backend subiu no host e está `healthy`; este PR corrige o erro operacional remanescente de schema.