### PR TITLE
[codex] Corrige fluxo NichoCNAE de fontes e persona

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -113,12 +113,19 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
         if (!StringUtils.hasText(cnaeDescription)) {
             cnaeDescription = "CNAE " + execution.getCnaeCode();
         }
-        String neutralNicheName = buildCnaeNicheName(execution.getCnaeCode(), cnaeDescription);
+        String neutralNicheName = textOrDefault(
+                firstText(output,
+                        "marketNicheCandidate.title",
+                        "materializedProfile.personaName",
+                        "neutralNicheName",
+                        "winningPersonaName",
+                        "personaName"),
+                buildCnaeNicheName(execution.getCnaeCode(), cnaeDescription));
         String routineSummary = textOrDefault(
-                firstText(output, "routineSummary", "routine", "rotina"),
+                firstText(output, "routineSummary", "materializedProfile.routineSummary", "marketNicheCandidate.summary", "routine", "rotina"),
                 "Rotina operacional materializada pelo NichoCNAE v3.");
         String dailyTasks = textOrDefault(
-                firstText(output, "personaDailyTasks", "dailyTasks", "tarefasDiarias", "tasks"),
+                firstText(output, "personaDailyTasks", "dailyTasks", "materializedProfile.dailyTasks", "tarefasDiarias", "tasks"),
                 "Tarefas diárias materializadas pelo NichoCNAE v3.");
         Instant now = Instant.now();
         Long existingMarketNicheId = nicheGateway
@@ -164,9 +171,9 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
                         dailyTasks,
                         textOrDefault(firstText(output, "evidenceSummary", "evidences"), execution.getOutputPayload()),
                         firstText(output, "sourceDomains", "sources"),
-                        firstText(output, "personaSummary", "persona"),
-                        firstText(output, "languagePatterns", "language"),
-                        firstText(output, "commercialTriggers", "triggers"),
+                        firstText(output, "personaSummary", "materializedProfile.personaDescription", "persona"),
+                        firstText(output, "languagePatterns", "materializedProfile.recognizableVocabularyAndScenes", "language"),
+                        firstText(output, "commercialTriggers", "materializedProfile.buyingSignals", "triggers"),
                         firstText(output, "objections"),
                         execution.getOutputPayload(),
                         CREATED_BY,
@@ -186,13 +193,13 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
         }
     }
 
-    /** Retorna o primeiro campo textual disponível no payload. */
+    /** Retorna o primeiro campo textual disponível no payload, aceitando caminhos aninhados com ponto. */
     private String firstText(JsonNode root, String... fieldNames) {
         if (root == null || root.isMissingNode() || root.isNull()) {
             return null;
         }
         for (String fieldName : fieldNames) {
-            JsonNode value = root.path(fieldName);
+            JsonNode value = path(root, fieldName);
             if (value.isMissingNode() || value.isNull()) {
                 continue;
             }
@@ -202,6 +209,18 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
             }
         }
         return null;
