### PR TITLE
[codex] Fix hypothesis proof template schema

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml
@@ -148,3 +148,22 @@ databaseChangeLog:
                 schema_json = VALUES(schema_json),
                 active = VALUES(active),
                 updated_at = CURRENT_TIMESTAMP;
+
+  - changeSet:
+      id: 2026-07-03-experiment-ai-prompt-schema-usage-proof-evidence-signals
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ai_prompt_schema_template
+              SET schema_json = '{"type":"object","additionalProperties":false,"required":["proofType","proofAsset","proofMessage","evidenceSignals","collectionMethod","credibilityRationale","objectionReduced","boundaryConditions","summary"],"properties":{"proofType":{"type":"string"},"proofAsset":{"type":"string"},"proofMessage":{"type":"string"},"evidenceSignals":{"type":"array","items":{"type":"string"}},"collectionMethod":{"type":"string"},"credibilityRationale":{"type":"string"},"objectionReduced":{"type":"string"},"boundaryConditions":{"type":"string"},"summary":{"type":"string"}}}',
+                  updated_at = CURRENT_TIMESTAMP
+              WHERE template_key = 'hypothesis-pipeline:hypothesis-proof:v1'
+                AND stage_code = 'hypothesis-proof';

--- a/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateChangelogTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateChangelogTest.java
@@ -1,0 +1,28 @@
+package com.marketinghub.aiprompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: proteger contratos Liquibase dos templates de prompt e schema de IA. */
+class AiPromptSchemaTemplateChangelogTest {
+    private static final Path PROMPT_SCHEMA_CHANGELOG = Path.of(
+            "src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml");
+
+    /** Garante que a etapa Prova use o mesmo campo de evidencias aceito pelo AI Worker. */
+    @Test
+    void hypothesisProofTemplateShouldUseEvidenceSignals() throws IOException {
+        String changelog = Files.readString(PROMPT_SCHEMA_CHANGELOG, StandardCharsets.UTF_8);
+        String changeSetId = "2026-07-03-experiment-ai-prompt-schema-usage-proof-evidence-signals";
+        String correctionChangeSet = changelog.substring(changelog.indexOf(changeSetId));
+
+        assertThat(correctionChangeSet)
+                .contains(changeSetId)
+                .contains("\"evidenceSignals\"")
+                .doesNotContain("\"proofSignals\"");
+    }
+}

--- a/docs/canonical/hypothesis-pipeline-evidence-signals-canon.v1.md
+++ b/docs/canonical/hypothesis-pipeline-evidence-signals-canon.v1.md
@@ -1,0 +1,22 @@
+# Cânone — Sinais de evidência do pipeline de hipótese
+
+## Regra
+
+Todas as etapas do pipeline de hipótese que carregam evidências de contexto devem usar o campo `evidenceSignals`.
+
+Esse contrato deve ser igual em quatro pontos:
+
+- template ativo em `ai_prompt_schema_template`;
+- schema entregue pelo endpoint `pending`;
+- validador do AI Worker;
+- payload persistido da execução.
+
+## Proibição
+
+É proibido renomear o campo por etapa, como `proofSignals` na etapa Prova.
+
+Essa variação quebra o fluxo Dor → Resultado → Mecanismo → Prova → Oferta, porque o worker passa a rejeitar uma resposta que o backend pediu com outro nome.
+
+## Prevenção
+
+Qualquer mudança de schema do pipeline de hipótese deve validar o contrato do template ativo em banco contra o schema esperado pelo worker antes de liberar execução operacional.


### PR DESCRIPTION
## O que mudou

- Corrige o template ativo em banco da etapa `hypothesis-proof` para exigir `evidenceSignals` em vez de `proofSignals`.
- Adiciona teste de contrato para impedir regressão no changelog.
- Cria cânone específico do contrato `evidenceSignals` no pipeline de hipótese.

## Causa-raiz

O backend entregava para a etapa Prova um schema com `proofSignals`, mas o AI Worker valida e persiste o padrão comum das etapas como `evidenceSignals`. Isso fez a Prova do nicho 29 falhar e bloqueou a continuidade do experimento 54.

## Validações locais

- `mvn -f backend/ads-service/pom.xml -Dtest=AiPromptSchemaTemplateChangelogTest test`
- `mvn -f ai-worker/pom.xml -Dtest=HypothesisProofResponseValidatorTest,HypothesisProofBackendClientTest test`
- `mvn -f backend/ads-service/pom.xml liquibase:validate -Dliquibase.url=jdbc:h2:mem:liquibase_validate -Dliquibase.driver=org.h2.Driver -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml -Dliquibase.username=sa -Dliquibase.password=`
- `git diff --check`

## Próximo passo após merge

Acompanhar deploy, confirmar backend saudável e retomar o pipeline do nicho 29 a partir de `hypothesis-proof`, depois seguir para Oferta e GeraSalesPage do experimento 54.