### PR TITLE
[codex] Add product AI personalized sample funnel

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
@@ -6,6 +6,7 @@ package com.marketinghub.experiment.dto;
 public enum ExperimentReadinessIssueType {
     CREATIVE,
     LEAD_PORTAL_FLOW,
+    PRODUCT_AI_FUNNEL,
     TARGETING,
     GERA_LANDING,
     GERA_SALES_PAGE

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
@@ -52,6 +53,15 @@ public class ExperimentReadinessService {
             TargetingElementType.BEHAVIOR
     );
     private static final Set<TargetingElementType> PUBLISHABLE_TARGETING_TYPE_SET = Set.copyOf(PUBLISHABLE_TARGETING_TYPES);
+    private static final Set<String> PRODUCT_AI_PERSONALIZED_SAMPLE_REQUIRED_KEYS = Set.of(
+            "nome",
+            "email",
+            "whatsapp",
+            "negocio_projeto",
+            "contexto_atual",
+            "objetivo_visual",
+            "dados_personalizacao"
+    );
 
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
     private final GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
@@ -108,6 +118,15 @@ public class ExperimentReadinessService {
                     "Sem fluxo do portal do lead",
                     "Ainda não há um fluxo do portal vinculado a este experimento.",
                     "Solicite a geração de um fluxo ou associe um existente na aba Portal do Lead.",
+                    List.of()
+            ));
+        }
+        if (isPersonalizedSampleProductAi(experiment) && !hasProductAiPersonalizationFunnel(experiment)) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.PRODUCT_AI_FUNNEL,
+                    "Sem funil de coleta para personalização",
+                    "Produto IA com amostra personalizada precisa coletar dados do lead antes de prometer uma entrega exclusiva.",
+                    "Crie o funil pelo comando de Produto IA antes de liberar campanha ou venda.",
                     List.of()
             ));
         }
@@ -208,6 +227,9 @@ public class ExperimentReadinessService {
         if (isLowTicketProduct(experiment) && !hasFacebookPixel(experiment)) {
             missing.add("facebookPixel");
         }
+        if (isPersonalizedSampleProductAi(experiment) && !hasProductAiPersonalizationFunnel(experiment)) {
+            missing.add("productAiPersonalizedSampleFunnel");
+        }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("approvedTargetingPackage");
         }
