### PR TITLE
[codex] Document AI product subtypes and systemic creation flow

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -211,6 +211,35 @@ Regras obrigatórias:
 - produto low-ticket deve ser interpretado como pacote de infoprodutos de baixo custo, produzido majoritariamente por IA e financeiramente viável;
 - Produto IA deve ser interpretado como infoproduto/ferramenta com integração OpenAI por trás, vendido pela facilidade e pelo resultado prático no dia a dia, não pelo jargão de IA.
 
+### 4.2.1.0 Regra mandatória — criação sistêmica de produto e variação
+
+Nenhum produto, oferta, página, amostra, checkout, campanha ou variação comercial deve ser criado por decisão manual isolada fora do fluxo do sistema.
+
+Toda criação precisa preservar a trilha:
+
+```text
+Nicho/contexto
+→ Hipótese
+→ Dor
+→ Resultado
+→ Mecanismo
+→ Prova
+→ Oferta
+→ Tipo/subtipo de produto
+→ Página/amostra/checkout
+→ Experimento
+→ Métrica e aprendizado
+```
+
+Regras obrigatórias:
+
+- Produto IA, low-ticket e suas variações devem nascer de recursos oficiais do sistema, nunca de documentos soltos ou criação manual direta;
+- criar para outro nicho significa executar novamente o fluxo com novo contexto de nicho;
+- melhorar um produto existente significa criar nova versão ou novo experimento com variável primária declarada;
+- prompts, schemas, custos, entradas, saídas e decisões devem permanecer auditáveis;
+- padrões da Biblioteca de Páginas de Vendas podem enriquecer o briefing, mas não substituem as etapas de hipótese, dor, mecanismo, prova, oferta e validação;
+- se algum ativo for criado emergencialmente fora do fluxo, ele deve ser tratado como material provisório não canônico e não pode ser publicado ou escalado até ser reconstruído pelo sistema.
+
 ### 4.2.1.1 Regra mandatória — prompt/schema por experimento
 
 Todo experimento criado a partir de hipótese gerada por IA deve preservar associação aos prompts e schemas usados nas etapas Dor, Resultado, Mecanismo, Prova e Oferta. Todo experimento que gerar página pelo GeraSalesPage v1 também deve preservar associação aos prompts e schemas usados nas etapas da página de venda.

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -51,6 +51,46 @@ Caracteristicas obrigatorias:
 
 Produto IA pode nascer como teste controlado dentro do planejamento, mas so deve virar campanha ou produto principal quando o ganho percebido for claro e o custo por uso permitir lucro.
 
