### PR TITLE
[codex] Corrige retry OpenAI no NichoCNAE v3

### DIFF
--- a/docs/registros/oprm-nichocnae-v3-2026-07-02.md
+++ b/docs/registros/oprm-nichocnae-v3-2026-07-02.md
@@ -8,3 +8,10 @@
 - Correção: o `source-searcher` limita queries/variações e para cedo quando encontra fontes qualificadas suficientes.
 - Correção: o backend passa a ler `marketNicheCandidate.title` e `materializedProfile.personaName` antes do fallback fiscal do CNAE.
 - Prevenção: testes cobrem parada antecipada da busca e materialização com payload funcional aninhado do executor.
+
+## Retry OpenAI no persona-candidate-generator
+
+- Diagnóstico: ao executar o CNAE `5620104`, a etapa `persona-candidate-generator` falhou na execução `293` com `ResourceAccessException` antes de receber resposta HTTP da OpenAI.
+- Causa-raiz: a chamada de integração tratava falha transitória de transporte como falha definitiva e usava `include` de resultados de web search mais pesado que o necessário para a auditoria funcional.
+- Correção: o cliente OpenAI da etapa passou a tentar novamente falhas de I/O e a solicitar `web_search_call.action.sources`.
+- Prevenção: teste unitário cobre retry de falha de transporte antes de resposta HTTP.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.ResourceAccessException;
 
 /** Integra a etapa persona-candidate-generator com a OpenAI Responses API usando saída estruturada. */
 @Component
@@ -106,6 +107,7 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
                     ex.getClass().getName(),
                     ex.getMessage(),
                     ex);
+            safeSendBackendResponseAudit(request, "", ex.getClass().getSimpleName() + ": " + ex.getMessage());
             throw new IllegalStateException("Falha na OpenAI ao gerar personas candidatas do NichoCNAE v3.", ex);
         }
     }
@@ -189,7 +191,7 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         body.put("service_tier", properties.serviceTier());
         if (properties.webSearchEnabled()) {
             body.put("tools", List.of(Map.of("type", "web_search")));
-            body.put("include", List.of("web_search_call.results"));
+            body.put("include", List.of("web_search_call.action.sources"));
         }
         return body;
     }
@@ -231,6 +233,20 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
                 request.stageExecutionId(),
                 request.cnaeCode());
         restClient.post().uri(URI.create(endpoint)).body(payload).retrieve().toBodilessEntity();
+    }
+
+    /** Tenta auditar a falha sem esconder a causa original da integração OpenAI. */
+    private void safeSendBackendResponseAudit(PersonaCandidateGenerationRequest request, String rawResponseBody, String errorMessage) {
+        try {
+            sendBackendResponseAudit(request, rawResponseBody, errorMessage);
+        } catch (RestClientException ex) {
+            log.error(
+                    "Erro ao auditar falha OpenAI da etapa persona-candidate-generator (jobId={}, stageExecutionId={}, cnaeCode={})",
+                    request.jobId(),
+                    request.stageExecutionId(),
+                    request.cnaeCode(),
+                    ex);
+        }
     }
 
     /** Envia ao backend exatamente a resposta bruta da OpenAI ou o erro capturado pelo endpoint recebeResponse. */
@@ -282,15 +298,24 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         }
     }
 