@@ -286,6 +308,22 @@ public class ExperimentReadinessService {
     /** Identifica experimento de venda direta low-ticket. */
     private boolean isLowTicketProduct(Experiment experiment) {
         return experiment != null && experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT;
+    }
+
+    /** Identifica Produto IA que depende de dados do lead para gerar amostra personalizada. */
+    private boolean isPersonalizedSampleProductAi(Experiment experiment) {
+        return experiment != null && experiment.getProductAiSubtype() == ProductAiSubtype.AI_PERSONALIZED_SAMPLE;
+    }
+
+    /** Verifica se o funil de personalização está aprovado e possui os campos mínimos de coleta. */
+    private boolean hasProductAiPersonalizationFunnel(Experiment experiment) {
+        if (experiment == null || experiment.getLeadPortalFlow() == null || !experiment.getLeadPortalFlow().isApproved()) {
+            return false;
+        }
+        Set<String> keys = experiment.getLeadPortalFlow().getQuestions().stream()
+                .map(question -> question.getDataKey() == null ? "" : question.getDataKey().toLowerCase(Locale.ROOT))
+                .collect(java.util.stream.Collectors.toSet());
+        return keys.containsAll(PRODUCT_AI_PERSONALIZED_SAMPLE_REQUIRED_KEYS);
     }
 
     /** Verifica a conclusão da etapa final que publica a página de venda canônica. */

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/dto/PersonalizedSampleFunnelDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/dto/PersonalizedSampleFunnelDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.productai.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Contrato que descreve o funil de coleta de dados para amostra personalizada de Produto IA. */
+public record PersonalizedSampleFunnelDto(
+        Long experimentId,
+        Long leadPortalFlowId,
+        String leadPortalFlowSlug,
+        boolean approved,
+        Instant approvedAt,
+        List<String> dataKeys) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelService.java
@@ -1,0 +1,198 @@
+package com.marketinghub.productai.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.leadportal.LeadPortalFlow;
+import com.marketinghub.leadportal.LeadPortalFlowQuestion;
+import com.marketinghub.leadportal.LeadPortalQuestionType;
+import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
+import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
+import com.marketinghub.productai.ProductAiSubtype;
+import com.marketinghub.productai.dto.PersonalizedSampleFunnelDto;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: criar e manter o funil de coleta para Produto IA com amostra personalizada. */
+@Service
+public class ProductAiPersonalizedSampleFunnelService {
+    private static final Logger log = LoggerFactory.getLogger(ProductAiPersonalizedSampleFunnelService.class);
+    private static final String SLUG_PREFIX = "product-ai-exp-";
+
+    private final ExperimentRepository experimentRepository;
+    private final LeadPortalFlowRepository leadPortalFlowRepository;
+    private final LeadPortalFlowPublisher leadPortalFlowPublisher;
+
+    /** Inicializa o serviço com repositórios e publicador do Lead Portal. */
+    public ProductAiPersonalizedSampleFunnelService(
+            ExperimentRepository experimentRepository,
+            LeadPortalFlowRepository leadPortalFlowRepository,
+            LeadPortalFlowPublisher leadPortalFlowPublisher) {
+        this.experimentRepository = experimentRepository;
+        this.leadPortalFlowRepository = leadPortalFlowRepository;
+        this.leadPortalFlowPublisher = leadPortalFlowPublisher;
+    }
+
+    /** Cria ou normaliza o funil canônico de coleta de dados para o experimento Produto IA. */
+    @Transactional
+    public PersonalizedSampleFunnelDto createOrUpdate(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "experiment not found"));
+        validateExperiment(experiment);
+
+        LeadPortalFlow flow = resolveFlow(experiment);
+        flow.setName("Produto IA - amostra personalizada - exp " + experiment.getId());
+        flow.setSlug(resolveSlug(flow, experiment.getId()));
+        flow.setDescription(buildDescription(experiment));
+        flow.setMarketNiche(experiment.getNiche());
+        flow.setExperiment(experiment);
+        flow.setSchemaFirst(true);
+        flow.setModel("AI_PERSONALIZED_SAMPLE_FUNNEL");
+        flow.getQuestions().clear();
+        flow.getQuestions().addAll(buildQuestions(flow));
+        flow.setApproved(true);
+        if (flow.getApprovedAt() == null) {
+            flow.setApprovedAt(Instant.now());
+        }
+
+        LeadPortalFlow saved = leadPortalFlowRepository.save(flow);
+        experiment.setLeadPortalFlow(saved);
+        experimentRepository.save(experiment);
+        publish(saved);
+        return toDto(saved, experiment.getId());
+    }
+
+    /** Bloqueia criação do funil quando o experimento não é o MVP de Produto IA personalizado. */
+    private void validateExperiment(Experiment experiment) {
+        if (experiment.getProductAiSubtype() != ProductAiSubtype.AI_PERSONALIZED_SAMPLE) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "experiment must be AI_PERSONALIZED_SAMPLE");
+        }
+        if (experiment.getNiche() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experiment niche is required");
+        }
+    }
+
+    /** Reaproveita o fluxo canônico existente antes de criar um novo. */
+    private LeadPortalFlow resolveFlow(Experiment experiment) {
+        if (experiment.getLeadPortalFlow() != null) {
+            return experiment.getLeadPortalFlow();
+        }
+        return leadPortalFlowRepository.findAllByExperimentIdOrderByCreatedAtDesc(experiment.getId()).stream()
+                .filter(flow -> flow.getSlug() != null && flow.getSlug().startsWith(SLUG_PREFIX + experiment.getId()))
+                .findFirst()
+                .orElseGet(LeadPortalFlow::new);
+    }
+
+    /** Define slug estável e evita colisão quando o slug antigo pertence a outro fluxo. */
+    private String resolveSlug(LeadPortalFlow flow, Long experimentId) {
+        String base = SLUG_PREFIX + experimentId + "-personalized-sample";
+        if (Objects.equals(flow.getSlug(), base)) {
+            return base;
+        }
+        return leadPortalFlowRepository.findBySlug(base)
+                .filter(existing -> !Objects.equals(existing.getId(), flow.getId()))
+                .map(existing -> base + "-" + System.currentTimeMillis())
+                .orElse(base);
+    }
+
+    /** Descreve a finalidade comercial do funil para auditoria operacional. */
+    private String buildDescription(Experiment experiment) {
+        String promise = StringUtils.hasText(experiment.getFunnelPromise())
+                ? experiment.getFunnelPromise()
+                : experiment.getHypothesis();
+        if (!StringUtils.hasText(promise)) {
+            promise = "gerar uma amostra visual personalizada antes da compra";
+        }
+        return "Funil canônico para coletar dados do lead e permitir geração de amostra personalizada: "
+                + promise.trim();
+    }
+
+    /** Monta as perguntas mínimas necessárias para gerar algo exclusivo para o lead. */
+    private List<LeadPortalFlowQuestion> buildQuestions(LeadPortalFlow flow) {
+        List<QuestionSpec> specs = List.of(
+                new QuestionSpec("Qual é o seu nome?", "nome", LeadPortalQuestionType.TEXT, true,
+                        "Usado para personalizar a entrega visual."),
+                new QuestionSpec("Qual é o seu e-mail?", "email", LeadPortalQuestionType.EMAIL, true,
+                        "Canal para enviar a amostra e continuar o relacionamento."),
+                new QuestionSpec("Qual é o seu WhatsApp?", "whatsapp", LeadPortalQuestionType.PHONE, true,
+                        "Canal operacional para entrega e suporte."),
+                new QuestionSpec("Qual negócio, projeto ou situação você quer melhorar?", "negocio_projeto",
+                        LeadPortalQuestionType.TEXTAREA, true, "Contexto principal que aparecerá na amostra."),
+                new QuestionSpec("Como está a situação hoje?", "contexto_atual", LeadPortalQuestionType.TEXTAREA,
+                        true, "Ajuda a IA a entender o ponto de partida."),
+                new QuestionSpec("Que resultado visual você quer enxergar na amostra?", "objetivo_visual",
+                        LeadPortalQuestionType.TEXTAREA, true, "Define o depois desejado pelo lead."),
+                new QuestionSpec("Quais detalhes precisam aparecer para parecer feito para você?",
+                        "dados_personalizacao", LeadPortalQuestionType.TEXTAREA, true,
+                        "Inclua nomes, cores, ambiente, produto, público ou referências próprias."),
+                new QuestionSpec("Existe algum estilo visual que você prefere?", "preferencias_visuais",
+                        LeadPortalQuestionType.TEXTAREA, false,
+                        "Exemplos: moderno, simples, premium, feminino, técnico, colorido.")
+        );
+        List<LeadPortalFlowQuestion> questions = new ArrayList<>();
+        for (int index = 0; index < specs.size(); index++) {
+            QuestionSpec spec = specs.get(index);
+            questions.add(LeadPortalFlowQuestion.builder()
+                    .flow(flow)
+                    .title(spec.title())
+                    .dataKey(spec.dataKey())
+                    .type(spec.type())
+                    .required(spec.required())
+                    .description(spec.description())
+                    .placeholder(spec.description())
+                    .position(index)
+                    .options(new ArrayList<>())
+                    .build());
+        }
+        return questions;
+    }
+
+    /** Publica o fluxo no Lead Portal sem esconder falhas de integração. */
+    private void publish(LeadPortalFlow flow) {
+        try {
+            leadPortalFlowPublisher.publish(flow);
+        } catch (LeadPortalPublicationException ex) {
+            log.error("Falha ao publicar funil Produto IA no Lead Portal: flowId={}, slug={}",
+                    flow.getId(), flow.getSlug(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "failed to publish product AI funnel", ex);
+        }
+    }
+
+    /** Converte o fluxo persistido no contrato administrativo retornado pela API. */
+    private PersonalizedSampleFunnelDto toDto(LeadPortalFlow flow, Long experimentId) {
+        List<String> keys = flow.getQuestions().stream()
+                .sorted(Comparator.comparingInt(LeadPortalFlowQuestion::getPosition))
+                .map(LeadPortalFlowQuestion::getDataKey)
+                .map(key -> key.toLowerCase(Locale.ROOT))
+                .toList();
+        return new PersonalizedSampleFunnelDto(
+                experimentId,
+                flow.getId(),
+                flow.getSlug(),
+                flow.isApproved(),
+                flow.getApprovedAt(),
+                keys);
+    }
+
+    /** Especificação interna de pergunta canônica do funil de personalização. */
+    private record QuestionSpec(
+            String title,
+            String dataKey,
+            LeadPortalQuestionType type,
+            boolean required,
+            String description) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/web/ProductAiExperimentPreparationController.java
@@ -1,8 +1,10 @@
 package com.marketinghub.productai.web;
 
 import com.marketinghub.productai.dto.PersonalizedSamplePreparationDto;
+import com.marketinghub.productai.dto.PersonalizedSampleFunnelDto;
 import com.marketinghub.productai.dto.ProductAiExperimentPreparationDto;
 import com.marketinghub.productai.service.ProductAiExperimentPreparationService;
+import com.marketinghub.productai.service.ProductAiPersonalizedSampleFunnelService;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,10 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/product-ai")
 public class ProductAiExperimentPreparationController {
     private final ProductAiExperimentPreparationService service;
+    private final ProductAiPersonalizedSampleFunnelService funnelService;
 
     /** Inicializa o controller com o serviço de preparo de Produto IA. */
-    public ProductAiExperimentPreparationController(ProductAiExperimentPreparationService service) {
+    public ProductAiExperimentPreparationController(
+            ProductAiExperimentPreparationService service,
+            ProductAiPersonalizedSampleFunnelService funnelService) {
         this.service = service;
+        this.funnelService = funnelService;
     }
 
     /** Retorna bloqueios e rascunho canônico para a hipótese informada. */
@@ -31,5 +37,11 @@ public class ProductAiExperimentPreparationController {
     @PostMapping("/hypotheses/{hypothesisId}/personalized-sample-preparation")
     public PersonalizedSamplePreparationDto preparePersonalizedSample(@PathVariable UUID hypothesisId) {
         return service.preparePersonalizedSampleHypothesis(hypothesisId);
+    }
+
+    /** Cria ou reaproveita o funil canônico que coleta dados do lead para a amostra personalizada. */
+    @PostMapping("/experiments/{experimentId}/personalized-sample-funnel")
+    public PersonalizedSampleFunnelDto createPersonalizedSampleFunnel(@PathVariable Long experimentId) {
+        return funnelService.createOrUpdate(experimentId);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -14,7 +14,10 @@ import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
+import com.marketinghub.leadportal.LeadPortalFlowQuestion;
+import com.marketinghub.leadportal.LeadPortalQuestionType;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementStatus;
@@ -323,6 +326,60 @@ class ExperimentReadinessServiceTest {
     }
 
     @Test
+    // Verifica que Produto IA personalizado não publica sem coleta prévia dos dados do lead.
+    void shouldRequirePersonalizedSampleFunnelForProductAiCampaign() {
+        Experiment experiment = buildExperiment(58L, 68L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp58.html");
+        experiment.getNiche().setFacebookPixelId("pixel-exp58");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(58L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(58L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(58L);
+        mockSalesPageAudit(
+                58L,
+                "https://pagamentopalf.site/sales-page-exp58.html",
+                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp58",
+                trackedSalesPageHtml());
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("productAiPersonalizedSampleFunnel");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    @Test
+    // Verifica que Produto IA personalizado completo exige funil aprovado com campos mínimos de personalização.
+    void shouldAllowPersonalizedSampleCampaignWhenFunnelCollectsRequiredData() {
+        Experiment experiment = buildExperiment(59L, 69L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp59.html");
+        experiment.getNiche().setFacebookPixelId("pixel-exp59");
+        experiment.setLeadPortalFlow(productAiFlow(
+                "nome",
+                "email",
+                "whatsapp",
+                "negocio_projeto",
+                "contexto_atual",
+                "objetivo_visual",
+                "dados_personalizacao",
+                "preferencias_visuais"));
+
+        when(creativeRepository.existsByExperimentIdAndStatus(59L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(59L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(59L);
+        mockSalesPageAudit(
+                59L,
+                "https://pagamentopalf.site/sales-page-exp59.html",
+                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp59",
+                trackedSalesPageHtml());
+
+        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
+        assertThat(service.isReadyForCampaign(experiment)).isTrue();
+    }
+
+    @Test
     // Verifica que low-ticket completo com página e pixel pode ser publicado.
     void shouldAllowLowTicketCampaignOnlyAfterGeraSalesPagePublicationPackage() {
         Experiment experiment = buildExperiment(53L, 63L);
@@ -426,6 +483,23 @@ class ExperimentReadinessServiceTest {
                 </script>
                 </body></html>
                 """;
+    }
+
+    /** Cria um funil aprovado de Produto IA com as chaves informadas. */
+    private LeadPortalFlow productAiFlow(String... dataKeys) {
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        for (int i = 0; i < dataKeys.length; i++) {
+            flow.getQuestions().add(LeadPortalFlowQuestion.builder()
+                    .flow(flow)
+                    .title("Pergunta " + i)
+                    .dataKey(dataKeys[i])
+                    .type(LeadPortalQuestionType.TEXT)
+                    .required(true)
+                    .position(i)
+                    .build());
+        }
+        return flow;
     }
 
     /** Cria um experimento base para os testes de prontidão. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.repository.jpa.creative.label.AngleRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.FixtureUtils;
 import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
@@ -26,6 +27,7 @@ import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecut
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -42,6 +44,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 /**
  * Responsabilidade: validar os contratos HTTP de criação e atualização de experimentos.
@@ -94,6 +98,8 @@ class ExperimentControllerTest {
     private DeliverablePackageRepository deliverablePackageRepository;
     @Autowired
     private DeliverableRepository deliverableRepository;
+    @MockBean
+    private LeadPortalFlowPublisher leadPortalFlowPublisher;
 
     Long nicheId;
 
@@ -296,6 +302,45 @@ class ExperimentControllerTest {
         assertThat(deliverablePackageRepository.findByHypothesisIdOrderByCreatedAtDesc(hyp.getId())).hasSize(1);
         assertThat(deliverableRepository.findAll()).hasSize(1);
         assertThat(prepared.getEntrega()).contains("Amostra visual personalizada");
+    }
+
+    /** Garante que o Produto IA cria pelo sistema um funil aprovado para coletar dados de personalização. */
+    @Test
+    void personalizedSampleFunnelEndpointCreatesApprovedLeadPortalFlow() throws Exception {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("AI funil").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("Hipótese funil")
+                .premiseAngle(angle)
+                .promise("Gerar uma prévia exclusiva")
+                .problem("O cliente não visualiza o resultado")
+                .persona("Dono de marmitaria")
+                .mechanism("Amostra visual personalizada")
+                .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
+                .build());
+        var experiment = repository.save(com.marketinghub.experiment.Experiment.builder()
+                .niche(nicheRepo.findById(nicheId).orElseThrow())
+                .name("Experimento Produto IA")
+                .hypothesis("Prévia exclusiva")
+                .funnelPromise("Visualize seu painel personalizado antes de comprar")
+                .hypothesisRef(hyp)
+                .productAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE)
+                .experimentType(com.marketinghub.experiment.ExperimentType.LOW_TICKET_PRODUCT)
+                .build());
+
+        mockMvc.perform(post("/api/product-ai/experiments/{experimentId}/personalized-sample-funnel", experiment.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.experimentId").value(experiment.getId()))
+                .andExpect(jsonPath("$.approved").value(true))
+                .andExpect(jsonPath("$.leadPortalFlowSlug")
+                        .value("product-ai-exp-" + experiment.getId() + "-personalized-sample"))
+                .andExpect(jsonPath("$.dataKeys[0]").value("nome"))
+                .andExpect(jsonPath("$.dataKeys[6]").value("dados_personalizacao"));
+
+        var updated = repository.findById(experiment.getId()).orElseThrow();
+        assertThat(updated.getLeadPortalFlow()).isNotNull();
+        assertThat(updated.getLeadPortalFlow().isApproved()).isTrue();
+        verify(leadPortalFlowPublisher).publish(any(com.marketinghub.leadportal.LeadPortalFlow.class));
     }
 
     /** Garante que Produto IA incompleto não vira experimento por chamada direta de API. */

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -239,6 +239,7 @@ Regras obrigatórias:
 - prompts, schemas, custos, entradas, saídas e decisões devem permanecer auditáveis;
 - padrões da Biblioteca de Páginas de Vendas podem enriquecer o briefing, mas não substituem as etapas de hipótese, dor, mecanismo, prova, oferta e validação;
 - Produto IA com subtipo declarado deve passar pelo preparo sistêmico antes da criação do experimento. Para `AI_PERSONALIZED_SAMPLE`, o backend deve bloquear a criação se faltar nicho/contexto, dor principal, persona, promessa, mecanismo, preço, pacote de oferta, entregáveis ou descrição da amostra;
+- Produto IA `AI_PERSONALIZED_SAMPLE` deve possuir funil de coleta de dados do lead criado pelo backend antes da publicação. O funil deve estar aprovado, vinculado ao experimento e coletar dados suficientes para gerar algo personalizado; sem isso, a campanha deve permanecer bloqueada;
 - se algum ativo for criado emergencialmente fora do fluxo, ele deve ser tratado como material provisório não canônico e não pode ser publicado ou escalado até ser reconstruído pelo sistema.
 
 ### 4.2.1.1 Regra mandatória — prompt/schema por experimento

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -103,6 +103,8 @@ Antes de criar o experimento, o backend deve validar o preparo da hipotese Produ
 
 Quando uma hipotese criada pelo sistema ja possuir nicho/contexto, dor principal, persona, promessa e mecanismo, mas ainda nao possuir os campos operacionais do MVP, o backend pode executar o comando sistemico `POST /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation`. Esse comando apenas completa a hipotese existente com `AI_PERSONALIZED_SAMPLE`, preco inicial, pacote de oferta e entregavel minimo de amostra personalizada. Ele nao cria hipotese nova, nao cria experimento e nao autoriza atalho manual fora do fluxo.
 
+Depois que o experimento `AI_PERSONALIZED_SAMPLE` existir, a publicacao de campanha deve continuar bloqueada ate o backend criar ou reaproveitar o funil canonico de coleta pelo endpoint `POST /api/product-ai/experiments/{experimentId}/personalized-sample-funnel`. Esse funil deve ser um `LeadPortalFlow` aprovado e vinculado ao experimento, coletando no minimo nome, e-mail, WhatsApp, negocio/projeto, contexto atual, objetivo visual e dados de personalizacao. Sem esses dados, o produto nao tem insumo suficiente para prometer amostra exclusiva.
+
 Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.
 
 Padroes externos, como os dossies da Biblioteca de Paginas de Vendas, podem ser usados como insumo de briefing e aprendizado. Eles nao podem substituir a geracao rastreavel de hipotese, dor, mecanismo, prova, oferta e experimento pelo sistema.

--- a/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
+++ b/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
@@ -73,6 +73,19 @@ O backend só libera rascunho de experimento quando a hipótese possui:
 
 Quando pronta, a tela aplica o rascunho canônico: `LOW_TICKET_PRODUCT`, `AI_PERSONALIZED_SAMPLE`, etapa `SAMPLE`, objetivo `SALES`, variável “Amostra visual personalizada” e métrica “Compra aprovada e custo de IA por compra”.
 
+Depois da criação do experimento, o sistema deve criar ou reaproveitar o funil de coleta pelo endpoint `POST /api/product-ai/experiments/{experimentId}/personalized-sample-funnel`. Esse funil é obrigatório antes de publicar campanha porque a personalização depende dos dados do lead.
+
+Campos mínimos do funil:
+
+- nome;
+- e-mail;
+- WhatsApp;
+- negócio/projeto;
+- contexto atual;
+- objetivo visual;
+- dados de personalização;
+- preferências visuais.
+
 ## Desenho experimental inicial
 
 Fluxo:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5589,3 +5589,10 @@
 - Correção aplicada: criado endpoint `POST /api/product-ai/hypotheses/{hypothesisId}/personalized-sample-preparation`.
 - Regra operacional: o comando exige rastreabilidade mínima de nicho, dor, persona, promessa e mecanismo; depois completa subtipo Produto IA, preço inicial, descrição da amostra, pacote de oferta e entregável mínimo.
 - Prevenção de recorrência: o comando não cria hipótese nova nem experimento; a criação do experimento continua bloqueada pelo diagnóstico `/api/product-ai/experiment-preparations/{hypothesisId}`.
+
+## 2026-07-03 — Funil de coleta para AI Personalized Sample
+
+- Decisão: o experimento `AI_PERSONALIZED_SAMPLE` precisa coletar dados do lead antes de publicar campanha, porque a promessa de amostra exclusiva depende de insumos individuais.
+- Correção aplicada: criado endpoint `POST /api/product-ai/experiments/{experimentId}/personalized-sample-funnel` para criar ou reaproveitar um `LeadPortalFlow` aprovado e vinculado ao experimento.
+- Regra operacional: a prontidão de campanha passa a bloquear Produto IA personalizado sem funil aprovado contendo nome, e-mail, WhatsApp, negócio/projeto, contexto atual, objetivo visual e dados de personalização.
+- Prevenção de recorrência: a coleta fica como ativo sistêmico auditável do experimento, evitando criar produto ou amostra personalizada fora do fluxo oficial.

--- a/docs/swagger/product-ai-experiment-preparation-swagger.yaml
+++ b/docs/swagger/product-ai-experiment-preparation-swagger.yaml
@@ -46,8 +46,61 @@ paths:
           description: Hipótese ainda não possui rastreabilidade mínima de nicho, dor, persona, promessa e mecanismo.
         '404':
           description: Hipótese não encontrada.
+  /api/product-ai/experiments/{experimentId}/personalized-sample-funnel:
+    post:
+      summary: Cria funil de coleta para AI Personalized Sample
+      description: Cria ou reaproveita o Lead Portal Flow canônico que coleta os dados mínimos do lead para gerar uma amostra personalizada. O fluxo fica aprovado e vinculado ao experimento.
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Funil criado ou normalizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalizedSampleFunnel'
+        '400':
+          description: Experimento não é AI_PERSONALIZED_SAMPLE ou não possui nicho.
+        '404':
+          description: Experimento não encontrado.
 components:
   schemas:
+    PersonalizedSampleFunnel:
+      type: object
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+        leadPortalFlowId:
+          type: integer
+          format: int64
+        leadPortalFlowSlug:
+          type: string
+          example: product-ai-exp-55-personalized-sample
+        approved:
+          type: boolean
+          example: true
+        approvedAt:
+          type: string
+          format: date-time
+        dataKeys:
+          type: array
+          items:
+            type: string
+          example:
+            - nome
+            - email
+            - whatsapp
+            - negocio_projeto
+            - contexto_atual
+            - objetivo_visual
+            - dados_personalizacao
+            - preferencias_visuais
     PersonalizedSamplePreparation:
       type: object
       properties:


### PR DESCRIPTION
## Resumo

- Cria o endpoint `POST /api/product-ai/experiments/{experimentId}/personalized-sample-funnel`.
- O backend cria ou reaproveita um `LeadPortalFlow` aprovado para coletar dados de personalizacao do lead.
- A prontidao de campanha passa a bloquear `AI_PERSONALIZED_SAMPLE` sem funil aprovado e com campos minimos.
- Documenta a regra no canon de tipos de produto, procedimento de experimento, plano do Produto IA e Swagger.

## Impacto

Produto IA personalizado deixa de poder seguir para campanha sem coletar os dados necessarios para gerar algo exclusivo ao lead. Isso protege a promessa comercial antes de vender ou publicar o experimento.

## Validacao

- `../mvnw -q -Dtest=ExperimentControllerTest,ExperimentReadinessServiceTest test`
- `../mvnw -q -Dtest=ArquiteturaTest test`
- `../mvnw -q test`
- `git diff --check`