### PR TITLE
[codex] Add creative image OpenAI retry fallback

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -32,7 +32,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 /**
- * Simple wrapper around OpenAI image-capable APIs for creative image generation.
+ * Cliente responsável por gerar imagens de criativos usando APIs de imagem da OpenAI.
  */
 @Component
 public class CreativeImageClient {
@@ -47,11 +47,12 @@ public class CreativeImageClient {
     private final boolean enabled;
     private static final Logger log = LoggerFactory.getLogger(CreativeImageClient.class);
     private static final int DEFAULT_MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024; // 10 MB
+    private static final int MAX_TRANSIENT_ATTEMPTS = 3;
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(15);
 
     /**
-     * Builds the OpenAI image client with the default Flex-compatible timeout and service tier.
+     * Monta o cliente de imagem da OpenAI com timeout e tier compatíveis com Flex.
      */
     public CreativeImageClient(WebClient.Builder builder,
                                BackendAssetClient assetClient,
@@ -90,21 +91,21 @@ public class CreativeImageClient {
     }
 
     /**
-     * Generates an image for a prompt without an intermediate prompt.
+     * Gera uma imagem para um prompt sem prompt intermediário.
      */
     public String generateImage(String prompt) {
         return generateImage(prompt, null, "creative-default");
     }
 
     /**
-     * Generates an image and returns a usable URL or fails when generation cannot run.
+     * Gera uma imagem e retorna uma URL utilizável ou falha quando a geração não puder executar.
      */
     public String generateImage(String prompt, String intermediatePrompt) {
         return generateImage(prompt, intermediatePrompt, "creative");
     }
 
     /**
-     * Generates an image with operational context so logs can isolate OpenAI, upload or configuration failures.
+     * Gera uma imagem com contexto operacional para isolar falhas de OpenAI, upload ou configuração.
      */
     public String generateImage(String prompt, String intermediatePrompt, String operationContext) {
         String context = normalizeContext(operationContext);
@@ -145,18 +146,36 @@ public class CreativeImageClient {
     }
 
     /**
-     * Calls the OpenAI image-capable endpoint and extracts the generated image payload.
+     * Chama o endpoint de imagem da OpenAI e extrai o payload de imagem gerado.
      */
     private OpenAiImageResult callOpenAiForImage(String prompt, String context) {
-        return isFlexTier(serviceTier)
-                ? callResponsesImageTool(prompt, context)
-                : callImageApi(prompt, context);
+        RuntimeException lastFailure = null;
+        for (int attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt++) {
+            String effectiveTier = effectiveServiceTierForAttempt(attempt);
+            try {
+                return isFlexTier(effectiveTier)
+                        ? callResponsesImageTool(prompt, context, effectiveTier, attempt)
+                        : callImageApi(prompt, context, effectiveTier, attempt);
+            } catch (RuntimeException ex) {
+                lastFailure = ex;
+                if (!isTransientOpenAiFailure(ex) || attempt == MAX_TRANSIENT_ATTEMPTS) {
+                    throw ex;
+                }
+                log.warn(
+                        "OpenAI creative image generation failed with transient error. context={} attempt={} nextAttemptTier={} error={}",
+                        context,
+                        attempt,
+                        effectiveServiceTierForAttempt(attempt + 1),
+                        ex.getMessage());
+            }
+        }
+        throw lastFailure != null ? lastFailure : new RuntimeException("No image returned from OpenAI");
     }
 
     /**
-     * Calls the Responses API image generation tool using Flex processing.
+     * Chama a ferramenta de imagem da Responses API usando o tier efetivo da tentativa.
      */
-    private OpenAiImageResult callResponsesImageTool(String prompt, String context) {
+    private OpenAiImageResult callResponsesImageTool(String prompt, String context, String effectiveTier, int attempt) {
         Map<String, Object> imageTool = new LinkedHashMap<>();
         imageTool.put("type", "image_generation");
         imageTool.put("action", "generate");
@@ -166,10 +185,14 @@ public class CreativeImageClient {
         payload.put("model", responsesModel);
         payload.put("input", prompt);
         payload.put("tools", List.of(imageTool));
-        payload.put("service_tier", serviceTier);
+        payload.put("service_tier", effectiveTier);
 
-        log.info("Sending creative image request to OpenAI Responses API. context={} timeoutSeconds={} payload={}",
-                context, requestTimeout.getSeconds(), payload);
+        log.info(
+                "Sending creative image request to OpenAI Responses API. context={} attempt={} timeoutSeconds={} payload={}",
+                context,
+                attempt,
+                requestTimeout.getSeconds(),
+                payload);
         ResponsesImageResponse response;
         try {
             response = webClient.post()
@@ -188,9 +211,9 @@ public class CreativeImageClient {
     }
 
     /**
-     * Calls the direct Image API for non-Flex image generation modes.
+     * Chama a Image API direta para modos de geração que não usam Flex.
      */
-    private OpenAiImageResult callImageApi(String prompt, String context) {
+    private OpenAiImageResult callImageApi(String prompt, String context, String effectiveTier, int attempt) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("model", model);
         payload.put("prompt", prompt);
@@ -198,8 +221,13 @@ public class CreativeImageClient {
             payload.put("response_format", "b64_json");
         }
 
-        log.info("Sending creative image request to OpenAI Image API. context={} timeoutSeconds={} payload={}",
-                context, requestTimeout.getSeconds(), payload);
+        log.info(
+                "Sending creative image request to OpenAI Image API. context={} attempt={} serviceTier={} timeoutSeconds={} payload={}",
+                context,
+                attempt,
+                effectiveTier,
+                requestTimeout.getSeconds(),
+                payload);
         ImageResponse response;
         try {
             response = webClient.post()
@@ -218,7 +246,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Extracts the first generated image from an Image API response.
+     * Extrai a primeira imagem gerada de uma resposta da Image API.
      */
     private OpenAiImageResult extractImageApiImage(ImageResponse response) {
         if (response == null) {
@@ -238,7 +266,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Extracts the first generated image from a Responses API image generation tool response.
+     * Extrai a primeira imagem gerada de uma resposta da ferramenta de imagem da Responses API.
      */
     private OpenAiImageResult extractResponsesImage(ResponsesImageResponse response) {
         if (response == null) {
@@ -262,7 +290,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Reads and logs the raw OpenAI response before parsing the image contract.
+     * Lê e registra a resposta bruta da OpenAI antes de interpretar o contrato de imagem.
      */
     private Mono<ImageResponse> readImageResponse(ClientResponse response, String context) {
         HttpStatusCode status = response.statusCode();
@@ -274,7 +302,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Copies a reactive data buffer to a byte array and releases it.
+     * Copia um buffer reativo para array de bytes e libera o buffer.
      */
     private byte[] toByteArray(DataBuffer buffer) {
         try {
@@ -287,7 +315,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Appends a response chunk while enforcing the configured memory limit.
+     * Adiciona um trecho de resposta respeitando o limite de memória configurado.
      */
     private ByteArrayOutputStream appendChunk(ByteArrayOutputStream output, byte[] chunk) {
         if (output.size() + chunk.length > DEFAULT_MAX_IN_MEMORY_SIZE) {
@@ -298,7 +326,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Reads and logs the raw OpenAI Responses API response before parsing the image tool contract.
+     * Lê e registra a resposta bruta da Responses API antes de interpretar o contrato da ferramenta de imagem.
      */
     private Mono<ResponsesImageResponse> readResponsesImageResponse(ClientResponse response, String context) {
         HttpStatusCode status = response.statusCode();
@@ -310,7 +338,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Parses the raw OpenAI image response after recording status and body for root-cause analysis.
+     * Interpreta a resposta bruta de imagem após registrar status e corpo para análise de causa-raiz.
      */
     private ImageResponse parseResponse(byte[] bytes, HttpStatusCode status, String context) {
         String rawResponse = new String(bytes, StandardCharsets.UTF_8);
@@ -326,7 +354,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Parses the raw OpenAI Responses API response after recording status and body for root-cause analysis.
+     * Interpreta a resposta bruta da Responses API após registrar status e corpo para causa-raiz.
      */
     private ResponsesImageResponse parseResponsesImageResponse(byte[] bytes, HttpStatusCode status, String context) {
         String rawResponse = new String(bytes, StandardCharsets.UTF_8);
@@ -342,7 +370,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Indicates whether the selected model supports an explicit response_format request field.
+     * Indica se o modelo selecionado aceita campo explícito de response_format.
      */
     private boolean supportsResponseFormat(String selectedModel) {
         if (selectedModel == null || selectedModel.isBlank()) {
@@ -352,14 +380,42 @@ public class CreativeImageClient {
     }
 
     /**
-     * Determines whether the configured service tier should use the Responses API Flex path.
+     * Determina se o tier configurado deve usar o caminho Flex da Responses API.
      */
     private boolean isFlexTier(String selectedServiceTier) {
         return "flex".equalsIgnoreCase(selectedServiceTier);
     }
 
     /**
-     * Resolves the request timeout, keeping Flex-compatible defaults for invalid configuration.
+     * Mantém as duas primeiras tentativas em Flex e usa Standard na terceira para erro transitório.
+     */
+    private String effectiveServiceTierForAttempt(int attempt) {
+        if (!isFlexTier(serviceTier)) {
+            return serviceTier;
+        }
+        return attempt >= MAX_TRANSIENT_ATTEMPTS ? "default" : "flex";
+    }
+
+    /**
+     * Identifica falhas transitórias da OpenAI que merecem nova tentativa em outro tier.
+     */
+    private boolean isTransientOpenAiFailure(RuntimeException ex) {
+        String message = ex.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase(Locale.ROOT);
+        return normalized.contains("429")
+                || normalized.contains("408")
+                || normalized.contains("5xx")
+                || normalized.contains("rate_limit")
+                || normalized.contains("too many requests")
+                || normalized.contains("temporarily unavailable")
+                || normalized.contains("timeout");
+    }
+
+    /**
+     * Resolve o timeout da requisição mantendo padrão compatível com Flex para configuração inválida.
      */
     private Duration resolveRequestTimeout(long requestTimeoutSeconds) {
         if (requestTimeoutSeconds <= 0) {
@@ -369,7 +425,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Normalizes blank configuration values to explicit operational defaults.
+     * Normaliza valores de configuração vazios para padrões operacionais explícitos.
      */
     private String normalizeConfig(String value, String defaultValue) {
         if (value == null || value.isBlank()) {
@@ -379,7 +435,7 @@ public class CreativeImageClient {
     }
 
     /**
-     * Normalizes absent context values to keep logs queryable.
+     * Normaliza contexto ausente para manter logs pesquisáveis.
      */
     private String normalizeContext(String operationContext) {
         if (operationContext == null || operationContext.isBlank()) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -17,12 +17,14 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +44,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 /**
- * Validates creative image generation client behavior against OpenAI and backend upload contracts.
+ * Valida o comportamento do cliente de imagens contra os contratos da OpenAI e do upload no backend.
  */
 class CreativeImageClientTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -55,7 +57,7 @@ class CreativeImageClientTest {
     AtomicReference<Map<String, Object>> lastRequestPayload;
 
     /**
-     * Creates the image client fixture with a stubbed successful OpenAI response.
+     * Cria a fixture do cliente de imagem com resposta OpenAI simulada com sucesso.
      */
     @BeforeEach
     void setup() throws Exception {
@@ -71,7 +73,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Ensures a base64 image returned by OpenAI is optimized and uploaded to the backend.
+     * Garante que a imagem base64 retornada pela OpenAI seja otimizada e enviada ao backend.
      */
     @Test
     void uploadsReturnedImageToBackend() {
@@ -92,7 +94,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Ensures large base64 image payloads are accepted within the configured memory limit.
+     * Garante que payloads grandes em base64 sejam aceitos dentro do limite de memória configurado.
      */
     @Test
     void supportsLargeBase64Payloads() {
@@ -114,7 +116,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Ensures OpenAI error messages are surfaced when the response has no image data.
+     * Garante que mensagens de erro da OpenAI sejam expostas quando a resposta não tem imagem.
      */
     @Test
     void surfacesErrorMessageWhenResponseLacksData() {
@@ -131,7 +133,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Ensures non GPT image models request a base64 response explicitly.
+     * Garante que modelos de imagem não GPT peçam resposta base64 explicitamente.
      */
     @Test
     void requestsBase64PayloadExplicitlyForNonGptModels() {
@@ -157,7 +159,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Ensures Flex service tier uses the Responses API image generation tool.
+     * Garante que o tier Flex use a ferramenta de geração de imagem da Responses API.
      */
     @Test
     void usesResponsesApiImageToolForFlexTier() {
@@ -195,9 +197,62 @@ class CreativeImageClientTest {
                 isNull());
     }
 
+    /**
+     * Deve tentar Flex duas vezes e cair para Standard/default na terceira tentativa quando a OpenAI retorna 429.
+     */
+    @Test
+    void retriesTransientFlexImageErrorWithStandardTierOnThirdAttempt() {
+        String imagePayload;
+        try {
+            imagePayload = Base64.getEncoder().encodeToString(createSolidPng(64, 64));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        String transientBody = "{\"error\":{\"message\":\"We're currently processing too many requests — please try again later.\",\"code\":\"rate_limit_exceeded\"}}";
+        String successBody = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
+        AtomicInteger calls = new AtomicInteger();
+        List<Map<String, Object>> payloads = new ArrayList<>();
+        ExchangeFunction exchange = request -> {
+            int attempt = calls.incrementAndGet();
+            MockClientHttpRequest httpRequest = new MockClientHttpRequest(request.method(), request.url());
+            request.body().insert(httpRequest, BODY_INSERTER_CONTEXT).block();
+            String requestBody = httpRequest.getBodyAsString().block();
+            try {
+                payloads.add(MAPPER.readValue(requestBody, new TypeReference<Map<String, Object>>() { }));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            String expectedPath = attempt < 3 ? "/responses" : "/images/generations";
+            assertThat(request.url().toString()).endsWith(expectedPath);
+            return Mono.just(ClientResponse.create(attempt < 3 ? HttpStatus.TOO_MANY_REQUESTS : HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(attempt < 3 ? transientBody : successBody)
+                    .build());
+        };
+        CreativeImageClient retryClient = new CreativeImageClient(
+                WebClient.builder().exchangeFunction(exchange),
+                backendAssetClient,
+                optimizer,
+                "key",
+                "http://openai",
+                "gpt-image-2",
+                "gpt-5.5",
+                "flex",
+                900);
+        when(backendAssetClient.uploadImage(any(), any(), any(), any(), any())).thenReturn("/uploads/retry.jpg");
+
+        String result = retryClient.generateImage("prompt", null, "creative-experiment-54");
+
+        assertThat(result).isEqualTo("/uploads/retry.jpg");
+        assertThat(calls).hasValue(3);
+        assertThat(payloads.get(0)).containsEntry("service_tier", "flex");
+        assertThat(payloads.get(1)).containsEntry("service_tier", "flex");
+        assertThat(payloads.get(2)).doesNotContainKey("service_tier");
+    }
+
 
     /**
-     * Ensures missing OpenAI credentials fail image generation instead of returning a null URL.
+     * Garante que ausência de credencial OpenAI falhe em vez de retornar URL nula.
      */
     @Test
     void failsWhenOpenAiKeyIsMissing() {
@@ -218,7 +273,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Builds an ExchangeFunction that captures OpenAI request payloads and returns a canned response.
+     * Monta um ExchangeFunction que captura payloads da OpenAI e retorna resposta simulada.
      */
     private ExchangeFunction stubImageApi(AtomicReference<Map<String, Object>> capturedPayload,
                                           String responseBody,
@@ -227,7 +282,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Builds an ExchangeFunction that captures OpenAI request payloads for a specific endpoint.
+     * Monta um ExchangeFunction que captura payloads da OpenAI para um endpoint específico.
      */
     private ExchangeFunction stubOpenAiApi(AtomicReference<Map<String, Object>> capturedPayload,
                                            String responseBody,
@@ -273,7 +328,7 @@ class CreativeImageClientTest {
     };
 
     /**
-     * Creates a small deterministic PNG image for upload tests.
+     * Cria uma imagem PNG pequena e determinística para testes de upload.
      */
     private static byte[] createSolidPng(int width, int height) throws IOException {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
@@ -289,7 +344,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Creates a deterministic pseudo-random PNG image for payload size tests.
+     * Cria uma imagem PNG pseudoaleatória determinística para testes de tamanho de payload.
      */
     private static byte[] createRandomPng(int width, int height) {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
@@ -308,7 +363,7 @@ class CreativeImageClientTest {
     }
 
     /**
-     * Encodes a buffered image as PNG bytes.
+     * Codifica uma imagem em memória como bytes PNG.
      */
     private static byte[] writePng(BufferedImage image) {
         try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {

--- a/docs/canonical/openai-service-tier-retry-canon.v1.md
+++ b/docs/canonical/openai-service-tier-retry-canon.v1.md
@@ -1,0 +1,29 @@
+# Cânone v1 — Retry por tier em integrações OpenAI
+
+## Objetivo
+
+Este cânone define a regra operacional de retry por `service_tier` para chamadas OpenAI usadas pelos workers do Marketing Hub.
+
+## Regra canônica
+
+Quando uma chamada OpenAI usar Flex como padrão operacional e encontrar falha transitória (`408`, `429`, `5xx`, timeout, `rate_limit` ou indisponibilidade temporária), o executor deve manter:
+
+1. primeira tentativa em Flex;
+2. segunda tentativa em Flex;
+3. terceira tentativa em Standard/default, quando a API/chamada suportar esse fallback sem quebrar o contrato.
+
+Essa regra vale para geração textual e para geração de imagens de criativos.
+
+## Imagens de criativos
+
+Em geração de imagem de criativo:
+
+- a primeira e a segunda tentativa podem usar a Responses API com `service_tier=flex`;
+- a terceira tentativa pode usar a Image API direta sem enviar `service_tier`, representando o modo Standard/default operacional;
+- a falha transitória não deve encerrar a geração antes da terceira tentativa quando houver fallback suportado.
+
+## Auditoria
+
+O tier efetivo de cada tentativa deve aparecer em log ou auditoria operacional suficiente para explicar custo, latência e motivo do fallback.
+
+Não é permitido transformar toda a etapa em Standard/default por padrão sem registro explícito de decisão funcional, porque isso aumenta custo e remove o benefício financeiro do Flex.

--- a/docs/registros/experimento-54-creative-openai-retry.md
+++ b/docs/registros/experimento-54-creative-openai-retry.md
@@ -1,0 +1,7 @@
+# 2026-07-03 — Experimento 54: fallback OpenAI na geração de imagem de criativo
+
+- contexto: o pipeline de hipótese do nicho `29` concluiu e criou o experimento `54` (`DODM-H001-E001`) como low-ticket `Painel do Almoço para Marmitas`.
+- diagnóstico: a geração textual dos criativos foi concluída, mas a geração de imagem falhou com `429 rate_limit_exceeded` na chamada OpenAI em Flex.
+- causa-raiz: o `CreativeImageClient` ainda não seguia a regra operacional Flex/Flex/Standard usada nas chamadas textuais, marcando indisponibilidade temporária da OpenAI como falha final da geração.
+- correção aplicada: o worker de criativos passa a tentar imagem em Flex na primeira e segunda tentativa e cair para Standard/default na terceira tentativa em falhas transitórias.
+- prevenção de recorrência: o cânone de informações tratadas por IA passou a exigir retry por tier também para geração de imagens de criativos, preservando custo baixo em Flex sem travar o ciclo comercial quando houver pico temporário da OpenAI.


### PR DESCRIPTION
## Resumo

- adiciona fallback de geração de imagem OpenAI para criativos: primeira tentativa Flex, segunda Flex e terceira Standard/default em falhas transitórias;
- cobre o caso de `429 rate_limit_exceeded` que bloqueou os criativos do experimento 54;
- adiciona cânone específico de retry por tier e registro operacional do experimento 54.

## Causa-raiz

A geração textual dos criativos do experimento 54 concluiu, mas a imagem falhou em `429` porque o `CreativeImageClient` encerrava a geração no erro transitório da OpenAI em Flex. O client de imagem ainda não seguia a regra Flex/Flex/Standard já adotada para chamadas textuais.

## Validação

- `mvn -f ai-worker/pom.xml -Dtest=CreativeImageClientTest,CreativeGenerationServiceTest test`
- `git diff --check HEAD^ HEAD`

Observação: o Maven registrou warning de autenticação no GitHub Packages para metadados de `ads-service`, mas os testes usaram dependências locais/cacheadas e passaram.