-    /** Executa a requisição HTTP para a Responses API. */
+    /** Executa a requisição HTTP para a Responses API com retry curto para falhas transitórias de transporte. */
     private String responseBody(String url, String rawRequestBody, String apiKey) {
-        return restClient.post()
-                .uri(URI.create(url))
-                .header("Authorization", "Bearer " + apiKey)
-                .header("Content-Type", "application/json")
-                .body(rawRequestBody)
-                .retrieve()
-                .body(String.class);
+        ResourceAccessException lastException = null;
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try {
+                return restClient.post()
+                        .uri(URI.create(url))
+                        .header("Authorization", "Bearer " + apiKey)
+                        .header("Content-Type", "application/json")
+                        .body(rawRequestBody)
+                        .retrieve()
+                        .body(String.class);
+            } catch (ResourceAccessException ex) {
+                lastException = ex;
+                log.warn("Falha transitória ao enviar request OpenAI persona-candidate-generator (attempt={}, endpoint={})", attempt, url, ex);
+            }
+        }
+        throw lastException;
     }
 
     /** Converte a resposta bruta da OpenAI para mapa apenas depois da auditoria crua. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,7 +29,7 @@ import org.springframework.web.client.RestClient;
 /** Valida o contrato de chamada da OpenAI para geração de personas candidatas v3. */
 @ExtendWith(OutputCaptureExtension.class)
 class OpenAiPersonaCandidateGenerationClientTest {
-    /** Confirma que a requisição usa Responses API com JSON Schema, Flex Processing e pesquisa web. */
+    /** Confirma que a requisição usa Responses API com JSON Schema, Flex Processing e fontes da pesquisa web. */
     @Test
     void shouldCallOpenAiResponsesApiWithStrictJsonSchemaAndFlex(CapturedOutput logs) throws Exception {
         RestClient.Builder builder = RestClient.builder();
@@ -56,7 +57,7 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 .andExpect(jsonPath("$.text.format.strict").value(true))
                 .andExpect(jsonPath("$.text.format.schema.required[6]").value("candidatePersonas"))
                 .andExpect(jsonPath("$.tools[0].type").value("web_search"))
-                .andExpect(jsonPath("$.include[0]").value("web_search_call.results"))
+                .andExpect(jsonPath("$.include[0]").value("web_search_call.action.sources"))
                 .andExpect(req -> openAiRequest.set(((MockClientHttpRequest) req).getBodyAsString()))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
         server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-1/recebeResponse")))
@@ -88,8 +89,47 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 .contains("cnaeCode=4781400")
                 .contains("\"service_tier\":\"flex\"")
                 .contains("\"tools\":[{\"type\":\"web_search\"}]")
+                .contains("\"web_search_call.action.sources\"")
                 .contains("\"output_text\"")
                 .doesNotContain("direct-key");
+        server.verify();
+    }
+
+    /** Garante retry quando a chamada OpenAI falha por I/O antes de receber resposta HTTP. */
+    @Test
+    void shouldRetryOpenAiRequestWhenTransportFailsBeforeHttpResponse() throws Exception {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        String modelJson = """
+                {\"candidatePersonas\":[{\"name\":\"p1\"},{\"name\":\"p2\"},{\"name\":\"p3\"}],\"personaSummary\":\"p1;p2;p3\"}
+                """.trim();
+        String response = new ObjectMapper().writeValueAsString(Map.of("output_text", modelJson));
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-retry/recebeRequest")))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+        server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
+                .andRespond(request -> {
+                    throw new IOException("broken pipe");
+                });
+        server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
+                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+        server.expect(once(), requestTo(URI.create("http://backend.test/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions/4781400/job-retry/recebeResponse")))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+        OpenAiPersonaCandidateGenerationClient client = new OpenAiPersonaCandidateGenerationClient(
+                builder.build(),
+                new ObjectMapper(),
+                new PersonaCandidateOpenAiProperties("https://api.openai.com/v1", "direct-key", "", "gpt-test", null, true),
+                new PersonaCandidatePromptBuilder(),
+                new PersonaCandidateSchemaLoader(new ObjectMapper()),
+                "http://backend.test");
+
+        Map<String, Object> output = client.generate(new PersonaCandidateGenerationRequest(
+                "job-retry",
+                "72",
+                "4781400",
+                "Comércio varejista de artigos do vestuário",
+                Map.of("cnaeCode", "4781400")));
+
+        assertThat((List<?>) output.get("candidatePersonas")).hasSize(3);
         server.verify();
     }
 


### PR DESCRIPTION
## O que mudou
- Ajusta o `persona-candidate-generator` do NichoCNAE v3 para usar `web_search_call.action.sources`, compatível com a Responses API.
- Adiciona retry para falha transitória de transporte ao chamar a OpenAI.
- Registra auditoria de falha no backend quando a chamada quebra antes de resposta HTTP.
- Atualiza o registro OPRM com a causa-raiz observada no CNAE 5620104.

## Causa-raiz
Ao executar o CNAE 5620104, o pipeline v3 passou pelo `cnae-intake`, mas falhou em `persona-candidate-generator` com `ResourceAccessException`: erro de I/O ao escrever o corpo da requisição para `https://api.openai.com/v1/responses`. O erro era tratado como falha definitiva, sem retry e com auditoria incompleta da resposta.

## Validação
- `mvn -q -Dtest=OpenAiPersonaCandidateGenerationClientTest test`
- `mvn -q -Dtest='OpenAiPersonaCandidateGenerationClientTest,NichoCnaeV3PendingExecutionServiceTest,NichoCnaeV3StageDefinitionsTest,NichoCnaeV3PipelineArchitectureTest' test`
- `git diff --check`
