### PR TITLE
[codex] Prepare product AI personalized sample hypotheses

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/productai/dto/PersonalizedSamplePreparationDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/dto/PersonalizedSamplePreparationDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.productai.dto;
+
+import com.marketinghub.productai.ProductAiSubtype;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/** Responsabilidade: representar o resultado do preparo sistêmico de uma hipótese para amostra personalizada. */
+public record PersonalizedSamplePreparationDto(
+        UUID hypothesisId,
+        String hypothesisTitle,
+        ProductAiSubtype productAiSubtype,
+        BigDecimal price,
+        Long offerPackageId,
+        String offerPackageName,
+        Long deliverableId,
+        String deliverableTitle,
+        ProductAiExperimentPreparationDto experimentPreparation) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiExperimentPreparationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiExperimentPreparationService.java
@@ -1,13 +1,22 @@
 package com.marketinghub.productai.service;
 
+import com.marketinghub.deliverable.Deliverable;
+import com.marketinghub.deliverable.DeliverablePackage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.OfferType;
 import com.marketinghub.productai.ProductAiSubtype;
+import com.marketinghub.productai.dto.PersonalizedSamplePreparationDto;
 import com.marketinghub.productai.dto.ProductAiExperimentPreparationDto;
+import com.marketinghub.repository.jpa.deliverable.DeliverablePackageRepository;
+import com.marketinghub.repository.jpa.deliverable.DeliverableRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,12 +28,20 @@ import org.springframework.http.HttpStatus;
 @Service
 public class ProductAiExperimentPreparationService {
     private static final String SAMPLE_DESCRIPTION_BLOCKER = "Descrição da amostra/entrega personalizada";
+    private static final BigDecimal DEFAULT_PERSONALIZED_SAMPLE_PRICE = new BigDecimal("27.00");
 
     private final HypothesisRepository hypothesisRepository;
+    private final DeliverableRepository deliverableRepository;
+    private final DeliverablePackageRepository deliverablePackageRepository;
 
     /** Inicializa o serviço com o repositório de hipóteses. */
-    public ProductAiExperimentPreparationService(HypothesisRepository hypothesisRepository) {
+    public ProductAiExperimentPreparationService(
+            HypothesisRepository hypothesisRepository,
+            DeliverableRepository deliverableRepository,
+            DeliverablePackageRepository deliverablePackageRepository) {
         this.hypothesisRepository = hypothesisRepository;
+        this.deliverableRepository = deliverableRepository;
+        this.deliverablePackageRepository = deliverablePackageRepository;
     }
 
     /** Retorna o diagnóstico de preparo de Produto IA para uma hipótese. */
@@ -44,6 +61,42 @@ public class ProductAiExperimentPreparationService {
                     HttpStatus.BAD_REQUEST,
                     "Produto IA incompleto para experimento: " + String.join(", ", preparation.blockers()));
         }
+    }
+
+    /** Completa uma hipótese rastreada do sistema para o MVP de amostra personalizada sem criar experimento manual. */
+    @Transactional
+    public PersonalizedSamplePreparationDto preparePersonalizedSampleHypothesis(UUID hypothesisId) {
+        Hypothesis hypothesis = hypothesisRepository.findById(hypothesisId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "hypothesis not found"));
+        validateTraceableHypothesis(hypothesis);
+
+        hypothesis.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        if (hypothesis.getOfferType() == null) {
+            hypothesis.setOfferType(OfferType.TRIPWIRE);
+        }
+        if (hypothesis.getPrice() == null) {
+            hypothesis.setPrice(DEFAULT_PERSONALIZED_SAMPLE_PRICE);
+        }
+        if (!StringUtils.hasText(hypothesis.getEntrega())) {
+            hypothesis.setEntrega(buildSampleDescription(hypothesis));
+        }
+
+        DeliverablePackage offerPackage = ensureOfferPackage(hypothesis);
+        hypothesis.setOfferPackage(offerPackage);
+        Hypothesis saved = hypothesisRepository.save(hypothesis);
+        ProductAiExperimentPreparationDto preparation = buildPreparation(saved);
+        Deliverable deliverable = offerPackage.getDeliverables().iterator().next();
+
+        return new PersonalizedSamplePreparationDto(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getProductAiSubtype(),
+                saved.getPrice(),
+                offerPackage.getId(),
+                offerPackage.getName(),
+                deliverable.getId(),
+                deliverable.getTitle(),
+                preparation);
     }
 
     /** Monta o diagnóstico e o rascunho aplicável a partir dos campos persistidos da hipótese. */
