### PR TITLE
[codex] Fix prompt schema usage timestamps for MySQL 5.7

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
@@ -66,17 +66,17 @@ databaseChangeLog:
                   type: VARCHAR(191)
               - column:
                   name: used_at
-                  type: TIMESTAMP
+                  type: DATETIME
                   constraints:
                     nullable: false
               - column:
                   name: created_at
-                  type: TIMESTAMP
+                  type: DATETIME
                   constraints:
                     nullable: false
               - column:
                   name: updated_at
-                  type: TIMESTAMP
+                  type: DATETIME
                   constraints:
                     nullable: false
         - addUniqueConstraint:

--- a/docs/canonical/liquibase-mysql57-temporal-fields-canon.v1.md
+++ b/docs/canonical/liquibase-mysql57-temporal-fields-canon.v1.md
@@ -1,0 +1,19 @@
+# Cânone — Campos temporais Liquibase/MySQL 5.7
+
+## Regra obrigatória
+
+Changelogs Liquibase executados em MySQL 5.7 não devem criar colunas `TIMESTAMP NOT NULL` sem `DEFAULT` explícito.
+
+Para campos obrigatórios de data/hora que são preenchidos pela aplicação, use preferencialmente `DATETIME NOT NULL`.
+
+Para campos preenchidos automaticamente pelo banco, declare explicitamente `DEFAULT CURRENT_TIMESTAMP` e, quando necessário, `ON UPDATE CURRENT_TIMESTAMP` via SQL compatível com MySQL 5.7.
+
+## Motivo
+
+Algumas configurações reais de MySQL 5.7 rejeitam `TIMESTAMP NOT NULL` sem default automático com erro `Invalid default value`, bloqueando o bootstrap do backend durante o Liquibase.
+
+## Aplicação
+
+Esta regra vale para tabelas de auditoria, rastreio, execução de pipeline, prompts/schemas, métricas e qualquer changelog novo que introduza campos como `created_at`, `updated_at`, `used_at`, `started_at` ou `completed_at`.
+
+Antes de finalizar changelog para MySQL 5.7, revisar mentalmente e no diff se existe `TIMESTAMP NOT NULL` sem default explícito.


### PR DESCRIPTION
## Resumo
- Corrige o changelog `experiment_ai_prompt_schema_usage` para usar `DATETIME` nos campos temporais obrigatorios.
- Evita falha de bootstrap no MySQL 5.7 com `Invalid default value` em `TIMESTAMP NOT NULL` sem default.
- Cria canone especifico de compatibilidade Liquibase/MySQL 5.7 para campos temporais.

## Causa-raiz
O backend em producao usa MySQL 5.7/configuracao que rejeita `TIMESTAMP NOT NULL` sem default automatico. A validacao anterior em H2 nao capturou esse contrato real.

## Validacoes locais
- `backend/mvnw -f backend/ads-service/pom.xml -Dtest=ExperimentAiPromptSchemaUsageServiceTest test`
- `git diff --check`
- conferidos includes relativos do changelog mestre.