### PR TITLE
[codex] Use standard tier for hypothesis result stage

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
@@ -107,7 +107,8 @@ public class HypothesisResultProcessor implements StageProcessor<HypothesisResul
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
-                        "marketNicheId", context.execution().aggregateId()));
+                        "marketNicheId", context.execution().aggregateId()),
+                properties.serviceTier());
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultWorkerProperties.java
@@ -19,6 +19,7 @@ public record HypothesisResultWorkerProperties(
         @NotBlank String schemaResource,
         @NotBlank String schemaName,
         @NotBlank String model,
+        @NotBlank String serviceTier,
         @NotNull Duration timeout
 ) {
     /** Normaliza valores opcionais usados pelo worker quando a configuração externa omite o campo. */
@@ -28,6 +29,13 @@ public record HypothesisResultWorkerProperties(
         }
         if (model == null || model.isBlank()) {
             model = "gpt-5.5";
+        }
+        if (serviceTier == null || serviceTier.isBlank()) {
+            serviceTier = "standard";
+        }
+        serviceTier = serviceTier.trim().toLowerCase();
+        if ("standard".equals(serviceTier)) {
+            serviceTier = "default";
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessorTest.java
@@ -1,0 +1,80 @@
+package com.marketinghub.worker.pipeline.hypothesisresult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import com.marketinghub.worker.pipeline.ArtifactStore;
+import com.marketinghub.worker.pipeline.StageArtifact;
+import com.marketinghub.worker.pipeline.StageContext;
+import com.marketinghub.worker.pipeline.StageExecution;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a montagem do request OpenAI da etapa Resultado da hipótese. */
+class HypothesisResultProcessorTest {
+
+    /** Deve usar modo standard como default operacional da etapa Resultado. */
+    @Test
+    void shouldBuildAuditableResponsesApiRequestWithStandardServiceTier() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        HypothesisResultProcessor processor = new HypothesisResultProcessor(
+                objectMapper,
+                properties("standard"),
+                org.mockito.Mockito.mock(OpenAiClientPort.class),
+                new HypothesisResultResponseValidator(objectMapper),
+                org.mockito.Mockito.mock(HypothesisResultBackendClient.class));
+        Method method = HypothesisResultProcessor.class.getDeclaredMethod("buildOpenAiRequest", StageContext.class);
+        method.setAccessible(true);
+
+        var request = method.invoke(processor, context());
+        var openAiRequest = (com.marketinghub.worker.openai.core.model.OpenAiRequest) request;
+        Map<String, Object> requestBody = objectMapper.readValue(openAiRequest.requestBodyJson(), new TypeReference<>() {});
+
+        assertThat(openAiRequest.serviceTier()).isEqualTo("default");
+        assertThat(requestBody)
+                .containsEntry("model", "gpt-5.5")
+                .containsKey("text");
+    }
+
+    /** Cria propriedades mínimas para montar o request OpenAI em teste unitário. */
+    private HypothesisResultWorkerProperties properties(String serviceTier) {
+        return new HypothesisResultWorkerProperties(
+                true,
+                5,
+                "http://backend",
+                "/api",
+                "prompts/hypothesis-pipeline/hypothesis-result.md",
+                "prompts/hypothesis-pipeline/hypothesis-result-schema.json",
+                "hypothesis_pipeline_result",
+                "gpt-5.5",
+                serviceTier,
+                Duration.ofMinutes(30));
+    }
+
+    /** Cria contexto mínimo com dados suficientes para resolver o template da etapa Resultado. */
+    private StageContext<HypothesisResultInput> context() {
+        HypothesisResultInput input = new HypothesisResultInput(
+                29L,
+                "hypothesis-result",
+                "job-1",
+                Map.of(
+                        "CASE_DATA_BLOCK", "marketNicheId: 29",
+                        "painModelResponse", Map.of("summary", "Dor validada")));
+        StageExecution<HypothesisResultInput> execution = new StageExecution<>(
+                "job-1",
+                29L,
+                "hypothesis-result",
+                "INICIADO",
+                Instant.now(),
+                input,
+                Map.of());
+        ArtifactStore artifactStore = (type, name, contentType, content, metadata) ->
+                new StageArtifact(type, name, contentType, name, "sha256", metadata);
+        return new StageContext<>(execution, input, artifactStore, Map.of());
+    }
+}

--- a/docs/canonical/hypothesis-pipeline-service-tier-canon.v1.md
+++ b/docs/canonical/hypothesis-pipeline-service-tier-canon.v1.md
@@ -1,0 +1,22 @@
+# Cânone — Service tier do pipeline de hipótese
+
+## Regra geral
+
+O pipeline de hipótese deve usar OpenAI com auditoria completa de request, response, modelo, tokens, custo e `jobId`.
+
+O padrão operacional continua sendo `service_tier=flex`, exceto quando houver falha recorrente comprovada, risco direto ao avanço comercial do pipeline ou decisão funcional registrada.
+
+## Exceção ativa — etapa Resultado
+
+A etapa `hypothesis-result` está autorizada a usar modo standard, enviado à Responses API como `service_tier=default`.
+
+Justificativa:
+
+- em 2026-07-02, o nicho 29 teve seis falhas consecutivas em `hypothesis-result` com `429 rate_limit_exceeded` no Flex;
+- a etapa Dor já estava concluída;
+- insistir em Flex bloqueava Mecanismo, Prova, Oferta e a criação do próximo experimento;
+- o custo maior do standard é aceitável para remover o gargalo operacional nesta etapa.
+
+## Prevenção
+
+Toda exceção de service tier deve ficar configurável por etapa, ter registro de causa-raiz e teste de contrato cobrindo o valor enviado à Responses API.

--- a/docs/registros/hypothesis-pipeline-2026-07-02.md
+++ b/docs/registros/hypothesis-pipeline-2026-07-02.md
@@ -1,0 +1,8 @@
+# Registro — Pipeline de hipótese em 2026-07-02
+
+## Resultado em modo standard
+
+- Problema: no nicho 29, a etapa `hypothesis-result` falhou seis vezes em modo Flex com `429 rate_limit_exceeded`, impedindo o avanço para Mecanismo, Prova e Oferta.
+- Causa-raiz: indisponibilidade/limite recorrente do service tier Flex na Responses API para essa etapa; a Dor já estava concluída e insistir em Flex atrasava a decisão comercial do novo experimento.
+- Correção aplicada: a etapa Resultado do AI Worker passou a aceitar `hypothesis-result.worker.service-tier`, com padrão `standard` normalizado para `default` no payload da Responses API.
+- Prevenção de recorrência: teste unitário garante que a etapa Resultado monta request em modo standard/default, mantendo a exceção documentada no cânone operacional de pipelines.


### PR DESCRIPTION
## O que mudou

- A etapa `hypothesis-result` passa a aceitar `serviceTier` próprio nas propriedades do worker.
- O padrão da etapa Resultado agora é `standard`, normalizado para `default` no payload da Responses API.
- As demais etapas do pipeline de hipótese continuam sem alteração.
- Adicionado teste unitário garantindo o contrato enviado à OpenAI.
- Criado cânone específico e registro operacional da decisão.

## Por quê

No nicho 29, a etapa Resultado falhou seis vezes em modo Flex com `429 rate_limit_exceeded`. A Dor já estava concluída e o bloqueio impedia avançar para Mecanismo, Prova, Oferta e criação do próximo experimento.

## Validações

- `backend/mvnw -f ai-worker/pom.xml -Dtest=HypothesisResultProcessorTest,ResponsesApiOpenAiClientTest test`
- `git diff --check`