### PR TITLE
[codex] Track product prompts by experiment

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/BackendPromptSchemaTemplate.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/BackendPromptSchemaTemplate.java
@@ -1,0 +1,48 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.Map;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: resolver prompt/schema enviados pelo backend com fallback local do worker. */
+public record BackendPromptSchemaTemplate(
+        String templateKey,
+        String version,
+        String model,
+        String schemaName,
+        String promptMarkdownContent,
+        String schemaJson) {
+
+    /** Monta o template efetivo a partir do contrato pending e dos valores locais de fallback. */
+    public static BackendPromptSchemaTemplate fromPromptData(
+            Map<String, Object> promptData,
+            String fallbackModel,
+            String fallbackSchemaName,
+            String fallbackPromptMarkdownContent,
+            String fallbackSchemaJson) {
+        Map<String, Object> template = promptData == null ? Map.of() : asMap(promptData.get("__promptTemplate"));
+        return new BackendPromptSchemaTemplate(
+                text(template.get("templateKey")),
+                text(template.get("version")),
+                firstText(template.get("model"), fallbackModel),
+                firstText(template.get("schemaName"), fallbackSchemaName),
+                firstText(template.get("promptMarkdownContent"), fallbackPromptMarkdownContent),
+                firstText(template.get("schemaJson"), fallbackSchemaJson));
+    }
+
+    /** Retorna o primeiro texto preenchido entre o valor remoto e o fallback local. */
+    private static String firstText(Object value, String fallback) {
+        String text = text(value);
+        return StringUtils.hasText(text) ? text : fallback;
+    }
+
+    /** Converte um valor textual opcional para string segura. */
+    private static String text(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    /** Normaliza um mapa vindo do JSON do backend. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object value) {
+        return value instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
@@ -136,6 +136,7 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
         Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
+        payload.put("__promptTemplate", asMap(pending.get("promptTemplate")));
         payload.put("nicheName", optionalText(niche.get("name")));
         payload.put("nicheDescription", optionalText(niche.get("description")));
         payload.put("demandVolume", optionalText(niche.get("demandVolume")));

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.BackendPromptSchemaTemplate;
 import com.marketinghub.worker.pipeline.StageArtifact;
 import com.marketinghub.worker.pipeline.StageContext;
 import com.marketinghub.worker.pipeline.StageProcessor;
@@ -88,17 +89,21 @@ public class HypothesisMechanismProcessor implements StageProcessor<HypothesisMe
     private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisMechanismInput> context) {
         Map<String, Object> data = context.input().promptData();
         String promptResource = properties.promptResource();
-        String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
-        String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
-        return new OpenAiRequest(
+        BackendPromptSchemaTemplate template = BackendPromptSchemaTemplate.fromPromptData(
+                data,
                 properties.model(),
+                properties.schemaName(),
+                loadResource(promptResource),
+                loadResource(properties.schemaResource()));
+        String prompt = promptTemplateResolver.resolve(template.promptMarkdownContent(), data, promptResource);
+        String requestBodyJson = buildResponsesApiRequest(prompt, template.schemaJson(), template.schemaName(), template.model());
+        return new OpenAiRequest(
+                template.model(),
                 prompt,
                 requestBodyJson,
-                properties.schemaName(),
-                schemaJson,
-                promptMarkdownContent,
+                template.schemaName(),
+                template.schemaJson(),
+                template.promptMarkdownContent(),
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
@@ -106,23 +111,23 @@ public class HypothesisMechanismProcessor implements StageProcessor<HypothesisMe
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+    private String buildResponsesApiRequest(String prompt, String schemaJson, String schemaName, String model) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
             format.put("type", "json_schema");
-            format.put("name", properties.schemaName());
+            format.put("name", schemaName);
             format.put("schema", schema);
             format.put("strict", true);
             Map<String, Object> text = new LinkedHashMap<>();
             text.put("format", format);
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", properties.model());
+            body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
-            log.error("Could not build OpenAI Responses API request for hypothesis mechanism. schemaName={}", properties.schemaName(), ex);
+            log.error("Could not build OpenAI Responses API request for hypothesis mechanism. schemaName={}", schemaName, ex);
             throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis mechanism", ex);
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
@@ -136,6 +136,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
+        payload.put("__promptTemplate", asMap(pending.get("promptTemplate")));
         payload.put("nicheName", optionalText(niche.get("name")));
         payload.put("nicheDescription", optionalText(niche.get("description")));
         payload.put("demandVolume", optionalText(niche.get("demandVolume")));

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.BackendPromptSchemaTemplate;
 import com.marketinghub.worker.pipeline.StageArtifact;
 import com.marketinghub.worker.pipeline.StageContext;
 import com.marketinghub.worker.pipeline.StageProcessor;
@@ -88,17 +89,21 @@ public class HypothesisOfferProcessor implements StageProcessor<HypothesisOfferI
     private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisOfferInput> context) {
         Map<String, Object> data = context.input().promptData();
         String promptResource = properties.promptResource();
-        String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
-        String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
-        return new OpenAiRequest(
+        BackendPromptSchemaTemplate template = BackendPromptSchemaTemplate.fromPromptData(
+                data,
                 properties.model(),
+                properties.schemaName(),
+                loadResource(promptResource),
+                loadResource(properties.schemaResource()));
+        String prompt = promptTemplateResolver.resolve(template.promptMarkdownContent(), data, promptResource);
+        String requestBodyJson = buildResponsesApiRequest(prompt, template.schemaJson(), template.schemaName(), template.model());
+        return new OpenAiRequest(
+                template.model(),
                 prompt,
                 requestBodyJson,
-                properties.schemaName(),
-                schemaJson,
-                promptMarkdownContent,
+                template.schemaName(),
+                template.schemaJson(),
+                template.promptMarkdownContent(),
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
@@ -106,23 +111,23 @@ public class HypothesisOfferProcessor implements StageProcessor<HypothesisOfferI
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+    private String buildResponsesApiRequest(String prompt, String schemaJson, String schemaName, String model) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
             format.put("type", "json_schema");
-            format.put("name", properties.schemaName());
+            format.put("name", schemaName);
             format.put("schema", schema);
             format.put("strict", true);
             Map<String, Object> text = new LinkedHashMap<>();
             text.put("format", format);
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", properties.model());
+            body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
-            log.error("Could not build OpenAI Responses API request for hypothesis offer. schemaName={}", properties.schemaName(), ex);
+            log.error("Could not build OpenAI Responses API request for hypothesis offer. schemaName={}", schemaName, ex);
             throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis offer", ex);
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
@@ -135,6 +135,7 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
+        payload.put("__promptTemplate", asMap(pending.get("promptTemplate")));
         payload.put("nicheName", optionalText(niche.get("name")));
         payload.put("nicheDescription", optionalText(niche.get("description")));
         payload.put("demandVolume", optionalText(niche.get("demandVolume")));

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.BackendPromptSchemaTemplate;
 import com.marketinghub.worker.pipeline.StageArtifact;
 import com.marketinghub.worker.pipeline.StageContext;
 import com.marketinghub.worker.pipeline.StageProcessor;
@@ -88,17 +89,21 @@ public class HypothesisPainProcessor implements StageProcessor<HypothesisPainInp
     private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisPainInput> context) {
         Map<String, Object> data = context.input().promptData();
         String promptResource = properties.promptResource();
-        String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
-        String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
-        return new OpenAiRequest(
+        BackendPromptSchemaTemplate template = BackendPromptSchemaTemplate.fromPromptData(
+                data,
                 properties.model(),
+                properties.schemaName(),
+                loadResource(promptResource),
+                loadResource(properties.schemaResource()));
+        String prompt = promptTemplateResolver.resolve(template.promptMarkdownContent(), data, promptResource);
+        String requestBodyJson = buildResponsesApiRequest(prompt, template.schemaJson(), template.schemaName(), template.model());
+        return new OpenAiRequest(
+                template.model(),
                 prompt,
                 requestBodyJson,
-                properties.schemaName(),
-                schemaJson,
-                promptMarkdownContent,
+                template.schemaName(),
+                template.schemaJson(),
+                template.promptMarkdownContent(),
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
@@ -106,24 +111,24 @@ public class HypothesisPainProcessor implements StageProcessor<HypothesisPainInp
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito e modo flex auditável. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+    private String buildResponsesApiRequest(String prompt, String schemaJson, String schemaName, String model) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
             format.put("type", "json_schema");
-            format.put("name", properties.schemaName());
+            format.put("name", schemaName);
             format.put("schema", schema);
             format.put("strict", true);
             Map<String, Object> text = new LinkedHashMap<>();
             text.put("format", format);
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", properties.model());
+            body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
             body.put("service_tier", "flex");
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
-            log.error("Could not build OpenAI Responses API request for hypothesis pain. schemaName={}", properties.schemaName(), ex);
+            log.error("Could not build OpenAI Responses API request for hypothesis pain. schemaName={}", schemaName, ex);
             throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis pain", ex);
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
@@ -136,6 +136,7 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
         Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
+        payload.put("__promptTemplate", asMap(pending.get("promptTemplate")));
         payload.put("nicheName", optionalText(niche.get("name")));
         payload.put("nicheDescription", optionalText(niche.get("description")));
         payload.put("demandVolume", optionalText(niche.get("demandVolume")));

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.BackendPromptSchemaTemplate;
 import com.marketinghub.worker.pipeline.StageArtifact;
 import com.marketinghub.worker.pipeline.StageContext;
 import com.marketinghub.worker.pipeline.StageProcessor;
@@ -88,17 +89,21 @@ public class HypothesisProofProcessor implements StageProcessor<HypothesisProofI
     private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisProofInput> context) {
         Map<String, Object> data = context.input().promptData();
         String promptResource = properties.promptResource();
-        String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
-        String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
-        return new OpenAiRequest(
+        BackendPromptSchemaTemplate template = BackendPromptSchemaTemplate.fromPromptData(
+                data,
                 properties.model(),
+                properties.schemaName(),
+                loadResource(promptResource),
+                loadResource(properties.schemaResource()));
+        String prompt = promptTemplateResolver.resolve(template.promptMarkdownContent(), data, promptResource);
+        String requestBodyJson = buildResponsesApiRequest(prompt, template.schemaJson(), template.schemaName(), template.model());
+        return new OpenAiRequest(
+                template.model(),
                 prompt,
                 requestBodyJson,
-                properties.schemaName(),
-                schemaJson,
-                promptMarkdownContent,
+                template.schemaName(),
+                template.schemaJson(),
+                template.promptMarkdownContent(),
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
@@ -106,23 +111,23 @@ public class HypothesisProofProcessor implements StageProcessor<HypothesisProofI
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+    private String buildResponsesApiRequest(String prompt, String schemaJson, String schemaName, String model) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
             format.put("type", "json_schema");
-            format.put("name", properties.schemaName());
+            format.put("name", schemaName);
             format.put("schema", schema);
             format.put("strict", true);
             Map<String, Object> text = new LinkedHashMap<>();
             text.put("format", format);
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", properties.model());
+            body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
-            log.error("Could not build OpenAI Responses API request for hypothesis proof. schemaName={}", properties.schemaName(), ex);
+            log.error("Could not build OpenAI Responses API request for hypothesis proof. schemaName={}", schemaName, ex);
             throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis proof", ex);
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
@@ -135,6 +135,7 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
         Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
+        payload.put("__promptTemplate", asMap(pending.get("promptTemplate")));
         payload.put("nicheName", optionalText(niche.get("name")));
         payload.put("nicheDescription", optionalText(niche.get("description")));
         payload.put("demandVolume", optionalText(niche.get("demandVolume")));

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.BackendPromptSchemaTemplate;
 import com.marketinghub.worker.pipeline.StageArtifact;
 import com.marketinghub.worker.pipeline.StageContext;
 import com.marketinghub.worker.pipeline.StageProcessor;
@@ -88,17 +89,21 @@ public class HypothesisResultProcessor implements StageProcessor<HypothesisResul
     private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisResultInput> context) {
         Map<String, Object> data = context.input().promptData();
         String promptResource = properties.promptResource();
-        String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
-        String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
-        return new OpenAiRequest(
+        BackendPromptSchemaTemplate template = BackendPromptSchemaTemplate.fromPromptData(
+                data,
                 properties.model(),
+                properties.schemaName(),
+                loadResource(promptResource),
+                loadResource(properties.schemaResource()));
+        String prompt = promptTemplateResolver.resolve(template.promptMarkdownContent(), data, promptResource);
+        String requestBodyJson = buildResponsesApiRequest(prompt, template.schemaJson(), template.schemaName(), template.model());
+        return new OpenAiRequest(
+                template.model(),
                 prompt,
                 requestBodyJson,
-                properties.schemaName(),
-                schemaJson,
-                promptMarkdownContent,
+                template.schemaName(),
+                template.schemaJson(),
+                template.promptMarkdownContent(),
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
@@ -106,23 +111,23 @@ public class HypothesisResultProcessor implements StageProcessor<HypothesisResul
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+    private String buildResponsesApiRequest(String prompt, String schemaJson, String schemaName, String model) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
             format.put("type", "json_schema");
-            format.put("name", properties.schemaName());
+            format.put("name", schemaName);
             format.put("schema", schema);
             format.put("strict", true);
             Map<String, Object> text = new LinkedHashMap<>();
             text.put("format", format);
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", properties.model());
+            body.put("model", model);
             body.put("input", prompt);
             body.put("text", text);
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
-            log.error("Could not build OpenAI Responses API request for hypothesis result. schemaName={}", properties.schemaName(), ex);
+            log.error("Could not build OpenAI Responses API request for hypothesis result. schemaName={}", schemaName, ex);
             throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis result", ex);
         }
     }

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
@@ -35,6 +35,7 @@ class HypothesisPainBackendClientTest {
         pending.put("marketNicheId", 18L);
         pending.put("niche", niche);
         pending.put("enrichmentProfile", enrichmentProfile);
+        pending.put("promptTemplate", Map.of("templateKey", "hypothesis-pipeline:hypothesis-pain:v1"));
         pending.put("existingHypotheses", java.util.List.of(existingHypothesis));
 
         Map<String, Object> promptData = client.buildPromptDataFromPending(pending);
@@ -42,6 +43,8 @@ class HypothesisPainBackendClientTest {
 
         assertThat(promptData).containsEntry("promises", "");
         assertThat(promptData).containsEntry("offers", "");
+        assertThat((Map<String, Object>) promptData.get("__promptTemplate"))
+                .containsEntry("templateKey", "hypothesis-pipeline:hypothesis-pain:v1");
         assertThat(input.promptData()).containsEntry("promises", "");
         assertThat(input.promptData()).containsEntry("offers", "");
         assertThat(promptData.get("CASE_DATA_BLOCK")).asString()

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessorTest.java
@@ -23,10 +23,20 @@ class HypothesisPainProcessorTest {
                 org.mockito.Mockito.mock(OpenAiClientPort.class),
                 new HypothesisPainResponseValidator(objectMapper),
                 org.mockito.Mockito.mock(HypothesisPainBackendClient.class));
-        Method method = HypothesisPainProcessor.class.getDeclaredMethod("buildResponsesApiRequest", String.class, String.class);
+        Method method = HypothesisPainProcessor.class.getDeclaredMethod(
+                "buildResponsesApiRequest",
+                String.class,
+                String.class,
+                String.class,
+                String.class);
         method.setAccessible(true);
 
-        String requestJson = (String) method.invoke(processor, "Prompt", "{\"type\":\"object\"}");
+        String requestJson = (String) method.invoke(
+                processor,
+                "Prompt",
+                "{\"type\":\"object\"}",
+                "hypothesis_pipeline_pain",
+                "gpt-5.5");
 
         Map<String, Object> request = objectMapper.readValue(requestJson, new TypeReference<>() {});
         assertThat(request)

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAiPromptSchemaUsage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAiPromptSchemaUsage.java
@@ -1,0 +1,76 @@
+package com.marketinghub.experiment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Responsabilidade: registrar quais prompts e schemas de IA foram associados a um experimento. */
+@Entity
+@Table(
+        name = "experiment_ai_prompt_schema_usage",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_experiment_ai_prompt_schema_usage",
+                columnNames = {"experiment_id", "template_key", "usage_context", "stage_code"}))
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentAiPromptSchemaUsage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    @Column(name = "experiment_id", nullable = false, insertable = false, updatable = false)
+    private Long experimentId;
+
+    @Column(name = "template_key", nullable = false, length = 191)
+    private String templateKey;
+
+    @Column(name = "pipeline_code", nullable = false, length = 100)
+    private String pipelineCode;
+
+    @Column(name = "stage_code", nullable = false, length = 100)
+    private String stageCode;
+
+    @Column(name = "template_version", nullable = false, length = 40)
+    private String templateVersion;
+
+    @Column(name = "openai_model", nullable = false, length = 120)
+    private String openAiModel;
+
+    @Column(name = "schema_name", nullable = false, length = 120)
+    private String schemaName;
+
+    @Column(name = "usage_context", nullable = false, length = 80)
+    private String usageContext;
+
+    @Column(name = "source_job_id", length = 191)
+    private String sourceJobId;
+
+    @Column(name = "used_at", nullable = false)
+    private Instant usedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentAiPromptSchemaUsageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentAiPromptSchemaUsageService.java
@@ -1,0 +1,124 @@
+package com.marketinghub.experiment.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentAiPromptSchemaUsage;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentAiPromptSchemaUsageRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePromptSchemaTemplateRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: associar prompts e schemas de IA usados aos experimentos que dependem deles. */
+@Service
+public class ExperimentAiPromptSchemaUsageService {
+    private static final String HYPOTHESIS_PIPELINE_CODE = "hypothesis-pipeline";
+    private static final String HYPOTHESIS_USAGE_CONTEXT = "HYPOTHESIS_PIPELINE";
+    private static final String SALES_PAGE_USAGE_CONTEXT = "GERA_SALES_PAGE_V1";
+
+    private final ExperimentRepository experimentRepository;
+    private final HypothesisPainStageExecutionRepository hypothesisExecutionRepository;
+    private final GeraSalesPagePromptSchemaTemplateRepository templateRepository;
+    private final ExperimentAiPromptSchemaUsageRepository usageRepository;
+
+    /** Inicializa o serviço com os repositórios de experimento, execuções e templates. */
+    public ExperimentAiPromptSchemaUsageService(
+            ExperimentRepository experimentRepository,
+            HypothesisPainStageExecutionRepository hypothesisExecutionRepository,
+            GeraSalesPagePromptSchemaTemplateRepository templateRepository,
+            ExperimentAiPromptSchemaUsageRepository usageRepository) {
+        this.experimentRepository = experimentRepository;
+        this.hypothesisExecutionRepository = hypothesisExecutionRepository;
+        this.templateRepository = templateRepository;
+        this.usageRepository = usageRepository;
+    }
+
+    /** Associa ao experimento todos os templates usados pelas etapas concluídas da hipótese origem. */
+    @Transactional
+    public void linkHypothesisTemplates(Long experimentId) {
+        Experiment experiment = findExperiment(experimentId);
+        if (experiment.getHypothesisRefIdForPending() == null) {
+            return;
+        }
+        List<HypothesisPainStageExecution> executions =
+                hypothesisExecutionRepository.findByHypothesisIdOrderByExecutionRequestedAtAsc(
+                        experiment.getHypothesisRefIdForPending());
+        executions.stream()
+                .filter(execution -> StringUtils.hasText(execution.getPromptTemplateId()))
+                .forEach(execution -> templateRepository.findById(execution.getPromptTemplateId())
+                        .ifPresent(template -> upsertUsage(
+                                experiment,
+                                template,
+                                HYPOTHESIS_USAGE_CONTEXT,
+                                execution.getStageCode(),
+                                fromDatabaseIdJob(execution.getIdJob()),
+                                execution.getCompletedAt())));
+    }
+
+    /** Associa ao experimento o template ativo usado por uma etapa do GeraSalesPage. */
+    @Transactional
+    public void linkSalesPageTemplate(Long experimentId, GeraSalesPagePromptSchemaTemplate template, String stageCode, String sourceJobId) {
+        Experiment experiment = findExperiment(experimentId);
+        upsertUsage(experiment, template, SALES_PAGE_USAGE_CONTEXT, stageCode, sourceJobId, Instant.now());
+    }
+
+    /** Retorna a quantidade de templates de hipótese associados ao experimento. */
+    @Transactional(readOnly = true)
+    public long countHypothesisTemplates(Long experimentId) {
+        return usageRepository.countByExperimentIdAndPipelineCode(experimentId, HYPOTHESIS_PIPELINE_CODE);
+    }
+
+    /** Cria ou atualiza o uso do template para o experimento informado. */
+    private void upsertUsage(
+            Experiment experiment,
+            GeraSalesPagePromptSchemaTemplate template,
+            String usageContext,
+            String stageCode,
+            String sourceJobId,
+            Instant usedAt) {
+        Instant now = Instant.now();
+        Optional<ExperimentAiPromptSchemaUsage> existing =
+                usageRepository.findByExperimentIdAndTemplateKeyAndUsageContextAndStageCode(
+                        experiment.getId(),
+                        template.getTemplateKey(),
+                        usageContext,
+                        stageCode);
+        ExperimentAiPromptSchemaUsage usage = existing.orElseGet(() -> ExperimentAiPromptSchemaUsage.builder()
+                .experiment(experiment)
+                .templateKey(template.getTemplateKey())
+                .usageContext(usageContext)
+                .createdAt(now)
+                .build());
+        usage.setPipelineCode(template.getPipelineCode());
+        usage.setStageCode(stageCode);
+        usage.setTemplateVersion(template.getVersion());
+        usage.setOpenAiModel(template.getOpenAiModel());
+        usage.setSchemaName(template.getSchemaName());
+        usage.setSourceJobId(sourceJobId);
+        usage.setUsedAt(usedAt != null ? usedAt : now);
+        usage.setUpdatedAt(now);
+        usageRepository.save(usage);
+    }
+
+    /** Busca o experimento de forma transacional para registrar a associação. */
+    private Experiment findExperiment(Long experimentId) {
+        return experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+    }
+
+    /** Converte o idJob binário usado no pipeline de hipótese para texto UUID. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        if (idJob == null || idJob.length != 16) {
+            return null;
+        }
+        java.nio.ByteBuffer buffer = java.nio.ByteBuffer.wrap(idJob);
+        return new java.util.UUID(buffer.getLong(), buffer.getLong()).toString();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -80,6 +80,7 @@ public class ExperimentService {
     private final GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
     private final ObjectMapper objectMapper;
     private final CurrencyConversionService currencyConversionService;
+    private final ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
 
     public ExperimentService(ExperimentRepository repository,
                              ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository,
@@ -104,7 +105,8 @@ public class ExperimentService {
                              GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository,
                              GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository,
                              ObjectMapper objectMapper,
-                             CurrencyConversionService currencyConversionService) {
+                             CurrencyConversionService currencyConversionService,
+                             ExperimentAiPromptSchemaUsageService promptSchemaUsageService) {
         this.repository = repository;
         this.promiseGenerationRequestRepository = promiseGenerationRequestRepository;
         this.nicheRepository = nicheRepository;
@@ -129,6 +131,7 @@ public class ExperimentService {
         this.geraSalesPagePublicationAuditRepository = geraSalesPagePublicationAuditRepository;
         this.objectMapper = objectMapper;
         this.currencyConversionService = currencyConversionService;
+        this.promptSchemaUsageService = promptSchemaUsageService;
     }
 
     /**
@@ -406,6 +409,7 @@ public class ExperimentService {
                 .creativeImagePrompt(normalizePrompt(request.getCreativeImagePrompt()))
                 .build();
         Experiment savedExperiment = repository.save(exp);
+        promptSchemaUsageService.linkHypothesisTemplates(savedExperiment.getId());
         dismissPromiseGenerationDrafts(request.getPromiseGenerationRequestIds());
         synchronizeLeadPortalFlow(savedExperiment);
         return savedExperiment;

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -3,6 +3,7 @@ package com.marketinghub.gerasalespage.v1.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.service.ExperimentAiPromptSchemaUsageService;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
@@ -39,6 +40,7 @@ public class GeraSalesPageStageService {
     private final GeraSalesPageStageExecutionRepository executionRepository;
     private final GeraSalesPagePromptSchemaTemplateRepository templateRepository;
     private final GeraSalesPagePublicationAuditService publicationAuditService;
+    private final ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
     private final ObjectMapper objectMapper;
 
     /** Inicializa o service com repositórios e serializador usados pelos contratos internos. */
@@ -47,11 +49,13 @@ public class GeraSalesPageStageService {
             GeraSalesPageStageExecutionRepository executionRepository,
             GeraSalesPagePromptSchemaTemplateRepository templateRepository,
             GeraSalesPagePublicationAuditService publicationAuditService,
+            ExperimentAiPromptSchemaUsageService promptSchemaUsageService,
             ObjectMapper objectMapper) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.templateRepository = templateRepository;
         this.publicationAuditService = publicationAuditService;
+        this.promptSchemaUsageService = promptSchemaUsageService;
         this.objectMapper = objectMapper;
     }
 
@@ -163,7 +167,9 @@ public class GeraSalesPageStageService {
                 .executionRequestedAt(Instant.now())
                 .promptTemplateKey(template.getTemplateKey())
                 .build();
-        return executionRepository.save(execution);
+        GeraSalesPageStageExecution saved = executionRepository.save(execution);
+        promptSchemaUsageService.linkSalesPageTemplate(experimentId, template, stageCode, saved.getIdJob());
+        return saved;
     }
 
     /** Converte uma execução persistida no payload de pendência consumido pelo worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -13,8 +13,10 @@ import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingNic
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -22,20 +24,25 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Responsabilidade: orquestrar execuções auditáveis das etapas do pipeline de hipótese por nicho. */
 @Service
 public class HypothesisPainStageService {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageService.class);
     private static final String STAGE_CODE = "hypothesis-pain";
+    private static final String PIPELINE_CODE = "hypothesis-pipeline";
     private static final String RESULT_STAGE_CODE = "hypothesis-result";
     private static final String MECHANISM_STAGE_CODE = "hypothesis-mechanism";
     private static final String PROOF_STAGE_CODE = "hypothesis-proof";
@@ -65,6 +72,7 @@ public class HypothesisPainStageService {
     private final MarketNicheRepository marketNicheRepository;
     private final HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
     private final HypothesisPainStageExecutionRepository executionRepository;
+    private final GeraSalesPagePromptSchemaTemplateRepository templateRepository;
     private final HypothesisPainCostCalculator costCalculator;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
@@ -72,10 +80,12 @@ public class HypothesisPainStageService {
             MarketNicheRepository marketNicheRepository,
             HypothesisPainEnrichmentProfileReader enrichmentProfileReader,
             HypothesisPainStageExecutionRepository executionRepository,
+            GeraSalesPagePromptSchemaTemplateRepository templateRepository,
             HypothesisPainCostCalculator costCalculator) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
+        this.templateRepository = templateRepository;
         this.costCalculator = costCalculator;
     }
 
@@ -174,13 +184,14 @@ public class HypothesisPainStageService {
             Instant now,
             String promptTemplateId,
             String promptContent) {
+        GeraSalesPagePromptSchemaTemplate template = loadTemplate(stageCode);
         return HypothesisPainStageExecution.builder()
                 .marketNicheId(niche.getId())
                 .marketNiche(niche)
                 .stageCode(stageCode)
                 .executionRequestedAt(now)
                 .createdAt(now)
-                .promptTemplateId(promptTemplateId)
+                .promptTemplateId(template.getTemplateKey())
                 .promptContent(promptContent)
                 .status(STATUS_STARTED)
                 .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
@@ -400,12 +411,33 @@ public class HypothesisPainStageService {
                         execution.getProcessingStartedAt(),
                         toPendingNiche(execution.getMarketNiche()),
                         toPendingEnrichmentProfile(execution.getMarketNicheId()),
+                        templatePayload(loadTemplate(execution.getStageCode())),
                         toExistingHypotheses(execution.getMarketNicheId()),
                         pendingPainResponse(execution),
                         pendingResultResponse(execution),
                         pendingMechanismResponse(execution),
                         pendingProofResponse(execution)))
                 .toList();
+    }
+
+    /** Carrega o template ativo do banco para a etapa do pipeline de hipótese. */
+    private GeraSalesPagePromptSchemaTemplate loadTemplate(String stageCode) {
+        return templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(PIPELINE_CODE, stageCode)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "Template ativo de prompt/schema não encontrado para " + stageCode));
+    }
+
+    /** Monta o bloco de prompt/schema enviado ao Worker AI. */
+    private Map<String, Object> templatePayload(GeraSalesPagePromptSchemaTemplate template) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("templateKey", template.getTemplateKey());
+        payload.put("version", template.getVersion());
+        payload.put("model", template.getOpenAiModel());
+        payload.put("schemaName", template.getSchemaName());
+        payload.put("promptMarkdownContent", template.getPromptMarkdownContent());
+        payload.put("schemaJson", template.getSchemaJson());
+        return payload;
     }
 
     /** Resume as hipóteses já geradas para o mesmo nicho antes de criar uma nova variação. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -2,6 +2,7 @@ package com.marketinghub.hypothesis.pain.service.pending;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 /** Execução pendente de etapa do pipeline de hipótese entregue ao Worker AI. */
 public record HypothesisPainPendingExecution(
@@ -13,6 +14,7 @@ public record HypothesisPainPendingExecution(
         Instant processingStartedAt,
         HypothesisPainPendingNiche niche,
         HypothesisPainPendingEnrichmentProfile enrichmentProfile,
+        Map<String, Object> promptTemplate,
         List<HypothesisPainPendingExistingHypothesis> existingHypotheses,
         String painModelResponse,
         String resultModelResponse,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentAiPromptSchemaUsageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentAiPromptSchemaUsageRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.repository.jpa.experiment;
+
+import com.marketinghub.experiment.ExperimentAiPromptSchemaUsage;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: consultar associações de prompt/schema de IA usadas por experimentos. */
+public interface ExperimentAiPromptSchemaUsageRepository extends JpaRepository<ExperimentAiPromptSchemaUsage, Long> {
+    /** Busca uso existente para manter registro idempotente por experimento, etapa e contexto. */
+    Optional<ExperimentAiPromptSchemaUsage> findByExperimentIdAndTemplateKeyAndUsageContextAndStageCode(
+            Long experimentId,
+            String templateKey,
+            String usageContext,
+            String stageCode);
+
+    /** Conta quantos templates foram associados a um experimento em determinado pipeline. */
+    long countByExperimentIdAndPipelineCode(Long experimentId, String pipelineCode);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
@@ -42,6 +42,9 @@ public interface HypothesisPainStageExecutionRepository extends JpaRepository<Hy
     @EntityGraph(attributePaths = {"hypothesis"})
     List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(Long marketNicheId, String stageCode);
 
+    /** Lista execuções vinculadas a uma hipótese para rastrear prompts/schemas usados no experimento. */
+    List<HypothesisPainStageExecution> findByHypothesisIdOrderByExecutionRequestedAtAsc(UUID hypothesisId);
+
     /** Lista execuções ainda não vinculadas a uma hipótese fechada para a tela de criação limpa. */
     List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
             Long marketNicheId,

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
@@ -1,0 +1,150 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-02-experiment-ai-prompt-schema-usage-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_ai_prompt_schema_usage
+      changes:
+        - createTable:
+            tableName: experiment_ai_prompt_schema_usage
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: template_key
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: pipeline_code
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: template_version
+                  type: VARCHAR(40)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: openai_model
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: schema_name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: usage_context
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: source_job_id
+                  type: VARCHAR(191)
+              - column:
+                  name: used_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: experiment_ai_prompt_schema_usage
+            columnNames: experiment_id, template_key, usage_context, stage_code
+            constraintName: uk_experiment_ai_prompt_schema_usage
+        - createIndex:
+            tableName: experiment_ai_prompt_schema_usage
+            indexName: idx_exp_ai_prompt_usage_experiment
+            columns:
+              - column:
+                  name: experiment_id
+        - createIndex:
+            tableName: experiment_ai_prompt_schema_usage
+            indexName: idx_exp_ai_prompt_usage_pipeline
+            columns:
+              - column:
+                  name: pipeline_code
+              - column:
+                  name: stage_code
+        - addForeignKeyConstraint:
+            baseTableName: experiment_ai_prompt_schema_usage
+            baseColumnNames: experiment_id
+            referencedTableName: experiment
+            referencedColumnNames: id
+            constraintName: fk_exp_ai_prompt_usage_experiment
+            onDelete: CASCADE
+
+  - changeSet:
+      id: 2026-07-02-experiment-ai-prompt-schema-usage-02
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO ai_prompt_schema_template
+                (template_key, pipeline_code, stage_code, version, openai_model, schema_name, prompt_markdown_content, schema_json, active, created_at, updated_at)
+              VALUES
+                ('hypothesis-pipeline:hypothesis-pain:v1', 'hypothesis-pipeline', 'hypothesis-pain', 'v1', 'gpt-5.5', 'hypothesis_pain',
+                 'Voce gera a etapa Dor do pipeline de hipotese. Use o CASE_DATA_BLOCK para descrever uma dor real, especifica e reconhecivel do nicho, sem criar oferta, pagina ou campanha. Responda somente JSON valido aderente ao schema. Contexto: {{CASE_DATA_BLOCK}}',
+                 '{"type":"object","additionalProperties":false,"required":["surface","root","emotional","social","cost","summary","evidenceSignals"],"properties":{"surface":{"type":"string"},"root":{"type":"string"},"emotional":{"type":"string"},"social":{"type":"string"},"cost":{"type":"string"},"summary":{"type":"string"},"evidenceSignals":{"type":"array","items":{"type":"string"}}}}',
+                 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('hypothesis-pipeline:hypothesis-result:v1', 'hypothesis-pipeline', 'hypothesis-result', 'v1', 'gpt-5.5', 'hypothesis_result',
+                 'Voce gera a etapa Resultado do pipeline de hipotese. Transforme a dor concluida em resultado desejado, mudanca mensuravel, contraste antes/depois e ganho de negocio plausivel. Responda somente JSON valido aderente ao schema. Contexto: {{CASE_DATA_BLOCK}} Dor: {{painModelResponse}}',
+                 '{"type":"object","additionalProperties":false,"required":["desiredOutcome","measurableChange","beforeAfterContrast","fastWin","businessValue","plausibilityLimits","summary","evidenceSignals"],"properties":{"desiredOutcome":{"type":"string"},"measurableChange":{"type":"string"},"beforeAfterContrast":{"type":"string"},"fastWin":{"type":"string"},"businessValue":{"type":"string"},"plausibilityLimits":{"type":"string"},"summary":{"type":"string"},"evidenceSignals":{"type":"array","items":{"type":"string"}}}}',
+                 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('hypothesis-pipeline:hypothesis-mechanism:v1', 'hypothesis-pipeline', 'hypothesis-mechanism', 'v1', 'gpt-5.5', 'hypothesis_mechanism',
+                 'Voce gera a etapa Mecanismo do pipeline de hipotese. Crie um mecanismo simples, plausivel e aplicavel que reduza esforco e aumente facilidade percebida, sem prometer automacao total. Responda somente JSON valido aderente ao schema. Contexto: {{CASE_DATA_BLOCK}} Dor: {{painModelResponse}} Resultado: {{resultModelResponse}}',
+                 '{"type":"object","additionalProperties":false,"required":["mechanismName","coreMechanism","howItWorks","steps","aiLeverage","effortReduction","whyBelievable","boundaryConditions","summary","evidenceSignals"],"properties":{"mechanismName":{"type":"string"},"coreMechanism":{"type":"string"},"howItWorks":{"type":"string"},"steps":{"type":"array","items":{"type":"string"}},"aiLeverage":{"type":"string"},"effortReduction":{"type":"string"},"whyBelievable":{"type":"string"},"boundaryConditions":{"type":"string"},"summary":{"type":"string"},"evidenceSignals":{"type":"array","items":{"type":"string"}}}}',
+                 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('hypothesis-pipeline:hypothesis-proof:v1', 'hypothesis-pipeline', 'hypothesis-proof', 'v1', 'gpt-5.5', 'hypothesis_proof',
+                 'Voce gera a etapa Prova do pipeline de hipotese. Defina uma prova demonstravel e barata de produzir que reduza ceticismo sem prometer resultado garantido. Responda somente JSON valido aderente ao schema. Contexto: {{CASE_DATA_BLOCK}} Dor: {{painModelResponse}} Resultado: {{resultModelResponse}} Mecanismo: {{mechanismModelResponse}}',
+                 '{"type":"object","additionalProperties":false,"required":["proofType","proofAsset","proofMessage","proofSignals","collectionMethod","credibilityRationale","objectionReduced","boundaryConditions","summary"],"properties":{"proofType":{"type":"string"},"proofAsset":{"type":"string"},"proofMessage":{"type":"string"},"proofSignals":{"type":"array","items":{"type":"string"}},"collectionMethod":{"type":"string"},"credibilityRationale":{"type":"string"},"objectionReduced":{"type":"string"},"boundaryConditions":{"type":"string"},"summary":{"type":"string"}}}',
+                 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('hypothesis-pipeline:hypothesis-offer:v1', 'hypothesis-pipeline', 'hypothesis-offer', 'v1', 'gpt-5.5', 'hypothesis_offer',
+                 'Voce gera a etapa Oferta do pipeline de hipotese. Converta dor, resultado, mecanismo e prova em produto low-ticket digital: pacote de infoprodutos barato, produzido por IA, aplicavel rapidamente e financeiramente viavel. Responda somente JSON valido aderente ao schema. Contexto: {{CASE_DATA_BLOCK}} Dor: {{painModelResponse}} Resultado: {{resultModelResponse}} Mecanismo: {{mechanismModelResponse}} Prova: {{proofModelResponse}}',
+                 '{"type":"object","additionalProperties":false,"required":["offerName","offerPositioning","entryPromise","pricePositioning","coreOffer","howItWorks","deliverables","valueStack","valuePerception","quickWinAsset","productionFormat","steps","aiLeverage","effortReduction","whyBelievable","boundaryConditions","nextStageReadiness","summary","evidenceSignals"],"properties":{"offerName":{"type":"string"},"offerPositioning":{"type":"string"},"entryPromise":{"type":"string"},"pricePositioning":{"type":"string"},"coreOffer":{"type":"string"},"howItWorks":{"type":"string"},"deliverables":{"type":"array","items":{"type":"string"}},"valueStack":{"type":"array","items":{"type":"string"}},"valuePerception":{"type":"string"},"quickWinAsset":{"type":"string"},"productionFormat":{"type":"string"},"steps":{"type":"array","items":{"type":"string"}},"aiLeverage":{"type":"string"},"effortReduction":{"type":"string"},"whyBelievable":{"type":"string"},"boundaryConditions":{"type":"string"},"nextStageReadiness":{"type":"string"},"summary":{"type":"string"},"evidenceSignals":{"type":"array","items":{"type":"string"}}}}',
+                 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+              ON DUPLICATE KEY UPDATE
+                openai_model = VALUES(openai_model),
+                schema_name = VALUES(schema_name),
+                prompt_markdown_content = VALUES(prompt_markdown_content),
+                schema_json = VALUES(schema_json),
+                active = VALUES(active),
+                updated_at = CURRENT_TIMESTAMP;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-02-commercial-planning-actual-goals.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentAiPromptSchemaUsageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentAiPromptSchemaUsageServiceTest.java
@@ -1,0 +1,104 @@
+package com.marketinghub.experiment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentAiPromptSchemaUsage;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentAiPromptSchemaUsageRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePromptSchemaTemplateRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar a associação de prompts/schemas de IA ao experimento. */
+@ExtendWith(MockitoExtension.class)
+class ExperimentAiPromptSchemaUsageServiceTest {
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private HypothesisPainStageExecutionRepository hypothesisExecutionRepository;
+    @Mock
+    private GeraSalesPagePromptSchemaTemplateRepository templateRepository;
+    @Mock
+    private ExperimentAiPromptSchemaUsageRepository usageRepository;
+    @InjectMocks
+    private ExperimentAiPromptSchemaUsageService service;
+
+    /** Deve vincular ao experimento os templates usados pelas etapas da hipótese origem. */
+    @Test
+    void linkHypothesisTemplatesCreatesUsageFromCompletedExecutions() {
+        UUID hypothesisId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID jobId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(hypothesisId);
+        Experiment experiment = Experiment.builder()
+                .id(52L)
+                .hypothesisRef(hypothesis)
+                .build();
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .stageCode("hypothesis-pain")
+                .promptTemplateId("hypothesis-pipeline:hypothesis-pain:v1")
+                .idJob(toBytes(jobId))
+                .completedAt(Instant.parse("2026-07-02T12:00:00Z"))
+                .build();
+        GeraSalesPagePromptSchemaTemplate template = GeraSalesPagePromptSchemaTemplate.builder()
+                .templateKey("hypothesis-pipeline:hypothesis-pain:v1")
+                .pipelineCode("hypothesis-pipeline")
+                .stageCode("hypothesis-pain")
+                .version("v1")
+                .openAiModel("gpt-5.5")
+                .schemaName("hypothesis_pain")
+                .promptMarkdownContent("Prompt")
+                .schemaJson("{\"type\":\"object\"}")
+                .active(true)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        when(experimentRepository.findById(52L)).thenReturn(Optional.of(experiment));
+        when(hypothesisExecutionRepository.findByHypothesisIdOrderByExecutionRequestedAtAsc(hypothesisId))
+                .thenReturn(List.of(execution));
+        when(templateRepository.findById("hypothesis-pipeline:hypothesis-pain:v1"))
+                .thenReturn(Optional.of(template));
+        when(usageRepository.findByExperimentIdAndTemplateKeyAndUsageContextAndStageCode(
+                52L,
+                "hypothesis-pipeline:hypothesis-pain:v1",
+                "HYPOTHESIS_PIPELINE",
+                "hypothesis-pain"))
+                .thenReturn(Optional.empty());
+
+        service.linkHypothesisTemplates(52L);
+
+        ArgumentCaptor<ExperimentAiPromptSchemaUsage> captor =
+                ArgumentCaptor.forClass(ExperimentAiPromptSchemaUsage.class);
+        verify(usageRepository).save(captor.capture());
+        assertThat(captor.getValue().getExperiment()).isEqualTo(experiment);
+        assertThat(captor.getValue().getTemplateKey()).isEqualTo("hypothesis-pipeline:hypothesis-pain:v1");
+        assertThat(captor.getValue().getPipelineCode()).isEqualTo("hypothesis-pipeline");
+        assertThat(captor.getValue().getUsageContext()).isEqualTo("HYPOTHESIS_PIPELINE");
+        assertThat(captor.getValue().getSourceJobId()).isEqualTo(jobId.toString());
+    }
+
+    /** Converte UUID textual para o formato binário usado pelo pipeline de hipótese. */
+    private byte[] toBytes(UUID uuid) {
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.putLong(uuid.getMostSignificantBits());
+        buffer.putLong(uuid.getLeastSignificantBits());
+        return buffer.array();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.service.ExperimentAiPromptSchemaUsageService;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
@@ -36,6 +37,8 @@ class GeraSalesPageStageServiceTest {
     @Mock
     private GeraSalesPagePublicationAuditService publicationAuditService;
     @Mock
+    private ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
+    @Mock
     private ObjectMapper objectMapper;
 
     @InjectMocks
@@ -57,9 +60,10 @@ class GeraSalesPageStageServiceTest {
 
         when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
         when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L)).thenReturn(List.of(previous));
+        GeraSalesPagePromptSchemaTemplate activeTemplate = template(GeraSalesPageStageCode.OFFER_BRIEF.code());
         when(templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
                 "gera-sales-page-v1", GeraSalesPageStageCode.OFFER_BRIEF.code()))
-                .thenReturn(Optional.of(template(GeraSalesPageStageCode.OFFER_BRIEF.code())));
+                .thenReturn(Optional.of(activeTemplate));
         when(executionRepository.save(any(GeraSalesPageStageExecution.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -73,6 +77,11 @@ class GeraSalesPageStageServiceTest {
         verify(executionRepository).save(newExecution.capture());
         assertThat(newExecution.getValue().getStageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
         assertThat(newExecution.getValue().getStatus()).isEqualTo("INICIADO");
+        verify(promptSchemaUsageService).linkSalesPageTemplate(
+                53L,
+                activeTemplate,
+                GeraSalesPageStageCode.OFFER_BRIEF.code(),
+                newExecution.getValue().getIdJob());
         assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePromptSchemaTemplate;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
@@ -14,6 +16,7 @@ import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfi
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileSnapshot;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
@@ -42,6 +45,9 @@ class HypothesisPainStageServiceTest {
     private HypothesisPainStageExecutionRepository executionRepository;
 
     @Mock
+    private GeraSalesPagePromptSchemaTemplateRepository templateRepository;
+
+    @Mock
     private HypothesisPainCostCalculator costCalculator;
 
     private HypothesisPainStageService service;
@@ -53,7 +59,33 @@ class HypothesisPainStageServiceTest {
                 marketNicheRepository,
                 enrichmentProfileReader,
                 executionRepository,
+                templateRepository,
                 costCalculator);
+        mockActiveTemplate("hypothesis-pain");
+        mockActiveTemplate("hypothesis-result");
+        mockActiveTemplate("hypothesis-mechanism");
+        mockActiveTemplate("hypothesis-proof");
+        mockActiveTemplate("hypothesis-offer");
+    }
+
+    /** Prepara template ativo do banco para a etapa informada. */
+    private void mockActiveTemplate(String stageCode) {
+        lenient().when(templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
+                        "hypothesis-pipeline",
+                        stageCode))
+                .thenReturn(Optional.of(GeraSalesPagePromptSchemaTemplate.builder()
+                        .templateKey("hypothesis-pipeline:" + stageCode + ":v1")
+                        .pipelineCode("hypothesis-pipeline")
+                        .stageCode(stageCode)
+                        .version("v1")
+                        .openAiModel("gpt-5.5")
+                        .schemaName(stageCode.replace('-', '_'))
+                        .promptMarkdownContent("Prompt {{CASE_DATA_BLOCK}}")
+                        .schemaJson("{\"type\":\"object\"}")
+                        .active(true)
+                        .createdAt(Instant.now())
+                        .updatedAt(Instant.now())
+                        .build()));
     }
 
     /** Deve atribuir ao nicho somente o delta de custo calculado para evitar soma duplicada em reprocessamentos. */
@@ -127,6 +159,7 @@ class HypothesisPainStageServiceTest {
         assertEquals(1, pending.size());
         assertEquals(idJob, pending.getFirst().jobid());
         assertEquals("INICIADO", pending.getFirst().status());
+        assertEquals("hypothesis-pipeline:hypothesis-pain:v1", pending.getFirst().promptTemplate().get("templateKey"));
         assertNull(pending.getFirst().processingStartedAt());
         ArgumentCaptor<List<HypothesisPainStageExecution>> captor = ArgumentCaptor.forClass(List.class);
         verify(executionRepository).saveAll(captor.capture());

--- a/docs/canonical/commercial-planning-canon.v1.md
+++ b/docs/canonical/commercial-planning-canon.v1.md
@@ -4,6 +4,8 @@
 
 O planejamento comercial do Marketing Hub deve transformar objetivos de venda em metas mensais e semanais mensuraveis, conectando produto, experimento, campanha, funil, custo e receita.
 
+As metas devem respeitar os tipos de produto definidos em `docs/canonical/product-types-canon.v1.md`: low-ticket como pacote de infoprodutos de baixo custo produzido por IA, e Produto IA como infoproduto/ferramenta com integracao OpenAI por tras e experiencia simples para o usuario.
+
 ## Regra canonica de metas numericas
 
 Todo plano comercial mensal deve persistir metas numericas planejadas em campos estruturados, nao apenas em texto livre:

--- a/docs/canonical/gerasalespage-arquitetura-canon.v1.md
+++ b/docs/canonical/gerasalespage-arquitetura-canon.v1.md
@@ -31,6 +31,7 @@ O GeraSalesPage v1 é um pipeline independente para gerar página de vendas dire
 - Quando uma página precisar ser refeita, o rebuild canônico deve marcar execuções anteriores como `SUBSTITUIDO` e enfileirar nova execução a partir de `sales-page-offer-brief`.
 - Cada página de venda publicada deve gerar um snapshot histórico em banco, associando a versão da página ao job final, HTML/pacote final, prompts renderizados, prompt markdown base, schema JSON, modelo OpenAI, request enviado e resposta bruta de cada etapa usada naquela versão.
 - A troca futura de prompt, schema ou modelo não pode sobrescrever a auditoria das páginas já publicadas; o frontend deve conseguir consultar as versões publicadas e seus prompts/schemas originais por experimento.
+- Cada etapa do GeraSalesPage v1 enfileirada para um experimento deve registrar o template de prompt/schema usado em `experiment_ai_prompt_schema_usage`, com contexto `GERA_SALES_PAGE_V1`, para que o experimento preserve a associação completa entre oferta, página, modelo, prompt e schema.
 
 ## Sugestões incorporadas
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -180,6 +180,8 @@ Regra mandatória para `AD_IMAGE_BRIEFING`: cada briefing de imagem de criativo 
 
 ### 4.2.1 Regra mandatória — oferta low-ticket da hipótese
 
+A definição canônica dos tipos de produto fica em `docs/canonical/product-types-canon.v1.md` e deve orientar decisões de hipótese, oferta, página, campanha, custo, preço, tracking e escala.
+
 A etapa `hypothesis-offer` do pipeline de hipótese deve materializar uma oferta low-ticket digital, não uma oferta genérica. O objetivo é entregar um produto de entrada simples, vendável e aplicável rapidamente, que depois possa alimentar página de vendas, isca digital e campanha sem precisar redescobrir a oferta.
 
 Regras obrigatórias:
@@ -189,6 +191,19 @@ Regras obrigatórias:
 - a etapa pode sugerir faixa de preço compatível com low-ticket, mas não deve criar checkout, desconto falso, urgência artificial, campanha de anúncios, página de vendas, headline completa de landing ou estratégia de Facebook;
 - a oferta deve preservar limites de plausibilidade: sem renda garantida, sem agenda cheia garantida, sem cura, sem automação total e sem depender de acesso interno ao negócio do cliente;
 - quando a solução ficar ampla demais, o prompt deve reduzir o escopo para o menor kit capaz de atacar a causa-raiz prioritária da dor.
+- produto low-ticket deve ser interpretado como pacote de infoprodutos de baixo custo, produzido majoritariamente por IA e financeiramente viável;
+- Produto IA deve ser interpretado como infoproduto/ferramenta com integração OpenAI por trás, vendido pela facilidade e pelo resultado prático no dia a dia, não pelo jargão de IA.
+
+### 4.2.1.1 Regra mandatória — prompt/schema por experimento
+
+Todo experimento criado a partir de hipótese gerada por IA deve preservar associação aos prompts e schemas usados nas etapas Dor, Resultado, Mecanismo, Prova e Oferta. Todo experimento que gerar página pelo GeraSalesPage v1 também deve preservar associação aos prompts e schemas usados nas etapas da página de venda.
+
+Regras obrigatórias:
+- templates ativos de prompt/schema devem ficar em `ai_prompt_schema_template`;
+- execuções devem registrar o `template_key` efetivo usado;
+- experimentos devem registrar em `experiment_ai_prompt_schema_usage` todos os templates de hipótese e de página de venda associados ao teste;
+- troca futura de prompt, schema ou modelo não pode apagar nem sobrescrever a associação histórica de experimentos já criados;
+- decisões comerciais, auditorias e relatórios devem conseguir distinguir qual versão de prompt/schema gerou cada hipótese, oferta e página.
 
 ### 4.2.2 Regra operacional — fluxo completo da hipótese
 

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -1,0 +1,60 @@
+# Tipos de Produto Canonicos v1
+
+## Objetivo
+
+Definir os tipos de produto do Marketing Hub para orientar decisoes futuras de nicho, hipotese, oferta, pagina, campanha, custo, preco, tracking e escala.
+
+## Regra financeira comum
+
+Todo produto precisa ser financeiramente viavel para o negocio. Antes de escalar, a decisao deve considerar:
+
+- custo de midia;
+- custo de IA;
+- custo de producao e operacao;
+- preco possivel;
+- margem esperada;
+- capacidade de entrega sem esforco manual relevante;
+- lucro esperado em relacao ao risco do experimento.
+
+Produto sem caminho plausivel de lucro nao deve receber escala paga, mesmo quando gerar curiosidade ou cliques.
+
+## Produto low-ticket
+
+Produto low-ticket e um pacote de infoprodutos de baixo custo, produzido majoritariamente com IA e entregue de forma digital.
+
+Caracteristicas obrigatorias:
+
+- preco baixo o suficiente para compra de baixo atrito;
+- entrega composta por ativos digitais, como PDF, checklist, roteiro, template, mensagens prontas, planilha simples, diagnostico, prompts, mini-kit ou plano de acao;
+- producao automatizavel por IA, sem consultoria, call, acompanhamento humano ou promessa de gestao manual;
+- promessa especifica, aplicavel rapidamente e ligada a uma dor real;
+- pagina de venda direta quando o objetivo for venda, com checkout, tracking e prova/preview do que sera recebido;
+- margem positiva apos considerar midia, IA, taxas e custo operacional.
+
+O low-ticket deve reduzir dor e esforco de forma simples. Ele nao deve prometer resultado absoluto, renda garantida, agenda cheia garantida, cura, automacao total ou qualquer entrega que dependa de trabalho humano recorrente.
+
+## Produto IA
+
+Produto IA e um infoproduto/ferramenta com integracao a API de IA da OpenAI, embalado para o usuario como uma ferramenta simples, facil e quase magica de usar no dia a dia.
+
+Para o usuario, o valor percebido nao deve ser "usar IA". O valor deve ser a ferramenta resolvendo uma tarefa real com pouco esforco, como organizar informacoes, transformar entradas brutas em saidas uteis, gerar materiais aplicaveis, diagnosticar uma rotina, adaptar mensagens, montar planos ou simplificar decisoes.
+
+Caracteristicas obrigatorias:
+
+- usa OpenAI por tras para gerar, transformar, revisar, classificar ou personalizar a entrega;
+- experiencia simples para o usuario, sem exigir que ele entenda prompts, modelos ou configuracoes de IA;
+- resolve uma tarefa frequente ou dolorosa da rotina da persona;
+- entrega saida pratica, editavel ou acionavel;
+- possui tracking de uso, custo de IA, resultado e sinal de valor percebido;
+- tem modelo economico com margem positiva considerando chamadas de IA, infraestrutura, suporte, midia e taxas;
+- antes de campanha paga dedicada, precisa demonstrar dor unica, promessa clara, entregavel demonstravel e sinal de interesse qualificado.
+
+Produto IA pode nascer como teste controlado dentro do planejamento, mas so deve virar campanha ou produto principal quando o ganho percebido for claro e o custo por uso permitir lucro.
+
+## Decisao entre tipos
+
+Use low-ticket quando o problema pode ser resolvido por um pacote digital estatico ou semi-estatico, barato, rapido de produzir e vendavel por pagina curta.
+
+Use Produto IA quando o valor principal depende de transformar uma entrada especifica do usuario em uma saida personalizada, com reducao forte de esforco e experiencia simples.
+
+Quando houver duvida, comece por low-ticket para validar dor/oferta com menor custo. Evolua para Produto IA quando a personalizacao aumentar claramente a percepcao de valor e a margem continuar viavel.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-02 — Definição canônica de tipos de produto e rastreio de prompt/schema por experimento
+
+- decisão registrada: produto low-ticket passa a significar pacote de infoprodutos de baixo custo produzido majoritariamente por IA; Produto IA passa a significar infoproduto/ferramenta com integração OpenAI por trás, entregue ao usuário como solução simples e prática, sem exigir entendimento de IA.
+- regra financeira: qualquer produto precisa ter caminho plausível de lucro considerando mídia, custo de IA, taxas, operação, preço e margem.
+- foi feito: criado cânone `docs/canonical/product-types-canon.v1.md` e referenciado nos cânones de experimento, GeraSalesPage e planejamento.
+- foi feito: experimentos passam a registrar associação aos templates de prompt/schema usados pela hipótese e pelo GeraSalesPage v1 em `experiment_ai_prompt_schema_usage`.
+- prevenção de recorrência: futuras decisões de hipótese, oferta, página, campanha e escala devem considerar tipo de produto, viabilidade financeira e rastreabilidade do prompt/schema que gerou o ativo comercial.
+
 ## 2026-06-26 — GeraLanding Quality Review em processamento default/standard da OpenAI
 
 - solicitação: testar a etapa `landing-page-quality-review` fora do modo Flex após falhas repetidas `HTTP 429 rate_limit_exceeded` em requisições multimodais grandes.


### PR DESCRIPTION
## O que mudou

- Define os tipos canonicos de produto: low-ticket e Produto IA.
- Registra a regra financeira comum: todo produto precisa ter caminho plausivel de lucro considerando midia, IA, taxas e operacao.
- Move o pipeline de hipotese para receber prompt/schema ativo do banco pelo contrato `pending`, com fallback local no worker.
- Adiciona associacao explicita entre experimento e prompts/schemas usados em hipotese e GeraSalesPage v1.
- Cria `experiment_ai_prompt_schema_usage` e seed dos templates do pipeline de hipotese em `ai_prompt_schema_template`.
- Atualiza canones e registro de experimentos.

## Por que

Precisamos garantir que decisoes futuras de produto/campanha considerem o tipo de produto e sua viabilidade financeira, e que cada experimento preserve quais prompts/schemas geraram hipotese, oferta e pagina de venda.

## Validacoes

- `mvn -f backend/ads-service/pom.xml -Dtest=HypothesisPainStageServiceTest,GeraSalesPageStageServiceTest test`
- `mvn -f ai-worker/pom.xml -Dtest=HypothesisPainBackendClientTest,HypothesisPainProcessorTest test`
- `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentServiceTest test`
- `mvn -f backend/ads-service/pom.xml -Dtest=HypothesisPainStageServiceTest,GeraSalesPageStageServiceTest,ExperimentAiPromptSchemaUsageServiceTest,ExperimentServiceTest test`
- `mvn -f backend/ads-service/pom.xml -DskipTests liquibase:validate -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml -Dliquibase.url='jdbc:h2:mem:liquibase_validate;MODE=MySQL;DB_CLOSE_DELAY=-1' -Dliquibase.driver=org.h2.Driver -Dliquibase.username=sa -Dliquibase.password=`
- `git diff --check`