### PR TITLE
[codex] Corrige CI da trava low-ticket

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -18,6 +18,7 @@ import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.repository.jpa.ads.CampaignRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for {@link ExperimentController}.
+ * Responsabilidade: validar os contratos HTTP de criação e atualização de experimentos.
  */
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
@@ -81,6 +82,8 @@ class ExperimentControllerTest {
     private com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository leadPortalFlowRepository;
     @Autowired
     private CampaignRepository campaignRepository;
+    @Autowired
+    private GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
 
     Long nicheId;
 
@@ -108,9 +111,11 @@ class ExperimentControllerTest {
     }
 
     @BeforeEach
+    // Limpa dados dependentes antes dos experimentos para preservar as FKs do schema real.
     void cleanDb() {
         creativeRepo.deleteAll();
         campaignRepository.deleteAll();
+        geraSalesPagePublicationAuditRepository.deleteAll();
 
         var experiments = repository.findAll();
         experiments.forEach(experiment -> experiment.setLeadPortalFlow(null));

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -32,9 +32,11 @@ import com.marketinghub.facebookads.service.publicationstep.FacebookCampaignPubl
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.creative.Creative;
 import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentMetricsDto;
@@ -110,6 +112,8 @@ class FacebookAdsCampaignControllerTest {
     CreativeRepository creativeRepository;
     @MockBean
     GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
+    @MockBean
+    GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
     @MockBean
     FacebookCampaignPublicationJobStepService publicationJobStepService;
 
@@ -339,6 +343,16 @@ class FacebookAdsCampaignControllerTest {
                         .stageCode(GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
                         .status("CONCLUIDO")
                         .executionRequestedAt(Instant.parse("2026-07-01T20:05:00Z"))
+                        .build()));
+        when(geraSalesPagePublicationAuditRepository.findTopByExperimentIdOrderByPublishedAtDesc(53L))
+                .thenReturn(Optional.of(GeraSalesPagePublicationAudit.builder()
+                        .experimentId(53L)
+                        .publicationJobId("job-exp53-publication")
+                        .salesPageUrl("https://pagamentopalf.site/sales-page-exp53.html")
+                        .checkoutUrl("https://mpago.la/checkout-exp53")
+                        .html("data-mh-sales-page-analytics page_view page_load_metric section_view_time checkout_click")
+                        .publishedAt(Instant.parse("2026-07-01T20:06:00Z"))
+                        .createdAt(Instant.parse("2026-07-01T20:06:00Z"))
                         .build()));
         when(leadPortalMetricsService.listExperimentMetrics()).thenReturn(List.of());
 


### PR DESCRIPTION
## O que mudou

- Ajusta o teste do endpoint `experiments-ready` para simular uma campanha low-ticket realmente publicável, com auditoria da página de venda e coletores obrigatórios.
- Corrige o cleanup de `ExperimentControllerTest` para apagar `gera_sales_page_publication_audit` antes de apagar `experiment`, respeitando a FK do schema real.

## Causa-raiz

O PR #4199 adicionou a trava correta, mas um teste antigo ainda esperava que low-ticket ficasse pronto apenas com a etapa final do GeraSalesPage. A nova regra exige também a auditoria da publicação com URL e coletores. A suíte completa também expôs uma limpeza de teste que não conhecia a nova tabela de auditoria.

## Validações

- `mvn -B -q -Dtest=FacebookAdsCampaignControllerTest#experimentsReadyIncludesExperimentTypeForLowTicketSalesCampaigns test`
- `mvn -B -q -Dtest=com.marketinghub.experiment.web.ExperimentControllerTest test`
- `mvn -B -q -Dtest=ExperimentReadinessServiceTest,ExperimentServiceTest,FacebookAdsCampaignControllerTest,com.marketinghub.experiment.web.ExperimentControllerTest test`
- `git diff --check`

## Observação

A suíte completa local passou pelo ponto que havia falhado no GitHub Actions, mas ao final confirmou a falha de cleanup corrigida neste PR. Depois do merge, o workflow deve destravar o build/deploy do backend.