+### Subtipos canonicos de Produto IA
+
+Produto IA nao deve ser tratado como uma categoria unica. O sistema deve classificar o subtipo porque cada um possui promessa, custo, experiencia, metrica e risco operacional diferentes.
+
+Subtipos iniciais:
+
+| Subtipo | Nome operacional | Objetivo comercial | Uso recomendado |
+|---|---|---|---|
+| `AI_VISUAL_PREVIEW` | AI Visual Preview | Mostrar uma previa visual do resultado, do depois ou da entrega. | Quando a imagem ajuda o lead a entender rapidamente o beneficio prometido. |
+| `AI_PERSONALIZED_SAMPLE` | AI Personalized Sample | Gerar uma amostra visual ou textual exclusiva para o lead antes da compra. | Primeiro MVP recomendado para testar impacto visual e personalizacao. |
+| `AI_TRANSFORMATION_SIMULATOR` | AI Transformation Simulator | Simular visualmente uma transformacao desejada. | Quando a promessa depende de comparar estado atual e estado desejado. |
+| `AI_VISUAL_ASSET_PACK` | AI Visual Asset Pack | Entregar pacote de imagens, criativos, mockups ou materiais visuais personalizados. | Quando o cliente compra ativos prontos para usar. |
+| `AI_IDENTITY_AVATAR_PRODUCT` | AI Identity / Avatar Product | Criar representacao visual de pessoa, marca, persona, avatar ou estilo. | Quando identidade, pertencimento ou expressao visual forem parte central do valor. |
+| `AI_REPORT_VISUAL_EVIDENCE` | AI Report + Visual Evidence | Combinar diagnostico textual com imagens, graficos ou quadros visuais. | Quando o visual aumenta clareza, prova ou urgencia da decisao. |
+
+O subtipo nao substitui o tipo principal `Produto IA`. Ele especializa a experiencia para que o sistema consiga comparar resultados, custos e aprendizados entre produtos parecidos.
+
+### Regra mandatória — Produto IA nasce pelo sistema
+
+Nenhum Produto IA, low-ticket, oferta, pagina, checkout, amostra, promessa ou variacao deve ser criado manualmente como atalho fora dos recursos do Marketing Hub.
+
+Todo Produto IA deve nascer por uma execucao rastreavel do sistema, preservando no minimo:
+
+- nicho ou contexto de origem;
+- hipotese;
+- dor principal;
+- resultado desejado;
+- mecanismo plausivel;
+- prova ou evidencia usada;
+- oferta;
+- tipo e subtipo de produto;
+- prompts e schemas usados;
+- custos estimados e realizados de IA;
+- experimento de validacao;
+- versao ou variavel primaria quando for uma variacao.
+
+Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.
+
+Padroes externos, como os dossies da Biblioteca de Paginas de Vendas, podem ser usados como insumo de briefing e aprendizado. Eles nao podem substituir a geracao rastreavel de hipotese, dor, mecanismo, prova, oferta e experimento pelo sistema.
+
 ## Decisao entre tipos
 
 Use low-ticket quando o problema pode ser resolvido por um pacote digital estatico ou semi-estatico, barato, rapido de produzir e vendavel por pagina curta.

--- a/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
+++ b/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
@@ -1,0 +1,89 @@
+# Plano — experimentos com Produto IA visual e personalizado
+
+## Objetivo
+
+Preparar experimentos de Produto IA que usem imagem gerada por IA e personalizacao como mecanismos de aumento de valor percebido, sem criar produtos manualmente fora do Marketing Hub.
+
+## Regra principal
+
+Nenhum Produto IA visual ou personalizado deve ser criado como ideia isolada, exemplo manual ou ativo avulso.
+
+Todo teste precisa nascer pelo fluxo:
+
+```text
+Nicho/contexto
+→ Hipotese
+→ Dor
+→ Resultado
+→ Mecanismo
+→ Prova
+→ Oferta
+→ Subtipo de Produto IA
+→ Amostra/produto
+→ Experimento
+→ Medicao
+```
+
+Isso garante que o sistema consiga:
+
+- explicar como o produto foi criado;
+- criar o mesmo tipo de produto para outro nicho;
+- variar a oferta de forma controlada;
+- comparar resultados por subtipo;
+- preservar prompts, schemas, custos e aprendizados.
+
+## Subtipos iniciais
+
+| Subtipo | Hipotese de valor | Primeiro uso recomendado |
+|---|---|---|
+| `AI_VISUAL_PREVIEW` | Ver o resultado aumenta clareza e desejo. | Previa visual do produto ou transformacao. |
+| `AI_PERSONALIZED_SAMPLE` | Receber algo exclusivo aumenta valor percebido e reciprocidade. | MVP inicial. |
+| `AI_TRANSFORMATION_SIMULATOR` | Antes/depois reduz abstracao da promessa. | Nichos com transformacao visual clara. |
+| `AI_VISUAL_ASSET_PACK` | Pacote visual pronto para uso aumenta percepcao de entrega. | Produtos para negocios, criadores e profissionais. |
+| `AI_IDENTITY_AVATAR_PRODUCT` | Identidade visual personalizada gera desejo de posse. | Marca pessoal, avatar, estilo e posicionamento. |
+| `AI_REPORT_VISUAL_EVIDENCE` | Evidencia visual torna diagnostico mais convincente. | Diagnosticos, auditorias e planos de acao. |
+
+## MVP recomendado
+
+Comecar por `AI_PERSONALIZED_SAMPLE`.
+
+Motivos:
+
+- testa impacto visual e personalizacao no mesmo experimento;
+- gera uma entrega concreta antes da compra;
+- permite medir custo de IA por lead;
+- pode ser comparado contra uma rota sem amostra;
+- cria aprendizado reutilizavel para outros nichos.
+
+## Desenho experimental inicial
+
+Fluxo:
+
+```text
+Anuncio
+→ Pagina/formulario com promessa unica
+→ Entrada minima do lead
+→ Amostra personalizada gerada por IA
+→ Oferta paga para pacote completo
+→ Compra/nao compra
+```
+
+Metricas:
+
+- custo por lead;
+- taxa de conclusao do formulario;
+- taxa de visualizacao da amostra;
+- clique da amostra para checkout;
+- compra;
+- custo de IA por lead;
+- custo de IA por compra;
+- margem por compra;
+- aprendizado qualitativo da amostra.
+
+## Cuidados
+
+- A imagem nao deve ser decoracao. Ela precisa provar, tangibilizar, personalizar ou reduzir esforco mental.
+- A amostra nao deve entregar valor suficiente para eliminar a compra.
+- O custo por geracao deve ter limite antes da escala.
+- Cada variacao deve declarar uma unica variavel primaria.
+- Se o ativo nao puder ser reconstruido pelo sistema, ele nao deve ser publicado como experimento canônico.