@@ -94,6 +147,74 @@ public class ProductAiExperimentPreparationService {
         return hypothesis.getOfferPackage() != null
                 && hypothesis.getOfferPackage().getDeliverables() != null
                 && !hypothesis.getOfferPackage().getDeliverables().isEmpty();
+    }
+
+    /** Bloqueia preparo quando a hipótese ainda não foi gerada com base comercial suficiente pelo sistema. */
+    private void validateTraceableHypothesis(Hypothesis hypothesis) {
+        var blockers = new ArrayList<String>();
+        require(blockers, hypothesis.getMarketNiche() != null, "Nicho/contexto");
+        requireText(blockers, hypothesis.getProblem(), "Dor principal");
+        requireText(blockers, hypothesis.getPersona(), "Persona");
+        requireText(blockers, hypothesis.getPromise(), "Promessa");
+        requireText(blockers, resolveMechanism(hypothesis), "Mecanismo");
+        if (!blockers.isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Hipótese sem rastreabilidade mínima para Produto IA: " + String.join(", ", blockers));
+        }
+    }
+
+    /** Garante um pacote de oferta mínimo vinculado à hipótese e ao nicho já existentes. */
+    private DeliverablePackage ensureOfferPackage(Hypothesis hypothesis) {
+        if (hasDeliverables(hypothesis)) {
+            return hypothesis.getOfferPackage();
+        }
+        Deliverable deliverable = deliverableRepository.save(Deliverable.builder()
+                .niche(hypothesis.getMarketNiche())
+                .title("Amostra visual personalizada")
+                .description(buildSampleDescription(hypothesis))
+                .content(buildSampleContent(hypothesis))
+                .build());
+        if (hypothesis.getOfferPackage() != null) {
+            DeliverablePackage existingPackage = hypothesis.getOfferPackage();
+            existingPackage.setDeliverables(new LinkedHashSet<>(List.of(deliverable)));
+            if (!StringUtils.hasText(existingPackage.getDescription())) {
+                existingPackage.setDescription(
+                        "Pacote mínimo para testar Produto IA com amostra visual personalizada antes da compra.");
+            }
+            return deliverablePackageRepository.save(existingPackage);
+        }
+        DeliverablePackage offerPackage = deliverablePackageRepository.save(DeliverablePackage.builder()
+                .hypothesis(hypothesis)
+                .name("Pacote inicial de amostra personalizada")
+                .description("Pacote mínimo para testar Produto IA com amostra visual personalizada antes da compra.")
+                .deliverables(new LinkedHashSet<>(List.of(deliverable)))
+                .build());
+        return offerPackage;
+    }
+
+    /** Descreve a amostra personalizada a partir da dor, promessa e mecanismo já persistidos. */
+    private String buildSampleDescription(Hypothesis hypothesis) {
+        return "Amostra visual personalizada para mostrar ao lead, antes da compra, uma prévia concreta da promessa: "
+                + compact(hypothesis.getPromise()) + ".";
+    }
+
+    /** Registra o conteúdo funcional mínimo do entregável para manter rastreabilidade da oferta. */
+    private String buildSampleContent(Hypothesis hypothesis) {
+        return String.join("\n",
+                "Dor: " + compact(hypothesis.getProblem()),
+                "Persona: " + compact(hypothesis.getPersona()),
+                "Promessa: " + compact(hypothesis.getPromise()),
+                "Mecanismo: " + compact(resolveMechanism(hypothesis)),
+                "Entrega: imagem/amostra personalizada gerada por IA para tangibilizar a transformação prometida.");
+    }
+
+    /** Normaliza texto usado no pacote mínimo sem remover o significado comercial. */
+    private String compact(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        return value.trim().replaceAll("\\s+", " ");
     }
 
     /** Registra bloqueio quando a condição obrigatória não foi atendida. */

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
@@ -1,16 +1,18 @@
 package com.marketinghub.productai.web;
 
+import com.marketinghub.productai.dto.PersonalizedSamplePreparationDto;
 import com.marketinghub.productai.dto.ProductAiExperimentPreparationDto;
 import com.marketinghub.productai.service.ProductAiExperimentPreparationService;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Responsabilidade: expor o preparo sistêmico de hipóteses Produto IA antes da criação de experimento. */
 @RestController
