### PR TITLE
[codex] Corrige analytics das páginas de venda direta

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
@@ -90,7 +90,7 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
                         effectiveRawResult.outputTokens() == null ? 0 : effectiveRawResult.outputTokens()));
     }
 
-    /** Injeta tracking de clique no checkout no HTML final publicado pelo GeraSalesPage v1. */
+    /** Injeta analytics de pagina e clique no checkout no HTML final publicado pelo GeraSalesPage v1. */
     private OpenAiResult<String> enrichFinalSalesPageResponse(
             StageContext<GeraSalesPageInput> context,
             OpenAiResult<String> rawResult,
@@ -99,11 +99,11 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
             return rawResult;
         }
         Object htmlValue = output.payload().get("html");
-        if (!(htmlValue instanceof String html) || html.isBlank() || html.contains("checkout_click")) {
+        if (!(htmlValue instanceof String html) || html.isBlank() || html.contains("data-mh-sales-page-analytics")) {
             return rawResult;
         }
         Map<String, Object> enrichedPayload = new LinkedHashMap<>(output.payload());
-        enrichedPayload.put("html", injectCheckoutClickTracking(html));
+        enrichedPayload.put("html", injectSalesPageAnalyticsTracking(html));
         try {
             String enrichedModelResponse = objectMapper.writeValueAsString(enrichedPayload);
             return new OpenAiResult<>(
@@ -115,50 +115,100 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
                     rawResult.outputTokens(),
                     rawResult.costUsd());
         } catch (JsonProcessingException ex) {
-            log.error("Falha ao injetar tracking de checkout no GeraSalesPage v1. jobId={}",
+            log.error("Falha ao injetar analytics de pagina de venda no GeraSalesPage v1. jobId={}",
                     context.execution().idJob(), ex);
-            throw new StageWorkerException("Falha ao injetar tracking de checkout no GeraSalesPage v1", ex);
+            throw new StageWorkerException("Falha ao injetar analytics de pagina de venda no GeraSalesPage v1", ex);
         }
     }
 
-    /** Adiciona script pequeno de analytics para registrar clique em links de checkout. */
-    private String injectCheckoutClickTracking(String html) {
+    /** Adiciona script de analytics para registrar page view, tempo de secao e clique em links de checkout. */
+    private String injectSalesPageAnalyticsTracking(String html) {
         String script = """
-                <script>
+                <script data-mh-sales-page-analytics="true">
                 (function(){
-                  function uid(prefix){return prefix+'-'+Date.now().toString(36)+'-'+Math.random().toString(36).slice(2,10);}
+                  function uid(prefix){
+                    try{if(window.crypto&&typeof window.crypto.randomUUID==='function'){return prefix+'-'+window.crypto.randomUUID();}}catch(e){}
+                    return prefix+'-'+Date.now().toString(36)+'-'+Math.random().toString(36).slice(2,10);
+                  }
                   function storageGet(key){try{return localStorage.getItem(key);}catch(e){return null;}}
                   function storageSet(key,value){try{localStorage.setItem(key,value);}catch(e){}}
                   var visitorKey='mhub_visitor_id';
                   var visitorId=storageGet(visitorKey)||uid('visitor');
                   storageSet(visitorKey,visitorId);
-                  var sessionId=storageGet('mhub_session_id')||uid('session');
-                  storageSet('mhub_session_id',sessionId);
+                  var sessionKey='mhub_session_id_'+(location.pathname||'sales-page');
+                  var sessionId=(function(){try{return sessionStorage.getItem(sessionKey);}catch(e){return null;}})()||uid('session');
+                  try{sessionStorage.setItem(sessionKey,sessionId);}catch(e){}
                   var slug=(location.pathname.split('/').pop()||'').replace(/\\.html$/,'');
-                  function sendCheckoutClick(){
+                  var endpoint='/mh-api/public/lead-portal/flows/'+encodeURIComponent(slug)+'/page-analytics';
+                  function deviceType(){return window.innerWidth<768?'mobile':(/ipad|tablet/i.test(navigator.userAgent||'')?'tablet':'desktop');}
+                  function operatingSystem(){
+                    var userAgent=navigator.userAgent||'';
+                    if(/iphone|ipad|ipod/i.test(userAgent)){return 'ios';}
+                    if(/android/i.test(userAgent)){return 'android';}
+                    return 'other';
+                  }
+                  function sendEvent(eventType, sectionId, elapsedMs, extra){
                     if(!slug){return;}
-                    var payload={
-                      eventId:uid('checkout-click'),
-                      eventType:'checkout_click',
+                    var payload=Object.assign({
+                      eventId:uid(eventType.replace(/_/g,'-')),
+                      eventType:eventType,
                       visitorId:visitorId,
                       sessionId:sessionId,
+                      sectionId:sectionId||null,
+                      elapsedMs:typeof elapsedMs==='number'?Math.max(0,Math.round(elapsedMs)):null,
                       pageUrl:location.href,
                       occurredAt:new Date().toISOString(),
                       userAgent:navigator.userAgent,
-                      deviceType:window.innerWidth<768?'mobile':'desktop',
-                      operatingSystem:navigator.platform||''
-                    };
+                      deviceType:deviceType(),
+                      operatingSystem:operatingSystem(),
+                      screenWidth:Math.round(window.innerWidth||document.documentElement.clientWidth||0)||null,
+                      screenHeight:Math.round(window.innerHeight||document.documentElement.clientHeight||0)||null
+                    }, extra||{});
                     try{
-                      navigator.sendBeacon('/api/public/lead-portal/flows/'+encodeURIComponent(slug)+'/page-analytics', new Blob([JSON.stringify(payload)], {type:'application/json'}));
+                      navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type:'application/json'}));
                     }catch(e){
-                      fetch('/api/public/lead-portal/flows/'+encodeURIComponent(slug)+'/page-analytics',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload),keepalive:true}).catch(function(){});
+                      fetch(endpoint,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload),keepalive:true}).catch(function(){});
                     }
                   }
+                  function sendPageLoadMetric(){
+                    var timing=performance&&performance.getEntriesByType?performance.getEntriesByType('navigation')[0]:null;
+                    sendEvent('page_load_metric',null,null,{
+                      loadDurationMs:timing&&typeof timing.duration==='number'?Math.round(timing.duration):null,
+                      domContentLoadedMs:timing&&typeof timing.domContentLoadedEventEnd==='number'?Math.round(timing.domContentLoadedEventEnd):null
+                    });
+                  }
+                  sendEvent('page_view',null,null);
+                  if(document.readyState==='complete'){sendPageLoadMetric();}else{window.addEventListener('load',sendPageLoadMetric,{once:true});}
+                  var visibleSince=new Map();
+                  var sections=Array.prototype.slice.call(document.querySelectorAll('section[id], [data-track-section]'));
+                  if('IntersectionObserver' in window){
+                    var observer=new IntersectionObserver(function(entries){
+                      entries.forEach(function(entry){
+                        var id=entry.target.getAttribute('data-track-section')||entry.target.id;
+                        if(!id){return;}
+                        if(entry.isIntersecting&&entry.intersectionRatio>=0.35){
+                          if(!visibleSince.has(id)){visibleSince.set(id,Date.now());}
+                        }else if(visibleSince.has(id)){
+                          var startedAt=visibleSince.get(id);
+                          visibleSince.delete(id);
+                          sendEvent('section_view_time',id,Date.now()-startedAt);
+                        }
+                      });
+                    },{threshold:[0,0.35,0.75]});
+                    sections.forEach(function(section){observer.observe(section);});
+                  }
+                  function flushVisibleSections(){
+                    var now=Date.now();
+                    visibleSince.forEach(function(startedAt,id){sendEvent('section_view_time',id,now-startedAt);});
+                    visibleSince.clear();
+                  }
+                  document.addEventListener('visibilitychange',function(){if(document.visibilityState==='hidden'){flushVisibleSections();}});
+                  window.addEventListener('beforeunload',flushVisibleSections);
                   document.addEventListener('click',function(event){
                     var link=event.target&&event.target.closest?event.target.closest('a[href]'):null;
                     if(!link){return;}
                     var href=link.getAttribute('href')||'';
-                    if(/mercadopago|checkout|pref_id/i.test(href)){sendCheckoutClick();}
+                    if(/mercadopago|checkout|pref_id/i.test(href)){sendEvent('checkout_click',null,null);}
                   },true);
                 })();
                 </script>

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
@@ -11,19 +11,22 @@ import org.junit.jupiter.api.Test;
 /** Responsabilidade: validar enriquecimentos técnicos aplicados pelo processor do GeraSalesPage v1. */
 class GeraSalesPageProcessorTest {
 
-    /** Garante que o HTML final registre clique real no checkout para métricas de low-ticket. */
+    /** Garante que o HTML final registre page view, tempo de secao e clique real no checkout para metricas de low-ticket. */
     @Test
-    void injectsCheckoutClickTrackingIntoFinalHtml() throws Exception {
+    void injectsSalesPageAnalyticsTrackingIntoFinalHtml() throws Exception {
         GeraSalesPageProcessor processor = processor();
-        Method method = GeraSalesPageProcessor.class.getDeclaredMethod("injectCheckoutClickTracking", String.class);
+        Method method = GeraSalesPageProcessor.class.getDeclaredMethod("injectSalesPageAnalyticsTracking", String.class);
         method.setAccessible(true);
 
         String html = (String) method.invoke(processor,
-                "<!doctype html><html><body><a href=\"https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc\">Comprar</a></body></html>");
+                "<!doctype html><html><body><section id=\"hero\"><a href=\"https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc\">Comprar</a></section></body></html>");
 
         assertThat(html)
+                .contains("data-mh-sales-page-analytics")
+                .contains("page_view")
+                .contains("section_view_time")
                 .contains("checkout_click")
-                .contains("/api/public/lead-portal/flows/")
+                .contains("/mh-api/public/lead-portal/flows/")
                 .contains("sendBeacon")
                 .contains("</body>");
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
@@ -63,6 +63,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     @Query("""
             select e from Experiment e
             where e.followUpActionUrl like concat(concat('%/api/flows/', :slug), '/page%')
+               or e.followUpActionUrl like concat(concat('%/', :slug), '.html%')
             """)
     Optional<Experiment> findFirstByFollowUpActionUrlFlowSlug(@Param("slug") String slug);
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -43,6 +43,31 @@ class ExperimentRepositoryTest {
     @Autowired
     JourneyTemplateRepository journeyTemplateRepository;
 
+    /** Garante que analytics de pagina de venda estatica encontra o experimento pelo slug publicado. */
+    @Test
+    void findFirstByFollowUpActionUrlFlowSlugAcceptsStaticSalesPageSlug() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Sales page niche").build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Sales page hypothesis")
+                .build());
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Venda direta").build());
+        Experiment experiment = repository.save(Experiment.builder()
+                .name("Static sales page")
+                .niche(niche)
+                .hypothesisRef(hypothesis)
+                .journeyTemplate(template)
+                .followUpActionUrl("https://pagamentopalf.site/sales-page-exp52-protocolo-manutencao-segura-7d.html")
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findFirstByFollowUpActionUrlFlowSlug(
+                "sales-page-exp52-protocolo-manutencao-segura-7d"))
+                .hasValueSatisfying(found -> assertThat(found.getId()).isEqualTo(experiment.getId()));
+    }
+
     @Test
     void findAllToGenerateCreativesFetchesHypothesis() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N1").build());

--- a/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
+++ b/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
@@ -1,0 +1,7 @@
+# 2026-07-02 — Correção de analytics nas páginas de venda direta
+
+- Problema: os experimentos 51, 52 e 53 tinham impressões e cliques pagos, mas o funil/analytics mostrava zero eventos de landing e nenhum dado de tempo de tela.
+- Causa-raiz confirmada: as páginas estáticas em `pagamentopalf.site/sales-page-*.html` eram publicadas sem script de analytics completo; além disso, o tracking existente de checkout apontava para `/api/...`, enquanto nesse host o proxy correto para o backend principal é `/mh-api/...`. O backend também só resolvia slugs antigos de `/api/flows/...`, não slugs de HTML estático.
+- Correção aplicada: o GeraSalesPage v1 passa a injetar `page_view`, `page_load_metric`, `section_view_time` e `checkout_click` usando `/mh-api/public/lead-portal/flows/{slug}/page-analytics`; o backend passa a resolver experimento por `followUpActionUrl` estático terminado em `/{slug}.html`.
+- Decisão operacional: não escalar nem criar novas campanhas completas até republicar as páginas de venda com o novo tracking e confirmar eventos reais no funil.
+- Prevenção de recorrência: adicionados testes no AI Worker para a instrumentação da página de venda e no backend para resolução de slug estático.


### PR DESCRIPTION
## O que mudou

- O GeraSalesPage v1 passa a injetar analytics completo nas páginas finais de venda direta.
- O script registra `page_view`, `page_load_metric`, `section_view_time` e `checkout_click`.
- O envio agora usa o proxy correto do host de pagamentos: `/mh-api/public/lead-portal/flows/{slug}/page-analytics`.
- O backend passa a localizar experimentos publicados como página estática `/{slug}.html`.
- Foi criado registro em `docs/registros` com causa-raiz, decisão operacional e prevenção.

## Causa-raiz

Os experimentos 51, 52 e 53 tinham cliques pagos, mas zero eventos no funil porque as páginas estáticas em `pagamentopalf.site/sales-page-*.html` não tinham analytics completo. O tracking existente também apontava para `/api/...`, rota incorreta nesse host, onde o backend principal passa por `/mh-api/...`. Além disso, o backend só resolvia slugs antigos de Lead Portal em `/api/flows/...`.

## Impacto

Depois do deploy e republicação das páginas de venda, o funil passa a mostrar acesso, tempo de tela por seção, métrica de carregamento e clique no checkout para campanhas de venda direta. Isso permite decidir se a falha está no anúncio, na página, na oferta ou no checkout.

## Validação

- `mvn test -Dtest=GeraSalesPageProcessorTest`
- `mvn test -Dtest=ExperimentRepositoryTest`
- `mvn test -Dtest=ExperimentFunnelServiceRenderCompleteTest`
- `git diff --check`

## Observação operacional

As páginas já publicadas precisam ser republicadas/regeradas após o deploy para receber o script novo. O experimento 51, por estar com destino direto para Mercado Pago, não gera tempo de tela próprio sem uma página ponte rastreável.