### PR TITLE
[codex] Corrige FKs da auditoria GeraSalesPage

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-gera-sales-page-publication-audit-fks.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-gera-sales-page-publication-audit-fks.yaml
@@ -1,0 +1,184 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-01-align-id-job-collation
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_stage_execution
+        - tableExists:
+            tableName: gera_sales_page_publication_audit
+        - tableExists:
+            tableName: gera_sales_page_publication_stage_audit
+        - columnExists:
+            tableName: gera_sales_page_publication_audit
+            columnName: publication_job_id
+        - columnExists:
+            tableName: gera_sales_page_publication_stage_audit
+            columnName: id_job
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE gera_sales_page_publication_audit
+                MODIFY publication_job_id VARCHAR(36)
+                  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;
+
+              ALTER TABLE gera_sales_page_publication_stage_audit
+                MODIFY id_job VARCHAR(36)
+                  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-02-index-publication-job
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_publication_audit
+        - not:
+            indexExists:
+              tableName: gera_sales_page_publication_audit
+              indexName: uk_gera_sales_page_publication_job
+        - sqlCheck:
+            expectedResult: "0"
+            sql: |
+              SELECT COUNT(*)
+              FROM (
+                SELECT publication_job_id
+                FROM gera_sales_page_publication_audit
+                GROUP BY publication_job_id
+                HAVING COUNT(*) > 1
+              ) duplicated_publication_jobs
+      changes:
+        - createIndex:
+            tableName: gera_sales_page_publication_audit
+            indexName: uk_gera_sales_page_publication_job
+            unique: true
+            columns:
+              - column:
+                  name: publication_job_id
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-03-index-publication-experiment
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_publication_audit
+        - not:
+            indexExists:
+              tableName: gera_sales_page_publication_audit
+              indexName: idx_gera_sales_page_publication_experiment
+      changes:
+        - createIndex:
+            tableName: gera_sales_page_publication_audit
+            indexName: idx_gera_sales_page_publication_experiment
+            columns:
+              - column:
+                  name: experiment_id
+              - column:
+                  name: published_at
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-04-index-stage-audit-order
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_publication_stage_audit
+        - not:
+            indexExists:
+              tableName: gera_sales_page_publication_stage_audit
+              indexName: idx_gera_sales_page_publication_stage_audit
+      changes:
+        - createIndex:
+            tableName: gera_sales_page_publication_stage_audit
+            indexName: idx_gera_sales_page_publication_stage_audit
+            columns:
+              - column:
+                  name: publication_audit_id
+              - column:
+                  name: stage_order
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-05-index-stage-job
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_publication_stage_audit
+        - not:
+            indexExists:
+              tableName: gera_sales_page_publication_stage_audit
+              indexName: idx_gera_sales_page_publication_stage_job
+      changes:
+        - createIndex:
+            tableName: gera_sales_page_publication_stage_audit
+            indexName: idx_gera_sales_page_publication_stage_job
+            columns:
+              - column:
+                  name: id_job
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-06-fk-publication-job
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_stage_execution
+        - tableExists:
+            tableName: gera_sales_page_publication_audit
+        - not:
+            foreignKeyConstraintExists:
+              foreignKeyTableName: gera_sales_page_publication_audit
+              foreignKeyName: fk_gera_sales_page_publication_audit_job
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_audit
+            baseColumnNames: publication_job_id
+            constraintName: fk_gera_sales_page_publication_audit_job
+            referencedTableName: gera_sales_page_stage_execution
+            referencedColumnNames: id_job
+
+  - changeSet:
+      id: 2026-07-02-gera-sales-page-publication-audit-fks-07-fk-stage-job
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: gera_sales_page_stage_execution
+        - tableExists:
+            tableName: gera_sales_page_publication_stage_audit
+        - not:
+            foreignKeyConstraintExists:
+              foreignKeyTableName: gera_sales_page_publication_stage_audit
+              foreignKeyName: fk_gera_sales_page_publication_stage_audit_job
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: gera_sales_page_publication_stage_audit
+            baseColumnNames: id_job
+            constraintName: fk_gera_sales_page_publication_stage_audit_job
+            referencedTableName: gera_sales_page_stage_execution
+            referencedColumnNames: id_job

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,6 +9,9 @@ databaseChangeLog:
       file: changesets/2026-07-01-gera-sales-page-publication-audit.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-02-gera-sales-page-publication-audit-fks.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-30-experiment-campaign-objective-sales.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
+++ b/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
@@ -12,3 +12,9 @@
 - Causa-raiz: validar apenas a conclusão da etapa final do pipeline ainda permitia publicar anúncio com destino direto para checkout ou página antiga sem métricas, impedindo leitura real do funil.
 - Correção aplicada: o checklist de prontidão e o endpoint de liberação para Facebook bloqueiam separadamente falta de página auditada, destino incorreto do anúncio e ausência de coletores.
 - Prevenção de recorrência: regras registradas nos cânones `facebook-campaign-publication-canon.v1.md` e `gerasalespage-arquitetura-canon.v1.md`, com testes cobrindo bloqueios e cenário positivo.
+
+## Correção do schema de auditoria GeraSalesPage v1
+
+- Sintoma pós-deploy: o backend subia saudável, mas o bootstrap registrava `Cannot add foreign key constraint` ao tentar criar FKs de `gera_sales_page_publication_audit.publication_job_id` e `gera_sales_page_publication_stage_audit.id_job` para `gera_sales_page_stage_execution.id_job`.
+- Causa-raiz confirmada via MCP/banco: as tabelas de auditoria foram criadas com `utf8mb4_unicode_ci`, enquanto `gera_sales_page_stage_execution.id_job` estava em `utf8mb4_general_ci`; no MySQL 5.7, FK entre `VARCHAR` com collation diferente é recusada. O changeset original estava `MARK_RAN`, deixando índices e FKs de job incompletos.
+- Correção aplicada: novo changelog alinha a collation das colunas-filhas para `utf8mb4_general_ci`, recria os índices previstos e adiciona as FKs de job de forma idempotente.


### PR DESCRIPTION
## O que mudou

- Adiciona changelog idempotente para alinhar a collation de `publication_job_id` e `id_job` nas tabelas de auditoria da publicação GeraSalesPage v1.
- Recria os índices previstos para auditoria de publicação e etapas.
- Adiciona as FKs de job que estavam faltando no banco real.
- Registra a causa-raiz no histórico de experimentos/analytics de página de venda.

## Causa-raiz

Após o deploy do #4200, o backend subiu saudável, mas o bootstrap registrou `Cannot add foreign key constraint`. Via MCP/banco, confirmei que `gera_sales_page_stage_execution.id_job` estava com collation `utf8mb4_general_ci`, enquanto as tabelas de auditoria estavam com `utf8mb4_unicode_ci`. No MySQL 5.7, FK entre `VARCHAR` com collation diferente é recusada. O changeset original estava `MARK_RAN`, deixando índices e FKs incompletos.

## Validações

- `mvn -B -q -DskipTests org.liquibase:liquibase-maven-plugin:4.26.0:validate -Dliquibase.url=offline:mysql -Dliquibase.username=dummy -Dliquibase.password=dummy -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml`
- `git diff --check`
- Validação de includes relativos no changelog mestre: OK

## Próximo passo pós-merge

Acompanhar workflow/deploy e confirmar nos logs que o backend não tenta mais criar essas FKs via Hibernate no bootstrap.