### PR TITLE
Add product AI subtype to experiment flow

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -13,6 +13,7 @@ import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.imagegeneration.ImageGenerationModel;
 import com.marketinghub.imagegeneration.ImageGenerationQuality;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.sampleemail.SampleEmail;
 
 import java.time.Instant;
@@ -64,6 +65,11 @@ public class Experiment {
     @Enumerated(EnumType.STRING)
     @Column(name = "experiment_type", length = 32, nullable = false)
     private ExperimentType experimentType = ExperimentType.NICHE_TEST;
+
+    /** Subtipo de Produto IA herdado da hipótese ou definido explicitamente para rastrear o experimento. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_ai_subtype", length = 48)
+    private ProductAiSubtype productAiSubtype;
 
     /** Objetivo de campanha exigido para publicação do experimento. */
     @Builder.Default

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.productai.ProductAiSubtype;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Data;
@@ -24,6 +25,7 @@ public class CreateExperimentRequest {
     private String funnelPromise;
     private String primaryCta;
     private ExperimentType experimentType;
+    private ProductAiSubtype productAiSubtype;
     private ExperimentCampaignObjective campaignObjective;
     private ExperimentStage stage;
     private String primaryVariable;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.CreativeGenerationStatus;
+import com.marketinghub.productai.ProductAiSubtype;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ public class ExperimentDto {
     private String funnelPromise;
     private String primaryCta;
     private ExperimentType experimentType;
+    private ProductAiSubtype productAiSubtype;
     private ExperimentCampaignObjective campaignObjective;
     private FacebookPageDto facebookPage;
     private FacebookInstantFormDto facebookInstantForm;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.productai.ProductAiSubtype;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import lombok.Data;
@@ -33,6 +34,9 @@ public class UpdateExperimentRequest {
     private ExperimentType experimentType;
     @JsonIgnore
     private boolean experimentTypePresent;
+    private ProductAiSubtype productAiSubtype;
+    @JsonIgnore
+    private boolean productAiSubtypePresent;
     private ExperimentCampaignObjective campaignObjective;
     @JsonIgnore
     private boolean campaignObjectivePresent;
@@ -143,6 +147,13 @@ public class UpdateExperimentRequest {
     public void setExperimentType(ExperimentType experimentType) {
         this.experimentType = experimentType;
         this.experimentTypePresent = true;
+    }
+
+    /** Registra a presença do subtipo de Produto IA no payload de atualização. */
+    @JsonSetter(value = "productAiSubtype", nulls = Nulls.SET)
+    public void setProductAiSubtype(ProductAiSubtype productAiSubtype) {
+        this.productAiSubtype = productAiSubtype;
+        this.productAiSubtypePresent = true;
     }
 
     /** Registra a presença do objetivo de campanha no payload de atualização. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -364,6 +364,7 @@ public class ExperimentService {
                 .funnelPromise(normalizeExperimentPromiseField(request.getFunnelPromise()))
                 .primaryCta(normalizeExperimentPromiseField(request.getPrimaryCta()))
                 .experimentType(resolveExperimentType(request.getExperimentType()))
+                .productAiSubtype(resolveProductAiSubtype(request.getProductAiSubtype(), hyp))
                 .campaignObjective(resolveCampaignObjective(
                         request.getCampaignObjective(), request.getFreeReward(), request.getExperimentType()))
                 .hypothesisRef(hyp)
@@ -494,6 +495,7 @@ public class ExperimentService {
                 .funnelPromise(original.getFunnelPromise())
                 .primaryCta(original.getPrimaryCta())
                 .experimentType(original.getExperimentType())
+                .productAiSubtype(original.getProductAiSubtype())
                 .campaignObjective(original.getCampaignObjective())
                 .hypothesisRef(original.getHypothesisRef())
                 .kpiTargetCpl(original.getKpiTargetCpl())
@@ -610,6 +612,9 @@ public class ExperimentService {
         }
         if (request.isExperimentTypePresent()) {
             exp.setExperimentType(resolveExperimentType(request.getExperimentType()));
+        }
+        if (request.isProductAiSubtypePresent()) {
+            exp.setProductAiSubtype(resolveProductAiSubtype(request.getProductAiSubtype(), exp.getHypothesisRef()));
         }
         if (request.isCampaignObjectivePresent()) {
             exp.setCampaignObjective(resolveCampaignObjective(
@@ -1069,6 +1074,18 @@ public class ExperimentService {
      */
     private ExperimentType resolveExperimentType(ExperimentType requestedType) {
         return requestedType != null ? requestedType : ExperimentType.NICHE_TEST;
+    }
+
+    /**
+     * Resolve o subtipo de Produto IA priorizando o experimento e herdando da hipótese quando ausente.
+     */
+    private com.marketinghub.productai.ProductAiSubtype resolveProductAiSubtype(
+            com.marketinghub.productai.ProductAiSubtype requestedSubtype,
+            com.marketinghub.hypothesis.Hypothesis hypothesis) {
+        if (requestedSubtype != null) {
+            return requestedSubtype;
+        }
+        return hypothesis != null ? hypothesis.getProductAiSubtype() : null;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -5,6 +5,7 @@ import com.marketinghub.deliverable.DeliverablePackage;
 import com.marketinghub.creative.label.Angle;
 import com.marketinghub.prompt.PromptAttributeDescription;
 import com.marketinghub.ads.FacebookInstantForm;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.targeting.TargetingElement;
 import jakarta.persistence.*;
 import lombok.*;
@@ -130,6 +131,11 @@ public class Hypothesis {
 
     @Column(precision = 7, scale = 2)
     private BigDecimal kpiTargetCpl;
+
+    /** Subtipo de Produto IA que esta hipótese pretende materializar no fluxo sistêmico. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_ai_subtype", length = 48)
+    private ProductAiSubtype productAiSubtype;
 
     @Enumerated(EnumType.STRING)
     @Builder.Default

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.hypothesis.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.marketinghub.productai.ProductAiSubtype;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -26,6 +27,7 @@ public class CreateHypothesisRequest {
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
+    private ProductAiSubtype productAiSubtype;
     private Long offerPackageId;
     private List<Long> promptAttributeDescriptionIds;
     private HypothesisFrameworkDto framework;
@@ -69,6 +71,10 @@ public class CreateHypothesisRequest {
     public void setPrice(BigDecimal price) { this.price = price; }
     public BigDecimal getKpiTargetCpl() { return kpiTargetCpl; }
     public void setKpiTargetCpl(BigDecimal kpiTargetCpl) { this.kpiTargetCpl = kpiTargetCpl; }
+    /** Retorna o subtipo de Produto IA associado à hipótese. */
+    public ProductAiSubtype getProductAiSubtype() { return productAiSubtype; }
+    /** Define o subtipo de Produto IA associado à hipótese. */
+    public void setProductAiSubtype(ProductAiSubtype productAiSubtype) { this.productAiSubtype = productAiSubtype; }
 
     public Long getOfferPackageId() { return offerPackageId; }
     public void setOfferPackageId(Long offerPackageId) { this.offerPackageId = offerPackageId; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -2,6 +2,7 @@ package com.marketinghub.hypothesis.dto;
 
 import com.marketinghub.hypothesis.HypothesisStatus;
 import com.marketinghub.hypothesis.OfferType;
+import com.marketinghub.productai.ProductAiSubtype;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -29,6 +30,7 @@ public class HypothesisDto {
     private OfferType offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
+    private ProductAiSubtype productAiSubtype;
     private Long offerPackageId;
     private String offerPackageName;
     private BigDecimal costUsd;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.hypothesis.dto;
 
+import com.marketinghub.productai.ProductAiSubtype;
 import java.math.BigDecimal;
 
 public class UpdateHypothesisRequest {
@@ -20,6 +21,7 @@ public class UpdateHypothesisRequest {
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
+    private ProductAiSubtype productAiSubtype;
     private Long offerPackageId;
     private HypothesisFrameworkDto framework;
 
@@ -71,6 +73,10 @@ public class UpdateHypothesisRequest {
 
     public BigDecimal getKpiTargetCpl() { return kpiTargetCpl; }
     public void setKpiTargetCpl(BigDecimal kpiTargetCpl) { this.kpiTargetCpl = kpiTargetCpl; }
+    /** Retorna o subtipo de Produto IA associado à hipótese. */
+    public ProductAiSubtype getProductAiSubtype() { return productAiSubtype; }
+    /** Define o subtipo de Produto IA associado à hipótese. */
+    public void setProductAiSubtype(ProductAiSubtype productAiSubtype) { this.productAiSubtype = productAiSubtype; }
 
     public Long getOfferPackageId() { return offerPackageId; }
     public void setOfferPackageId(Long offerPackageId) { this.offerPackageId = offerPackageId; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -193,6 +193,7 @@ public class HypothesisService {
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
                 .price(req.getPrice())
                 .kpiTargetCpl(req.getKpiTargetCpl())
+                .productAiSubtype(req.getProductAiSubtype())
                 .build();
         h.setOfferPackage(resolveOfferPackage(req.getOfferPackageId(), h.getMarketNiche()));
         frameworkMapperSupport.applyPartial(h, req.getFramework());
@@ -253,6 +254,7 @@ public class HypothesisService {
         h.setOfferType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()));
         h.setPrice(req.getPrice());
         h.setKpiTargetCpl(req.getKpiTargetCpl());
+        h.setProductAiSubtype(req.getProductAiSubtype());
         h.setOfferPackage(resolveOfferPackage(req.getOfferPackageId(), h.getMarketNiche()));
         frameworkMapperSupport.applyPartial(h, req.getFramework());
         return h;

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/ProductAiSubtype.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/ProductAiSubtype.java
@@ -1,0 +1,11 @@
+package com.marketinghub.productai;
+
+/** Responsabilidade: classificar o mecanismo principal de valor de um Produto IA. */
+public enum ProductAiSubtype {
+    AI_VISUAL_PREVIEW,
+    AI_PERSONALIZED_SAMPLE,
+    AI_TRANSFORMATION_SIMULATOR,
+    AI_VISUAL_ASSET_PACK,
+    AI_IDENTITY_AVATAR_PRODUCT,
+    AI_REPORT_VISUAL_EVIDENCE
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-mois-dossier-prompt-schema-templates.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-mois-dossier-prompt-schema-templates.yaml
@@ -52,71 +52,71 @@ databaseChangeLog:
                   'sales_page_patterns_v1',
                   'Você está analisando uma página de venda de produto com sinais de sucesso.
 
-Objetivo: extrair padrões abstratos que possam melhorar páginas próprias do Marketing Hub, sem copiar conteúdo, marca, layout literal, imagens, depoimentos ou promessa exclusiva de terceiros.
+                  Objetivo: extrair padrões abstratos que possam melhorar páginas próprias do Marketing Hub, sem copiar conteúdo, marca, layout literal, imagens, depoimentos ou promessa exclusiva de terceiros.
 
-Contexto coletado da página:
+                  Contexto coletado da página:
 
-{{context}}
+                  {{context}}
 
-Extraia padrões reutilizáveis sobre:
-- estrutura da página;
-- hierarquia visual;
-- paleta, tipografia e densidade visual;
-- sequência de copy;
-- promessa, dor, mecanismo e oferta;
-- prova, autoridade, garantia, CTA e objeções;
-- tipos de imagem ou mídia usados;
-- riscos de cópia literal que devem ser evitados;
-- recomendações práticas para GeraLanding/GeraSalesPage.
+                  Extraia padrões reutilizáveis sobre:
+                  - estrutura da página;
+                  - hierarquia visual;
+                  - paleta, tipografia e densidade visual;
+                  - sequência de copy;
+                  - promessa, dor, mecanismo e oferta;
+                  - prova, autoridade, garantia, CTA e objeções;
+                  - tipos de imagem ou mídia usados;
+                  - riscos de cópia literal que devem ser evitados;
+                  - recomendações práticas para GeraLanding/GeraSalesPage.
 
-Responda em JSON válido aderente ao schema.',
+                  Responda em JSON válido aderente ao schema.',
                   '{
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "status",
-    "page_pattern_summary",
-    "design_patterns",
-    "copy_patterns",
-    "offer_patterns",
-    "proof_patterns",
-    "cta_patterns",
-    "adaptation_recommendations",
-    "do_not_copy"
-  ],
-  "properties": {
-    "status": { "type": "string" },
-    "page_pattern_summary": { "type": "string" },
-    "design_patterns": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "copy_patterns": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "offer_patterns": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "proof_patterns": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "cta_patterns": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "adaptation_recommendations": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "do_not_copy": {
-      "type": "array",
-      "items": { "type": "string" }
-    }
-  }
-}',
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "status",
+                      "page_pattern_summary",
+                      "design_patterns",
+                      "copy_patterns",
+                      "offer_patterns",
+                      "proof_patterns",
+                      "cta_patterns",
+                      "adaptation_recommendations",
+                      "do_not_copy"
+                    ],
+                    "properties": {
+                      "status": { "type": "string" },
+                      "page_pattern_summary": { "type": "string" },
+                      "design_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "copy_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "offer_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "proof_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "cta_patterns": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "adaptation_recommendations": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "do_not_copy": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    }
+                  }',
                   TRUE,
                   UTC_TIMESTAMP(6),
                   UTC_TIMESTAMP(6)
@@ -130,43 +130,43 @@ Responda em JSON válido aderente ao schema.',
                   'warmup_ecosystem_product_understanding_v1',
                   'Entenda o produto para orientar a investigação comercial do dossiê MOIS.
 
-Use exclusivamente o contexto recebido. Não invente dados externos.
+                  Use exclusivamente o contexto recebido. Não invente dados externos.
 
-Organize a análise pelo eixo Dor → Resultado → Mecanismo → Prova → Oferta e responda em JSON válido com os campos:
-- produto
-- publico
-- dor_superficie
-- dor_raiz
-- dor_emocional_social
-- ganho_desejado
-- promessa
-- mecanismo
-- formato
-- arquitetura_oferta
-- prova
-- objecao_principal
-- custo_de_nao_agir
-- nivel_consciencia_publico
-- maturidade_dor
-- urgencia
-- desejo_dominante
-- angulo_central
-- porque_agora
-- hipotese_sucesso
-- lacunas
-- resumo_final
+                  Organize a análise pelo eixo Dor → Resultado → Mecanismo → Prova → Oferta e responda em JSON válido com os campos:
+                  - produto
+                  - publico
+                  - dor_superficie
+                  - dor_raiz
+                  - dor_emocional_social
+                  - ganho_desejado
+                  - promessa
+                  - mecanismo
+                  - formato
+                  - arquitetura_oferta
+                  - prova
+                  - objecao_principal
+                  - custo_de_nao_agir
+                  - nivel_consciencia_publico
+                  - maturidade_dor
+                  - urgencia
+                  - desejo_dominante
+                  - angulo_central
+                  - porque_agora
+                  - hipotese_sucesso
+                  - lacunas
+                  - resumo_final
 
-A hipótese de sucesso deve seguir o formato: "o produto ganha força porque combina [dor forte] + [resultado desejado] + [mecanismo crível] + [prova/autoridade] + [oferta fácil de comprar]".
+                  A hipótese de sucesso deve seguir o formato: "o produto ganha força porque combina [dor forte] + [resultado desejado] + [mecanismo crível] + [prova/autoridade] + [oferta fácil de comprar]".
 
-Se o contexto não sustentar algum campo, informe claramente "não informado no contexto" e registre a lacuna. Não transforme metadados operacionais em conclusão comercial.
+                  Se o contexto não sustentar algum campo, informe claramente "não informado no contexto" e registre a lacuna. Não transforme metadados operacionais em conclusão comercial.
 
-Contexto:
-{{context}}',
+                  Contexto:
+                  {{context}}',
                   '{
-  "type": "object",
-  "required": ["produto", "publico", "promessa", "mecanismo", "prova", "lacunas", "resumo_final"],
-  "additionalProperties": true
-}',
+                    "type": "object",
+                    "required": ["produto", "publico", "promessa", "mecanismo", "prova", "lacunas", "resumo_final"],
+                    "additionalProperties": true
+                  }',
                   TRUE,
                   UTC_TIMESTAMP(6),
                   UTC_TIMESTAMP(6)

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-product-ai-subtype.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-product-ai-subtype.yaml
@@ -1,0 +1,43 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-03-product-ai-subtype-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: hypothesis
+        - not:
+            columnExists:
+              tableName: hypothesis
+              columnName: product_ai_subtype
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE hypothesis
+                ADD COLUMN product_ai_subtype VARCHAR(48) NULL AFTER kpi_target_cpl;
+  - changeSet:
+      id: 2026-07-03-product-ai-subtype-02
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment
+        - not:
+            columnExists:
+              tableName: experiment
+              columnName: product_ai_subtype
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                ADD COLUMN product_ai_subtype VARCHAR(48) NULL AFTER experiment_type;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-03-product-ai-subtype.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-03-mois-dossier-prompt-schema-templates.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.repository.jpa.creative.label.AngleRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.FixtureUtils;
 import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.repository.jpa.ads.CampaignRepository;
@@ -154,6 +155,7 @@ class ExperimentControllerTest {
                 .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(BigDecimal.ONE)
+                .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
                 .build());
         metricPresetRepository.save(com.marketinghub.experiment.MetricPreset.builder()
                 .id("LEAN_150")
@@ -184,12 +186,14 @@ class ExperimentControllerTest {
         mockMvc.perform(post("/api/niches/" + nicheId + "/experiments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productAiSubtype").value("AI_PERSONALIZED_SAMPLE"));
 
         var saved = repository.findAll();
         assertThat(saved).hasSize(1);
         assertThat(saved.get(0).getJourneyTemplate()).isNotNull();
         assertThat(saved.get(0).getJourneyTemplate().getId()).isEqualTo(template.getId());
+        assertThat(saved.get(0).getProductAiSubtype()).isEqualTo(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
     }
 
     /** Garante que o contrato do AI Worker lista e conclui geração pendente de criativos. */

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -68,6 +68,18 @@ Subtipos iniciais:
 
 O subtipo nao substitui o tipo principal `Produto IA`. Ele especializa a experiencia para que o sistema consiga comparar resultados, custos e aprendizados entre produtos parecidos.
 
+### Persistencia operacional do subtipo
+
+O subtipo de Produto IA deve ser persistido como `product_ai_subtype` na hipotese e no experimento.
+
+Regra operacional:
+
+- a hipotese pode declarar o subtipo quando o fluxo sistemico identificar que a oferta e Produto IA;
+- o experimento herda o subtipo da hipotese quando nasce pelo fluxo normal;
+- se o experimento declarar um subtipo explicitamente, esse valor deve ficar registrado para rastrear a variacao testada;
+- o primeiro MVP visual/personalizado usa `AI_PERSONALIZED_SAMPLE` como subtipo inicial;
+- relatórios, custos, prompts, schemas e aprendizados devem sempre conseguir voltar ao tipo/subtipo do produto testado.
+
 ### Regra mandatória — Produto IA nasce pelo sistema
 
 Nenhum Produto IA, low-ticket, oferta, pagina, checkout, amostra, promessa ou variacao deve ser criado manualmente como atalho fora dos recursos do Marketing Hub.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5567,3 +5567,11 @@
 - MVP recomendado: `AI_PERSONALIZED_SAMPLE`, por testar impacto visual e personalizacao no mesmo fluxo.
 - Regra registrada: nenhum produto, oferta, pagina, amostra, checkout ou variacao deve ser criado manualmente como atalho; tudo precisa nascer por recursos oficiais do sistema com rastreabilidade de nicho, hipotese, dor, resultado, mecanismo, prova, oferta, prompts/schemas, custos e experimento.
 - Prevenção de recorrência: padrões externos e ideias estratégicas podem enriquecer o briefing, mas não substituem o fluxo sistêmico de criação e validação.
+
+## 2026-07-03 — Subtipo operacional de Produto IA em hipótese e experimento
+
+- Decisão: o subtipo de Produto IA passa a ser dado operacional persistido em `hypothesis.product_ai_subtype` e `experiment.product_ai_subtype`.
+- Regra: experimento criado pelo fluxo normal herda o subtipo da hipótese quando o payload não informar valor explícito.
+- Primeiro MVP: a criação de experimento low-ticket no frontend inicia com `AI_PERSONALIZED_SAMPLE`, preservando o teste das hipóteses de impacto visual e personalização.
+- Correção de CI incluída: o changelog de templates MOIS foi normalizado para YAML válido, mantendo prompts/schemas versionados no backend.
+- Prevenção de recorrência: o sistema passa a conseguir filtrar custos, aprendizados e resultados por subtipo, evitando que Produto IA fique como categoria genérica sem comparação operacional.

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -5,6 +5,7 @@ import type {
   ExperimentCampaignObjective,
   ExperimentStage,
   ExperimentType,
+  ProductAiSubtype,
 } from "./useExperiments";
 
 export interface CreateExperiment {
@@ -17,6 +18,7 @@ export interface CreateExperiment {
   funnelPromise?: string;
   primaryCta?: string;
   experimentType?: ExperimentType;
+  productAiSubtype?: ProductAiSubtype | null;
   campaignObjective?: ExperimentCampaignObjective;
   stage: ExperimentStage;
   primaryVariable?: string;

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -17,6 +17,13 @@ export interface InstagramAccountSummary {
 
 export type ExperimentStage = "AD" | "LANDING" | "SAMPLE" | "SALES";
 export type ExperimentType = "NICHE_TEST" | "LOW_TICKET_PRODUCT";
+export type ProductAiSubtype =
+  | "AI_VISUAL_PREVIEW"
+  | "AI_PERSONALIZED_SAMPLE"
+  | "AI_TRANSFORMATION_SIMULATOR"
+  | "AI_VISUAL_ASSET_PACK"
+  | "AI_IDENTITY_AVATAR_PRODUCT"
+  | "AI_REPORT_VISUAL_EVIDENCE";
 export type ExperimentCampaignObjective = "LEADS" | "TRAFFIC" | "SALES";
 
 export interface FacebookInstantFormSummary {
@@ -67,6 +74,7 @@ export interface Experiment {
   funnelPromise?: string | null;
   primaryCta?: string | null;
   experimentType?: ExperimentType | null;
+  productAiSubtype?: ProductAiSubtype | null;
   campaignObjective?: ExperimentCampaignObjective | null;
   pageId?: string | null;
   facebookPage?: FacebookPageSummary | null;

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -5,6 +5,7 @@ import type {
   ExperimentCampaignObjective,
   ExperimentStage,
   ExperimentType,
+  ProductAiSubtype,
 } from "./useExperiments";
 
 export interface UpdateExperiment {
@@ -15,6 +16,7 @@ export interface UpdateExperiment {
   funnelPromise?: string;
   primaryCta?: string;
   experimentType?: ExperimentType;
+  productAiSubtype?: ProductAiSubtype | null;
   campaignObjective?: ExperimentCampaignObjective;
   stage?: ExperimentStage;
   primaryVariable?: string;

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import { Hypothesis } from "./useHypothesisBoard";
 import type { HypothesisFramework } from "./types";
+import type { ProductAiSubtype } from "../experiment/useExperiments";
 
 export interface CreateHypothesis {
   marketNicheId: number;
@@ -20,6 +21,7 @@ export interface CreateHypothesis {
   model?: string;
   offerType?: string;
   kpiTargetCpl?: number;
+  productAiSubtype?: ProductAiSubtype | null;
   price?: number;
   offerPackageId?: number;
   costUsd?: number;

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import type { HypothesisFramework } from "./types";
+import type { ProductAiSubtype } from "../experiment/useExperiments";
 
 export interface Hypothesis {
   id: string;
@@ -21,6 +22,7 @@ export interface Hypothesis {
   offerType?: string;
   price?: number;
   kpiTargetCpl?: number;
+  productAiSubtype?: ProductAiSubtype | null;
   offerPackageId?: number | null;
   offerPackageName?: string | null;
   costUsd?: number;

--- a/frontend/src/api/hypothesis/useUpdateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useUpdateHypothesis.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import { Hypothesis } from "./useHypothesisBoard";
 import type { HypothesisFramework } from "./types";
+import type { ProductAiSubtype } from "../experiment/useExperiments";
 
 export interface UpdateHypothesisPayload {
   id: string;
@@ -23,6 +24,7 @@ export interface UpdateHypothesisPayload {
   offerType?: string;
   price?: number | null;
   kpiTargetCpl?: number;
+  productAiSubtype?: ProductAiSubtype | null;
   offerPackageId?: number | null;
   framework?: HypothesisFramework | null;
 }

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -6,6 +6,7 @@ import { useExperiment } from "../../api/experiment/useExperiment";
 import type {
   ExperimentStage,
   ExperimentType,
+  ProductAiSubtype,
 } from "../../api/experiment/useExperiments";
 import { useImageGenerationModels } from "../../api/ai/useImageGenerationModels";
 import {
@@ -20,6 +21,15 @@ import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { experimentStageLabels } from "./stageLabels";
+
+const productAiSubtypeLabels: Record<ProductAiSubtype, string> = {
+  AI_VISUAL_PREVIEW: "Prévia visual IA",
+  AI_PERSONALIZED_SAMPLE: "Amostra personalizada IA",
+  AI_TRANSFORMATION_SIMULATOR: "Simulador de transformação IA",
+  AI_VISUAL_ASSET_PACK: "Pacote visual IA",
+  AI_IDENTITY_AVATAR_PRODUCT: "Identidade/avatar IA",
+  AI_REPORT_VISUAL_EVIDENCE: "Relatório com evidência visual IA",
+};
 
 interface FormData {
   name: string;
@@ -45,6 +55,7 @@ interface FormData {
   funnelPromise: string;
   primaryCta: string;
   experimentType: ExperimentType;
+  productAiSubtype: ProductAiSubtype | "";
 }
 
 function toDateInputValue(value?: string | null) {
@@ -102,6 +113,7 @@ export default function EditExperimentPage() {
       funnelPromise: "",
       primaryCta: "",
       experimentType: "NICHE_TEST",
+      productAiSubtype: "",
     },
   });
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
@@ -155,6 +167,11 @@ export default function EditExperimentPage() {
         funnelPromise: data.funnelPromise ?? "",
         primaryCta: data.primaryCta ?? "",
         experimentType: data.experimentType ?? "NICHE_TEST",
+        productAiSubtype:
+          data.productAiSubtype ??
+          (data.experimentType === "LOW_TICKET_PRODUCT"
+            ? "AI_PERSONALIZED_SAMPLE"
+            : ""),
       });
     }
   }, [data, reset]);
@@ -168,6 +185,7 @@ export default function EditExperimentPage() {
   const selectedImageQualityId = watch("imageModelQualityId");
   const imagesPerPackageValue = watch("imagesPerPackage");
   const experimentTypeValue = watch("experimentType");
+  const productAiSubtypeValue = watch("productAiSubtype");
   const isLowTicketProduct = experimentTypeValue === "LOW_TICKET_PRODUCT";
   const stageEntries = playbook ?? [];
   const stageSelectOptions =
@@ -486,6 +504,9 @@ export default function EditExperimentPage() {
         funnelPromise: values.funnelPromise.trim(),
         primaryCta: values.primaryCta.trim(),
         experimentType: values.experimentType,
+        productAiSubtype: isLowTicketProduct
+          ? values.productAiSubtype || "AI_PERSONALIZED_SAMPLE"
+          : null,
         campaignObjective: isLowTicketProduct ? "SALES" : "LEADS",
         kpiTarget: Number(values.kpiTarget),
         dailyBudget: parsedDailyBudget,
@@ -568,6 +589,18 @@ export default function EditExperimentPage() {
               id="experimentType"
               className="form-select mb-2"
               {...register("experimentType")}
+              onChange={(event) => {
+                register("experimentType").onChange(event);
+                if (event.target.value === "LOW_TICKET_PRODUCT") {
+                  setValue(
+                    "productAiSubtype",
+                    productAiSubtypeValue || "AI_PERSONALIZED_SAMPLE",
+                    { shouldDirty: true },
+                  );
+                } else {
+                  setValue("productAiSubtype", "", { shouldDirty: true });
+                }
+              }}
             >
               <option value="LOW_TICKET_PRODUCT">Produto low-ticket</option>
               <option value="NICHE_TEST">Teste de nicho / lead</option>
@@ -577,6 +610,26 @@ export default function EditExperimentPage() {
                 ? "Prioriza venda direta: página curta, checkout e entrega."
                 : "Prioriza captura de lead: isca/amostra antes da venda."}
             </div>
+            {isLowTicketProduct && (
+              <>
+                <label className="form-label" htmlFor="productAiSubtype">
+                  Mecanismo de Produto IA
+                </label>
+                <select
+                  id="productAiSubtype"
+                  className="form-select mb-3"
+                  {...register("productAiSubtype")}
+                >
+                  {Object.entries(productAiSubtypeLabels).map(
+                    ([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ),
+                  )}
+                </select>
+              </>
+            )}
             <label className="form-label" htmlFor="stageSelect">
               Etapa do experimento <span className="text-danger">*</span>
             </label>

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1850,6 +1850,14 @@ export default function ExperimentDetailPage() {
   const experimentTypeLabel = isLowTicketProduct
     ? "Produto low-ticket"
     : "Teste de nicho / lead";
+  const productAiSubtypeLabel: Record<string, string> = {
+    AI_VISUAL_PREVIEW: "Prévia visual IA",
+    AI_PERSONALIZED_SAMPLE: "Amostra personalizada IA",
+    AI_TRANSFORMATION_SIMULATOR: "Simulador de transformação IA",
+    AI_VISUAL_ASSET_PACK: "Pacote visual IA",
+    AI_IDENTITY_AVATAR_PRODUCT: "Identidade/avatar IA",
+    AI_REPORT_VISUAL_EVIDENCE: "Relatório com evidência visual IA",
+  };
   const campaignObjectiveLabel =
     data.campaignObjective === "LEADS"
       ? "Leads"
@@ -1945,6 +1953,12 @@ export default function ExperimentDetailPage() {
     {
       label: "Tipo de experimento",
       value: experimentTypeLabel,
+    },
+    {
+      label: "Mecanismo de Produto IA",
+      value: data.productAiSubtype
+        ? productAiSubtypeLabel[data.productAiSubtype] ?? data.productAiSubtype
+        : "-",
     },
     {
       label: "Nicho",

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -18,10 +18,23 @@ import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { getStatisticsDefaultsForBudget } from "./statisticsDefaults";
-import type { ExperimentType } from "../../api/experiment/useExperiments";
+import type {
+  ExperimentType,
+  ProductAiSubtype,
+} from "../../api/experiment/useExperiments";
+
+const productAiSubtypeLabels: Record<ProductAiSubtype, string> = {
+  AI_VISUAL_PREVIEW: "Prévia visual IA",
+  AI_PERSONALIZED_SAMPLE: "Amostra personalizada IA",
+  AI_TRANSFORMATION_SIMULATOR: "Simulador de transformação IA",
+  AI_VISUAL_ASSET_PACK: "Pacote visual IA",
+  AI_IDENTITY_AVATAR_PRODUCT: "Identidade/avatar IA",
+  AI_REPORT_VISUAL_EVIDENCE: "Relatório com evidência visual IA",
+};
 
 type FormState = {
   experimentType: ExperimentType;
+  productAiSubtype: ProductAiSubtype | "";
   nicheId: string;
   hypothesisId: string;
   hypothesis: string;
@@ -61,6 +74,7 @@ export default function NewExperimentPage() {
   const { data: niches } = useNiches();
   const [form, setForm] = useState<FormState>({
     experimentType: "LOW_TICKET_PRODUCT",
+    productAiSubtype: "AI_PERSONALIZED_SAMPLE",
     nicheId: nicheIdParam,
     hypothesisId: hypothesisIdParam,
     hypothesis: "",
@@ -167,7 +181,12 @@ export default function NewExperimentPage() {
 
   useEffect(() => {
     if (selectedHypothesis?.title) {
-      setForm((f) => ({ ...f, hypothesis: selectedHypothesis.title }));
+      setForm((f) => ({
+        ...f,
+        hypothesis: selectedHypothesis.title,
+        productAiSubtype:
+          selectedHypothesis.productAiSubtype ?? f.productAiSubtype,
+      }));
     }
   }, [selectedHypothesis]);
 
@@ -306,6 +325,10 @@ export default function NewExperimentPage() {
         funnelPromise: form.funnelPromise.trim(),
         primaryCta: form.primaryCta.trim(),
         experimentType: form.experimentType,
+        productAiSubtype:
+          form.experimentType === "LOW_TICKET_PRODUCT"
+            ? form.productAiSubtype || undefined
+            : undefined,
         campaignObjective,
         kpiTarget: Number(form.kpiTarget),
         metricPresetId: form.metricPresetId || undefined,
@@ -340,6 +363,7 @@ export default function NewExperimentPage() {
       }
       setForm({
         experimentType: "LOW_TICKET_PRODUCT",
+        productAiSubtype: "AI_PERSONALIZED_SAMPLE",
         nicheId: nicheIdParam,
         hypothesisId: hypothesisIdParam,
         hypothesis: "",
@@ -398,6 +422,10 @@ export default function NewExperimentPage() {
           setForm((prev) => ({
             ...prev,
             experimentType: e.target.value as ExperimentType,
+            productAiSubtype:
+              e.target.value === "LOW_TICKET_PRODUCT"
+                ? prev.productAiSubtype || "AI_PERSONALIZED_SAMPLE"
+                : "",
             primaryCta:
               e.target.value === "LOW_TICKET_PRODUCT"
                 ? "Comprar agora"
@@ -413,6 +441,30 @@ export default function NewExperimentPage() {
           ? "Fluxo principal: anúncio, página curta, checkout e entrega. Métrica central: compra ou clique no checkout."
           : "Fluxo principal: anúncio, captura de lead e entrega de isca/amostra."}
       </div>
+      {isLowTicketProduct && (
+        <>
+          <label className="form-label" htmlFor="productAiSubtype">
+            Mecanismo de Produto IA
+          </label>
+          <select
+            id="productAiSubtype"
+            className="form-select mb-3"
+            value={form.productAiSubtype}
+            onChange={(e) =>
+              setForm((prev) => ({
+                ...prev,
+                productAiSubtype: e.target.value as ProductAiSubtype,
+              }))
+            }
+          >
+            {Object.entries(productAiSubtypeLabels).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
       {showNicheSelect && (
         <select
           className="form-select mb-2"


### PR DESCRIPTION
## Resumo
- adiciona `ProductAiSubtype` como classificação operacional de Produto IA em hipótese e experimento
- cria colunas Liquibase `product_ai_subtype` em `hypothesis` e `experiment`
- faz o experimento herdar o subtipo da hipótese quando o payload não informar override
- atualiza frontend para criar/editar/exibir o mecanismo de Produto IA, com MVP inicial em `AI_PERSONALIZED_SAMPLE`
- corrige o changelog MOIS de prompt/schema para YAML válido
- documenta a persistência operacional do subtipo e o primeiro MVP

## Validação
- `../mvnw -q liquibase:validate -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml -Dliquibase.url=offline:mysql?version=5.7 -Dliquibase.username=offline -Dliquibase.password=offline`
- `../mvnw -q -Dtest=ExperimentControllerTest,HypothesisControllerTest test`
- `../mvnw -q -Dtest=ArquiteturaTest test`
- `../mvnw -q test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`