+    }
+
+    /** Lê um campo simples ou aninhado de um payload JSON da etapa final. */
+    private JsonNode path(JsonNode root, String fieldName) {
+        JsonNode current = root;
+        for (String segment : fieldName.split("\\.")) {
+            current = current.path(segment);
+            if (current.isMissingNode() || current.isNull()) {
+                return current;
+            }
+        }
+        return current;
     }
 
     /** Retorna texto padrão quando o campo final ainda não veio no payload do executor. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -71,7 +71,7 @@ class BackendPersonaRoutineMaterializerServiceTest {
         when(repository.findById(19L)).thenReturn(Optional.of(execution));
         when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(nicheGateway.findPersonaRoutineMaterializedNiche(
-                eq("4781400"), eq("cnae 4781400 — comércio varejista de artigos do vestuário")))
+                eq("4781400"), eq("lojistas de roupas infantis com rotina de reposição")))
                 .thenReturn(Optional.empty());
         when(nicheGateway.materialize(any(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class), any(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class)))
                 .thenReturn(new PersonaRoutineMaterializerNicheGateway.NicheMaterializationResult(300L, 400L, Instant.now()));
@@ -86,7 +86,7 @@ class BackendPersonaRoutineMaterializerServiceTest {
         ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.MarketNicheDraft> nicheCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class);
         ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft> profileCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class);
         verify(nicheGateway).materialize(nicheCaptor.capture(), profileCaptor.capture());
-        assertThat(nicheCaptor.getValue().name()).isEqualTo("CNAE 4781400 — Comércio varejista de artigos do vestuário");
+        assertThat(nicheCaptor.getValue().name()).isEqualTo("Lojistas de roupas infantis com rotina de reposição");
         assertThat(nicheCaptor.getValue().sourceCnaeCode()).isEqualTo("4781400");
         assertThat(nicheCaptor.getValue().sourceCnaeDescription()).isEqualTo("Comércio varejista de artigos do vestuário");
         assertThat(nicheCaptor.getValue().description()).contains("Compram, organizam vitrines");
@@ -98,6 +98,50 @@ class BackendPersonaRoutineMaterializerServiceTest {
         assertThat(profileCaptor.getValue().routineSummary()).contains("Compram");
         assertThat(profileCaptor.getValue().personaDailyTasks()).contains("repor peças");
         assertThat(cnae.getNichocnaePipelineStatus()).isEqualTo("CONCLUIDO");
+    }
+
+    /** Garante que payload funcional aninhado do executor vira nicho com nome de persona real. */
+    @Test
+    void completeUsesNestedPersonaNameInsteadOfGenericCnaeName() {
+        OprmNichoCnaeV3StageExecution execution = execution();
+        String outputPayload = """
+                {
+                  "cnaeDescription":"Comércio varejista de artigos do vestuário",
+                  "materializedProfile":{
+                    "personaName":"Dona de loja pequena de roupas que vende por WhatsApp e controla estoque manualmente",
+                    "routineSummary":"Atende clientes no balcão e no WhatsApp, separa peças e registra reservas em caderno.",
+                    "dailyTasks":["responder clientes", "separar pedidos", "controlar trocas"],
+                    "personaDescription":"Dona-operadora MEI de loja de roupas."
+                  },
+                  "marketNicheCandidate":{
+                    "title":"Dona de loja pequena de roupas que vende por WhatsApp e controla estoque manualmente"
+                  }
+                }
+                """;
+        when(repository.findById(19L)).thenReturn(Optional.of(execution));
+        when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(nicheGateway.findPersonaRoutineMaterializedNiche(
+                eq("4781400"),
+                eq("dona de loja pequena de roupas que vende por whatsapp e controla estoque manualmente")))
+                .thenReturn(Optional.empty());
+        when(nicheGateway.materialize(any(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class), any(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class)))
+                .thenReturn(new PersonaRoutineMaterializerNicheGateway.NicheMaterializationResult(300L, 400L, Instant.now()));
+        OprmCnpjCnaeDim cnae = new OprmCnpjCnaeDim();
+        cnae.setCnaeCode("4781400");
+        cnae.setNichocnaeCurrentStageCode("persona-routine-materializer");
+        cnae.setNichocnaePipelineStatus("INICIADO");
+        when(cnaeRepository.findById("4781400")).thenReturn(Optional.of(cnae));
+
+        service.complete(19L, outputPayload, "");
+
+        ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.MarketNicheDraft> nicheCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class);
+        ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft> profileCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class);
+        verify(nicheGateway).materialize(nicheCaptor.capture(), profileCaptor.capture());
+        assertThat(nicheCaptor.getValue().name()).isEqualTo("Dona de loja pequena de roupas que vende por WhatsApp e controla estoque manualmente");
+        assertThat(nicheCaptor.getValue().description()).contains("Atende clientes no balcão");
+        assertThat(profileCaptor.getValue().neutralNicheName()).isEqualTo("Dona de loja pequena de roupas que vende por WhatsApp e controla estoque manualmente");
+        assertThat(profileCaptor.getValue().personaSummary()).contains("Dona-operadora MEI");
+        assertThat(profileCaptor.getValue().personaDailyTasks()).contains("responder clientes");
     }
 
     /** Garante que o start marca o status do pipeline e a etapa atual no cadastro do CNAE. */

--- a/docs/canonical/oprm-nichocnae-v3-persona-source-flow.md
+++ b/docs/canonical/oprm-nichocnae-v3-persona-source-flow.md
@@ -1,0 +1,12 @@
+# Cânone OPRM NichoCNAE v3 — busca curta e persona materializada
+
+## Regra canônica
+
+- A etapa `source-searcher` deve limitar queries planejadas, variações por tentativa e parar cedo quando encontrar fontes qualificadas suficientes.
+- A parada antecipada não pode relaxar qualidade: fontes comerciais, utilitárias, duplicadas, sem URL, de solução prematura ou fora do domínio continuam bloqueadas.
+- A etapa `persona-routine-materializer` deve materializar o nome da persona/subnicho operacional entregue pelo executor antes de usar o nome fiscal do CNAE.
+- `CNAE <codigo> — <descricao>` é apenas fallback técnico quando não houver persona real no payload.
+
+## Objetivo de negócio
+
+Gerar nichos com rotina, linguagem e cenas reais do dia a dia para alimentar hipótese, produto e campanhas sem desperdiçar mídia com persona genérica.