-@RequestMapping("/api/product-ai/experiment-preparations")
+@RequestMapping("/api/product-ai")
 public class ProductAiExperimentPreparationController {
     private final ProductAiExperimentPreparationService service;
 
@@ -20,8 +22,14 @@ public class ProductAiExperimentPreparationController {
     }
 
     /** Retorna bloqueios e rascunho canônico para a hipótese informada. */
-    @GetMapping("/{hypothesisId}")
+    @GetMapping("/experiment-preparations/{hypothesisId}")
     public ProductAiExperimentPreparationDto get(@PathVariable UUID hypothesisId) {
         return service.prepare(hypothesisId);
+    }
+
+    /** Completa a hipótese existente para o MVP de amostra personalizada antes da criação do experimento. */
+    @PostMapping("/hypotheses/{hypothesisId}/personalized-sample-preparation")
+    public PersonalizedSamplePreparationDto preparePersonalizedSample(@PathVariable UUID hypothesisId) {
+        return service.preparePersonalizedSampleHypothesis(hypothesisId);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -261,6 +261,43 @@ class ExperimentControllerTest {
                 .andExpect(jsonPath("$.draft.campaignObjective").value("SALES"));
     }
 
+    /** Garante que o comando sistêmico completa uma hipótese rastreada para o MVP de amostra personalizada. */
+    @Test
+    void personalizedSamplePreparationCompletesTraceableHypothesis() throws Exception {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("AI preparo").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Hipótese para preparo")
+                .premiseAngle(angle)
+                .promise("Mostrar uma prévia visual personalizada da melhoria")
+                .problem("O cliente não enxerga o resultado antes de comprar")
+                .persona("Dono de pequeno negócio")
+                .mechanism("Prévia visual gerada por IA com dados do lead")
+                .build());
+
+        mockMvc.perform(get("/api/product-ai/experiment-preparations/{hypothesisId}", hyp.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ready").value(false));
+
+        mockMvc.perform(post("/api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation", hyp.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productAiSubtype").value("AI_PERSONALIZED_SAMPLE"))
+                .andExpect(jsonPath("$.price").value(27.00))
+                .andExpect(jsonPath("$.offerPackageName").value("Pacote inicial de amostra personalizada"))
+                .andExpect(jsonPath("$.deliverableTitle").value("Amostra visual personalizada"))
+                .andExpect(jsonPath("$.experimentPreparation.ready").value(true))
+                .andExpect(jsonPath("$.experimentPreparation.draft.experimentType").value("LOW_TICKET_PRODUCT"))
+                .andExpect(jsonPath("$.experimentPreparation.draft.stage").value("SAMPLE"));
+
+        var prepared = hypothesisRepository.findById(hyp.getId()).orElseThrow();
+        assertThat(prepared.getProductAiSubtype()).isEqualTo(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        assertThat(prepared.getPrice()).isEqualByComparingTo("27.00");
+        assertThat(prepared.getOfferPackage()).isNotNull();
+        assertThat(deliverablePackageRepository.findByHypothesisIdOrderByCreatedAtDesc(hyp.getId())).hasSize(1);
+        assertThat(deliverableRepository.findAll()).hasSize(1);
+        assertThat(prepared.getEntrega()).contains("Amostra visual personalizada");
+    }
+
     /** Garante que Produto IA incompleto não vira experimento por chamada direta de API. */
     @Test
     void createEndpointRejectsIncompleteProductAiHypothesis() throws Exception {

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -101,6 +101,8 @@ Todo Produto IA deve nascer por uma execucao rastreavel do sistema, preservando 
 
 Antes de criar o experimento, o backend deve validar o preparo da hipotese Produto IA por endpoint sistemico. Para o MVP `AI_PERSONALIZED_SAMPLE`, a hipotese so pode virar experimento quando possuir nicho/contexto, dor principal, persona, promessa, mecanismo, preco, pacote de oferta, entregaveis do pacote e descricao da amostra personalizada. A tela pode exibir bloqueios e aplicar um rascunho canonico, mas a trava definitiva fica no backend.
 
+Quando uma hipotese criada pelo sistema ja possuir nicho/contexto, dor principal, persona, promessa e mecanismo, mas ainda nao possuir os campos operacionais do MVP, o backend pode executar o comando sistemico `POST /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation`. Esse comando apenas completa a hipotese existente com `AI_PERSONALIZED_SAMPLE`, preco inicial, pacote de oferta e entregavel minimo de amostra personalizada. Ele nao cria hipotese nova, nao cria experimento e nao autoriza atalho manual fora do fluxo.
+
 Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.
 
 Padroes externos, como os dossies da Biblioteca de Paginas de Vendas, podem ser usados como insumo de briefing e aprendizado. Eles nao podem substituir a geracao rastreavel de hipotese, dor, mecanismo, prova, oferta e experimento pelo sistema.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5582,3 +5582,10 @@
 - Correção aplicada: criado endpoint `/api/product-ai/experiment-preparations/{hypothesisId}` para expor bloqueios e rascunho canônico; o backend bloqueia criação direta de experimento Produto IA incompleto.
 - Regra operacional: a hipótese precisa ter nicho, dor, persona, promessa, mecanismo, preço, pacote de oferta, entregáveis e descrição da amostra personalizada.
 - Prevenção de recorrência: a tela mostra os bloqueios, mas a trava definitiva fica no backend para impedir produto manual fora do fluxo.
+
+## 2026-07-03 — Comando de preparo AI Personalized Sample
+
+- Decisão: uma hipótese já criada pelo sistema pode receber preparo operacional para o MVP `AI_PERSONALIZED_SAMPLE` sem virar experimento automaticamente.
+- Correção aplicada: criado endpoint `POST /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation`.
+- Regra operacional: o comando exige rastreabilidade mínima de nicho, dor, persona, promessa e mecanismo; depois completa subtipo Produto IA, preço inicial, descrição da amostra, pacote de oferta e entregável mínimo.
+- Prevenção de recorrência: o comando não cria hipótese nova nem experimento; a criação do experimento continua bloqueada pelo diagnóstico `/api/product-ai/experiment-preparations/{hypothesisId}`.

--- a/docs/swagger/product-ai-experiment-preparation-swagger.yaml
+++ b/docs/swagger/product-ai-experiment-preparation-swagger.yaml
@@ -24,8 +24,59 @@ paths:
                 $ref: '#/components/schemas/ProductAiExperimentPreparation'
         '404':
           description: Hipótese não encontrada.
+  /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation:
+    post:
+      summary: Prepara hipótese para AI Personalized Sample
+      description: Completa uma hipótese já criada pelo sistema com subtipo, preço inicial, pacote de oferta e entregável mínimo para o MVP de amostra personalizada. Não cria experimento.
+      parameters:
+        - name: hypothesisId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Hipótese preparada e diagnóstico de experimento retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalizedSamplePreparation'
+        '400':
+          description: Hipótese ainda não possui rastreabilidade mínima de nicho, dor, persona, promessa e mecanismo.
+        '404':
+          description: Hipótese não encontrada.
 components:
   schemas:
+    PersonalizedSamplePreparation:
+      type: object
+      properties:
+        hypothesisId:
+          type: string
+          format: uuid
+        hypothesisTitle:
+          type: string
+        productAiSubtype:
+          type: string
+          example: AI_PERSONALIZED_SAMPLE
+        price:
+          type: number
+          format: decimal
+          example: 27.00
+        offerPackageId:
+          type: integer
+          format: int64
+        offerPackageName:
+          type: string
+          example: Pacote inicial de amostra personalizada
+        deliverableId:
+          type: integer
+          format: int64
+        deliverableTitle:
+          type: string
+          example: Amostra visual personalizada
+        experimentPreparation:
+          $ref: '#/components/schemas/ProductAiExperimentPreparation'
     ProductAiExperimentPreparation:
       type: object
       required: [hypothesisId, hypothesisTitle, ready, blockers]


### PR DESCRIPTION
## O que mudou

- Adiciona o comando sistêmico `POST /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation`.
- O comando completa uma hipótese já criada pelo sistema para o MVP `AI_PERSONALIZED_SAMPLE`, sem criar experimento manual.
- O preparo exige rastreabilidade mínima de nicho, dor, persona, promessa e mecanismo.
- Quando aprovado, preenche subtipo Produto IA, preço inicial, descrição da amostra, pacote de oferta e entregável mínimo.
- Atualiza Swagger e cânone de tipos de produto.

## Por que

Precisamos conseguir avançar para o primeiro experimento de Produto IA sem violar a regra canônica: nenhum produto/oferta/amostra/experimento nasce por atalho manual. O comando transforma uma hipótese rastreada em uma hipótese pronta para passar pela trava já existente de criação de experimento.

## Validação

- `../mvnw -q -Dtest=ExperimentControllerTest,ArquiteturaTest test`
- `../mvnw -q test`
- `git diff --check`

## Observação

A criação do experimento continua dependente do diagnóstico `GET /api/product-ai/experiment-preparations/{hypothesisId}` retornar `ready=true`.