--- a/docs/implementacao/experimentos/plano-mestre-evolucao-funis-produtos-personalizacao.md
+++ b/docs/implementacao/experimentos/plano-mestre-evolucao-funis-produtos-personalizacao.md
@@ -1700,3 +1700,65 @@ O primeiro PR deve entregar:
 8. testes.
 
 Isso cria o vocabulário necessário para todas as fases seguintes e reduz o risco de adicionar novas automações sobre estados implícitos.
+
+---
+
+## 24. Produto IA visual e personalizado
+
+### 24.1 Decisão
+
+O tipo `Produto IA` deve ser subdividido para que o Marketing Hub consiga testar mecanismos diferentes sem misturar aprendizado comercial.
+
+Subtipos iniciais:
+
+- `AI_VISUAL_PREVIEW`;
+- `AI_PERSONALIZED_SAMPLE`;
+- `AI_TRANSFORMATION_SIMULATOR`;
+- `AI_VISUAL_ASSET_PACK`;
+- `AI_IDENTITY_AVATAR_PRODUCT`;
+- `AI_REPORT_VISUAL_EVIDENCE`.
+
+O primeiro MVP recomendado e `AI_PERSONALIZED_SAMPLE`, porque testa duas hipoteses importantes ao mesmo tempo:
+
+- imagens geradas por IA podem aumentar impacto, desejo e tangibilizacao do resultado;
+- personalizacao visual pode aumentar valor percebido porque o lead recebe algo criado para ele.
+
+### 24.2 Alternativas avaliadas
+
+| Alternativa | Beneficio | Risco | Esforco | Decisao |
+|---|---|---|---|---|
+| Usar imagens bonitas apenas em anuncio ou pagina | Rapido e barato | Pode melhorar CTR sem melhorar venda | Baixo | Nao e suficiente como estrategia principal |
+| Criar exemplos manuais de Produto IA | Ajuda a visualizar possibilidades | Quebra rastreabilidade e dificulta repetir em outro nicho | Baixo/medio | Rejeitado |
+| Criar produtos pelo fluxo sistemico com subtipo, hipotese e experimento | Repetivel, auditavel e comparavel | Exige evoluir contratos e telas | Medio | Escolhido |
+
+### 24.3 Regra operacional
+
+Produto nenhum deve nascer por conta propria. O sistema deve ser capaz de explicar como ele foi criado e de recria-lo para outro nicho ou varia-lo para melhoria.
+
+Todo Produto IA visual ou personalizado precisa registrar:
+
+- nicho/contexto;
+- hipotese;
+- dor;
+- resultado;
+- mecanismo;
+- prova;
+- oferta;
+- subtipo;
+- entrada solicitada ao lead;
+- saida prometida;
+- prompts/schemas;
+- custo estimado por lead ou cliente;
+- experimento de validacao;
+- metrica primaria;
+- regra de parada ou invalidacao.
+
+### 24.4 Experimentos a preparar
+
+Sequencia recomendada:
+
+1. Criar suporte sistemico para declarar subtipo de Produto IA na criacao/estrategia do experimento.
+2. Permitir que o fluxo de hipotese/oferta gere um Produto IA `AI_PERSONALIZED_SAMPLE` sem criar ativos manualmente.
+3. Criar contrato de amostra personalizada com entrada minima do lead, saida gerada, custo e status.
+4. Publicar experimento pequeno comparando amostra personalizada contra rota sem amostra, mantendo uma unica variavel primaria.
+5. Medir custo por lead, taxa de visualizacao da amostra, clique para checkout, compra, custo de IA por compra e margem.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5559,3 +5559,11 @@
 - Causa-raiz: o changelog não seguiu o padrão seguro do projeto para datas em MySQL 5.7 e ainda estava incluído antes das tabelas base do GeraSalesPage.
 - Correção aplicada: `published_at` e `created_at` passaram para `DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`, `completed_at` passou para `DATETIME(6)` e o include da auditoria foi movido para depois dos changelogs base do GeraSalesPage.
 - Prevenção de recorrência: o diff foi revisado contra as regras de Liquibase/MySQL 5.7, mantendo `relativeToChangelogFile: true` no changelog mestre.
