### PR TITLE
Add Product AI experiment preparation gate

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -31,6 +31,7 @@ import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.productai.service.ProductAiExperimentPreparationService;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.imagegeneration.ImageGenerationModel;
 import com.marketinghub.imagegeneration.ImageGenerationQuality;
@@ -81,6 +82,7 @@ public class ExperimentService {
     private final ObjectMapper objectMapper;
     private final CurrencyConversionService currencyConversionService;
     private final ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
+    private final ProductAiExperimentPreparationService productAiExperimentPreparationService;
 
     public ExperimentService(ExperimentRepository repository,
                              ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository,
@@ -106,7 +108,8 @@ public class ExperimentService {
                              GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository,
                              ObjectMapper objectMapper,
                              CurrencyConversionService currencyConversionService,
-                             ExperimentAiPromptSchemaUsageService promptSchemaUsageService) {
+                             ExperimentAiPromptSchemaUsageService promptSchemaUsageService,
+                             ProductAiExperimentPreparationService productAiExperimentPreparationService) {
         this.repository = repository;
         this.promiseGenerationRequestRepository = promiseGenerationRequestRepository;
         this.nicheRepository = nicheRepository;
@@ -132,6 +135,7 @@ public class ExperimentService {
         this.objectMapper = objectMapper;
         this.currencyConversionService = currencyConversionService;
         this.promptSchemaUsageService = promptSchemaUsageService;
+        this.productAiExperimentPreparationService = productAiExperimentPreparationService;
     }
 
     /**
@@ -312,6 +316,8 @@ public class ExperimentService {
         if (!hyp.getMarketNiche().getId().equals(nicheId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesis and experiment niche mismatch");
         }
+        var resolvedProductAiSubtype = resolveProductAiSubtype(request.getProductAiSubtype(), hyp);
+        validateProductAiPreparation(request.getHypothesisId(), resolvedProductAiSubtype);
         if (request.getStartDate() != null && request.getEndDate() != null &&
                 request.getStartDate().isAfter(request.getEndDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must be before endDate");
@@ -364,7 +370,7 @@ public class ExperimentService {
                 .funnelPromise(normalizeExperimentPromiseField(request.getFunnelPromise()))
                 .primaryCta(normalizeExperimentPromiseField(request.getPrimaryCta()))
                 .experimentType(resolveExperimentType(request.getExperimentType()))
-                .productAiSubtype(resolveProductAiSubtype(request.getProductAiSubtype(), hyp))
+                .productAiSubtype(resolvedProductAiSubtype)
                 .campaignObjective(resolveCampaignObjective(
                         request.getCampaignObjective(), request.getFreeReward(), request.getExperimentType()))
                 .hypothesisRef(hyp)
@@ -1086,6 +1092,18 @@ public class ExperimentService {
             return requestedSubtype;
         }
         return hypothesis != null ? hypothesis.getProductAiSubtype() : null;
+    }
+
+    /**
+     * Impede que Produto IA avance para experimento sem preparo sistêmico da hipótese.
+     */
+    private void validateProductAiPreparation(
+            java.util.UUID hypothesisId,
+            com.marketinghub.productai.ProductAiSubtype productAiSubtype) {
+        if (productAiSubtype == null) {
+            return;
+        }
+        productAiExperimentPreparationService.assertReadyForExperiment(hypothesisId);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/dto/ProductAiExperimentPreparationDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/dto/ProductAiExperimentPreparationDto.java
@@ -1,0 +1,30 @@
+package com.marketinghub.productai.dto;
+
+import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentStage;
+import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.productai.ProductAiSubtype;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/** Responsabilidade: expor a prontidão sistêmica de uma hipótese para virar experimento de Produto IA. */
+public record ProductAiExperimentPreparationDto(
+        UUID hypothesisId,
+        String hypothesisTitle,
+        ProductAiSubtype productAiSubtype,
+        boolean ready,
+        List<String> blockers,
+        ProductAiExperimentDraftDto draft) {
+
+    /** Responsabilidade: representar o rascunho canônico aplicável na tela de criação de experimento. */
+    public record ProductAiExperimentDraftDto(
+            ExperimentType experimentType,
+            ProductAiSubtype productAiSubtype,
+            ExperimentStage stage,
+            ExperimentCampaignObjective campaignObjective,
+            String primaryVariable,
+            String primaryMetric,
+            BigDecimal unitPrice) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiExperimentPreparationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiExperimentPreparationService.java
@@ -1,0 +1,110 @@
+package com.marketinghub.productai.service;
+
+import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentStage;
+import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.productai.ProductAiSubtype;
+import com.marketinghub.productai.dto.ProductAiExperimentPreparationDto;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import java.util.ArrayList;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+/** Responsabilidade: validar se uma hipótese Produto IA tem insumos rastreáveis para virar experimento. */
+@Service
+public class ProductAiExperimentPreparationService {
+    private static final String SAMPLE_DESCRIPTION_BLOCKER = "Descrição da amostra/entrega personalizada";
+
+    private final HypothesisRepository hypothesisRepository;
+
+    /** Inicializa o serviço com o repositório de hipóteses. */
+    public ProductAiExperimentPreparationService(HypothesisRepository hypothesisRepository) {
+        this.hypothesisRepository = hypothesisRepository;
+    }
+
+    /** Retorna o diagnóstico de preparo de Produto IA para uma hipótese. */
+    @Transactional(readOnly = true)
+    public ProductAiExperimentPreparationDto prepare(UUID hypothesisId) {
+        Hypothesis hypothesis = hypothesisRepository.findById(hypothesisId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "hypothesis not found"));
+        return buildPreparation(hypothesis);
+    }
+
+    /** Bloqueia criação de experimento Produto IA quando a hipótese ainda não tem rastreabilidade mínima. */
+    @Transactional(readOnly = true)
+    public void assertReadyForExperiment(UUID hypothesisId) {
+        ProductAiExperimentPreparationDto preparation = prepare(hypothesisId);
+        if (!preparation.ready()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Produto IA incompleto para experimento: " + String.join(", ", preparation.blockers()));
+        }
+    }
+
+    /** Monta o diagnóstico e o rascunho aplicável a partir dos campos persistidos da hipótese. */
+    private ProductAiExperimentPreparationDto buildPreparation(Hypothesis hypothesis) {
+        var blockers = new ArrayList<String>();
+        require(blockers, hypothesis.getProductAiSubtype() == ProductAiSubtype.AI_PERSONALIZED_SAMPLE,
+                "Subtipo AI_PERSONALIZED_SAMPLE");
+        require(blockers, hypothesis.getMarketNiche() != null, "Nicho/contexto");
+        requireText(blockers, hypothesis.getProblem(), "Dor principal");
+        requireText(blockers, hypothesis.getPersona(), "Persona");
+        requireText(blockers, hypothesis.getPromise(), "Promessa");
+        requireText(blockers, resolveMechanism(hypothesis), "Mecanismo");
+        require(blockers, hypothesis.getPrice() != null, "Preço");
+        require(blockers, hypothesis.getOfferPackage() != null, "Pacote de oferta");
+        require(blockers, hasDeliverables(hypothesis), "Entregáveis do pacote");
+        requireText(blockers, hypothesis.getEntrega(), SAMPLE_DESCRIPTION_BLOCKER);
+
+        boolean ready = blockers.isEmpty();
+        ProductAiExperimentPreparationDto.ProductAiExperimentDraftDto draft = ready
+                ? new ProductAiExperimentPreparationDto.ProductAiExperimentDraftDto(
+                        ExperimentType.LOW_TICKET_PRODUCT,
+                        ProductAiSubtype.AI_PERSONALIZED_SAMPLE,
+                        ExperimentStage.SAMPLE,
+                        ExperimentCampaignObjective.SALES,
+                        "Amostra visual personalizada",
+                        "Compra aprovada e custo de IA por compra",
+                        hypothesis.getPrice())
+                : null;
+
+        return new ProductAiExperimentPreparationDto(
+                hypothesis.getId(),
+                hypothesis.getTitle(),
+                hypothesis.getProductAiSubtype(),
+                ready,
+                blockers,
+                draft);
+    }
+
+    /** Retorna o mecanismo mais específico disponível na hipótese. */
+    private String resolveMechanism(Hypothesis hypothesis) {
+        return StringUtils.hasText(hypothesis.getUniqueMechanism())
+                ? hypothesis.getUniqueMechanism()
+                : hypothesis.getMechanism();
+    }
+
+    /** Verifica se a hipótese possui pacote com ao menos um entregável persistido. */
+    private boolean hasDeliverables(Hypothesis hypothesis) {
+        return hypothesis.getOfferPackage() != null
+                && hypothesis.getOfferPackage().getDeliverables() != null
+                && !hypothesis.getOfferPackage().getDeliverables().isEmpty();
+    }
+
+    /** Registra bloqueio quando a condição obrigatória não foi atendida. */
+    private void require(ArrayList<String> blockers, boolean condition, String label) {
+        if (!condition) {
+            blockers.add(label);
+        }
+    }
+
+    /** Registra bloqueio quando o texto obrigatório está ausente. */
+    private void requireText(ArrayList<String> blockers, String value, String label) {
+        require(blockers, StringUtils.hasText(value), label);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
@@ -1,0 +1,27 @@
+package com.marketinghub.productai.web;
+
+import com.marketinghub.productai.dto.ProductAiExperimentPreparationDto;
+import com.marketinghub.productai.service.ProductAiExperimentPreparationService;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor o preparo sistêmico de hipóteses Produto IA antes da criação de experimento. */
+@RestController
+@RequestMapping("/api/product-ai/experiment-preparations")
+public class ProductAiExperimentPreparationController {
+    private final ProductAiExperimentPreparationService service;
+
+    /** Inicializa o controller com o serviço de preparo de Produto IA. */
+    public ProductAiExperimentPreparationController(ProductAiExperimentPreparationService service) {
+        this.service = service;
+    }
+
+    /** Retorna bloqueios e rascunho canônico para a hipótese informada. */
+    @GetMapping("/{hypothesisId}")
+    public ProductAiExperimentPreparationDto get(@PathVariable UUID hypothesisId) {
+        return service.prepare(hypothesisId);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -19,6 +19,8 @@ import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.repository.jpa.ads.CampaignRepository;
+import com.marketinghub.repository.jpa.deliverable.DeliverablePackageRepository;
+import com.marketinghub.repository.jpa.deliverable.DeliverableRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import org.junit.jupiter.api.Test;
@@ -88,6 +90,10 @@ class ExperimentControllerTest {
     private GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
     @Autowired
     private GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
+    @Autowired
+    private DeliverablePackageRepository deliverablePackageRepository;
+    @Autowired
+    private DeliverableRepository deliverableRepository;
 
     Long nicheId;
 
@@ -135,6 +141,11 @@ class ExperimentControllerTest {
         journeyTemplateRepository.deleteAll();
         targetingElementRepository.deleteAll();
         instagramAccountRepository.deleteAll();
+        var hypotheses = hypothesisRepository.findAll();
+        hypotheses.forEach(hypothesis -> hypothesis.setOfferPackage(null));
+        hypothesisRepository.saveAll(hypotheses);
+        deliverablePackageRepository.deleteAll();
+        deliverableRepository.deleteAll();
         hypothesisRepository.deleteAll();
         metricPresetRepository.deleteAll();
         angleRepository.deleteAll();
@@ -153,10 +164,26 @@ class ExperimentControllerTest {
                 .promise("Promessa")
                 .problem("Problema")
                 .persona("Persona")
+                .mechanism("Mecanismo")
+                .entrega("Amostra visual personalizada")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .price(new BigDecimal("27.00"))
                 .kpiTargetCpl(BigDecimal.ONE)
                 .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
                 .build());
+        var deliverable = deliverableRepository.save(com.marketinghub.deliverable.Deliverable.builder()
+                .niche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Amostra")
+                .description("Entrega da amostra")
+                .build());
+        var deliverablePackage = deliverablePackageRepository.save(com.marketinghub.deliverable.DeliverablePackage.builder()
+                .hypothesis(hyp)
+                .name("Pacote")
+                .description("Pacote de oferta")
+                .deliverables(new java.util.LinkedHashSet<>(java.util.List.of(deliverable)))
+                .build());
+        hyp.setOfferPackage(deliverablePackage);
+        hypothesisRepository.save(hyp);
         metricPresetRepository.save(com.marketinghub.experiment.MetricPreset.builder()
                 .id("LEAN_150")
                 .name("Lean-Startup 150")
@@ -194,6 +221,83 @@ class ExperimentControllerTest {
         assertThat(saved.get(0).getJourneyTemplate()).isNotNull();
         assertThat(saved.get(0).getJourneyTemplate().getId()).isEqualTo(template.getId());
         assertThat(saved.get(0).getProductAiSubtype()).isEqualTo(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+    }
+
+    /** Garante que o preparo de Produto IA expõe rascunho somente quando a hipótese está completa. */
+    @Test
+    void productAiPreparationReturnsDraftWhenHypothesisIsReady() throws Exception {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("AI").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Hipótese AI")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .mechanism("Mecanismo")
+                .entrega("Amostra visual personalizada")
+                .price(new BigDecimal("37.00"))
+                .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
+                .build());
+        var deliverable = deliverableRepository.save(com.marketinghub.deliverable.Deliverable.builder()
+                .niche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Amostra")
+                .description("Entrega da amostra")
+                .build());
+        var deliverablePackage = deliverablePackageRepository.save(com.marketinghub.deliverable.DeliverablePackage.builder()
+                .hypothesis(hyp)
+                .name("Pacote AI")
+                .deliverables(new java.util.LinkedHashSet<>(java.util.List.of(deliverable)))
+                .build());
+        hyp.setOfferPackage(deliverablePackage);
+        hypothesisRepository.save(hyp);
+
+        mockMvc.perform(get("/api/product-ai/experiment-preparations/{hypothesisId}", hyp.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ready").value(true))
+                .andExpect(jsonPath("$.draft.experimentType").value("LOW_TICKET_PRODUCT"))
+                .andExpect(jsonPath("$.draft.productAiSubtype").value("AI_PERSONALIZED_SAMPLE"))
+                .andExpect(jsonPath("$.draft.stage").value("SAMPLE"))
+                .andExpect(jsonPath("$.draft.campaignObjective").value("SALES"));
+    }
+
+    /** Garante que Produto IA incompleto não vira experimento por chamada direta de API. */
+    @Test
+    void createEndpointRejectsIncompleteProductAiHypothesis() throws Exception {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("AI incompleto").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Hipótese incompleta")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
+                .build());
+        metricPresetRepository.save(com.marketinghub.experiment.MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
+        var instagramAccount = fixtures.createAndSaveInstagramAccount();
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setHypothesisId(hyp.getId());
+        req.setHypothesis("H1");
+        req.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150");
+        req.setDailyBudget(new BigDecimal("10"));
+        req.setUnitPrice(new BigDecimal("27"));
+        req.setJourneyTemplateId(template.getId());
+        req.setInstagramAccountId(instagramAccount.getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow());
+
+        mockMvc.perform(post("/api/niches/" + nicheId + "/experiments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
     }
 
     /** Garante que o contrato do AI Worker lista e conclui geração pendente de criativos. */

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -238,6 +238,7 @@ Regras obrigatórias:
 - melhorar um produto existente significa criar nova versão ou novo experimento com variável primária declarada;
 - prompts, schemas, custos, entradas, saídas e decisões devem permanecer auditáveis;
 - padrões da Biblioteca de Páginas de Vendas podem enriquecer o briefing, mas não substituem as etapas de hipótese, dor, mecanismo, prova, oferta e validação;
+- Produto IA com subtipo declarado deve passar pelo preparo sistêmico antes da criação do experimento. Para `AI_PERSONALIZED_SAMPLE`, o backend deve bloquear a criação se faltar nicho/contexto, dor principal, persona, promessa, mecanismo, preço, pacote de oferta, entregáveis ou descrição da amostra;
 - se algum ativo for criado emergencialmente fora do fluxo, ele deve ser tratado como material provisório não canônico e não pode ser publicado ou escalado até ser reconstruído pelo sistema.
 
 ### 4.2.1.1 Regra mandatória — prompt/schema por experimento

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -99,6 +99,8 @@ Todo Produto IA deve nascer por uma execucao rastreavel do sistema, preservando 
 - experimento de validacao;
 - versao ou variavel primaria quando for uma variacao.
 
+Antes de criar o experimento, o backend deve validar o preparo da hipotese Produto IA por endpoint sistemico. Para o MVP `AI_PERSONALIZED_SAMPLE`, a hipotese so pode virar experimento quando possuir nicho/contexto, dor principal, persona, promessa, mecanismo, preco, pacote de oferta, entregaveis do pacote e descricao da amostra personalizada. A tela pode exibir bloqueios e aplicar um rascunho canonico, mas a trava definitiva fica no backend.
+
 Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.
 
 Padroes externos, como os dossies da Biblioteca de Paginas de Vendas, podem ser usados como insumo de briefing e aprendizado. Eles nao podem substituir a geracao rastreavel de hipotese, dor, mecanismo, prova, oferta e experimento pelo sistema.

--- a/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
+++ b/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
@@ -55,6 +55,24 @@ Motivos:
 - pode ser comparado contra uma rota sem amostra;
 - cria aprendizado reutilizavel para outros nichos.
 
+## Preparo sistêmico antes do experimento
+
+O primeiro experimento não deve ser criado manualmente. A hipótese `AI_PERSONALIZED_SAMPLE` precisa passar pelo preparo sistêmico exposto em `/api/product-ai/experiment-preparations/{hypothesisId}`.
+
+O backend só libera rascunho de experimento quando a hipótese possui:
+
+- nicho/contexto;
+- dor principal;
+- persona;
+- promessa;
+- mecanismo;
+- preço;
+- pacote de oferta;
+- entregáveis do pacote;
+- descrição da amostra personalizada.
+
+Quando pronta, a tela aplica o rascunho canônico: `LOW_TICKET_PRODUCT`, `AI_PERSONALIZED_SAMPLE`, etapa `SAMPLE`, objetivo `SALES`, variável “Amostra visual personalizada” e métrica “Compra aprovada e custo de IA por compra”.
+
 ## Desenho experimental inicial
 
 Fluxo:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5575,3 +5575,10 @@
 - Primeiro MVP: a criação de experimento low-ticket no frontend inicia com `AI_PERSONALIZED_SAMPLE`, preservando o teste das hipóteses de impacto visual e personalização.
 - Correção de CI incluída: o changelog de templates MOIS foi normalizado para YAML válido, mantendo prompts/schemas versionados no backend.
 - Prevenção de recorrência: o sistema passa a conseguir filtrar custos, aprendizados e resultados por subtipo, evitando que Produto IA fique como categoria genérica sem comparação operacional.
+
+## 2026-07-03 — Preparo sistêmico para experimento Produto IA
+
+- Decisão: Produto IA `AI_PERSONALIZED_SAMPLE` passa por preparo sistêmico antes de virar experimento.
+- Correção aplicada: criado endpoint `/api/product-ai/experiment-preparations/{hypothesisId}` para expor bloqueios e rascunho canônico; o backend bloqueia criação direta de experimento Produto IA incompleto.
+- Regra operacional: a hipótese precisa ter nicho, dor, persona, promessa, mecanismo, preço, pacote de oferta, entregáveis e descrição da amostra personalizada.
+- Prevenção de recorrência: a tela mostra os bloqueios, mas a trava definitiva fica no backend para impedir produto manual fora do fluxo.

--- a/docs/swagger/product-ai-experiment-preparation-swagger.yaml
+++ b/docs/swagger/product-ai-experiment-preparation-swagger.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.3
+info:
+  title: Product AI Experiment Preparation API
+  version: 1.0.0
+  description: Contrato para validar se uma hipótese Produto IA pode virar experimento rastreável.
+paths:
+  /api/product-ai/experiment-preparations/{hypothesisId}:
+    get:
+      summary: Consulta preparo sistêmico de Produto IA
+      description: Retorna bloqueios e rascunho canônico para criar experimento somente quando a hipótese possui nicho, dor, persona, promessa, mecanismo, preço, pacote de oferta, entregáveis e descrição da amostra.
+      parameters:
+        - name: hypothesisId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Preparo retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductAiExperimentPreparation'
+        '404':
+          description: Hipótese não encontrada.
+components:
+  schemas:
+    ProductAiExperimentPreparation:
+      type: object
+      required: [hypothesisId, hypothesisTitle, ready, blockers]
+      properties:
+        hypothesisId:
+          type: string
+          format: uuid
+        hypothesisTitle:
+          type: string
+        productAiSubtype:
+          type: string
+          nullable: true
+          example: AI_PERSONALIZED_SAMPLE
+        ready:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            type: string
+        draft:
+          nullable: true
+          $ref: '#/components/schemas/ProductAiExperimentDraft'
+    ProductAiExperimentDraft:
+      type: object
+      properties:
+        experimentType:
+          type: string
+          example: LOW_TICKET_PRODUCT
+        productAiSubtype:
+          type: string
+          example: AI_PERSONALIZED_SAMPLE
+        stage:
+          type: string
+          example: SAMPLE
+        campaignObjective:
+          type: string
+          example: SALES
+        primaryVariable:
+          type: string
+          example: Amostra visual personalizada
+        primaryMetric:
+          type: string
+          example: Compra aprovada e custo de IA por compra
+        unitPrice:
+          type: number
+          format: decimal

--- a/frontend/src/api/product-ai/useProductAiExperimentPreparation.ts
+++ b/frontend/src/api/product-ai/useProductAiExperimentPreparation.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  ExperimentCampaignObjective,
+  ExperimentStage,
+  ExperimentType,
+  ProductAiSubtype,
+} from "../experiment/useExperiments";
+
+export interface ProductAiExperimentDraft {
+  experimentType: ExperimentType;
+  productAiSubtype: ProductAiSubtype;
+  stage: ExperimentStage;
+  campaignObjective: ExperimentCampaignObjective;
+  primaryVariable: string;
+  primaryMetric: string;
+  unitPrice?: number | null;
+}
+
+export interface ProductAiExperimentPreparation {
+  hypothesisId: string;
+  hypothesisTitle: string;
+  productAiSubtype?: ProductAiSubtype | null;
+  ready: boolean;
+  blockers: string[];
+  draft?: ProductAiExperimentDraft | null;
+}
+
+export function useProductAiExperimentPreparation(hypothesisId?: string) {
+  return useQuery({
+    queryKey: ["product-ai-experiment-preparation", hypothesisId],
+    enabled: Boolean(hypothesisId),
+    queryFn: async () => {
+      const { data } = await axios.get<ProductAiExperimentPreparation>(
+        `/api/product-ai/experiment-preparations/${hypothesisId}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -12,6 +12,7 @@ import { useImageGenerationModels } from "../../api/ai/useImageGenerationModels"
 import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
+import { useProductAiExperimentPreparation } from "../../api/product-ai/useProductAiExperimentPreparation";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
 import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
@@ -138,6 +139,13 @@ export default function NewExperimentPage() {
     !["COMPLETED", "FAILED"].includes(promiseRequestStatus ?? ""),
   );
   const isLowTicketProduct = form.experimentType === "LOW_TICKET_PRODUCT";
+  const isProductAiExperiment = isLowTicketProduct && Boolean(form.productAiSubtype);
+  const productAiPreparation = useProductAiExperimentPreparation(
+    isProductAiExperiment ? form.hypothesisId : undefined,
+  );
+  const productAiPreparationData = productAiPreparation.data;
+  const productAiReady =
+    !isProductAiExperiment || Boolean(productAiPreparationData?.ready);
   const experimentTypeLabel = isLowTicketProduct
     ? "Produto low-ticket"
     : "Teste de nicho";
@@ -261,6 +269,25 @@ export default function NewExperimentPage() {
     setSelectedProductOffer(option.productOffer || "");
   };
 
+  const applyProductAiDraft = () => {
+    const draft = productAiPreparationData?.draft;
+    if (!draft) {
+      return;
+    }
+    setForm((prev) => ({
+      ...prev,
+      experimentType: draft.experimentType,
+      productAiSubtype: draft.productAiSubtype,
+      stage: draft.stage,
+      primaryVariable: draft.primaryVariable,
+      primaryMetric: draft.primaryMetric,
+      unitPrice:
+        draft.unitPrice != null && draft.unitPrice > 0
+          ? String(draft.unitPrice)
+          : prev.unitPrice,
+    }));
+  };
+
   const submit = async () => {
     try {
       if (noInstagramAccounts) {
@@ -271,6 +298,10 @@ export default function NewExperimentPage() {
       }
       if (!form.instagramAccountId) {
         alert("Selecione uma conta do Instagram");
+        return;
+      }
+      if (!productAiReady) {
+        alert("Complete o preparo do Produto IA antes de criar o experimento.");
         return;
       }
       const defaultJourneyTemplateId = journeyTemplates?.content?.[0]?.id;
@@ -523,6 +554,46 @@ export default function NewExperimentPage() {
         </>
       )}
       {form.hypothesis && <h2 className="h5 mb-2">{form.hypothesis}</h2>}
+      {isProductAiExperiment && form.hypothesisId && (
+        <div
+          className={`alert ${
+            productAiPreparation.isLoading
+              ? "alert-secondary"
+              : productAiPreparationData?.ready
+                ? "alert-success"
+                : "alert-warning"
+          } py-2 mb-3`}
+          role="status"
+        >
+          <div className="d-flex flex-column flex-md-row align-items-md-start justify-content-between gap-2">
+            <div>
+              <div className="fw-semibold">Preparo do Produto IA</div>
+              {productAiPreparation.isLoading ? (
+                <div className="small">Verificando hipótese e oferta...</div>
+              ) : productAiPreparationData?.ready ? (
+                <div className="small">
+                  Hipótese pronta para experimento com amostra personalizada.
+                </div>
+              ) : (
+                <div className="small">
+                  Complete os itens pendentes antes de criar o experimento:{" "}
+                  {(productAiPreparationData?.blockers ?? []).join(", ") ||
+                    "preparo indisponível"}
+                </div>
+              )}
+            </div>
+            {productAiPreparationData?.ready && (
+              <button
+                type="button"
+                className="btn btn-outline-primary btn-sm"
+                onClick={applyProductAiDraft}
+              >
+                Aplicar rascunho
+              </button>
+            )}
+          </div>
+        </div>
+      )}
       <div className="alert alert-info py-2 mb-3">
         O nome do experimento será gerado automaticamente pelo backend com o
         código da hipótese e a próxima numeração.
@@ -844,6 +915,7 @@ export default function NewExperimentPage() {
         disabled={
           create.isPending ||
           noInstagramAccounts ||
+          !productAiReady ||
           (!isLoadingJourneyTemplates && !journeyTemplates?.content?.length)
         }
       >


### PR DESCRIPTION
## Resumo
- Cria o preparo sistêmico de Produto IA em `/api/product-ai/experiment-preparations/{hypothesisId}`.
- Bloqueia no backend a criação direta de experimento Produto IA quando a hipótese ainda não tem nicho, dor, persona, promessa, mecanismo, preço, pacote, entregáveis e descrição da amostra.
- Atualiza a tela de novo experimento para mostrar bloqueios e aplicar o rascunho canônico de `AI_PERSONALIZED_SAMPLE`.
- Documenta a regra no cânone, plano de experimentos, registro e Swagger.

## Validação
- `../mvnw -q -Dtest=ExperimentControllerTest test`
- `../mvnw -q -Dtest=ArquiteturaTest test`
- `../mvnw -q test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`