### PR TITLE
[codex] Use standard tier on third OpenAI retry

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -65,21 +65,23 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                 .build();
     }
 
-    /** Envia o request final com o service tier da etapa para a OpenAI e devolve os dados de despacho para auditoria no backend. */
+    /** Envia o request final com fallback de service tier por tentativa e devolve os dados de despacho para auditoria no backend. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
         String originalRequestBodyJson = request.requestBodyJson();
         String marketingHubJobId = marketingHubJobId(request);
         String requestBodyJson = originalRequestBodyJson;
+        String finalServiceTier = request.serviceTier();
         try {
             Map<String, Object> requestBody = buildServiceTierRequestBody(originalRequestBodyJson, request.serviceTier());
-            requestBodyJson = objectMapper.writeValueAsString(requestBody);
-            Map<String, Object> raw = postResponsesWithTransientRetry(
+            OpenAiPostResponse response = postResponsesWithTransientRetry(
                     marketingHubJobId,
                     request.schemaName(),
                     request.serviceTier(),
-                    requestBody,
-                    requestBodyJson);
+                    requestBody);
+            Map<String, Object> raw = response.raw();
+            requestBodyJson = response.requestBodyJson();
+            finalServiceTier = response.serviceTier();
 
             if (raw == null) {
                 throw new StageWorkerException("OpenAI returned an empty response");
@@ -99,7 +101,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     modelResponse,
                     inputTokens,
                     outputTokens,
-                    costEstimator.estimate(request.model(), inputTokens, outputTokens, request.serviceTier())
+                    costEstimator.estimate(request.model(), inputTokens, outputTokens, finalServiceTier)
             );
 
             if (openAiJobId != null) {
@@ -136,28 +138,32 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         }
     }
 
-    /** Executa a chamada OpenAI com retry local para falhas transitórias de capacidade ou transporte HTTP. */
-    private Map<String, Object> postResponsesWithTransientRetry(
+    /** Executa a chamada OpenAI com retry local e troca Flex por Standard somente na terceira tentativa. */
+    private OpenAiPostResponse postResponsesWithTransientRetry(
             String marketingHubJobId,
             String schemaName,
             String serviceTier,
-            Map<String, Object> requestBody,
-            String requestBodyJson) {
+            Map<String, Object> baseRequestBody) throws JsonProcessingException {
         for (int attempt = 1; attempt <= MAX_TRANSIENT_HTTP_ATTEMPTS; attempt++) {
+            String effectiveServiceTier = serviceTierForAttempt(serviceTier, attempt);
+            Map<String, Object> requestBody = new ConcurrentHashMap<>(baseRequestBody);
+            requestBody.put("service_tier", effectiveServiceTier);
+            String requestBodyJson = objectMapper.writeValueAsString(requestBody);
             try {
                 log.info(
                         "Enviando request final para OpenAI Responses API [jobId={}, schemaName={}, serviceTier={}, attempt={}, requestBodyJson={}]",
                         marketingHubJobId,
                         schemaName,
-                        serviceTier,
+                        effectiveServiceTier,
                         attempt,
                         requestBodyJson);
-                return webClient.post()
+                Map<String, Object> raw = webClient.post()
                         .uri("/responses")
                         .bodyValue(requestBody)
                         .retrieve()
                         .bodyToMono(Map.class)
                         .block(properties.timeout());
+                return new OpenAiPostResponse(raw, requestBodyJson, effectiveServiceTier);
             } catch (WebClientResponseException error) {
                 if (shouldRetry(error) && attempt < MAX_TRANSIENT_HTTP_ATTEMPTS) {
                     Duration delay = TRANSIENT_HTTP_RETRY_DELAYS.get(attempt - 1);
@@ -193,11 +199,23 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         return status == 408 || status == 429 || (status >= 500 && status < 600);
     }
 
+    /** Define o service tier efetivo: Flex nas duas primeiras tentativas e Standard na terceira. */
+    private String serviceTierForAttempt(String requestedServiceTier, int attempt) {
+        if ("flex".equals(requestedServiceTier) && attempt >= MAX_TRANSIENT_HTTP_ATTEMPTS) {
+            return "default";
+        }
+        return requestedServiceTier;
+    }
+
     /** Monta o payload final da Responses API aplicando o service_tier solicitado pela etapa. */
     private Map<String, Object> buildServiceTierRequestBody(String requestBodyJson, String serviceTier) throws JsonProcessingException {
         Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, new TypeReference<>() {});
         requestBody.put("service_tier", serviceTier);
         return requestBody;
+    }
+
+    /** Resultado da chamada OpenAI com payload e tier efetivos usados na tentativa bem-sucedida. */
+    private record OpenAiPostResponse(Map<String, Object> raw, String requestBodyJson, String serviceTier) {
     }
 
     /** Recupera o idJob do Marketing Hub a partir dos metadados do request para correlacionar logs operacionais. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessor.java
@@ -107,8 +107,7 @@ public class HypothesisResultProcessor implements StageProcessor<HypothesisResul
                 Map.of(
                         "stageCode", context.execution().stageCode(),
                         "idJob", context.execution().idJob(),
-                        "marketNicheId", context.execution().aggregateId()),
-                properties.serviceTier());
+                        "marketNicheId", context.execution().aggregateId()));
     }
 
     /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultWorkerProperties.java
@@ -19,7 +19,6 @@ public record HypothesisResultWorkerProperties(
         @NotBlank String schemaResource,
         @NotBlank String schemaName,
         @NotBlank String model,
-        @NotBlank String serviceTier,
         @NotNull Duration timeout
 ) {
     /** Normaliza valores opcionais usados pelo worker quando a configuração externa omite o campo. */
@@ -29,13 +28,6 @@ public record HypothesisResultWorkerProperties(
         }
         if (model == null || model.isBlank()) {
             model = "gpt-5.5";
-        }
-        if (serviceTier == null || serviceTier.isBlank()) {
-            serviceTier = "standard";
-        }
-        serviceTier = serviceTier.trim().toLowerCase();
-        if ("standard".equals(serviceTier)) {
-            serviceTier = "default";
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -149,9 +149,9 @@ class ResponsesApiOpenAiClientTest {
         assertThat(result.costUsd()).isEqualByComparingTo(new BigDecimal("0.00006000"));
     }
 
-    /** Deve repetir chamadas transitórias antes de falhar a etapa por limite momentâneo da OpenAI. */
+    /** Deve tentar Flex duas vezes e usar Standard na terceira tentativa após falhas transitórias. */
     @Test
-    void dispatchShouldRetryTransientOpenAiHttpFailuresBeforeReturningSuccess() throws Exception {
+    void dispatchShouldFallbackToStandardOnThirdTransientOpenAiAttempt() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(429)
                 .setHeader("Content-Type", "application/json")
@@ -191,6 +191,24 @@ class ResponsesApiOpenAiClientTest {
         assertThat(dispatch.openAiJobId()).isEqualTo("resp-retry");
         assertThat(result.modelResponse()).isEqualTo("{\"ok\":true}");
         assertThat(server.getRequestCount()).isEqualTo(4);
+        Map<String, Object> firstAttemptPayload = new ObjectMapper().readValue(
+                server.takeRequest().getBody().readUtf8(),
+                new TypeReference<>() {});
+        Map<String, Object> secondAttemptPayload = new ObjectMapper().readValue(
+                server.takeRequest().getBody().readUtf8(),
+                new TypeReference<>() {});
+        Map<String, Object> thirdAttemptPayload = new ObjectMapper().readValue(
+                server.takeRequest().getBody().readUtf8(),
+                new TypeReference<>() {});
+        server.takeRequest();
+        assertThat(firstAttemptPayload).containsEntry("service_tier", "flex");
+        assertThat(secondAttemptPayload).containsEntry("service_tier", "flex");
+        assertThat(thirdAttemptPayload).containsEntry("service_tier", "default");
+        Map<String, Object> dispatchPayload = new ObjectMapper().readValue(
+                dispatch.requestBodyJson(),
+                new TypeReference<>() {});
+        assertThat(dispatchPayload).containsEntry("service_tier", "default");
+        assertThat(result.costUsd()).isEqualByComparingTo(new BigDecimal("0.00006000"));
         assertThat(appender.list)
                 .extracting(ILoggingEvent::getFormattedMessage)
                 .anySatisfy(message -> assertThat(message)

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultProcessorTest.java
@@ -18,13 +18,13 @@ import org.junit.jupiter.api.Test;
 /** Responsabilidade: validar a montagem do request OpenAI da etapa Resultado da hipótese. */
 class HypothesisResultProcessorTest {
 
-    /** Deve usar modo standard como default operacional da etapa Resultado. */
+    /** Deve montar request auditável em Flex, deixando fallback Standard para o client comum. */
     @Test
-    void shouldBuildAuditableResponsesApiRequestWithStandardServiceTier() throws Exception {
+    void shouldBuildAuditableResponsesApiRequestWithFlexServiceTier() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         HypothesisResultProcessor processor = new HypothesisResultProcessor(
                 objectMapper,
-                properties("standard"),
+                properties(),
                 org.mockito.Mockito.mock(OpenAiClientPort.class),
                 new HypothesisResultResponseValidator(objectMapper),
                 org.mockito.Mockito.mock(HypothesisResultBackendClient.class));
@@ -35,14 +35,14 @@ class HypothesisResultProcessorTest {
         var openAiRequest = (com.marketinghub.worker.openai.core.model.OpenAiRequest) request;
         Map<String, Object> requestBody = objectMapper.readValue(openAiRequest.requestBodyJson(), new TypeReference<>() {});
 
-        assertThat(openAiRequest.serviceTier()).isEqualTo("default");
+        assertThat(openAiRequest.serviceTier()).isEqualTo("flex");
         assertThat(requestBody)
                 .containsEntry("model", "gpt-5.5")
                 .containsKey("text");
     }
 
     /** Cria propriedades mínimas para montar o request OpenAI em teste unitário. */
-    private HypothesisResultWorkerProperties properties(String serviceTier) {
+    private HypothesisResultWorkerProperties properties() {
         return new HypothesisResultWorkerProperties(
                 true,
                 5,
@@ -52,7 +52,6 @@ class HypothesisResultProcessorTest {
                 "prompts/hypothesis-pipeline/hypothesis-result-schema.json",
                 "hypothesis_pipeline_result",
                 "gpt-5.5",
-                serviceTier,
                 Duration.ofMinutes(30));
     }
 

--- a/docs/canonical/hypothesis-pipeline-service-tier-canon.v1.md
+++ b/docs/canonical/hypothesis-pipeline-service-tier-canon.v1.md
@@ -4,19 +4,20 @@
 
 O pipeline de hipótese deve usar OpenAI com auditoria completa de request, response, modelo, tokens, custo e `jobId`.
 
-O padrão operacional continua sendo `service_tier=flex`, exceto quando houver falha recorrente comprovada, risco direto ao avanço comercial do pipeline ou decisão funcional registrada.
+O padrão operacional continua sendo `service_tier=flex`.
 
-## Exceção ativa — etapa Resultado
+## Fallback operacional
 
-A etapa `hypothesis-result` está autorizada a usar modo standard, enviado à Responses API como `service_tier=default`.
+Quando uma chamada OpenAI do pipeline de hipótese falhar por erro transitório de capacidade ou transporte (`408`, `429` ou `5xx`), o worker deve aplicar a seguinte sequência:
 
-Justificativa:
+- primeira tentativa: `service_tier=flex`;
+- segunda tentativa: `service_tier=flex`;
+- terceira tentativa: `service_tier=default` (modo standard).
 
-- em 2026-07-02, o nicho 29 teve seis falhas consecutivas em `hypothesis-result` com `429 rate_limit_exceeded` no Flex;
-- a etapa Dor já estava concluída;
-- insistir em Flex bloqueava Mecanismo, Prova, Oferta e a criação do próximo experimento;
-- o custo maior do standard é aceitável para remover o gargalo operacional nesta etapa.
+O payload auditável e o cálculo de custo devem refletir o `service_tier` efetivamente usado na tentativa bem-sucedida.
+
+Essa regra evita trocar uma etapa inteira para Standard antes de saber se Flex está disponível, mas remove o bloqueio operacional quando Flex falha repetidamente.
 
 ## Prevenção
 
-Toda exceção de service tier deve ficar configurável por etapa, ter registro de causa-raiz e teste de contrato cobrindo o valor enviado à Responses API.
+Toda exceção fixa de service tier por etapa deve ter justificativa comercial explícita, registro de causa-raiz e teste de contrato. Na ausência dessa exceção, vale o fallback operacional por tentativa descrito acima.

--- a/docs/registros/hypothesis-pipeline-2026-07-02.md
+++ b/docs/registros/hypothesis-pipeline-2026-07-02.md
@@ -1,8 +1,8 @@
 # Registro — Pipeline de hipótese em 2026-07-02
 
-## Resultado em modo standard
+## Fallback Flex/Flex/Standard
 
 - Problema: no nicho 29, a etapa `hypothesis-result` falhou seis vezes em modo Flex com `429 rate_limit_exceeded`, impedindo o avanço para Mecanismo, Prova e Oferta.
-- Causa-raiz: indisponibilidade/limite recorrente do service tier Flex na Responses API para essa etapa; a Dor já estava concluída e insistir em Flex atrasava a decisão comercial do novo experimento.
-- Correção aplicada: a etapa Resultado do AI Worker passou a aceitar `hypothesis-result.worker.service-tier`, com padrão `standard` normalizado para `default` no payload da Responses API.
-- Prevenção de recorrência: teste unitário garante que a etapa Resultado monta request em modo standard/default, mantendo a exceção documentada no cânone operacional de pipelines.
+- Causa-raiz: indisponibilidade/limite recorrente do service tier Flex na Responses API em horários de saturação; a Dor já estava concluída e insistir somente em Flex atrasava a decisão comercial do novo experimento.
+- Correção aplicada: o client comum da Responses API passa a tentar chamadas Flex nas duas primeiras tentativas e trocar para Standard (`service_tier=default`) apenas na terceira tentativa transitória.
+- Prevenção de recorrência: teste unitário garante a sequência Flex, Flex e Standard, além de validar que o payload auditável e o custo usam o tier efetivo da tentativa vencedora.


### PR DESCRIPTION
## O que mudou

- O client comum da OpenAI Responses API agora mantém Flex nas duas primeiras tentativas transitórias.
- Na terceira tentativa, quando o request original é Flex, troca para `service_tier=default`.
- O payload auditável do dispatch e o cálculo de custo passam a refletir o tier efetivo usado na tentativa vencedora.
- A etapa Resultado do pipeline de hipótese volta a montar request em Flex; Standard deixa de ser exceção fixa por etapa.
- Cânone e registro do pipeline de hipótese atualizados com a regra Flex/Flex/Standard.

## Por quê

O nicho 29 ficou bloqueado por falhas `429` no Flex. Trocar uma etapa inteira para Standard resolve o bloqueio, mas aumenta custo desnecessariamente quando Flex está disponível. O fallback por tentativa preserva economia nas tentativas normais e usa Standard apenas para destravar falhas transitórias repetidas.

## Validações

- `mvn -f ai-worker/pom.xml -Dtest=ResponsesApiOpenAiClientTest,HypothesisResultProcessorTest test`
- `git diff --check`

Observação: `./mvnw` não existe na raiz deste checkout; por isso a validação foi feita com o `pom.xml` do `ai-worker`.