+
+## 2026-07-03 — Produto IA visual e personalizacao
+
+- Decisão: o tipo `Produto IA` passa a ter subtipos canonicos para separar mecanismos de valor visual e personalizacao: `AI_VISUAL_PREVIEW`, `AI_PERSONALIZED_SAMPLE`, `AI_TRANSFORMATION_SIMULATOR`, `AI_VISUAL_ASSET_PACK`, `AI_IDENTITY_AVATAR_PRODUCT` e `AI_REPORT_VISUAL_EVIDENCE`.
+- Hipótese inicial: imagens geradas pela OpenAI podem aumentar impacto, desejo e tangibilizacao do resultado; personalizacao visual pode aumentar valor percebido por entregar algo exclusivo ao lead ou cliente.
+- MVP recomendado: `AI_PERSONALIZED_SAMPLE`, por testar impacto visual e personalizacao no mesmo fluxo.
+- Regra registrada: nenhum produto, oferta, pagina, amostra, checkout ou variacao deve ser criado manualmente como atalho; tudo precisa nascer por recursos oficiais do sistema com rastreabilidade de nicho, hipotese, dor, resultado, mecanismo, prova, oferta, prompts/schemas, custos e experimento.
+- Prevenção de recorrência: padrões externos e ideias estratégicas podem enriquecer o briefing, mas não substituem o fluxo sistêmico de criação e validação.


### PR DESCRIPTION
## Resumo

- Documenta os subtipos canonicos de Produto IA: visual preview, personalized sample, transformation simulator, visual asset pack, identity/avatar e report visual evidence.
- Registra a regra de que nenhum produto, oferta, pagina, amostra, checkout ou variacao deve nascer manualmente fora do fluxo do sistema.
- Adiciona plano inicial para experimentos com Produto IA visual/personalizado, com MVP recomendado em `AI_PERSONALIZED_SAMPLE`.
- Atualiza o plano mestre e o registro de experimentos com a decisao e a justificativa.

## Impacto

A mudanca organiza o caminho para testar imagens e personalizacao por IA sem perder rastreabilidade de nicho, hipotese, dor, mecanismo, prova, oferta, prompts/schemas, custos e experimento.

## Validacao

- `git diff --check`
- Mudanca apenas documental; testes de codigo nao foram executados.