### PR TITLE
[codex] Fix experiment total cost display

### DIFF
--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -205,4 +205,63 @@ describe("ExperimentListPage", () => {
     expect(screen.queryByText("R$ 99,81")).toBeNull();
   });
 
+  it("prioritizes totalCost when the legacy cost field is zero", async () => {
+    const experiments = [
+      {
+        id: "54",
+        nicheId: 29,
+        hypothesisId: "hypothesis-54",
+        name: "Experimento 54",
+        hypothesis: "Painel do Almoço para Marmitas",
+        cost: 0,
+        totalCost: 0.08,
+        campaignMetric: { spend: 0 },
+        startDate: "2026-07-03",
+        endDate: null,
+        creativeApproved: true,
+        status: "RUNNING",
+        platform: "FACEBOOK",
+        stage: "AD",
+        createdAt: "2026-07-03T00:00:00Z",
+        updatedAt: "2026-07-03T00:00:00Z",
+      },
+    ];
+
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/experiments")
+        return Promise.resolve({ data: experiments });
+      if (url === "/api/niches") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 29,
+              name: "Marmitarias",
+              description: "",
+              demandVolume: "",
+              promises: "",
+              offers: "",
+              baseSegmentation: "",
+              interests: "",
+              demographicFilters: "",
+              extraTips: "",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderPage();
+
+    const row = (await screen.findByText("Experimento 54")).closest("tr");
+
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLTableRowElement).getByText("R$ 0,08"),
+    ).toBeTruthy();
+    expect(
+      within(row as HTMLTableRowElement).queryByText("R$ 0,00"),
+    ).toBeNull();
+  });
+
 });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -44,10 +44,10 @@ function resolveExperimentCost(experiment: {
   campaignMetric?: { spend?: number | null } | null;
 }) {
   return (
-    experiment.cost ??
     experiment.totalCost ??
-    experiment.expense ??
     experiment.campaignMetric?.spend ??
+    experiment.cost ??
+    experiment.expense ??
     null
   );
 }


### PR DESCRIPTION
## O que mudou

- A listagem de experimentos agora prioriza `totalCost` antes do campo legado `cost`.
- O gasto de campanha continua como fallback antes de `cost`/`expense`.
- Foi adicionado teste de regressão para o caso real em que `cost = 0` e `totalCost > 0`.

## Por que

A tela mostrava `R$ 0,00` quando o backend enviava `cost` zerado, mesmo com o custo acumulado correto em `totalCost`. Isso escondia a soma esperada de custos de IA e campanha.

## Validação

- `npm run typecheck` passou.
- `NODE_ENV=test npm test -- ExperimentListPage.test.tsx --run` passou com 4 testes.

Observação: o ambiente local não tinha `gh` nem credencial HTTPS para `git push`, então a branch e o PR foram publicados pelo conector GitHub.