--- a/docs/registros/oprm-nichocnae-v3-2026-07-02.md
+++ b/docs/registros/oprm-nichocnae-v3-2026-07-02.md
@@ -1,0 +1,10 @@
+# Registro OPRM NichoCNAE v3 — 2026-07-02
+
+## Busca curta e nome real de persona materializada
+
+- Diagnóstico: o NichoCNAE ainda podia consumir tempo excessivo no `source-searcher` quando recebia várias queries e variações.
+- Diagnóstico complementar: a etapa final podia materializar nicho como `CNAE <codigo> — <descricao>` mesmo quando o executor já entregava persona operacional útil.
+- Causa-raiz: a busca pública tentava variações demais antes de parar, enquanto o backend lia apenas campos de topo do payload final.
+- Correção: o `source-searcher` limita queries/variações e para cedo quando encontra fontes qualificadas suficientes.
+- Correção: o backend passa a ler `marketNicheCandidate.title` e `materializedProfile.personaName` antes do fallback fiscal do CNAE.
+- Prevenção: testes cobrem parada antecipada da busca e materialização com payload funcional aninhado do executor.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessor.java
@@ -19,6 +19,9 @@ import java.util.regex.Pattern;
 public final class SourceSearcherProcessor implements StageProcessor {
     private static final int SEARCH_RESULTS_PER_QUERY = 8;
     private static final int MAX_SELECTED_SOURCES = 8;
+    private static final int MIN_EARLY_STOP_SOURCES = 3;
+    private static final int MAX_PLANNED_QUERY_ATTEMPTS = 3;
+    private static final int MAX_QUERY_VARIANTS_PER_ATTEMPT = 4;
     private static final int MIN_ROUTINE_EVIDENCE_SCORE = 45;
     private static final int MAX_REJECTED_SOURCES_PER_ATTEMPT = 8;
     private static final int MAX_DOMAIN_FALLBACK_QUERIES = 6;
@@ -113,15 +116,22 @@ public final class SourceSearcherProcessor implements StageProcessor {
     /** Executa as queries planejadas e seleciona fontes qualificadas para a próxima etapa. */
     private SearchOutput search(List<Map<String, Object>> plannedQueries) {
         Set<String> seenUrls = new HashSet<>();
-        List<Map<String, Object>> attempts = new ArrayList<>(plannedQueries.stream()
-                .map(query -> searchOneQuery(query, seenUrls))
-                .toList());
+        List<Map<String, Object>> attempts = new ArrayList<>();
+        for (Map<String, Object> query : plannedQueries.stream().limit(MAX_PLANNED_QUERY_ATTEMPTS).toList()) {
+            attempts.add(searchOneQuery(query, seenUrls));
+            if (selectSources(attempts).size() >= MIN_EARLY_STOP_SOURCES) {
+                break;
+            }
+        }
         List<Map<String, Object>> selectedSources = selectSources(attempts);
         if (selectedSources.isEmpty()) {
             List<Map<String, Object>> fallbackQueries = domainFallbackQueries(plannedQueries);
-            attempts.addAll(fallbackQueries.stream()
-                    .map(query -> searchOneQuery(query, seenUrls))
-                    .toList());
+            for (Map<String, Object> query : fallbackQueries) {
+                attempts.add(searchOneQuery(query, seenUrls));
+                if (selectSources(attempts).size() >= MIN_EARLY_STOP_SOURCES) {
+                    break;
+                }
+            }
             selectedSources = selectSources(attempts);
         }
         return new SearchOutput(selectedSources, attempts);
@@ -141,7 +151,9 @@ public final class SourceSearcherProcessor implements StageProcessor {
     /** Busca uma query por variações simples e registra quantidade bruta, fontes aceitas e descartes. */
     private Map<String, Object> searchOneQuery(Map<String, Object> plannedQuery, Set<String> seenUrls) {
         String originalQuery = text(plannedQuery.get("query"));
-        List<String> queryVariants = queryVariants(plannedQuery);
+        List<String> queryVariants = queryVariants(plannedQuery).stream()
+                .limit(MAX_QUERY_VARIANTS_PER_ATTEMPT)
+                .toList();
         List<SourceSearchResult> rawResults = queryVariants.stream()
                 .flatMap(query -> searchClient.search(query, SEARCH_RESULTS_PER_QUERY).stream())
                 .toList();
@@ -251,12 +263,15 @@ public final class SourceSearcherProcessor implements StageProcessor {
         String operationalQuery = operationalQuery(simplifiedQuery);
         String domainQuery = domainQuery(simplifiedQuery + " " + objective);
         List<String> variants = new ArrayList<>();
+        if ("DOMAIN_FALLBACK".equals(text(plannedQuery.get("intent")))) {
+            addVariant(variants, originalQuery);
+        }
         addVariant(variants, enrichBrazilFirstQuery(domainQuery));
+        addVariant(variants, complaintQuery(operationalQuery, simplifiedQuery));
+        addVariant(variants, enrichBrazilFirstQuery(operationalQuery));
         addVariant(variants, retailQuestionQuery(domainQuery));
         addVariant(variants, enrichBrazilFirstQuery(simplifiedQuery));
-        addVariant(variants, enrichBrazilFirstQuery(operationalQuery));
         addVariant(variants, realPainQuery(operationalQuery, simplifiedQuery));
-        addVariant(variants, complaintQuery(operationalQuery, simplifiedQuery));
         addVariant(variants, professionalQuestionQuery(operationalQuery, simplifiedQuery));
         addVariant(variants, enrichBrazilFirstQuery(objective));
         addVariant(variants, naturalRoutineQuery(simplifiedQuery));

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/sourcesearcher/SourceSearcherProcessorTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /** Valida a decisão de avanço da etapa source-searcher no pipeline NichoCNAE v3. */
@@ -73,6 +74,35 @@ class SourceSearcherProcessorTest {
         assertThat(source.get("searchProvider")).isEqualTo("TEST_PROVIDER");
         assertThat(source.containsKey("routineEvidenceScore")).isTrue();
         assertThat(source.containsKey("brazilRelevanceScore")).isTrue();
+    }
+
+    /** Para cedo quando já encontrou fontes suficientes, reduzindo timeout operacional do executor. */
+    @Test
+    void shouldStopSearchingAfterEnoughQualifiedSources() {
+        AtomicInteger calls = new AtomicInteger();
+        SourceSearchClient searchClient = (query, limit) -> {
+            calls.incrementAndGet();
+            return List.of(new SourceSearchResult(
+                    "Rotina de loja com pedidos e estoque",
+                    "https://varejo.example.com.br/" + calls.get(),
+                    "Dono MEI relata atendimento a clientes, pedidos por WhatsApp, trocas, cobrança e controle manual de estoque.",
+                    "TEST_PROVIDER",
+                    "<item />"));
+        };
+
+        StageResult result = new SourceSearcherProcessor(searchClient).process(new StageContext("job", "5", Map.of(
+                "plannedQueries", List.of(
+                        Map.of("query", "loja roupas atendimento pedidos"),
+                        Map.of("query", "loja roupas estoque caixa"),
+                        Map.of("query", "loja roupas trocas entrega"),
+                        Map.of("query", "loja roupas cobrança cliente"),
+                        Map.of("query", "loja roupas instagram whatsapp")))));
+
+        assertThat(result.status()).isEqualTo("FONTES_ENCONTRADAS");
+        assertThat(calls.get()).isLessThanOrEqualTo(4);
+        assertThat((List<?>) result.output().get("selectedSources")).hasSize(4);
+        List<?> attempts = (List<?>) result.output().get("searchAttempts");
+        assertThat(attempts).hasSize(1);
     }
 
     /** Usa variações curtas para encontrar fontes mesmo quando a query planejada vem longa e ruidosa. */


### PR DESCRIPTION
## O que mudou

- Limita o `source-searcher` do NichoCNAE v3 a poucas queries/variações por tentativa.
- Para cedo quando já existem fontes qualificadas suficientes, reduzindo risco de timeout e fila travada.
- Preserva a query original nos fallbacks de domínio para não perder buscas determinísticas úteis.
- Materializa o nome real da persona/subnicho vindo do executor antes do fallback genérico `CNAE <codigo> — <descricao>`.
- Adiciona cânone complementar e registro operacional do ajuste.

## Por que

O pipeline pode melhorar nossos experimentos se entregar persona real, rotina, linguagem e cenas do dia a dia para alimentar hipótese/oferta. A causa-raiz tratada aqui é dupla: busca pública extensa demais no `source-searcher` e materialização final genérica quando o payload funcional já trazia persona operacional.

## Validações

- `mvn -q -Dtest=SourceSearcherProcessorTest test` em `oprm-coletor-mei`
- `mvn -q -Dtest=BackendPersonaRoutineMaterializerServiceTest test` em `backend/ads-service`
- `git diff --check`