### PR TITLE
[codex] Add hot product dossier candidate flow

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -322,6 +322,72 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+    /**
+     * Representa uma página quente já analisada e elegível para virar dossiê comercial.
+     */
+    public record HotProductDossierCandidateItem(
+            long pageId,
+            String workspaceId,
+            String source,
+            String urlCanonical,
+            String title,
+            String productName,
+            BigDecimal hotmartTemperature,
+            BigDecimal scoreTotal,
+            String dossieProdutoStatus,
+            String dossieProdutoCurrentStage,
+            Instant dossieProdutoUpdatedAt,
+            Instant lastAnalyzedAt
+    ) {
+    }
+
+    /**
+     * Representa a fila consultiva de produtos quentes prontos para dossiê.
+     */
+    public record HotProductDossierCandidateResponse(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int limit,
+            int totalReturned,
+            List<HotProductDossierCandidateItem> items
+    ) {
+    }
+
+    /**
+     * Representa o pedido de enfileiramento recorrente de produtos quentes no dossiê v1.
+     */
+    public record HotProductDossierEnqueueRequest(
+            @NotBlank String workspaceId,
+            BigDecimal minTemperature,
+            Integer limit
+    ) {
+    }
+
+    /**
+     * Representa um item promovido para a etapa inicial do pipeline dossieproduto.v1.
+     */
+    public record HotProductDossierEnqueueItem(
+            long pageId,
+            String jobId,
+            String status,
+            String stageCode
+    ) {
+    }
+
+    /**
+     * Representa o resultado do comando de enfileiramento de dossiês de produtos quentes.
+     */
+    public record HotProductDossierEnqueueResponse(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int requestedLimit,
+            int candidatesFound,
+            int enqueued,
+            int skipped,
+            List<HotProductDossierEnqueueItem> items
+    ) {
+    }
+
 
     /**
      * Representa a cobertura de URLs únicas vindas da origem bruta mois_collected_reference.

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -41,6 +41,10 @@ public class MoisSalesLibraryService {
     private static final String JOB_STATUS_PENDING = "PENDING";
     private static final String ANALYSIS_STATUS_CANCELED = "ANULADO";
     private static final int COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT = 2000;
+    private static final BigDecimal DEFAULT_HOT_PRODUCT_MIN_TEMPERATURE = BigDecimal.valueOf(80);
+    private static final String DOSSIE_PRODUTO_PIPELINE_VERSION = "v1";
+    private static final String DOSSIE_PRODUTO_INTAKE_STAGE = "intake";
+    private static final String DOSSIE_PRODUTO_STATUS_STARTED = "INICIADO";
 
     private final JdbcTemplate jdbcTemplate;
     private final MoisSalesLibraryPricingService pricingService;
@@ -1652,6 +1656,171 @@ public class MoisSalesLibraryService {
                 page.dossieProdutoUpdatedAt(),
                 stages,
                 finalResult
+        );
+    }
+
+    /**
+     * Lista produtos Hotmart quentes que já possuem material suficiente para iniciar dossiê comercial.
+     */
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductDossierCandidates(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int limit
+    ) {
+        BigDecimal normalizedTemperature = normalizeHotProductTemperature(minTemperature);
+        int normalizedLimit = Math.max(1, Math.min(limit, 200));
+        List<MoisSalesLibraryDtos.HotProductDossierCandidateItem> items = jdbcTemplate.query(hotProductDossierCandidateSql(),
+                this::mapHotProductDossierCandidate,
+                workspaceId,
+                normalizedTemperature,
+                normalizedLimit);
+        return new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
+                workspaceId,
+                normalizedTemperature,
+                normalizedLimit,
+                items.size(),
+                items
+        );
+    }
+
+    /**
+     * Enfileira candidatos quentes na etapa intake do pipeline dossieproduto.v1 sem executar IA no backend.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductDossierCandidates(
+            MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        BigDecimal normalizedTemperature = normalizeHotProductTemperature(request.minTemperature());
+        int requestedLimit = request.limit() == null ? 50 : Math.max(1, Math.min(request.limit(), 200));
+        MoisSalesLibraryDtos.HotProductDossierCandidateResponse candidates =
+                listHotProductDossierCandidates(request.workspaceId(), normalizedTemperature, requestedLimit);
+        List<MoisSalesLibraryDtos.HotProductDossierEnqueueItem> enqueuedItems = new ArrayList<>();
+        int skipped = 0;
+        for (MoisSalesLibraryDtos.HotProductDossierCandidateItem candidate : candidates.items()) {
+            String jobId = UUID.randomUUID().toString();
+            int updated = jdbcTemplate.update("""
+                    UPDATE mois_sales_page
+                    SET status_pipeline_dossieproduto = ?,
+                        dossie_produto_current_stage = ?,
+                        data_pipeline_dossieproduto = UTC_TIMESTAMP(),
+                        updated_at = UTC_TIMESTAMP()
+                    WHERE id = ?
+                      AND (status_pipeline_dossieproduto IS NULL
+                           OR status_pipeline_dossieproduto NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
+                    """, DOSSIE_PRODUTO_STATUS_STARTED, DOSSIE_PRODUTO_INTAKE_STAGE, candidate.pageId());
+            if (updated == 0) {
+                skipped++;
+                continue;
+            }
+            jdbcTemplate.update("""
+                    INSERT INTO pipeline_dossieproduto (
+                        id_externo,
+                        codigo_etapa,
+                        status,
+                        data_hora,
+                        job_id,
+                        versao_pipeline
+                    ) VALUES (?, ?, ?, UTC_TIMESTAMP(6), ?, ?)
+                    """,
+                    String.valueOf(candidate.pageId()),
+                    DOSSIE_PRODUTO_INTAKE_STAGE,
+                    DOSSIE_PRODUTO_STATUS_STARTED,
+                    jobId,
+                    DOSSIE_PRODUTO_PIPELINE_VERSION);
+            enqueuedItems.add(new MoisSalesLibraryDtos.HotProductDossierEnqueueItem(
+                    candidate.pageId(),
+                    jobId,
+                    DOSSIE_PRODUTO_STATUS_STARTED,
+                    DOSSIE_PRODUTO_INTAKE_STAGE
+            ));
+        }
+        return new MoisSalesLibraryDtos.HotProductDossierEnqueueResponse(
+                request.workspaceId(),
+                normalizedTemperature,
+                requestedLimit,
+                candidates.totalReturned(),
+                enqueuedItems.size(),
+                skipped,
+                enqueuedItems
+        );
+    }
+
+    /**
+     * Define a temperatura mínima segura para priorizar produtos com tração real de marketplace.
+     */
+    private BigDecimal normalizeHotProductTemperature(BigDecimal minTemperature) {
+        if (minTemperature == null || minTemperature.compareTo(BigDecimal.ZERO) <= 0) {
+            return DEFAULT_HOT_PRODUCT_MIN_TEMPERATURE;
+        }
+        return minTemperature;
+    }
+
+    /**
+     * Mantém a consulta de candidatos em SQL fixo para evitar variações perigosas de ordenação/filtro.
+     */
+    private String hotProductDossierCandidateSql() {
+        return """
+                SELECT p.id AS page_id,
+                       p.workspace_id,
+                       p.source,
+                       p.url_canonical,
+                       p.title,
+                       p.product_name,
+                       COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature,
+                       p.score_total,
+                       p.status_pipeline_dossieproduto AS dossie_produto_status,
+                       p.dossie_produto_current_stage,
+                       p.data_pipeline_dossieproduto AS dossie_produto_updated_at,
+                       p.last_analyzed_at
+                FROM mois_sales_page p
+                LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
+                LEFT JOIN (
+                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    FROM mois_collected_reference
+                    WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
+                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
+                WHERE p.workspace_id = ?
+                  AND p.source = 'HOTMART'
+                  AND COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) >= ?
+                  AND COALESCE(p.html_bytes, 0) > 0
+                  AND COALESCE(p.analysis_status, p.current_status) IN ('DONE', 'ANALYZED')
+                  AND p.score_total IS NOT NULL
+                  AND (p.status_pipeline_dossieproduto IS NULL
+                       OR p.status_pipeline_dossieproduto NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM pipeline_dossieproduto pd
+                      WHERE pd.id_externo = CAST(p.id AS CHAR)
+                        AND pd.versao_pipeline = 'v1'
+                        AND pd.status IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO')
+                  )
+                ORDER BY COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) DESC,
+                         p.score_total DESC,
+                         p.last_analyzed_at DESC,
+                         p.id DESC
+                LIMIT ?
+                """;
+    }
+
+    /**
+     * Converte a linha SQL do candidato quente para contrato estável da API.
+     */
+    private MoisSalesLibraryDtos.HotProductDossierCandidateItem mapHotProductDossierCandidate(ResultSet rs, int rowNum) throws SQLException {
+        return new MoisSalesLibraryDtos.HotProductDossierCandidateItem(
+                rs.getLong("page_id"),
+                rs.getString("workspace_id"),
+                rs.getString("source"),
+                rs.getString("url_canonical"),
+                rs.getString("title"),
+                rs.getString("product_name"),
+                rs.getBigDecimal("hotmart_temperature"),
+                rs.getBigDecimal("score_total"),
+                rs.getString("dossie_produto_status"),
+                rs.getString("dossie_produto_current_stage"),
+                toInstant(rs, "dossie_produto_updated_at"),
+                toInstant(rs, "last_analyzed_at")
         );
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -187,6 +187,29 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Lista produtos Hotmart quentes com página capturada e analisada que podem alimentar o dossiê v1.
+     */
+    @GetMapping("/hot-products/dossier-candidates")
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductDossierCandidates(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "80") java.math.BigDecimal minTemperature,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return service.listHotProductDossierCandidates(workspaceId, minTemperature, limit);
+    }
+
+    /**
+     * Enfileira produtos Hotmart quentes na etapa intake do pipeline dossieproduto.v1.
+     */
+    @PostMapping("/hot-products/dossier-candidates:enqueue")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductDossierCandidates(
+            @Valid @RequestBody MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        return service.enqueueHotProductDossierCandidates(request);
+    }
+
+    /**
      * Lista oportunidades priorizadas pela combinação de análise comercial e aquecimento de mercado.
      */
     @GetMapping("/market-warmup/opportunity-ranking")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -531,6 +531,60 @@ class MoisSalesLibraryServiceTest {
     }
 
     /**
+     * Garante que a fila consultiva prioriza produtos Hotmart quentes já analisados para o dossiê v1.
+     */
+    @Test
+    void shouldListHotProductDossierCandidates() throws Exception {
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq(10)))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    return List.of(mapper.mapRow(hotProductDossierCandidateRow(), 0));
+                });
+
+        MoisSalesLibraryDtos.HotProductDossierCandidateResponse response =
+                service.listHotProductDossierCandidates("workspace-001", BigDecimal.valueOf(80), 10);
+
+        org.assertj.core.api.Assertions.assertThat(response.totalReturned()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).pageId()).isEqualTo(401L);
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).hotmartTemperature()).isEqualByComparingTo("127.07");
+    }
+
+    /**
+     * Garante que o comando promove candidatos quentes para o intake do dossiê sem executar o worker.
+     */
+    @Test
+    void shouldEnqueueHotProductDossierCandidates() {
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq(5)))
+                .willReturn(List.of(new MoisSalesLibraryDtos.HotProductDossierCandidateItem(
+                        401L,
+                        "workspace-001",
+                        "HOTMART",
+                        "https://example.com/oferta",
+                        "BLACK MAGRA",
+                        "BLACK MAGRA",
+                        BigDecimal.valueOf(127.07),
+                        BigDecimal.valueOf(86),
+                        null,
+                        null,
+                        null,
+                        Instant.parse("2026-07-01T10:00:00Z")
+                )));
+        given(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any(), any())).willReturn(1);
+        given(jdbcTemplate.update(contains("INSERT INTO pipeline_dossieproduto"), any(), any(), any(), any(), any())).willReturn(1);
+
+        MoisSalesLibraryDtos.HotProductDossierEnqueueResponse response =
+                service.enqueueHotProductDossierCandidates(new MoisSalesLibraryDtos.HotProductDossierEnqueueRequest(
+                        "workspace-001",
+                        BigDecimal.valueOf(80),
+                        5
+                ));
+
+        org.assertj.core.api.Assertions.assertThat(response.enqueued()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).stageCode()).isEqualTo("intake");
+        verify(jdbcTemplate).update(contains("INSERT INTO pipeline_dossieproduto"), eq("401"), eq("intake"), eq("INICIADO"), any(), eq("v1"));
+    }
+
+    /**
      * Configura mocks comuns da ingestão operacional principal em mois_sales_page.
      */
     private void stubOperationalIngest(int... upsertResults) {
@@ -624,6 +678,28 @@ class MoisSalesLibraryServiceTest {
                 .willReturn(Timestamp.from(Instant.parse("2026-06-02T10:00:00Z")));
         given(resultSet.getTimestamp(eq("updated_at"), any(Calendar.class)))
                 .willReturn(Timestamp.from(Instant.parse("2026-06-03T10:00:00Z")));
+        return resultSet;
+    }
+
+    /**
+     * Monta uma linha simulada de candidato quente ao dossiê de produto.
+     */
+    private ResultSet hotProductDossierCandidateRow() throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getLong("page_id")).willReturn(401L);
+        given(resultSet.getString("workspace_id")).willReturn("workspace-001");
+        given(resultSet.getString("source")).willReturn("HOTMART");
+        given(resultSet.getString("url_canonical")).willReturn("https://example.com/oferta");
+        given(resultSet.getString("title")).willReturn("BLACK MAGRA");
+        given(resultSet.getString("product_name")).willReturn("BLACK MAGRA");
+        given(resultSet.getBigDecimal("hotmart_temperature")).willReturn(BigDecimal.valueOf(127.07));
+        given(resultSet.getBigDecimal("score_total")).willReturn(BigDecimal.valueOf(86));
+        given(resultSet.getString("dossie_produto_status")).willReturn(null);
+        given(resultSet.getString("dossie_produto_current_stage")).willReturn(null);
+        given(resultSet.getTimestamp(eq("dossie_produto_updated_at"), any(Calendar.class))).willReturn(null);
+        given(resultSet.getTimestamp("dossie_produto_updated_at")).willReturn(null);
+        given(resultSet.getTimestamp(eq("last_analyzed_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-07-01T10:00:00Z")));
         return resultSet;
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -136,6 +136,73 @@ class MoisSalesLibraryControllerTest {
     }
 
     /**
+     * Garante que o endpoint lista candidatos quentes ao dossiê de produto.
+     */
+    @Test
+    void shouldExposeHotProductDossierCandidatesEndpoint() throws Exception {
+        when(service.listHotProductDossierCandidates("workspace-001", BigDecimal.valueOf(80), 10))
+                .thenReturn(new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
+                        "workspace-001",
+                        BigDecimal.valueOf(80),
+                        10,
+                        1,
+                        List.of(new MoisSalesLibraryDtos.HotProductDossierCandidateItem(
+                                401L,
+                                "workspace-001",
+                                "HOTMART",
+                                "https://example.com/oferta",
+                                "BLACK MAGRA",
+                                "BLACK MAGRA",
+                                BigDecimal.valueOf(127.07),
+                                BigDecimal.valueOf(86),
+                                null,
+                                null,
+                                null,
+                                Instant.parse("2026-07-01T10:00:00Z")
+                        ))
+                ));
+
+        mockMvc.perform(get("/api/mois/sales-library/hot-products/dossier-candidates")
+                        .param("workspaceId", "workspace-001")
+                        .param("minTemperature", "80")
+                        .param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalReturned").value(1))
+                .andExpect(jsonPath("$.items[0].pageId").value(401))
+                .andExpect(jsonPath("$.items[0].hotmartTemperature").value(127.07));
+    }
+
+    /**
+     * Garante que o endpoint aceita enfileirar candidatos quentes no intake do dossiê.
+     */
+    @Test
+    void shouldExposeHotProductDossierEnqueueEndpoint() throws Exception {
+        when(service.enqueueHotProductDossierCandidates(any(MoisSalesLibraryDtos.HotProductDossierEnqueueRequest.class)))
+                .thenReturn(new MoisSalesLibraryDtos.HotProductDossierEnqueueResponse(
+                        "workspace-001",
+                        BigDecimal.valueOf(80),
+                        5,
+                        1,
+                        1,
+                        0,
+                        List.of(new MoisSalesLibraryDtos.HotProductDossierEnqueueItem(401L, "job-1", "INICIADO", "intake"))
+                ));
+
+        mockMvc.perform(post("/api/mois/sales-library/hot-products/dossier-candidates:enqueue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "workspaceId": "workspace-001",
+                                  "minTemperature": 80,
+                                  "limit": 5
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.enqueued").value(1))
+                .andExpect(jsonPath("$.items[0].stageCode").value("intake"));
+    }
+
+    /**
      * Garante que o resumo global consolidado da Fase 4 seja exposto ao frontend.
      */
     @Test

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
@@ -44,6 +44,23 @@ padrões reutilizáveis
 insumos por etapa de geração
 ```
 
+## Processo recorrente para produtos quentes
+
+A partir de 2026-07-03, produtos Hotmart com temperatura `>= 80` são o primeiro critério operacional para alimentar o aprendizado comercial recorrente.
+
+O processo não deve recapturar ou reanalisar páginas sem necessidade. A captura já existe como HTML bruto e a análise comercial já existe na Biblioteca de Páginas de Vendas. O novo passo é promover, de forma recorrente, os produtos quentes já capturados e analisados para o pipeline `dossieproduto.v1`.
+
+Fluxo canônico:
+
+1. Listar candidatos em `GET /api/mois/sales-library/hot-products/dossier-candidates`.
+2. Exigir Hotmart, temperatura mínima, HTML útil, análise concluída e ausência de dossiê ativo/concluído.
+3. Enfileirar lote em `POST /api/mois/sales-library/hot-products/dossier-candidates:enqueue`.
+4. O backend apenas marca a página como `INICIADO/intake` e registra auditoria em `pipeline_dossieproduto`.
+5. O `mois-sales-library-worker` consome o endpoint `pending` do `dossieproduto.v1` e executa IA, pesquisa externa, síntese e validação.
+6. O resultado deve virar padrões abstratos para melhorar páginas próprias, nunca cópia literal de páginas externas.
+
+Essa separação mantém o backend como fonte de verdade de leitura/escrita e o worker como executor da inteligência principal.
+
 ---
 
 # As 4 camadas

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -2003,3 +2003,10 @@ Arquivos principais:
 - Ajustada a tela do dossiê de produto para separar o texto gerado pela OpenAI do response técnico em cada etapa.
 - O response técnico agora mantém visão JSON com collapse sem despejar o campo textual longo dentro do card de auditoria.
 - Adicionado quadro de dossiê final do produto com a síntese limpa da etapa `dossier-synthesis`, facilitando decisão comercial sem misturar metadados de auditoria.
+
+## 2026-07-03 — Processo recorrente de produtos quentes para dossiê MOIS v1
+
+- Criados contratos para listar produtos Hotmart com temperatura `>= 80`, HTML útil, análise concluída e sem dossiê ativo/concluído.
+- Criado comando de enfileiramento em lote que publica os candidatos na etapa `intake` do `dossieproduto.v1`, mantendo IA e pesquisa externa no `mois-sales-library-worker`.
+- Causa-raiz tratada: produtos de sucesso já capturados/analisados ficavam como informação passiva na biblioteca, sem processo recorrente para virar aprendizado comercial reutilizável.
+- Prevenção de recorrência: endpoint e Swagger tornam a seleção/enfileiramento repetíveis para novos produtos quentes que surgirem nas coletas futuras.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -436,6 +436,54 @@ paths:
                 $ref: '#/components/schemas/DossierProductPipelineResponse'
         '404':
           description: Página não encontrada
+  /hot-products/dossier-candidates:
+    get:
+      summary: Lista produtos quentes prontos para dossiê comercial
+      description: Retorna páginas Hotmart com temperatura acima do limite, HTML útil capturado, análise comercial concluída e sem dossiê v1 ativo/concluído.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: minTemperature
+          schema:
+            type: number
+            default: 80
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Candidatos priorizados para alimentar o dossiê v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierCandidateResponse'
+  /hot-products/dossier-candidates:enqueue:
+    post:
+      summary: Enfileira produtos quentes no intake do dossiê v1
+      description: Marca páginas elegíveis como `INICIADO/intake` e registra auditoria mínima em `pipeline_dossieproduto`; a execução de IA permanece no worker externo.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HotProductDossierEnqueueRequest'
+      responses:
+        '202':
+          description: Candidatos promovidos para o pipeline dossieproduto.v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierEnqueueResponse'
   /pages/{pageId}/market-warmup:request:
     post:
       summary: Solicita investigação de sucesso do produto para uma página
@@ -2130,6 +2178,103 @@ components:
         capturedAt:
           type: string
           format: date-time
+
+    HotProductDossierCandidateResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        minTemperature:
+          type: number
+        limit:
+          type: integer
+        totalReturned:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/HotProductDossierCandidateItem'
+    HotProductDossierCandidateItem:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        source:
+          type: string
+        urlCanonical:
+          type: string
+        title:
+          type: string
+          nullable: true
+        productName:
+          type: string
+          nullable: true
+        hotmartTemperature:
+          type: number
+        scoreTotal:
+          type: number
+        dossieProdutoStatus:
+          type: string
+          nullable: true
+        dossieProdutoCurrentStage:
+          type: string
+          nullable: true
+        dossieProdutoUpdatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastAnalyzedAt:
+          type: string
+          format: date-time
+          nullable: true
+    HotProductDossierEnqueueRequest:
+      type: object
+      required: [workspaceId]
+      properties:
+        workspaceId:
+          type: string
+        minTemperature:
+          type: number
+          default: 80
+        limit:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 200
+    HotProductDossierEnqueueResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        minTemperature:
+          type: number
+        requestedLimit:
+          type: integer
+        candidatesFound:
+          type: integer
+        enqueued:
+          type: integer
+        skipped:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/HotProductDossierEnqueueItem'
+    HotProductDossierEnqueueItem:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        jobId:
+          type: string
+        status:
+          type: string
+        stageCode:
+          type: string
 
     DossierProductPipelineResponse:
       type: object


### PR DESCRIPTION
## O que mudou

- Adiciona listagem de produtos Hotmart quentes elegíveis para dossiê: `GET /api/mois/sales-library/hot-products/dossier-candidates`.
- Adiciona comando recorrente de enfileiramento: `POST /api/mois/sales-library/hot-products/dossier-candidates:enqueue`.
- Usa temperatura inicial `>= 80`, HTML útil capturado, análise comercial concluída e ausência de dossiê ativo/concluído.
- Publica os candidatos na etapa `intake` do pipeline `dossieproduto.v1`, mantendo IA e pesquisa externa no `mois-sales-library-worker`.
- Atualiza Swagger e documentação do processo MOIS.

## Por quê

A biblioteca já tinha captura e análise, mas os produtos de sucesso ficavam como informação passiva. O ajuste transforma produtos quentes em uma fila recorrente de aprendizado comercial para melhorar páginas próprias sem copiar páginas externas.

## Impacto

O backend continua responsável por leitura, escrita, contratos e publicação de pendência. A inteligência principal segue no módulo externo, preservando o padrão de arquitetura do pipeline.

## Validação

- `../mvnw -Dtest=MoisSalesLibraryServiceTest,MoisSalesLibraryControllerTest test` passou: 37 testes, 0 falhas.
- `../mvnw spotless:check` não rodou porque o módulo não tem plugin Spotless configurado (`No plugin found for prefix 'spotless'`).