### PR TITLE
[codex] separa dossiês da biblioteca MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -346,6 +346,8 @@ public final class MoisSalesLibraryDtos {
      */
     public record HotProductDossierCandidateResponse(
             String workspaceId,
+            String pipelineCode,
+            String pipelineName,
             BigDecimal minTemperature,
             int limit,
             int totalReturned,
@@ -369,6 +371,8 @@ public final class MoisSalesLibraryDtos {
     public record HotProductDossierEnqueueItem(
             long pageId,
             String jobId,
+            String pipelineCode,
+            String pipelineName,
             String status,
             String stageCode
     ) {
@@ -379,6 +383,8 @@ public final class MoisSalesLibraryDtos {
      */
     public record HotProductDossierEnqueueResponse(
             String workspaceId,
+            String pipelineCode,
+            String pipelineName,
             BigDecimal minTemperature,
             int requestedLimit,
             int candidatesFound,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingService.java
@@ -1,42 +1,23 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /**
- * Calcula custos de modelos OpenAI usados pela Biblioteca de Páginas de Vendas do MOIS.
+ * Calcula custos de modelos OpenAI da Biblioteca MOIS usando o serviço comum de IA do backend.
  */
 @Service
 @RequiredArgsConstructor
 public class MoisSalesLibraryPricingService {
 
-    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000);
-
-    private final MoisSalesLibraryPricingGateway pricingGateway;
+    private final OpenAiPricingService openAiPricingService;
 
     /**
-     * Estima o custo batch do modelo usado na análise da página de venda MOIS.
+     * Estima o custo Flex/batch do modelo usado na análise da página de venda MOIS.
      */
     public BigDecimal estimateBatchCost(String modelCode, Integer inputTokens, Integer outputTokens) {
-        MoisSalesLibraryPricingGateway.ModelPricing pricing = pricingGateway.findPricingByModelCode(modelCode)
-                .orElseThrow(() -> new IllegalStateException(
-                        "Modelo OpenAI não encontrado no catálogo para cálculo de custo MOIS: " + modelCode));
-        BigDecimal inputCost = multiplyTokens(pricing.priceInputBatch(), inputTokens);
-        BigDecimal outputCost = multiplyTokens(pricing.priceOutputBatch(), outputTokens);
-        return inputCost.add(outputCost).setScale(4, RoundingMode.HALF_UP);
-    }
-
-    /**
-     * Multiplica o preço por milhão pela quantidade de tokens informada.
-     */
-    private BigDecimal multiplyTokens(BigDecimal pricePerMillion, Integer tokens) {
-        if (pricePerMillion == null || tokens == null || tokens <= 0) {
-            return BigDecimal.ZERO;
-        }
-        return pricePerMillion.multiply(BigDecimal.valueOf(tokens))
-                .divide(ONE_MILLION, 6, RoundingMode.HALF_UP);
+        return openAiPricingService.estimateFlexCost(modelCode, inputTokens, outputTokens);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -43,6 +43,18 @@ public class MoisSalesLibraryService {
     private static final int COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT = 2000;
     private static final BigDecimal DEFAULT_HOT_PRODUCT_MIN_TEMPERATURE = BigDecimal.valueOf(80);
     private static final String DOSSIE_PRODUTO_PIPELINE_VERSION = "v1";
+    private static final PipelineSpec SALES_PAGE_PATTERNS_PIPELINE = new PipelineSpec(
+            "salespagepatterns.v1",
+            "Padrões de Página de Venda",
+            "status_pipeline_salespagepatterns",
+            "salespagepatterns_current_stage",
+            "data_pipeline_salespagepatterns");
+    private static final PipelineSpec WARMUP_ECOSYSTEM_PIPELINE = new PipelineSpec(
+            "warmupecosystem.v1",
+            "Aquecimento e Ecossistema",
+            "status_pipeline_warmupecosystem",
+            "warmupecosystem_current_stage",
+            "data_pipeline_warmupecosystem");
     private static final String DOSSIE_PRODUTO_INTAKE_STAGE = "intake";
     private static final String DOSSIE_PRODUTO_STATUS_STARTED = "INICIADO";
 
@@ -226,11 +238,14 @@ public class MoisSalesLibraryService {
                 UPDATE mois_sales_page
                 SET current_stage = 'ANALYSIS', current_status = 'DONE', analysis_status = 'DONE', score_total = ?,
                     model_name = ?, input_tokens = ?, output_tokens = ?, model_cost_usd = ?,
+                    total_model_cost_usd = COALESCE(total_model_cost_usd, 0) + COALESCE(?, 0),
                     last_error_category = NULL, last_error_message = NULL, last_job_execution_id = ?,
                     last_analyzed_at = ?, updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
                 """, request.scoreTotal(), request.modelName(), request.inputTokens(), request.outputTokens(), modelCostUsd,
+                modelCostUsd,
                 jobId, Timestamp.from(analyzedAt), salesPageId);
+        accumulateLibraryCost(salesPageId, modelCostUsd);
         log.info(
                 "MOIS sales-library análise concluída no modelo operacional novo. modulo=MOIS, operacao=completeJob, "
                         + "pageId={}, executionId={}, scoreTotal={}, modelName={}, inputTokens={}, outputTokens={}, modelCostUsd={}",
@@ -265,6 +280,24 @@ public class MoisSalesLibraryService {
                     ex);
             return null;
         }
+    }
+
+    /**
+     * Acumula custo de IA no total da biblioteca por workspace quando há custo conhecido.
+     */
+    private void accumulateLibraryCost(Long salesPageId, BigDecimal costUsd) {
+        if (salesPageId == null || costUsd == null || costUsd.compareTo(BigDecimal.ZERO) <= 0) {
+            return;
+        }
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_cost_total (workspace_id, total_cost_usd, updated_at)
+                SELECT workspace_id, ?, UTC_TIMESTAMP(6)
+                FROM mois_sales_page
+                WHERE id = ?
+                ON DUPLICATE KEY UPDATE
+                    total_cost_usd = total_cost_usd + VALUES(total_cost_usd),
+                    updated_at = VALUES(updated_at)
+                """, costUsd, salesPageId);
     }
 
     /**
@@ -1667,15 +1700,52 @@ public class MoisSalesLibraryService {
             BigDecimal minTemperature,
             int limit
     ) {
+        return listHotProductWarmupEcosystemCandidates(workspaceId, minTemperature, limit);
+    }
+
+    /**
+     * Lista produtos quentes elegíveis para o pipeline de padrões visuais/copy da página de venda.
+     */
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductSalesPagePatternCandidates(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int limit
+    ) {
+        return listHotProductDossierCandidates(workspaceId, minTemperature, limit, SALES_PAGE_PATTERNS_PIPELINE);
+    }
+
+    /**
+     * Lista produtos quentes elegíveis para o pipeline de aquecimento e ecossistema de canais.
+     */
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductWarmupEcosystemCandidates(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int limit
+    ) {
+        return listHotProductDossierCandidates(workspaceId, minTemperature, limit, WARMUP_ECOSYSTEM_PIPELINE);
+    }
+
+    /**
+     * Lista candidatos quentes aplicando o estado independente do pipeline solicitado.
+     */
+    private MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductDossierCandidates(
+            String workspaceId,
+            BigDecimal minTemperature,
+            int limit,
+            PipelineSpec pipeline
+    ) {
         BigDecimal normalizedTemperature = normalizeHotProductTemperature(minTemperature);
         int normalizedLimit = Math.max(1, Math.min(limit, 200));
-        List<MoisSalesLibraryDtos.HotProductDossierCandidateItem> items = jdbcTemplate.query(hotProductDossierCandidateSql(),
+        List<MoisSalesLibraryDtos.HotProductDossierCandidateItem> items = jdbcTemplate.query(hotProductDossierCandidateSql(pipeline),
                 this::mapHotProductDossierCandidate,
                 workspaceId,
                 normalizedTemperature,
+                pipeline.code(),
                 normalizedLimit);
         return new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
                 workspaceId,
+                pipeline.code(),
+                pipeline.name(),
                 normalizedTemperature,
                 normalizedLimit,
                 items.size(),
@@ -1690,28 +1760,67 @@ public class MoisSalesLibraryService {
     public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductDossierCandidates(
             MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
     ) {
+        return enqueueHotProductWarmupEcosystemCandidates(request);
+    }
+
+    /**
+     * Enfileira produtos quentes no pipeline salespagepatterns.v1, sem misturar com aquecimento de canais.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductSalesPagePatternCandidates(
+            MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        return enqueueHotProductDossierCandidates(request, SALES_PAGE_PATTERNS_PIPELINE);
+    }
+
+    /**
+     * Enfileira produtos quentes no pipeline warmupecosystem.v1, compatível com a execução legada do dossiê.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductWarmupEcosystemCandidates(
+            MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        return enqueueHotProductDossierCandidates(request, WARMUP_ECOSYSTEM_PIPELINE);
+    }
+
+    /**
+     * Enfileira candidatos quentes na etapa inicial do pipeline informado sem executar IA no backend.
+     */
+    private MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductDossierCandidates(
+            MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request,
+            PipelineSpec pipeline
+    ) {
         BigDecimal normalizedTemperature = normalizeHotProductTemperature(request.minTemperature());
         int requestedLimit = request.limit() == null ? 50 : Math.max(1, Math.min(request.limit(), 200));
         MoisSalesLibraryDtos.HotProductDossierCandidateResponse candidates =
-                listHotProductDossierCandidates(request.workspaceId(), normalizedTemperature, requestedLimit);
+                listHotProductDossierCandidates(request.workspaceId(), normalizedTemperature, requestedLimit, pipeline);
         List<MoisSalesLibraryDtos.HotProductDossierEnqueueItem> enqueuedItems = new ArrayList<>();
         int skipped = 0;
         for (MoisSalesLibraryDtos.HotProductDossierCandidateItem candidate : candidates.items()) {
             String jobId = UUID.randomUUID().toString();
             int updated = jdbcTemplate.update("""
                     UPDATE mois_sales_page
-                    SET status_pipeline_dossieproduto = ?,
-                        dossie_produto_current_stage = ?,
-                        data_pipeline_dossieproduto = UTC_TIMESTAMP(),
+                    SET %s = ?,
+                        %s = ?,
+                        %s = UTC_TIMESTAMP(6),
                         updated_at = UTC_TIMESTAMP()
                     WHERE id = ?
-                      AND (status_pipeline_dossieproduto IS NULL
-                           OR status_pipeline_dossieproduto NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
-                    """, DOSSIE_PRODUTO_STATUS_STARTED, DOSSIE_PRODUTO_INTAKE_STAGE, candidate.pageId());
+                      AND (%s IS NULL
+                           OR %s NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
+                    """.formatted(
+                            pipeline.statusColumn(),
+                            pipeline.stageColumn(),
+                            pipeline.updatedAtColumn(),
+                            pipeline.statusColumn(),
+                            pipeline.statusColumn()),
+                    DOSSIE_PRODUTO_STATUS_STARTED,
+                    DOSSIE_PRODUTO_INTAKE_STAGE,
+                    candidate.pageId());
             if (updated == 0) {
                 skipped++;
                 continue;
             }
+            mirrorWarmupPipelineToLegacyDossierColumns(candidate.pageId(), pipeline);
             jdbcTemplate.update("""
                     INSERT INTO pipeline_dossieproduto (
                         id_externo,
@@ -1719,23 +1828,29 @@ public class MoisSalesLibraryService {
                         status,
                         data_hora,
                         job_id,
-                        versao_pipeline
-                    ) VALUES (?, ?, ?, UTC_TIMESTAMP(6), ?, ?)
+                        versao_pipeline,
+                        pipeline_code
+                    ) VALUES (?, ?, ?, UTC_TIMESTAMP(6), ?, ?, ?)
                     """,
                     String.valueOf(candidate.pageId()),
                     DOSSIE_PRODUTO_INTAKE_STAGE,
                     DOSSIE_PRODUTO_STATUS_STARTED,
                     jobId,
-                    DOSSIE_PRODUTO_PIPELINE_VERSION);
+                    DOSSIE_PRODUTO_PIPELINE_VERSION,
+                    pipeline.code());
             enqueuedItems.add(new MoisSalesLibraryDtos.HotProductDossierEnqueueItem(
                     candidate.pageId(),
                     jobId,
+                    pipeline.code(),
+                    pipeline.name(),
                     DOSSIE_PRODUTO_STATUS_STARTED,
                     DOSSIE_PRODUTO_INTAKE_STAGE
             ));
         }
         return new MoisSalesLibraryDtos.HotProductDossierEnqueueResponse(
                 request.workspaceId(),
+                pipeline.code(),
+                pipeline.name(),
                 normalizedTemperature,
                 requestedLimit,
                 candidates.totalReturned(),
@@ -1743,6 +1858,23 @@ public class MoisSalesLibraryService {
                 skipped,
                 enqueuedItems
         );
+    }
+
+    /**
+     * Mantém o pipeline warmupecosystem.v1 visível para os controllers internos legados do dossieproduto.v1.
+     */
+    private void mirrorWarmupPipelineToLegacyDossierColumns(long pageId, PipelineSpec pipeline) {
+        if (!WARMUP_ECOSYSTEM_PIPELINE.code().equals(pipeline.code())) {
+            return;
+        }
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page
+                SET status_pipeline_dossieproduto = ?,
+                    dossie_produto_current_stage = ?,
+                    data_pipeline_dossieproduto = UTC_TIMESTAMP(6),
+                    updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, DOSSIE_PRODUTO_STATUS_STARTED, DOSSIE_PRODUTO_INTAKE_STAGE, pageId);
     }
 
     /**
@@ -1758,7 +1890,7 @@ public class MoisSalesLibraryService {
     /**
      * Mantém a consulta de candidatos em SQL fixo para evitar variações perigosas de ordenação/filtro.
      */
-    private String hotProductDossierCandidateSql() {
+    private String hotProductDossierCandidateSql(PipelineSpec pipeline) {
         return """
                 SELECT p.id AS page_id,
                        p.workspace_id,
@@ -1768,9 +1900,9 @@ public class MoisSalesLibraryService {
                        p.product_name,
                        COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature,
                        p.score_total,
-                       p.status_pipeline_dossieproduto AS dossie_produto_status,
-                       p.dossie_produto_current_stage,
-                       p.data_pipeline_dossieproduto AS dossie_produto_updated_at,
+                       p.%s AS dossie_produto_status,
+                       p.%s AS dossie_produto_current_stage,
+                       p.%s AS dossie_produto_updated_at,
                        p.last_analyzed_at
                 FROM mois_sales_page p
                 LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
@@ -1787,13 +1919,14 @@ public class MoisSalesLibraryService {
                   AND COALESCE(p.html_bytes, 0) > 0
                   AND COALESCE(p.analysis_status, p.current_status) IN ('DONE', 'ANALYZED')
                   AND p.score_total IS NOT NULL
-                  AND (p.status_pipeline_dossieproduto IS NULL
-                       OR p.status_pipeline_dossieproduto NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
+                  AND (p.%s IS NULL
+                       OR p.%s NOT IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO'))
                   AND NOT EXISTS (
                       SELECT 1
                       FROM pipeline_dossieproduto pd
                       WHERE pd.id_externo = CAST(p.id AS CHAR)
                         AND pd.versao_pipeline = 'v1'
+                        AND pd.pipeline_code = ?
                         AND pd.status IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO')
                   )
                 ORDER BY COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) DESC,
@@ -1801,7 +1934,12 @@ public class MoisSalesLibraryService {
                          p.last_analyzed_at DESC,
                          p.id DESC
                 LIMIT ?
-                """;
+                """.formatted(
+                pipeline.statusColumn(),
+                pipeline.stageColumn(),
+                pipeline.updatedAtColumn(),
+                pipeline.statusColumn(),
+                pipeline.statusColumn());
     }
 
     /**
@@ -1822,6 +1960,18 @@ public class MoisSalesLibraryService {
                 toInstant(rs, "dossie_produto_updated_at"),
                 toInstant(rs, "last_analyzed_at")
         );
+    }
+
+    /**
+     * Define os nomes canônicos e colunas seguras usadas por cada pipeline da biblioteca.
+     */
+    private record PipelineSpec(
+            String code,
+            String name,
+            String statusColumn,
+            String stageColumn,
+            String updatedAtColumn
+    ) {
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -199,6 +199,30 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Lista produtos quentes para o pipeline salespagepatterns.v1 de padrões de design, visual e copy.
+     */
+    @GetMapping("/hot-products/salespagepatterns/v1/candidates")
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductSalesPagePatternCandidates(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "80") java.math.BigDecimal minTemperature,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return service.listHotProductSalesPagePatternCandidates(workspaceId, minTemperature, limit);
+    }
+
+    /**
+     * Lista produtos quentes para o pipeline warmupecosystem.v1 de aquecimento e canais externos.
+     */
+    @GetMapping("/hot-products/warmupecosystem/v1/candidates")
+    public MoisSalesLibraryDtos.HotProductDossierCandidateResponse listHotProductWarmupEcosystemCandidates(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "80") java.math.BigDecimal minTemperature,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return service.listHotProductWarmupEcosystemCandidates(workspaceId, minTemperature, limit);
+    }
+
+    /**
      * Enfileira produtos Hotmart quentes na etapa intake do pipeline dossieproduto.v1.
      */
     @PostMapping("/hot-products/dossier-candidates:enqueue")
@@ -207,6 +231,28 @@ public class MoisSalesLibraryController {
             @Valid @RequestBody MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
     ) {
         return service.enqueueHotProductDossierCandidates(request);
+    }
+
+    /**
+     * Enfileira produtos quentes no pipeline salespagepatterns.v1 sem executar IA no backend.
+     */
+    @PostMapping("/hot-products/salespagepatterns/v1/candidates:enqueue")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductSalesPagePatternCandidates(
+            @Valid @RequestBody MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        return service.enqueueHotProductSalesPagePatternCandidates(request);
+    }
+
+    /**
+     * Enfileira produtos quentes no pipeline warmupecosystem.v1 sem executar IA no backend.
+     */
+    @PostMapping("/hot-products/warmupecosystem/v1/candidates:enqueue")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.HotProductDossierEnqueueResponse enqueueHotProductWarmupEcosystemCandidates(
+            @Valid @RequestBody MoisSalesLibraryDtos.HotProductDossierEnqueueRequest request
+    ) {
+        return service.enqueueHotProductWarmupEcosystemCandidates(request);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -58,6 +58,7 @@ public class DossierDossierSynthesisService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -84,6 +85,7 @@ public class DossierDossierSynthesisService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierDossierSynthesisRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -122,6 +124,7 @@ public class DossierDossierSynthesisService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierDossierSynthesisRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -182,6 +185,7 @@ public class DossierDossierSynthesisService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -64,6 +64,7 @@ public class DossierIntakeService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -90,6 +91,7 @@ public class DossierIntakeService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierIntakeRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -128,6 +130,7 @@ public class DossierIntakeService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierIntakeRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -187,6 +190,7 @@ public class DossierIntakeService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -57,6 +57,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -83,6 +84,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierInvestigationAnchorBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -121,6 +123,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierInvestigationAnchorBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -175,6 +178,7 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -12,10 +12,12 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.dossieproduto.DossierProductContextGateway;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.Map;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
@@ -24,15 +26,18 @@ public class DossierProductUnderstandingService {
     private final MoisSalesPageRepository salesPageRepository;
     private final PipelineDossieProdutoRepository pipelineDossieProdutoRepository;
     private final DossierProductContextGateway productContextGateway;
+    private final JdbcTemplate jdbcTemplate;
 
     /** Cria o service da etapa com acesso aos repositórios canônicos da página/produto e da auditoria do pipeline. */
     public DossierProductUnderstandingService(
             MoisSalesPageRepository salesPageRepository,
             PipelineDossieProdutoRepository pipelineDossieProdutoRepository,
-            DossierProductContextGateway productContextGateway) {
+            DossierProductContextGateway productContextGateway,
+            JdbcTemplate jdbcTemplate) {
         this.salesPageRepository = salesPageRepository;
         this.pipelineDossieProdutoRepository = pipelineDossieProdutoRepository;
         this.productContextGateway = productContextGateway;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     private static final String STAGE_CODE = "product-understanding";
@@ -61,6 +66,7 @@ public class DossierProductUnderstandingService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -87,6 +93,7 @@ public class DossierProductUnderstandingService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierProductUnderstandingRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -125,9 +132,33 @@ public class DossierProductUnderstandingService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
+        accumulateCosts(pageId, request.custo());
 
         return new DossierProductUnderstandingRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Acumula custo OpenAI no total individual da página e no total da biblioteca. */
+    private void accumulateCosts(long pageId, BigDecimal costUsd) {
+        if (costUsd == null || costUsd.compareTo(BigDecimal.ZERO) <= 0) {
+            return;
+        }
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page
+                   SET total_model_cost_usd = COALESCE(total_model_cost_usd, 0) + ?,
+                       updated_at = UTC_TIMESTAMP()
+                 WHERE id = ?
+                """, costUsd, pageId);
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_cost_total (workspace_id, total_cost_usd, updated_at)
+                SELECT workspace_id, ?, UTC_TIMESTAMP(6)
+                FROM mois_sales_page
+                WHERE id = ?
+                ON DUPLICATE KEY UPDATE
+                    total_cost_usd = total_cost_usd + VALUES(total_cost_usd),
+                    updated_at = VALUES(updated_at)
+                """, costUsd, pageId);
     }
 
     /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
@@ -187,6 +218,7 @@ public class DossierProductUnderstandingService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -57,6 +57,7 @@ public class DossierSourceProductMatchService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -83,6 +84,7 @@ public class DossierSourceProductMatchService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierSourceProductMatchRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -121,6 +123,7 @@ public class DossierSourceProductMatchService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierSourceProductMatchRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -175,6 +178,7 @@ public class DossierSourceProductMatchService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -57,6 +57,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -83,6 +84,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupMapBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -121,6 +123,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupMapBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -175,6 +178,7 @@ public class DossierWarmupMapBuilderService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -57,6 +57,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -83,6 +84,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupResourceDiscoveryRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -121,6 +123,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupResourceDiscoveryRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -175,6 +178,7 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -57,6 +57,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setDataHora(now);
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
     }
 
@@ -83,6 +84,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupSignalExtractionRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
@@ -121,6 +123,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setModelo(request.modelo());
         pipeline.setDescricaoErro(request.descricaoErro());
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupSignalExtractionRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
@@ -175,6 +178,7 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setDataHora(Instant.now());
         pipeline.setJobId(jobId);
         pipeline.setVersaoPipeline("v1");
+        pipeline.setPipelineCode("warmupecosystem.v1");
         pipelineDossieProdutoRepository.save(pipeline);
         return jobId;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,6 +29,27 @@ public class MoisSalesPage {
 
     @Column(name = "data_pipeline_dossieproduto")
     private Instant dossieProdutoUpdatedAt;
+
+    @Column(name = "status_pipeline_salespagepatterns", length = 40)
+    private String salesPagePatternsStatus;
+
+    @Column(name = "salespagepatterns_current_stage", length = 80)
+    private String salesPagePatternsCurrentStage;
+
+    @Column(name = "data_pipeline_salespagepatterns")
+    private Instant salesPagePatternsUpdatedAt;
+
+    @Column(name = "status_pipeline_warmupecosystem", length = 40)
+    private String warmupEcosystemStatus;
+
+    @Column(name = "warmupecosystem_current_stage", length = 80)
+    private String warmupEcosystemCurrentStage;
+
+    @Column(name = "data_pipeline_warmupecosystem")
+    private Instant warmupEcosystemUpdatedAt;
+
+    @Column(name = "total_model_cost_usd", precision = 19, scale = 6)
+    private BigDecimal totalModelCostUsd;
 
     @Column(name = "status_pipeline_geracaoanuncios", length = 40)
     private String statusPipelineGeracaoAnuncios;

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
@@ -74,4 +74,7 @@ public class PipelineDossieProduto {
 
     @Column(name = "versao_pipeline", length = 80)
     private String versaoPipeline;
+
+    @Column(name = "pipeline_code", length = 80)
+    private String pipelineCode;
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-mois-sales-library-two-dossier-pipelines.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-mois-sales-library-two-dossier-pipelines.yaml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-03-mois-sales-library-two-dossier-pipelines-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            columnExists:
+              tableName: mois_sales_page
+              columnName: status_pipeline_salespagepatterns
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_page
+                ADD COLUMN status_pipeline_salespagepatterns VARCHAR(40) NULL AFTER data_pipeline_dossieproduto,
+                ADD COLUMN salespagepatterns_current_stage VARCHAR(80) NULL AFTER status_pipeline_salespagepatterns,
+                ADD COLUMN data_pipeline_salespagepatterns DATETIME(6) NULL AFTER salespagepatterns_current_stage,
+                ADD COLUMN status_pipeline_warmupecosystem VARCHAR(40) NULL AFTER data_pipeline_salespagepatterns,
+                ADD COLUMN warmupecosystem_current_stage VARCHAR(80) NULL AFTER status_pipeline_warmupecosystem,
+                ADD COLUMN data_pipeline_warmupecosystem DATETIME(6) NULL AFTER warmupecosystem_current_stage,
+                ADD COLUMN total_model_cost_usd DECIMAL(19,6) NULL AFTER model_cost_usd;
+              CREATE INDEX idx_mois_sales_page_salespagepatterns_pipeline
+                ON mois_sales_page (status_pipeline_salespagepatterns, salespagepatterns_current_stage, data_pipeline_salespagepatterns);
+              CREATE INDEX idx_mois_sales_page_warmupecosystem_pipeline
+                ON mois_sales_page (status_pipeline_warmupecosystem, warmupecosystem_current_stage, data_pipeline_warmupecosystem);
+  - changeSet:
+      id: 2026-07-03-mois-sales-library-two-dossier-pipelines-02
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_dossieproduto
+        - not:
+            columnExists:
+              tableName: pipeline_dossieproduto
+              columnName: pipeline_code
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pipeline_dossieproduto
+                ADD COLUMN pipeline_code VARCHAR(80) NULL AFTER versao_pipeline;
+              UPDATE pipeline_dossieproduto
+                 SET pipeline_code = 'warmupecosystem.v1'
+               WHERE pipeline_code IS NULL;
+              CREATE INDEX idx_pipeline_dossieproduto_pipeline_status
+                ON pipeline_dossieproduto (pipeline_code, id_externo, status, data_hora);
+  - changeSet:
+      id: 2026-07-03-mois-sales-library-two-dossier-pipelines-03
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_sales_library_cost_total
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_cost_total (
+                workspace_id VARCHAR(120) NOT NULL,
+                total_cost_usd DECIMAL(19,6) NOT NULL DEFAULT 0,
+                updated_at DATETIME(6) NOT NULL,
+                PRIMARY KEY (workspace_id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1235,3 +1235,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-28-openai-gpt52-pricing.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-07-03-mois-sales-library-two-dossier-pipelines.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/architecture/MoisSalesLibraryArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/architecture/MoisSalesLibraryArchitectureTest.java
@@ -1,0 +1,44 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+/** Protege a biblioteca MOIS backend para manter execução de IA no worker externo. */
+@AnalyzeClasses(packages = "com.marketinghub", importOptions = ImportOption.DoNotIncludeTests.class)
+class MoisSalesLibraryArchitectureTest {
+
+    /** Garante que o backend da biblioteca não vire executor runtime de OpenAI. */
+    @ArchTest
+    static final ArchRule backend_mois_sales_library_nao_deve_chamar_openai_diretamente = classes()
+            .that()
+            .resideInAPackage("..mois.bibliotecapaginavenda.worker.v1..")
+            .should(notDependOnOpenAiRuntimeClients())
+            .because("[ARQUITETURA] backend MOIS deve persistir contratos/custos; OpenAI deve rodar no mois-sales-library-worker");
+
+    private static ArchCondition<JavaClass> notDependOnOpenAiRuntimeClients() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de clients runtime OpenAI") {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    String packageName = target.getPackageName();
+                    boolean invalid = packageName.startsWith("okhttp3")
+                            || packageName.startsWith("org.springframework.web.reactive.function.client")
+                            || target.getName().contains("OpenAiClient");
+                    events.add(new SimpleConditionEvent(dependency, !invalid,
+                            "[ARQUITETURA] " + javaClass.getName()
+                                    + " não pode depender de client runtime OpenAI " + target.getName()));
+                }
+            }
+        };
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingServiceTest.java
@@ -1,12 +1,10 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
-import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,40 +12,27 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Valida o cálculo de custos OpenAI mantido dentro do pacote da Biblioteca MOIS.
+ * Valida o cálculo de custos OpenAI da Biblioteca MOIS usando o serviço comum de IA.
  */
 @ExtendWith(MockitoExtension.class)
 class MoisSalesLibraryPricingServiceTest {
 
     @Mock
-    private MoisSalesLibraryPricingGateway pricingGateway;
+    private OpenAiPricingService openAiPricingService;
 
     @InjectMocks
     private MoisSalesLibraryPricingService service;
 
     /**
-     * Garante cálculo batch usando os preços obtidos do banco pelo gateway permitido do MOIS.
+     * Garante cálculo flex usando o serviço comum de preços OpenAI do backend.
      */
     @Test
-    void shouldEstimateBatchCostFromMoisPricingGateway() {
-        given(pricingGateway.findPricingByModelCode("gpt-5.2"))
-                .willReturn(Optional.of(new MoisSalesLibraryPricingGateway.ModelPricing(
-                        new BigDecimal("1.25000"), new BigDecimal("10.00000"))));
+    void shouldEstimateBatchCostFromCommonOpenAiPricingService() {
+        given(openAiPricingService.estimateFlexCost("gpt-5.2", 250_000, 125_000))
+                .willReturn(new BigDecimal("1.5625"));
 
         BigDecimal cost = service.estimateBatchCost("gpt-5.2", 250_000, 125_000);
 
         assertThat(cost).isEqualByComparingTo("1.5625");
-    }
-
-    /**
-     * Garante erro controlado quando o modelo ainda não existe no catálogo de preços.
-     */
-    @Test
-    void shouldFailWhenModelPricingIsMissing() {
-        given(pricingGateway.findPricingByModelCode("modelo-ausente")).willReturn(Optional.empty());
-
-        assertThatThrownBy(() -> service.estimateBatchCost("modelo-ausente", 1000, 1000))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Modelo OpenAI não encontrado");
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -535,7 +535,7 @@ class MoisSalesLibraryServiceTest {
      */
     @Test
     void shouldListHotProductDossierCandidates() throws Exception {
-        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq(10)))
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq("warmupecosystem.v1"), eq(10)))
                 .willAnswer(invocation -> {
                     RowMapper<?> mapper = invocation.getArgument(1);
                     return List.of(mapper.mapRow(hotProductDossierCandidateRow(), 0));
@@ -545,6 +545,7 @@ class MoisSalesLibraryServiceTest {
                 service.listHotProductDossierCandidates("workspace-001", BigDecimal.valueOf(80), 10);
 
         org.assertj.core.api.Assertions.assertThat(response.totalReturned()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.pipelineCode()).isEqualTo("warmupecosystem.v1");
         org.assertj.core.api.Assertions.assertThat(response.items().get(0).pageId()).isEqualTo(401L);
         org.assertj.core.api.Assertions.assertThat(response.items().get(0).hotmartTemperature()).isEqualByComparingTo("127.07");
     }
@@ -554,7 +555,7 @@ class MoisSalesLibraryServiceTest {
      */
     @Test
     void shouldEnqueueHotProductDossierCandidates() {
-        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq(5)))
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq("warmupecosystem.v1"), eq(5)))
                 .willReturn(List.of(new MoisSalesLibraryDtos.HotProductDossierCandidateItem(
                         401L,
                         "workspace-001",
@@ -570,7 +571,7 @@ class MoisSalesLibraryServiceTest {
                         Instant.parse("2026-07-01T10:00:00Z")
                 )));
         given(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any(), any())).willReturn(1);
-        given(jdbcTemplate.update(contains("INSERT INTO pipeline_dossieproduto"), any(), any(), any(), any(), any())).willReturn(1);
+        given(jdbcTemplate.update(contains("INSERT INTO pipeline_dossieproduto"), any(), any(), any(), any(), any(), any())).willReturn(1);
 
         MoisSalesLibraryDtos.HotProductDossierEnqueueResponse response =
                 service.enqueueHotProductDossierCandidates(new MoisSalesLibraryDtos.HotProductDossierEnqueueRequest(
@@ -580,8 +581,45 @@ class MoisSalesLibraryServiceTest {
                 ));
 
         org.assertj.core.api.Assertions.assertThat(response.enqueued()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.pipelineCode()).isEqualTo("warmupecosystem.v1");
         org.assertj.core.api.Assertions.assertThat(response.items().get(0).stageCode()).isEqualTo("intake");
-        verify(jdbcTemplate).update(contains("INSERT INTO pipeline_dossieproduto"), eq("401"), eq("intake"), eq("INICIADO"), any(), eq("v1"));
+        verify(jdbcTemplate).update(contains("INSERT INTO pipeline_dossieproduto"), eq("401"), eq("intake"), eq("INICIADO"), any(), eq("v1"), eq("warmupecosystem.v1"));
+        verify(jdbcTemplate).update(contains("status_pipeline_dossieproduto"), eq("INICIADO"), eq("intake"), eq(401L));
+    }
+
+    /**
+     * Garante que o pipeline de padrões de página não disputa a fila legada do dossiê de aquecimento.
+     */
+    @Test
+    void shouldEnqueueSalesPagePatternsWithoutTouchingWarmupLegacyQueue() {
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq("salespagepatterns.v1"), eq(5)))
+                .willReturn(List.of(new MoisSalesLibraryDtos.HotProductDossierCandidateItem(
+                        401L,
+                        "workspace-001",
+                        "HOTMART",
+                        "https://example.com/oferta",
+                        "BLACK MAGRA",
+                        "BLACK MAGRA",
+                        BigDecimal.valueOf(127.07),
+                        BigDecimal.valueOf(86),
+                        null,
+                        null,
+                        null,
+                        Instant.parse("2026-07-01T10:00:00Z")
+                )));
+        given(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any(), any())).willReturn(1);
+        given(jdbcTemplate.update(contains("INSERT INTO pipeline_dossieproduto"), any(), any(), any(), any(), any(), any())).willReturn(1);
+
+        MoisSalesLibraryDtos.HotProductDossierEnqueueResponse response =
+                service.enqueueHotProductSalesPagePatternCandidates(new MoisSalesLibraryDtos.HotProductDossierEnqueueRequest(
+                        "workspace-001",
+                        BigDecimal.valueOf(80),
+                        5
+                ));
+
+        org.assertj.core.api.Assertions.assertThat(response.pipelineCode()).isEqualTo("salespagepatterns.v1");
+        verify(jdbcTemplate).update(contains("INSERT INTO pipeline_dossieproduto"), eq("401"), eq("intake"), eq("INICIADO"), any(), eq("v1"), eq("salespagepatterns.v1"));
+        verify(jdbcTemplate, never()).update(contains("status_pipeline_dossieproduto"), any(), any(), any());
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -143,6 +143,8 @@ class MoisSalesLibraryControllerTest {
         when(service.listHotProductDossierCandidates("workspace-001", BigDecimal.valueOf(80), 10))
                 .thenReturn(new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
                         "workspace-001",
+                        "warmupecosystem.v1",
+                        "Aquecimento e Ecossistema",
                         BigDecimal.valueOf(80),
                         10,
                         1,
@@ -167,6 +169,7 @@ class MoisSalesLibraryControllerTest {
                         .param("minTemperature", "80")
                         .param("limit", "10"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pipelineCode").value("warmupecosystem.v1"))
                 .andExpect(jsonPath("$.totalReturned").value(1))
                 .andExpect(jsonPath("$.items[0].pageId").value(401))
                 .andExpect(jsonPath("$.items[0].hotmartTemperature").value(127.07));
@@ -180,12 +183,15 @@ class MoisSalesLibraryControllerTest {
         when(service.enqueueHotProductDossierCandidates(any(MoisSalesLibraryDtos.HotProductDossierEnqueueRequest.class)))
                 .thenReturn(new MoisSalesLibraryDtos.HotProductDossierEnqueueResponse(
                         "workspace-001",
+                        "warmupecosystem.v1",
+                        "Aquecimento e Ecossistema",
                         BigDecimal.valueOf(80),
                         5,
                         1,
                         1,
                         0,
-                        List.of(new MoisSalesLibraryDtos.HotProductDossierEnqueueItem(401L, "job-1", "INICIADO", "intake"))
+                        List.of(new MoisSalesLibraryDtos.HotProductDossierEnqueueItem(
+                                401L, "job-1", "warmupecosystem.v1", "Aquecimento e Ecossistema", "INICIADO", "intake"))
                 ));
 
         mockMvc.perform(post("/api/mois/sales-library/hot-products/dossier-candidates:enqueue")
@@ -198,8 +204,57 @@ class MoisSalesLibraryControllerTest {
                                 }
                                 """))
                 .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.pipelineCode").value("warmupecosystem.v1"))
                 .andExpect(jsonPath("$.enqueued").value(1))
                 .andExpect(jsonPath("$.items[0].stageCode").value("intake"));
+    }
+
+    /**
+     * Garante que o endpoint nomeado de padrões de página consulta o pipeline correto.
+     */
+    @Test
+    void shouldExposeSalesPagePatternsCandidatesEndpoint() throws Exception {
+        when(service.listHotProductSalesPagePatternCandidates("workspace-001", BigDecimal.valueOf(80), 10))
+                .thenReturn(new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
+                        "workspace-001",
+                        "salespagepatterns.v1",
+                        "Padrões de Página de Venda",
+                        BigDecimal.valueOf(80),
+                        10,
+                        0,
+                        List.of()
+                ));
+
+        mockMvc.perform(get("/api/mois/sales-library/hot-products/salespagepatterns/v1/candidates")
+                        .param("workspaceId", "workspace-001")
+                        .param("minTemperature", "80")
+                        .param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pipelineCode").value("salespagepatterns.v1"));
+    }
+
+    /**
+     * Garante que o endpoint nomeado de aquecimento consulta o pipeline correto.
+     */
+    @Test
+    void shouldExposeWarmupEcosystemCandidatesEndpoint() throws Exception {
+        when(service.listHotProductWarmupEcosystemCandidates("workspace-001", BigDecimal.valueOf(80), 10))
+                .thenReturn(new MoisSalesLibraryDtos.HotProductDossierCandidateResponse(
+                        "workspace-001",
+                        "warmupecosystem.v1",
+                        "Aquecimento e Ecossistema",
+                        BigDecimal.valueOf(80),
+                        10,
+                        0,
+                        List.of()
+                ));
+
+        mockMvc.perform(get("/api/mois/sales-library/hot-products/warmupecosystem/v1/candidates")
+                        .param("workspaceId", "workspace-001")
+                        .param("minTemperature", "80")
+                        .param("limit", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pipelineCode").value("warmupecosystem.v1"));
     }
 
     /**

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -64,10 +64,10 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 - `openai.model` → `${OPENAI_MODEL:gpt-5.2}`
 - `openai.request-timeout-ms` → `${OPENAI_REQUEST_TIMEOUT_MS:900000}`
 - Para payload de `/v1/responses`, o formato estruturado deve usar `text.format` (não usar `response_format`).
-- Toda análise comercial OpenAI do MOIS Sales Library deve enviar `service_tier: "flex"` no payload auditado.
+- Toda análise comercial OpenAI do MOIS Sales Library deve seguir a sequência de tentativas: tentativa 1 com `service_tier: "flex"`, tentativa 2 com `service_tier: "flex"` e tentativa 3 em Standard/default.
 
 ## 8. Regra canônica de processamento OpenAI Flex (MOIS Worker)
-Para análises comerciais OpenAI no contexto do MOIS Worker, o modo canônico é **Responses API com `service_tier: "flex"`**, sem criação de Batch API. O timeout canônico da chamada síncrona Flex é de **15 minutos** (`900000 ms` / `PT15M`), alinhado ao caráter assíncrono/baixo custo da etapa.
+Para análises comerciais OpenAI no contexto do MOIS Worker, o modo canônico é **Responses API com Flex nas duas primeiras tentativas e Standard/default na terceira**, sem criação de Batch API. O timeout canônico da chamada síncrona é de **15 minutos** (`900000 ms` / `PT15M`), alinhado ao caráter assíncrono/baixo custo da etapa.
 
 
 ## 8.1 Taxonomia canônica de status (monitoramento de fetching)
@@ -155,6 +155,17 @@ Portanto, rankings, scores e pesquisas complementares da biblioteca devem respon
 5. **Receber resultado OpenAI e persistir no banco**
    - Em sucesso: worker chama `jobs/{jobId}:complete`; backend atualiza `mois_sales_page_job_execution` e consolida `mois_sales_page` como `DONE`.
    - Em falha: worker chama `jobs/{jobId}:fail`; backend marca a execução e o estado consolidado da página como `FAILED` com categoria/mensagem para diagnóstico.
+
+### 12.3 Pipelines de dossiê de produtos quentes
+
+Produtos Hotmart com temperatura `>= 80` alimentam dois pipelines separados no `mois-sales-library-worker`:
+
+- `salespagepatterns.v1`: padrões de página de venda para design, visual, estrutura e copy.
+- `warmupecosystem.v1`: aquecimento e ecossistema para canais externos, sinais de autoridade, prova social e pré-venda.
+
+O backend apenas lista candidatos, enfileira o `intake`, persiste auditoria, recebe callbacks e acumula custo. A inteligência principal, chamadas OpenAI, pesquisa externa e síntese ficam no worker.
+
+Todo custo OpenAI deve ser persistido no registro da etapa, somado em `mois_sales_page.total_model_cost_usd` e somado em `mois_sales_library_cost_total.total_cost_usd`.
 
 ### 12.2 Diagrama (sequência ponta a ponta)
 ```mermaid

--- a/docs/canonical/openai-service-tier-retry-canon.v1.md
+++ b/docs/canonical/openai-service-tier-retry-canon.v1.md
@@ -6,13 +6,13 @@ Este cânone define a regra operacional de retry por `service_tier` para chamada
 
 ## Regra canônica
 
-Quando uma chamada OpenAI usar Flex como padrão operacional e encontrar falha transitória (`408`, `429`, `5xx`, timeout, `rate_limit` ou indisponibilidade temporária), o executor deve manter:
+Quando uma chamada OpenAI usar Flex como padrão operacional, o executor deve manter a sequência canônica de até três tentativas:
 
 1. primeira tentativa em Flex;
 2. segunda tentativa em Flex;
 3. terceira tentativa em Standard/default, quando a API/chamada suportar esse fallback sem quebrar o contrato.
 
-Essa regra vale para geração textual e para geração de imagens de criativos.
+Essa regra vale para todo o sistema em chamadas OpenAI síncronas ou assíncronas em que o executor controle a tentativa: geração textual, análise, classificação, extração, síntese e geração de imagens de criativos. Falhas transitórias (`408`, `429`, `5xx`, timeout, `rate_limit` ou indisponibilidade temporária`) não devem encerrar a chamada antes da terceira tentativa quando o fallback for suportado.
 
 ## Imagens de criativos
 
@@ -27,3 +27,7 @@ Em geração de imagem de criativo:
 O tier efetivo de cada tentativa deve aparecer em log ou auditoria operacional suficiente para explicar custo, latência e motivo do fallback.
 
 Não é permitido transformar toda a etapa em Standard/default por padrão sem registro explícito de decisão funcional, porque isso aumenta custo e remove o benefício financeiro do Flex.
+
+## Custos
+
+Toda chamada OpenAI deve coletar tokens/custo quando o provedor retornar esses dados ou quando o backend conseguir calcular pelo catálogo canônico de modelos. O custo deve ser persistido no registro individual da execução e somado ao agregado de negócio correspondente, quando existir.

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/processo-geracao-dossie.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/processo-geracao-dossie.md
@@ -1,10 +1,40 @@
-# Processo simples — geração do dossiê da Biblioteca de Páginas de Vendas
+# Processo simples — dossiês da Biblioteca de Páginas de Vendas
 
-Data: 2026-06-25
+Data: 2026-07-03
 
 ## Objetivo
 
-Gerar um dossiê simples para entender o prestígio e o aquecimento público de um produto a partir da página de venda já capturada na biblioteca.
+A Biblioteca de Páginas de Vendas passa a ter dois dossiês separados, com objetivos diferentes e pipelines independentes:
+
+1. `salespagepatterns.v1` — **Padrões de Página de Venda**
+   - foco: design, visual, estrutura da página, copy, oferta, prova, garantia e CTA;
+   - uso: melhorar páginas próprias, GeraSalesPage, GeraLanding, wireframes, prompts de imagem e presets de design.
+
+2. `warmupecosystem.v1` — **Aquecimento e Ecossistema**
+   - foco: redes sociais, vídeos, reviews, afiliados, comunidades, páginas auxiliares, canais do produtor e outros sinais externos que aquecem leads;
+   - uso: entender se produtos vencedores dependem de pré-venda, autoridade externa ou distribuição além da página.
+
+Os dois pipelines usam produtos quentes como fonte inicial, começando por Hotmart com temperatura `>= 80`, mas não compartilham estado operacional. Um dossiê concluído não deve bloquear o outro.
+
+## Pipeline `salespagepatterns.v1`
+
+Este pipeline deve responder:
+
+- quais padrões de design aparecem em páginas de produtos quentes;
+- quais padrões de hierarquia visual e densidade ajudam a venda;
+- quais fórmulas de copy são recorrentes;
+- quais blocos de prova, garantia, oferta e CTA aparecem;
+- quais padrões podem virar insumo abstrato para páginas próprias sem copiar conteúdo, marca ou identidade visual.
+
+Etapas planejadas:
+
+1. `intake`;
+2. `page-pattern-extraction`;
+3. `pattern-synthesis`.
+
+## Pipeline `warmupecosystem.v1`
+
+Este pipeline substitui o nome genérico anterior `dossieproduto.v1` para o objetivo de aquecimento.
 
 O dossiê deve responder:
 
@@ -13,7 +43,7 @@ O dossiê deve responder:
 - quais recursos, além da própria página de venda, estão aquecendo o público;
 - qual conclusão final deve ficar disponível na tela do item da biblioteca.
 
-## Etapas do processo
+## Etapas do processo de aquecimento
 
 ### Etapa 1 — Extrair termos de pesquisa
 
@@ -59,3 +89,5 @@ Esse dossiê passa a ficar disponível na tela do item da biblioteca para apoiar
 - O worker não acessa o banco diretamente.
 - Cada etapa deve deixar evidência persistida suficiente para auditoria e exibição ao usuário.
 - A tela deve mostrar o dossiê final vindo do backend, sem recomputar conclusões no frontend.
+- Chamadas OpenAI devem usar três tentativas: tentativa 1 Flex, tentativa 2 Flex e tentativa 3 Standard/default.
+- Todo custo retornado por OpenAI deve ser persistido no registro da etapa, somado ao custo individual da página e somado ao custo total da biblioteca.

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
@@ -48,16 +48,24 @@ insumos por etapa de geração
 
 A partir de 2026-07-03, produtos Hotmart com temperatura `>= 80` são o primeiro critério operacional para alimentar o aprendizado comercial recorrente.
 
-O processo não deve recapturar ou reanalisar páginas sem necessidade. A captura já existe como HTML bruto e a análise comercial já existe na Biblioteca de Páginas de Vendas. O novo passo é promover, de forma recorrente, os produtos quentes já capturados e analisados para o pipeline `dossieproduto.v1`.
+O processo não deve recapturar ou reanalisar páginas sem necessidade. A captura já existe como HTML bruto e a análise comercial já existe na Biblioteca de Páginas de Vendas. O novo passo é promover, de forma recorrente, os produtos quentes já capturados e analisados para dois pipelines separados:
+
+- `salespagepatterns.v1`: extrai padrões de design, visual, estrutura e copy.
+- `warmupecosystem.v1`: investiga aquecimento de leads por canais e sinais externos.
 
 Fluxo canônico:
 
-1. Listar candidatos em `GET /api/mois/sales-library/hot-products/dossier-candidates`.
+1. Listar candidatos em:
+   - `GET /api/mois/sales-library/hot-products/salespagepatterns/v1/candidates`;
+   - `GET /api/mois/sales-library/hot-products/warmupecosystem/v1/candidates`.
 2. Exigir Hotmart, temperatura mínima, HTML útil, análise concluída e ausência de dossiê ativo/concluído.
-3. Enfileirar lote em `POST /api/mois/sales-library/hot-products/dossier-candidates:enqueue`.
-4. O backend apenas marca a página como `INICIADO/intake` e registra auditoria em `pipeline_dossieproduto`.
-5. O `mois-sales-library-worker` consome o endpoint `pending` do `dossieproduto.v1` e executa IA, pesquisa externa, síntese e validação.
-6. O resultado deve virar padrões abstratos para melhorar páginas próprias, nunca cópia literal de páginas externas.
+3. Enfileirar lote em:
+   - `POST /api/mois/sales-library/hot-products/salespagepatterns/v1/candidates:enqueue`;
+   - `POST /api/mois/sales-library/hot-products/warmupecosystem/v1/candidates:enqueue`.
+4. O backend apenas marca a página como `INICIADO/intake` no estado do pipeline correto e registra auditoria em `pipeline_dossieproduto` com `pipeline_code`.
+5. O `mois-sales-library-worker` consome o endpoint `pending` do pipeline aplicável e executa IA, pesquisa externa, síntese e validação.
+6. O resultado de `salespagepatterns.v1` deve virar padrões abstratos para melhorar páginas próprias, nunca cópia literal de páginas externas.
+7. O resultado de `warmupecosystem.v1` deve explicar quais canais e evidências externas parecem aquecer leads antes da venda.
 
 Essa separação mantém o backend como fonte de verdade de leitura/escrita e o worker como executor da inteligência principal.
 

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -50,3 +50,10 @@
 - Pacote canônico mantido para o backend: `com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1`.
 - Módulo executor responsável pela execução operacional: `mois-sales-library-worker`.
 - 2026-06-26 — Aplicado ao pipeline `geraanuncio` v2 no backend, pacote `com.marketinghub.geraanuncio.v2`, etapas `texto` e `imagem`, com endpoints pending canônicos `/api/internal/geraanuncio/v2/texto/stage-executions/pending` e `/api/internal/geraanuncio/v2/imagem/stage-executions/pending` e contratos DTO como `record` em subpacotes de service.
+
+## 2026-07-03 — MOIS Biblioteca de Páginas de Vendas — dois dossiês
+
+- Pacote backend protegido: `com.marketinghub.mois.bibliotecapaginavenda.worker.v1`.
+- Módulo executor externo: `mois-sales-library-worker`.
+- Pipelines expostos para enfileiramento: `salespagepatterns.v1` e `warmupecosystem.v1`.
+- Aplicação: ArchUnit no backend para impedir que a biblioteca vire executor runtime de OpenAI; backend mantém leitura/escrita, custos e contratos.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -78,3 +78,11 @@
 - Pacote protegido: `com.marketinghub.pipelines.geracaoanuncios.v1`.
 - Etapas protegidas: `texto` e `imagem`.
 - Aplicação: protocolo padrão módulo reforçado com conjunto completo de classes por etapa (`BackendClient`, `ExecutionScheduler`, `Input`, `Output`, `Processor`, `PromptBuilder`, `ResponseHandler`, `ResponseValidator`, `WorkerConfiguration` e `WorkerProperties`), mantendo consumo pelo endpoint `pending` canônico e backend fora do escopo do protocolo módulo.
+
+## 2026-07-03 — MOIS Sales Library Worker — dois dossiês
+
+- Módulo executor: `mois-sales-library-worker`.
+- Pipelines nomeados: `salespagepatterns.v1` para padrões de design/visual/copy e `warmupecosystem.v1` para aquecimento/ecossistema.
+- Pacotes protegidos: `com.marketinghub.pipelines.salespagepatterns.v1` e `com.marketinghub.pipelines.warmupecosystem.v1`.
+- Aplicação: reforço ArchUnit para existência dos dois códigos canônicos e bloqueio de dependência direta entre os pipelines.
+- Backend permanece como fonte de verdade de contratos, pendências, callbacks e custos; inteligência principal permanece no worker.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -2010,3 +2010,12 @@ Arquivos principais:
 - Criado comando de enfileiramento em lote que publica os candidatos na etapa `intake` do `dossieproduto.v1`, mantendo IA e pesquisa externa no `mois-sales-library-worker`.
 - Causa-raiz tratada: produtos de sucesso já capturados/analisados ficavam como informação passiva na biblioteca, sem processo recorrente para virar aprendizado comercial reutilizável.
 - Prevenção de recorrência: endpoint e Swagger tornam a seleção/enfileiramento repetíveis para novos produtos quentes que surgirem nas coletas futuras.
+
+## 2026-07-03 — Separação dos dois dossiês da Biblioteca de Páginas de Vendas
+
+- Separados os objetivos em dois pipelines nomeados:
+  - `salespagepatterns.v1`: padrões de design, visual, estrutura e copy.
+  - `warmupecosystem.v1`: aquecimento de leads, canais externos e ecossistema público.
+- O backend passou a enfileirar candidatos por pipeline, registrando `pipeline_code` na auditoria e mantendo custos por página e no total da biblioteca.
+- Regra OpenAI consolidada: tentativa 1 Flex, tentativa 2 Flex e tentativa 3 Standard/default.
+- Prevenção de recorrência: testes ArchUnit protegem separação entre pipelines no worker e impedem que o backend da biblioteca vire executor runtime de OpenAI.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -438,8 +438,8 @@ paths:
           description: Página não encontrada
   /hot-products/dossier-candidates:
     get:
-      summary: Lista produtos quentes prontos para dossiê comercial
-      description: Retorna páginas Hotmart com temperatura acima do limite, HTML útil capturado, análise comercial concluída e sem dossiê v1 ativo/concluído.
+      summary: Lista produtos quentes prontos para o dossiê de aquecimento
+      description: Endpoint compatível que aponta para `warmupecosystem.v1`.
       tags: [MOIS Sales Library]
       parameters:
         - in: query
@@ -468,8 +468,8 @@ paths:
                 $ref: '#/components/schemas/HotProductDossierCandidateResponse'
   /hot-products/dossier-candidates:enqueue:
     post:
-      summary: Enfileira produtos quentes no intake do dossiê v1
-      description: Marca páginas elegíveis como `INICIADO/intake` e registra auditoria mínima em `pipeline_dossieproduto`; a execução de IA permanece no worker externo.
+      summary: Enfileira produtos quentes no intake do dossiê de aquecimento
+      description: Endpoint compatível que aponta para `warmupecosystem.v1`; a execução de IA permanece no worker externo.
       tags: [MOIS Sales Library]
       requestBody:
         required: true
@@ -479,7 +479,99 @@ paths:
               $ref: '#/components/schemas/HotProductDossierEnqueueRequest'
       responses:
         '202':
-          description: Candidatos promovidos para o pipeline dossieproduto.v1
+          description: Candidatos promovidos para o pipeline warmupecosystem.v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierEnqueueResponse'
+  /hot-products/salespagepatterns/v1/candidates:
+    get:
+      summary: Lista produtos quentes para padrões de página
+      description: Retorna páginas Hotmart elegíveis para o pipeline `salespagepatterns.v1`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: minTemperature
+          schema:
+            type: number
+            default: 80
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: Candidatos do pipeline salespagepatterns.v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierCandidateResponse'
+  /hot-products/salespagepatterns/v1/candidates:enqueue:
+    post:
+      summary: Enfileira produtos quentes para padrões de página
+      description: Marca páginas elegíveis no intake de `salespagepatterns.v1`.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HotProductDossierEnqueueRequest'
+      responses:
+        '202':
+          description: Candidatos promovidos para salespagepatterns.v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierEnqueueResponse'
+  /hot-products/warmupecosystem/v1/candidates:
+    get:
+      summary: Lista produtos quentes para aquecimento e ecossistema
+      description: Retorna páginas Hotmart elegíveis para o pipeline `warmupecosystem.v1`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: minTemperature
+          schema:
+            type: number
+            default: 80
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: Candidatos do pipeline warmupecosystem.v1
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotProductDossierCandidateResponse'
+  /hot-products/warmupecosystem/v1/candidates:enqueue:
+    post:
+      summary: Enfileira produtos quentes para aquecimento e ecossistema
+      description: Marca páginas elegíveis no intake de `warmupecosystem.v1`.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HotProductDossierEnqueueRequest'
+      responses:
+        '202':
+          description: Candidatos promovidos para warmupecosystem.v1
           content:
             application/json:
               schema:
@@ -2184,6 +2276,12 @@ components:
       properties:
         workspaceId:
           type: string
+        pipelineCode:
+          type: string
+          example: salespagepatterns.v1
+        pipelineName:
+          type: string
+          example: Padrões de Página de Venda
         minTemperature:
           type: number
         limit:
@@ -2236,6 +2334,12 @@ components:
       properties:
         workspaceId:
           type: string
+        pipelineCode:
+          type: string
+          example: warmupecosystem.v1
+        pipelineName:
+          type: string
+          example: Aquecimento e Ecossistema
         minTemperature:
           type: number
           default: 80
@@ -2270,6 +2374,10 @@ components:
           type: integer
           format: int64
         jobId:
+          type: string
+        pipelineCode:
+          type: string
+        pipelineName:
           type: string
         status:
           type: string

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiServiceTierRetryPolicy.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiServiceTierRetryPolicy.java
@@ -1,0 +1,24 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai;
+
+/** Define a sequência canônica de tentativas OpenAI: duas em Flex e a terceira em Standard/default. */
+public final class OpenAiServiceTierRetryPolicy {
+
+    /** Quantidade máxima de tentativas canônicas para chamadas OpenAI síncronas. */
+    public static final int MAX_ATTEMPTS = 3;
+
+    private OpenAiServiceTierRetryPolicy() {
+    }
+
+    /** Retorna o service_tier efetivo da tentativa informada, usando Standard/default na terceira tentativa. */
+    public static String serviceTierForAttempt(int attempt) {
+        if (attempt <= 0 || attempt > MAX_ATTEMPTS) {
+            throw new IllegalArgumentException("Tentativa OpenAI fora da regra canônica: " + attempt);
+        }
+        return attempt < MAX_ATTEMPTS ? "flex" : "default";
+    }
+
+    /** Informa se a tentativa deve omitir service_tier explícito para representar Standard/default. */
+    public static boolean shouldOmitServiceTier(int attempt) {
+        return "default".equals(serviceTierForAttempt(attempt));
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
@@ -3,6 +3,8 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanaly
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai.OpenAiServiceTierRetryPolicy;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.List;
@@ -15,7 +17,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 /**
- * Executa a análise comercial de páginas de venda via OpenAI Responses em modo Flex e normaliza o JSON retornado.
+ * Executa a análise comercial de páginas de venda via OpenAI Responses e normaliza o JSON retornado.
  */
 @Component
 @Slf4j
@@ -40,33 +42,35 @@ public class OpenAiSalesPageAnalyzer {
     }
 
     /**
-     * Envia o texto capturado da página para análise comercial em modo Flex e retorna o diagnóstico estruturado.
+     * Envia o texto capturado da página para análise comercial com retry Flex/Flex/Standard e retorna o diagnóstico estruturado.
      */
     public SalesPageAnalysisResult analyze(long jobId, long pageId, String canonicalUrl, String htmlBodyText) {
         if (!StringUtils.hasText(properties.resolvedApiKey())) {
             throw new IllegalStateException("OpenAI api key não configurada para análise de sales page");
         }
-        String requestPayload = buildResponsesRequestPayload(pageId, canonicalUrl, htmlBodyText);
-        log.info("MOIS sales-library enviando request cru para OpenAI. jobId={}, requestPayload={}", jobId, requestPayload);
-        String responsePayload = executeFlexResponsesRequest(requestPayload);
+        OpenAiCallResult callResult = executeResponsesRequestWithCanonicalRetry(jobId, pageId, canonicalUrl, htmlBodyText);
+        String requestPayload = callResult.requestPayload();
+        String responsePayload = callResult.responsePayload();
         log.info("MOIS sales-library recebeu resposta crua da OpenAI. jobId={}, rawResponse={}", jobId, responsePayload);
         return parseResponsesOutput(responsePayload, requestPayload);
     }
 
     /**
-     * Monta o JSON enviado diretamente ao endpoint Responses da OpenAI em modo Flex.
+     * Monta o JSON enviado diretamente ao endpoint Responses da OpenAI com o tier da tentativa.
      */
-    String buildResponsesRequestPayload(long pageId, String canonicalUrl, String htmlBodyText) {
+    String buildResponsesRequestPayload(long pageId, String canonicalUrl, String htmlBodyText, int attempt) {
         String prompt = "Analise a página de vendas para identificar por que este produto alcançou sucesso e devolva JSON válido com os campos: score_total (0-100), sections_json (objeto), copy_json (objeto), visual_json (objeto), image_json (objeto), geralanding_wireframe_json (objeto), geralanding_copy_json (objeto), geralanding_image_prompt_json (objeto), geralanding_design_preset_json (objeto), analysis_notes (texto curto). "
                 + "A análise é diagnóstico de sucesso, não consultoria de melhoria: não inclua sugestões, recomendações, próximos passos, itens a adicionar/remover, nem chaves como recommended, suggestions, melhorias ou lacunas em nenhum campo. "
                 + "No campo image_json, explique somente a função persuasiva das imagens existentes no fluxo real: densidade visual, repetição de depoimentos/antes-e-depois, provas visuais, risco assumido de poluição visual e como isso sustenta ou prejudica a clareza da oferta já vencedora. Nos campos geralanding_* extraia somente padrões observados que sirvam de insumo para o pipeline GeraLanding: wireframe deve mapear estrutura/seções/CTAs/formulário; copy deve mapear promessa, dor, mecanismo, prova, oferta e CTA; image_prompt deve mapear funções comerciais das imagens, tipo visual, objeção removida e padrão de prompt reaproveitável; design_preset deve mapear direção visual, hierarquia, CTAs, cards, mockups, mobile e confiança. Não proponha melhorias para a página analisada; descreva padrões vencedores observados como insumo reutilizável. "
                 + "Use o eixo Dor → Resultado → Mecanismo → Prova → Oferta apenas para explicar a fórmula observada que parece ter levado à venda, nunca para propor mudanças. URL: "
                 + canonicalUrl + "\nConteúdo e resumo visual: " + htmlBodyText;
         try {
-            return objectMapper.writeValueAsString(Map.of(
+            ObjectNode request = objectMapper.valueToTree(Map.of(
                     "model", properties.normalizedModel(),
-                    "service_tier", "flex",
-                    "metadata", Map.of("page_id", Long.toString(pageId)),
+                    "metadata", Map.of(
+                            "page_id", Long.toString(pageId),
+                            "openai_attempt", Integer.toString(attempt),
+                            "service_tier_effective", OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt)),
                     "input", List.of(
                             Map.of("role", "system", "content", "Você analisa páginas de venda e responde exclusivamente em JSON válido sem markdown."),
                             Map.of("role", "user", "content", prompt)
@@ -75,24 +79,46 @@ public class OpenAiSalesPageAnalyzer {
                             "format", Map.of("type", "json_object")
                     )
             ));
+            if (!OpenAiServiceTierRetryPolicy.shouldOmitServiceTier(attempt)) {
+                request.put("service_tier", OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt));
+            }
+            return objectMapper.writeValueAsString(request);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Falha ao serializar request Responses Flex", e);
+            throw new IllegalStateException("Falha ao serializar request Responses OpenAI", e);
         }
     }
 
     /**
-     * Executa a chamada síncrona ao endpoint Responses usando service_tier flex.
+     * Executa a chamada síncrona ao endpoint Responses usando duas tentativas Flex e terceira Standard/default.
      */
-    private String executeFlexResponsesRequest(String requestPayload) {
-        String response = restClient.post().uri("/responses")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(requestPayload)
-                .retrieve()
-                .body(String.class);
-        if (!StringUtils.hasText(response)) {
-            throw new IllegalStateException("OpenAI Responses Flex retornou corpo vazio");
+    private OpenAiCallResult executeResponsesRequestWithCanonicalRetry(long jobId, long pageId, String canonicalUrl, String htmlBodyText) {
+        RuntimeException lastFailure = null;
+        for (int attempt = 1; attempt <= OpenAiServiceTierRetryPolicy.MAX_ATTEMPTS; attempt++) {
+            String requestPayload = buildResponsesRequestPayload(pageId, canonicalUrl, htmlBodyText, attempt);
+            String tier = OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt);
+            try {
+                log.info("MOIS sales-library enviando request cru para OpenAI. jobId={}, attempt={}, serviceTier={}, requestPayload={}",
+                        jobId, attempt, tier, requestPayload);
+                String response = restClient.post().uri("/responses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(requestPayload)
+                        .retrieve()
+                        .body(String.class);
+                if (!StringUtils.hasText(response)) {
+                    throw new IllegalStateException("OpenAI Responses retornou corpo vazio");
+                }
+                return new OpenAiCallResult(requestPayload, response);
+            } catch (RuntimeException ex) {
+                lastFailure = ex;
+                log.warn("Falha transitória OpenAI sales-library. jobId={}, attempt={}, serviceTier={}",
+                        jobId, attempt, tier, ex);
+            }
         }
-        return response;
+        throw lastFailure == null ? new IllegalStateException("OpenAI não executou nenhuma tentativa") : lastFailure;
+    }
+
+    /** Guarda o request e a response brutos da tentativa OpenAI bem-sucedida. */
+    private record OpenAiCallResult(String requestPayload, String responsePayload) {
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1Runner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1Runner.java
@@ -7,26 +7,19 @@ import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1Ba
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.DossierV1BackendClient.DossierRecebeResponseRequest;
 import com.marketinghub.pipelines.dossie.v1.PipelineWorker;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
+import com.marketinghub.pipelines.warmupecosystem.v1.WarmupEcosystemPipelineDefinition;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-/** Executa somente o pipeline canônico de dossiê MOIS v1, substituindo o fluxo legado de market-warmup. */
+/** Executa somente o pipeline canônico warmupecosystem.v1, substituindo o fluxo legado de market-warmup. */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class DossierV1Runner {
-    private static final List<String> STAGES = List.of(
-            "intake",
-            "product-understanding",
-            "investigation-anchor-builder",
-            "warmup-resource-discovery",
-            "source-product-match",
-            "warmup-signal-extraction",
-            "warmup-map-builder",
-            "dossier-synthesis");
+    private static final List<String> STAGES = WarmupEcosystemPipelineDefinition.stages();
 
     private final DossierV1BackendClient backendClient;
     private final PipelineWorker pipelineWorker;

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/productunderstanding/DossierProductUnderstandingProcessor.java
@@ -2,6 +2,8 @@ package com.marketinghub.pipelines.dossie.v1.productunderstanding;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai.OpenAiServiceTierRetryPolicy;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis.OpenAiProperties;
 import com.marketinghub.pipelines.dossie.v1.DossierStageSupport;
 import com.marketinghub.pipelines.dossie.v1.StageContext;
@@ -68,14 +70,9 @@ public class DossierProductUnderstandingProcessor implements StageProcessor {
     /** Executa a etapa usando OpenAI e preserva request, response, texto final, modelo e tokens para auditoria. */
     private StageResult processWithOpenAi(StageContext context) {
         try {
-            String rawRequest = buildOpenAiRequest(context);
-            log.info("MOIS dossie v1 product-understanding enviando request cru para OpenAI. jobId={}, requestPayload={}",
-                    context.stageExecutionId(), rawRequest);
-            String rawResponse = openAiClient.post().uri("/responses")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(rawRequest)
-                    .retrieve()
-                    .body(String.class);
+            OpenAiCallResult callResult = executeOpenAiWithCanonicalRetry(context);
+            String rawRequest = callResult.rawRequest();
+            String rawResponse = callResult.rawResponse();
             if (!StringUtils.hasText(rawResponse)) {
                 throw new IllegalStateException("OpenAI Responses Flex retornou corpo vazio em product-understanding");
             }
@@ -105,19 +102,53 @@ public class DossierProductUnderstandingProcessor implements StageProcessor {
     }
 
     /** Monta o request Responses Flex enviado diretamente à OpenAI para entender o produto. */
-    private String buildOpenAiRequest(StageContext context) throws Exception {
+    private String buildOpenAiRequest(StageContext context, int attempt) throws Exception {
         String prompt = loadPrompt().replace("{{context}}", objectMapper.writeValueAsString(context.input()));
-        return objectMapper.writeValueAsString(Map.of(
-                "model", openAiProperties.normalizedModel(),
-                "service_tier", "flex",
-                "metadata", Map.of(
-                        "stage", STAGE_NAME,
-                        "stage_execution_id", Long.toString(context.stageExecutionId()),
-                        "dossier_id", Long.toString(context.dossierId())),
-                "input", List.of(
-                        Map.of("role", "system", "content", "Você estrutura entendimento comercial de produto, protege o dossiê contra inferência sem evidência e responde exclusivamente JSON válido sem markdown."),
-                        Map.of("role", "user", "content", prompt)),
-                "text", Map.of("format", Map.of("type", "json_object"))));
+        ObjectNode request = objectMapper.valueToTree(Map.of(
+            "model", openAiProperties.normalizedModel(),
+            "metadata", Map.of(
+                    "stage", STAGE_NAME,
+                    "stage_execution_id", Long.toString(context.stageExecutionId()),
+                    "dossier_id", Long.toString(context.dossierId()),
+                    "openai_attempt", Integer.toString(attempt),
+                    "service_tier_effective", OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt)),
+            "input", List.of(
+                    Map.of("role", "system", "content", "Você estrutura entendimento comercial de produto, protege o dossiê contra inferência sem evidência e responde exclusivamente JSON válido sem markdown."),
+                    Map.of("role", "user", "content", prompt)),
+            "text", Map.of("format", Map.of("type", "json_object"))));
+        if (!OpenAiServiceTierRetryPolicy.shouldOmitServiceTier(attempt)) {
+            request.put("service_tier", OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt));
+        }
+        return objectMapper.writeValueAsString(request);
+    }
+
+    /** Executa OpenAI com duas tentativas Flex e terceira Standard/default, preservando o último request bruto. */
+    private OpenAiCallResult executeOpenAiWithCanonicalRetry(StageContext context) throws Exception {
+        RuntimeException lastFailure = null;
+        String lastRequest = null;
+        for (int attempt = 1; attempt <= OpenAiServiceTierRetryPolicy.MAX_ATTEMPTS; attempt++) {
+            lastRequest = buildOpenAiRequest(context, attempt);
+            String tier = OpenAiServiceTierRetryPolicy.serviceTierForAttempt(attempt);
+            try {
+                log.info("MOIS dossie v1 product-understanding enviando request cru para OpenAI. jobId={}, attempt={}, serviceTier={}, requestPayload={}",
+                        context.stageExecutionId(), attempt, tier, lastRequest);
+                String rawResponse = openAiClient.post().uri("/responses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(lastRequest)
+                        .retrieve()
+                        .body(String.class);
+                return new OpenAiCallResult(lastRequest, rawResponse);
+            } catch (RuntimeException ex) {
+                lastFailure = ex;
+                log.warn("Falha transitória OpenAI product-understanding. jobId={}, attempt={}, serviceTier={}",
+                        context.stageExecutionId(), attempt, tier, ex);
+            }
+        }
+        throw lastFailure == null ? new IllegalStateException("OpenAI não executou nenhuma tentativa") : lastFailure;
+    }
+
+    /** Guarda o último request enviado e a resposta recebida da OpenAI. */
+    private record OpenAiCallResult(String rawRequest, String rawResponse) {
     }
 
     /** Carrega o prompt versionado da etapa para evitar contrato hardcoded na classe Java. */

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/salespagepatterns/v1/SalesPagePatternsPipelineDefinition.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/salespagepatterns/v1/SalesPagePatternsPipelineDefinition.java
@@ -1,0 +1,23 @@
+package com.marketinghub.pipelines.salespagepatterns.v1;
+
+import java.util.List;
+
+/** Define o pipeline de padrões de página de venda, focado em design, visual e copy reutilizáveis. */
+public final class SalesPagePatternsPipelineDefinition {
+
+    /** Código canônico usado nos contratos e relatórios do Marketing Hub. */
+    public static final String CODE = "salespagepatterns.v1";
+
+    private static final List<String> STAGES = List.of(
+            "intake",
+            "page-pattern-extraction",
+            "pattern-synthesis");
+
+    private SalesPagePatternsPipelineDefinition() {
+    }
+
+    /** Lista as etapas independentes planejadas para o pipeline de padrões de página. */
+    public static List<String> stages() {
+        return STAGES;
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/warmupecosystem/v1/WarmupEcosystemPipelineDefinition.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/warmupecosystem/v1/WarmupEcosystemPipelineDefinition.java
@@ -1,0 +1,28 @@
+package com.marketinghub.pipelines.warmupecosystem.v1;
+
+import java.util.List;
+
+/** Define o pipeline de aquecimento e ecossistema, focado em canais, sinais externos e pré-venda. */
+public final class WarmupEcosystemPipelineDefinition {
+
+    /** Código canônico usado nos contratos e relatórios do Marketing Hub. */
+    public static final String CODE = "warmupecosystem.v1";
+
+    private static final List<String> STAGES = List.of(
+            "intake",
+            "product-understanding",
+            "investigation-anchor-builder",
+            "warmup-resource-discovery",
+            "source-product-match",
+            "warmup-signal-extraction",
+            "warmup-map-builder",
+            "dossier-synthesis");
+
+    private WarmupEcosystemPipelineDefinition() {
+    }
+
+    /** Lista as etapas independentes executadas pelo pipeline de aquecimento e ecossistema. */
+    public static List<String> stages() {
+        return STAGES;
+    }
+}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/ArquiteturaTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/ArquiteturaTest.java
@@ -4,6 +4,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.StageProcessor;
+import com.marketinghub.pipelines.salespagepatterns.v1.SalesPagePatternsPipelineDefinition;
+import com.marketinghub.pipelines.warmupecosystem.v1.WarmupEcosystemPipelineDefinition;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -29,6 +31,8 @@ class ArquiteturaTest {
     private static final String PIPELINE_ROOT = "com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline";
     private static final String DOSSIER_V1_PIPELINE_ROOT = "com.marketinghub.pipelines.dossie.v1";
     private static final String DOSSIE_PRODUTO_V1_PIPELINE_ROOT = "com.marketinghub.pipelines.dossieproduto.v1";
+    private static final String SALES_PAGE_PATTERNS_V1_ROOT = "com.marketinghub.pipelines.salespagepatterns.v1";
+    private static final String WARMUP_ECOSYSTEM_V1_ROOT = "com.marketinghub.pipelines.warmupecosystem.v1";
     private static final List<String> DOSSIE_PRODUTO_STAGE_SUFFIXES = List.of(
             "BackendClient",
             "ExecutionScheduler",
@@ -136,6 +140,40 @@ class ArquiteturaTest {
             .resideInAPackage(DOSSIER_V1_PIPELINE_ROOT)
             .should(notDependOnConcreteTechnologies())
             .because("[ARQUITETURA] o núcleo do dossiê MOIS v1 deve depender de abstrações, não de tecnologias concretas");
+
+    /** Garante que os dois pipelines de dossiê da biblioteca existem com nomes versionados e comunicáveis. */
+    @ArchTest
+    static void dois_pipelines_da_biblioteca_devem_ter_codigos_canonicos(JavaClasses classes) {
+        boolean hasSalesPagePatterns = classes.stream()
+                .anyMatch(javaClass -> javaClass.getName().equals(SalesPagePatternsPipelineDefinition.class.getName()));
+        boolean hasWarmupEcosystem = classes.stream()
+                .anyMatch(javaClass -> javaClass.getName().equals(WarmupEcosystemPipelineDefinition.class.getName()));
+        if (!hasSalesPagePatterns || !hasWarmupEcosystem) {
+            throw new AssertionError("[ARQUITETURA] a biblioteca deve declarar os pipelines salespagepatterns.v1 e warmupecosystem.v1");
+        }
+        if (!"salespagepatterns.v1".equals(SalesPagePatternsPipelineDefinition.CODE)) {
+            throw new AssertionError("[ARQUITETURA] código canônico do pipeline de padrões deve ser salespagepatterns.v1");
+        }
+        if (!"warmupecosystem.v1".equals(WarmupEcosystemPipelineDefinition.CODE)) {
+            throw new AssertionError("[ARQUITETURA] código canônico do pipeline de aquecimento deve ser warmupecosystem.v1");
+        }
+    }
+
+    /** Garante desacoplamento direto entre os dois pipelines de dossiê da biblioteca. */
+    @ArchTest
+    static final ArchRule salespagepatterns_nao_deve_depender_de_warmupecosystem = classes()
+            .that()
+            .resideInAPackage(SALES_PAGE_PATTERNS_V1_ROOT + "..")
+            .should(notDependOnPackage(WARMUP_ECOSYSTEM_V1_ROOT))
+            .because("[ARQUITETURA] salespagepatterns.v1 deve ser coeso e não depender do pipeline warmupecosystem.v1");
+
+    /** Garante desacoplamento direto entre os dois pipelines de dossiê da biblioteca. */
+    @ArchTest
+    static final ArchRule warmupecosystem_nao_deve_depender_de_salespagepatterns = classes()
+            .that()
+            .resideInAPackage(WARMUP_ECOSYSTEM_V1_ROOT + "..")
+            .should(notDependOnPackage(SALES_PAGE_PATTERNS_V1_ROOT))
+            .because("[ARQUITETURA] warmupecosystem.v1 deve ser coeso e não depender do pipeline salespagepatterns.v1");
 
 
     /** Garante que cada subpacote de dossieproduto.v1 tenha somente as 9 classes canônicas da etapa. */
@@ -268,6 +306,20 @@ class ArquiteturaTest {
                     events.add(new SimpleConditionEvent(dependency, valid,
                             "[ARQUITETURA] " + javaClass.getName() + " da etapa " + sourceStage
                                     + " não pode depender de " + target.getName() + " da etapa " + targetStage));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> notDependOnPackage(String forbiddenPackagePrefix) {
+        return new ArchCondition<>("[ARQUITETURA] não depender de " + forbiddenPackagePrefix) {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    boolean valid = !target.getPackageName().startsWith(forbiddenPackagePrefix);
+                    events.add(new SimpleConditionEvent(dependency, valid,
+                            "[ARQUITETURA] " + javaClass.getName() + " não pode depender de " + target.getName()));
                 }
             }
         };

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiServiceTierRetryPolicyTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiServiceTierRetryPolicyTest.java
@@ -1,0 +1,18 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Valida a regra canônica de tentativas OpenAI Flex, Flex e Standard/default. */
+class OpenAiServiceTierRetryPolicyTest {
+
+    /** Garante que as três tentativas usam os tiers definidos para todo o sistema. */
+    @Test
+    void shouldUseFlexFlexAndStandardDefault() {
+        assertThat(OpenAiServiceTierRetryPolicy.serviceTierForAttempt(1)).isEqualTo("flex");
+        assertThat(OpenAiServiceTierRetryPolicy.serviceTierForAttempt(2)).isEqualTo("flex");
+        assertThat(OpenAiServiceTierRetryPolicy.serviceTierForAttempt(3)).isEqualTo("default");
+        assertThat(OpenAiServiceTierRetryPolicy.shouldOmitServiceTier(3)).isTrue();
+    }
+}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzerTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzerTest.java
@@ -15,7 +15,7 @@ class OpenAiSalesPageAnalyzerTest {
                 RestClient.builder(),
                 new OpenAiProperties("test-key", "http://localhost", "gpt-test", 900000, null));
 
-        String payload = analyzer.buildResponsesRequestPayload(10L, "https://example.com", "Resumo visual extraído do HTML: total_img=12");
+        String payload = analyzer.buildResponsesRequestPayload(10L, "https://example.com", "Resumo visual extraído do HTML: total_img=12", 1);
 
         assertTrue(payload.contains("identificar por que este produto alcançou sucesso"));
         assertTrue(payload.contains("não inclua sugestões"));
@@ -25,5 +25,18 @@ class OpenAiSalesPageAnalyzerTest {
         assertTrue(payload.contains("padrões vencedores observados como insumo reutilizável"));
         assertFalse(payload.contains("recommended_images"));
         assertTrue(payload.contains("\"service_tier\":\"flex\""));
+    }
+
+    /** Garante que a terceira tentativa representa Standard/default omitindo service_tier explícito. */
+    @Test
+    void shouldUseStandardDefaultOnThirdOpenAiAttempt() {
+        OpenAiSalesPageAnalyzer analyzer = new OpenAiSalesPageAnalyzer(
+                RestClient.builder(),
+                new OpenAiProperties("test-key", "http://localhost", "gpt-test", 900000, null));
+
+        String payload = analyzer.buildResponsesRequestPayload(10L, "https://example.com", "Resumo visual extraído do HTML", 3);
+
+        assertFalse(payload.contains("\"service_tier\":\""));
+        assertTrue(payload.contains("\"service_tier_effective\":\"default\""));
     }
 }


### PR DESCRIPTION
## O que mudou

- Separa a Biblioteca de Páginas de Vendas em dois pipelines nomeados:
  - `salespagepatterns.v1`: padrões de design, visual, estrutura e copy.
  - `warmupecosystem.v1`: aquecimento de leads, canais externos e ecossistema.
- Adiciona endpoints explícitos de candidatos/enfileiramento para os dois pipelines, mantendo os endpoints antigos como compatibilidade para `warmupecosystem.v1`.
- Persiste `pipeline_code` na auditoria do dossiê e adiciona estados paralelos por pipeline em `mois_sales_page`.
- Passa a acumular custo OpenAI no total individual da página e no total da biblioteca.
- Centraliza o cálculo de custo MOIS no serviço comum de preço OpenAI do backend.
- Implementa regra OpenAI: tentativa 1 Flex, tentativa 2 Flex, tentativa 3 Standard/default.
- Adiciona definições versionadas dos dois pipelines no worker e regras ArchUnit de desacoplamento.
- Atualiza Swagger, cânones, registros de protocolo e documentação MOIS.

## Validação

- `./backend/mvnw -f backend/ads-service/pom.xml -Dtest=MoisSalesLibraryServiceTest,MoisSalesLibraryControllerTest,MoisSalesLibraryPricingServiceTest,MoisSalesLibraryArchitectureTest test`
- `./backend/mvnw -f mois-sales-library-worker/pom.xml -Dtest=ArquiteturaTest,OpenAiSalesPageAnalyzerTest,OpenAiServiceTierRetryPolicyTest,DossierV1RunnerTest,PipelineWorkerTest test`
- `git diff --check`
- Validação manual do changelog: includes relativos com `relativeToChangelogFile: true` e sem `TIMESTAMP NOT NULL` sem default.

## Observação

`spotless:check` não está disponível no `backend/ads-service` neste checkout: Maven retornou `No plugin found for prefix 'spotless'`.