### PR TITLE
[codex] Add product AI paid delivery worker

### DIFF
--- a/.github/workflows/product-ai-worker-ci.yml
+++ b/.github/workflows/product-ai-worker-ci.yml
@@ -1,0 +1,130 @@
+name: Product AI Worker CI
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - 'product-ai-worker/**'
+      - '.github/workflows/product-ai-worker-ci.yml'
+  pull_request:
+    paths:
+      - 'product-ai-worker/**'
+      - '.github/workflows/product-ai-worker-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: product-ai-worker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+      - name: Build
+        run: mvn -B package -DskipTests
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}/marketing-hub
+      IMAGE_TAG: latest
+      IMAGE_SHA_TAG: ${{ github.sha }}
+    outputs:
+      image-tag: ${{ steps.image_tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build jar
+        working-directory: product-ai-worker
+        run: mvn -B package -DskipTests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/product-ai-worker
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ env.IMAGE_SHA_TAG }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: product-ai-worker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Expose image tag
+        id: image_tag
+        run: echo "value=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DEPLOY_HOST: 191.252.120.96
+      DEPLOY_USER: root
+      REMOTE_PATH: ${{ secrets.PRODUCT_AI_WORKER_REMOTE_PATH || '/root/product-ai-worker' }}
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}/marketing-hub
+      IMAGE_TAG: ${{ needs.docker.outputs['image-tag'] }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Prepare remote directory
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+      - name: Sync Product AI Worker stack to VPS
+        run: |
+          rsync -az --delete \
+            -e "ssh ${SSH_COMMON_ARGS}" \
+            --exclude '.git/' \
+            --exclude 'target/' \
+            product-ai-worker/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+      - name: Publish service
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && if [ -n '${GHCR_TOKEN}' ]; then echo '${GHCR_TOKEN}' | docker login ${IMAGE_REGISTRY} -u '${GHCR_USERNAME}' --password-stdin; fi \
+            && docker compose -f docker-compose.yml pull \
+            && docker compose -f docker-compose.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -139,6 +139,13 @@ public class GeraSalesPageStageService {
             execution.setCostUsd(payload.costUsd());
             execution.setOpenAiJobId(payload.openAiJobId());
             execution.setCompletedAt(Instant.now());
+            if (isRejectedQualityReview(execution)) {
+                execution.setStatus(STATUS_FAILED);
+                execution.setErrorMessage("Quality review reprovou a página; publicação bloqueada.");
+                execution.setErrorDetail(extractQualityReviewBlockers(execution.getModelResponse()));
+                executionRepository.save(execution);
+                return;
+            }
             publicationAuditService.snapshotPublication(execution);
             GeraSalesPageStageCode.nextAfter(execution.getStageCode())
                     .ifPresent(nextStage -> enqueue(execution.getExperimentId(), nextStage));
@@ -265,6 +272,31 @@ public class GeraSalesPageStageService {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
                     "GeraSalesPage v1 exige followUpActionUrl com URL real de checkout antes de iniciar.");
+        }
+    }
+
+    /** Verifica se a etapa de revisão comercial reprovou a página. */
+    private boolean isRejectedQualityReview(GeraSalesPageStageExecution execution) {
+        if (!GeraSalesPageStageCode.CHECKOUT_QUALITY_REVIEW.code().equals(execution.getStageCode())) {
+            return false;
+        }
+        try {
+            Object approved = objectMapper.readValue(execution.getModelResponse(), Map.class).get("approved");
+            return Boolean.FALSE.equals(approved);
+        } catch (Exception ex) {
+            log.warn("Falha ao interpretar quality review do GeraSalesPage job {}", execution.getIdJob(), ex);
+            return true;
+        }
+    }
+
+    /** Extrai os bloqueios de revisão para deixar a causa da falha auditável. */
+    private String extractQualityReviewBlockers(String modelResponse) {
+        try {
+            Object blockers = objectMapper.readValue(modelResponse, Map.class).get("blockers");
+            return objectMapper.writeValueAsString(blockers);
+        } catch (Exception ex) {
+            log.warn("Falha ao extrair bloqueios do quality review do GeraSalesPage.", ex);
+            return modelResponse;
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryDtos.java
@@ -1,0 +1,51 @@
+package com.marketinghub.productai.delivery;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+
+/** Responsabilidade: agrupar contratos internos da entrega paga de Produto IA. */
+public final class ProductAiPaidDeliveryDtos {
+    private ProductAiPaidDeliveryDtos() {
+    }
+
+    /** Contrato entregue ao worker para execução de uma entrega paga pendente. */
+    public record PendingResponse(
+            String idJob,
+            Long purchaseId,
+            Long packageId,
+            Long experimentId,
+            String pipelineCode,
+            String stageCode,
+            Instant requestedAt,
+            Map<String, Object> buyer,
+            Map<String, Object> personalizationInput,
+            Map<String, Object> experiment,
+            Map<String, Object> promptSchemaTemplate) {}
+
+    /** Payload usado pelo payments-service para notificar compra aprovada. */
+    public record PurchaseApprovedRequest(Long purchaseId, Long packageId) {}
+
+    /** Resposta de enfileiramento da entrega paga. */
+    public record EnqueueResponse(String idJob, String status) {}
+
+    /** Request bruto que o worker enviará ao provedor externo. */
+    public record ReceiveRequestRequest(
+            String prompt,
+            String schemaJson,
+            String requestBodyJson,
+            String openAiModel,
+            String serviceTier) {}
+
+    /** Resultado ou falha reportado pelo worker após a execução. */
+    public record ReceiveResponseRequest(
+            String responseBodyJson,
+            String functionalOutputJson,
+            String artifactUrl,
+            String openAiModel,
+            String serviceTier,
+            Integer inputTokens,
+            Integer outputTokens,
+            BigDecimal estimatedCostUsd,
+            String errorMessage) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryInternalController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryInternalController.java
@@ -1,0 +1,53 @@
+package com.marketinghub.productai.delivery;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor contratos internos da entrega paga para payments-service e product-ai-worker. */
+@RestController
+@RequestMapping("/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions")
+public class ProductAiPaidDeliveryInternalController {
+    private final ProductAiPaidDeliveryService service;
+
+    /** Inicializa controller com o service de entrega paga. */
+    public ProductAiPaidDeliveryInternalController(ProductAiPaidDeliveryService service) {
+        this.service = service;
+    }
+
+    /** Recebe notificação de compra aprovada e enfileira entrega paga. */
+    @PostMapping("/approved-purchase")
+    public ProductAiPaidDeliveryDtos.EnqueueResponse approvedPurchase(
+            @RequestBody ProductAiPaidDeliveryDtos.PurchaseApprovedRequest request) {
+        return service.enqueueApprovedPurchase(request);
+    }
+
+    /** Lista entregas pendentes para consumo do worker. */
+    @GetMapping("/pending")
+    public List<ProductAiPaidDeliveryDtos.PendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Registra request bruto e prompt antes da chamada externa. */
+    @PostMapping("/{idJob}/recebeRequest")
+    public ResponseEntity<Void> recebeRequest(
+            @PathVariable String idJob,
+            @RequestBody ProductAiPaidDeliveryDtos.ReceiveRequestRequest request) {
+        service.receiveRequest(idJob, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** Registra resposta, custo e artefato gerado pelo worker. */
+    @PostMapping("/{idJob}/recebeResponse")
+    public ResponseEntity<Void> recebeResponse(
+            @PathVariable String idJob,
+            @RequestBody ProductAiPaidDeliveryDtos.ReceiveResponseRequest request) {
+        service.receiveResponse(idJob, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryService.java
@@ -1,0 +1,280 @@
+package com.marketinghub.productai.delivery;
+
+import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
+import com.marketinghub.cost.CostAttributionService;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
+import com.marketinghub.productai.ProductAiSubtype;
+import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.productai.ProductAiPaidDeliveryStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: controlar fila e auditoria da entrega paga do Produto IA personalizado. */
+@Service
+public class ProductAiPaidDeliveryService {
+    static final String PIPELINE_CODE = "personalizedsample.v1";
+    static final String STAGE_CODE = "paid-delivery";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_OPENAI";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
+
+    private final ProductAiPaidDeliveryStageExecutionRepository repository;
+    private final ExperimentRepository experimentRepository;
+    private final AiPromptSchemaTemplateRepository templateRepository;
+    private final OpenAiPricingService pricingService;
+    private final CostAttributionService costAttributionService;
+    private final JdbcTemplate jdbcTemplate;
+
+    /** Inicializa dependências de persistência, custo e consulta operacional. */
+    public ProductAiPaidDeliveryService(
+            ProductAiPaidDeliveryStageExecutionRepository repository,
+            ExperimentRepository experimentRepository,
+            AiPromptSchemaTemplateRepository templateRepository,
+            OpenAiPricingService pricingService,
+            CostAttributionService costAttributionService,
+            JdbcTemplate jdbcTemplate) {
+        this.repository = repository;
+        this.experimentRepository = experimentRepository;
+        this.templateRepository = templateRepository;
+        this.pricingService = pricingService;
+        this.costAttributionService = costAttributionService;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /** Enfileira entrega paga após confirmação de compra aprovada. */
+    @Transactional
+    public ProductAiPaidDeliveryDtos.EnqueueResponse enqueueApprovedPurchase(
+            ProductAiPaidDeliveryDtos.PurchaseApprovedRequest request) {
+        PurchaseContext context = loadPurchaseContext(request.purchaseId(), request.packageId());
+        Experiment experiment = experimentRepository.findById(context.experimentId())
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + context.experimentId()));
+        if (experiment.getProductAiSubtype() != ProductAiSubtype.AI_PERSONALIZED_SAMPLE) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Compra não pertence a AI_PERSONALIZED_SAMPLE.");
+        }
+        ProductAiPaidDeliveryStageExecution execution = repository
+                .findTopByPurchaseIdOrderByExecutionRequestedAtDesc(context.purchaseId())
+                .filter(existing -> !STATUS_FAILED.equals(existing.getStatus()))
+                .orElseGet(() -> createExecution(context, experiment));
+        return new ProductAiPaidDeliveryDtos.EnqueueResponse(execution.getIdJob(), execution.getStatus());
+    }
+
+    /** Lista entregas pendentes para consumo exclusivo do product-ai-worker. */
+    @Transactional(readOnly = true)
+    public List<ProductAiPaidDeliveryDtos.PendingResponse> pending() {
+        AiPromptSchemaTemplate template = loadTemplate();
+        return repository.findTop20ByPipelineCodeAndStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        PIPELINE_CODE, STAGE_CODE, STATUS_STARTED)
+                .stream()
+                .map(execution -> toPending(execution, template, loadPurchaseContext(execution.getPurchaseId(), execution.getPackageId())))
+                .toList();
+    }
+
+    /** Registra o request bruto antes da chamada OpenAI feita pelo worker. */
+    @Transactional
+    public void receiveRequest(String idJob, ProductAiPaidDeliveryDtos.ReceiveRequestRequest request) {
+        ProductAiPaidDeliveryStageExecution execution = findExecution(idJob);
+        execution.setStatus(STATUS_WAITING);
+        execution.setPrompt(request.prompt());
+        execution.setSchemaJson(request.schemaJson());
+        execution.setOpenAiRequestBody(request.requestBodyJson());
+        execution.setOpenAiModel(request.openAiModel());
+        execution.setServiceTier(request.serviceTier());
+        execution.setProcessingStartedAt(Instant.now());
+        repository.save(execution);
+    }
+
+    /** Registra o resultado funcional, calcula custo autoritativo e marca compra como entregue. */
+    @Transactional
+    public void receiveResponse(String idJob, ProductAiPaidDeliveryDtos.ReceiveResponseRequest request) {
+        ProductAiPaidDeliveryStageExecution execution = findExecution(idJob);
+        if (StringUtils.hasText(request.errorMessage())) {
+            execution.setStatus(STATUS_FAILED);
+            execution.setErrorMessage(request.errorMessage());
+            repository.save(execution);
+            return;
+        }
+        BigDecimal costUsd = calculateCost(request);
+        execution.setStatus(STATUS_COMPLETED);
+        execution.setOpenAiResponseBody(request.responseBodyJson());
+        execution.setFunctionalOutput(request.functionalOutputJson());
+        execution.setArtifactUrl(request.artifactUrl());
+        execution.setOpenAiModel(request.openAiModel());
+        execution.setServiceTier(request.serviceTier());
+        execution.setInputTokens(request.inputTokens());
+        execution.setOutputTokens(request.outputTokens());
+        execution.setCostUsd(costUsd);
+        execution.setCompletedAt(Instant.now());
+        repository.save(execution);
+        experimentRepository.findById(execution.getExperimentId())
+                .ifPresent(experiment -> costAttributionService.addUsdCostToExperimentHierarchy(experiment, costUsd));
+        markPurchaseDelivered(execution.getPurchaseId(), request.artifactUrl());
+    }
+
+    /** Cria execução inicial associada ao template ativo do pipeline. */
+    private ProductAiPaidDeliveryStageExecution createExecution(PurchaseContext context, Experiment experiment) {
+        AiPromptSchemaTemplate template = loadTemplate();
+        ProductAiPaidDeliveryStageExecution execution = ProductAiPaidDeliveryStageExecution.builder()
+                .idJob(UUID.randomUUID().toString())
+                .purchaseId(context.purchaseId())
+                .packageId(context.packageId())
+                .experimentId(experiment.getId())
+                .pipelineCode(PIPELINE_CODE)
+                .stageCode(STAGE_CODE)
+                .status(STATUS_STARTED)
+                .executionRequestedAt(Instant.now())
+                .promptTemplateKey(template.getTemplateKey())
+                .promptTemplateVersion(template.getVersion())
+                .schemaName(template.getSchemaName())
+                .build();
+        return repository.save(execution);
+    }
+
+    /** Monta o contrato de pending com dados funcionais e template do backend. */
+    private ProductAiPaidDeliveryDtos.PendingResponse toPending(
+            ProductAiPaidDeliveryStageExecution execution,
+            AiPromptSchemaTemplate template,
+            PurchaseContext context) {
+        return new ProductAiPaidDeliveryDtos.PendingResponse(
+                execution.getIdJob(),
+                execution.getPurchaseId(),
+                execution.getPackageId(),
+                execution.getExperimentId(),
+                execution.getPipelineCode(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                Map.of("name", nullToEmpty(context.buyerName()), "email", nullToEmpty(context.buyerEmail())),
+                context.personalizationInput(),
+                context.experimentPayload(),
+                templatePayload(template));
+    }
+
+    /** Carrega o template ativo persistido no banco. */
+    private AiPromptSchemaTemplate loadTemplate() {
+        return templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
+                        PIPELINE_CODE, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "Template ativo de prompt/schema não encontrado para " + PIPELINE_CODE + "/" + STAGE_CODE));
+    }
+
+    /** Busca a execução pelo idJob do contrato interno. */
+    private ProductAiPaidDeliveryStageExecution findExecution(String idJob) {
+        return repository.findTopByIdJobOrderByExecutionRequestedAtDesc(idJob)
+                .orElseThrow(() -> new EntityNotFoundException("Product AI paid delivery job not found: " + idJob));
+    }
+
+    /** Calcula custo canônico conforme o service tier usado na tentativa. */
+    private BigDecimal calculateCost(ProductAiPaidDeliveryDtos.ReceiveResponseRequest request) {
+        OpenAiResponse.OpenAiUsage usage =
+                new OpenAiResponse.OpenAiUsage(request.inputTokens(), request.outputTokens(), null, null, null);
+        if ("flex".equalsIgnoreCase(request.serviceTier())) {
+            return pricingService.estimateFlexCost(request.openAiModel(), request.inputTokens(), request.outputTokens());
+        }
+        return pricingService.estimateStandardCost(request.openAiModel(), usage);
+    }
+
+    /** Marca a compra como entregue quando o produto personalizado foi gerado. */
+    private void markPurchaseDelivered(Long purchaseId, String artifactUrl) {
+        jdbcTemplate.update("""
+                UPDATE lead_portal_purchase
+                   SET status = 'DELIVERED',
+                       delivered_at = UTC_TIMESTAMP(),
+                       zip_object_key = COALESCE(?, zip_object_key),
+                       updated_at = UTC_TIMESTAMP()
+                 WHERE id = ?
+                """, artifactUrl, purchaseId);
+    }
+
+    /** Lê compra, pacote, experimento e respostas do formulário para formar contexto funcional. */
+    private PurchaseContext loadPurchaseContext(Long purchaseId, Long packageId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT p.id AS purchase_id,
+                       p.package_id,
+                       p.buyer_name,
+                       p.buyer_email,
+                       pack.submission_id,
+                       sub.name AS submission_name,
+                       sub.email AS submission_email,
+                       sub.answers AS submission_answers,
+                       flow.id AS flow_id,
+                       COALESCE(exp.id, flow_exp.id) AS experiment_id,
+                       COALESCE(exp.name, flow_exp.name) AS experiment_name,
+                       COALESCE(exp.hypothesis, flow_exp.hypothesis) AS hypothesis,
+                       COALESCE(exp.single_pain, flow_exp.single_pain) AS single_pain,
+                       COALESCE(exp.funnel_promise, flow_exp.funnel_promise) AS funnel_promise,
+                       COALESCE(exp.primary_cta, flow_exp.primary_cta) AS primary_cta,
+                       COALESCE(exp.unit_price_brl, flow_exp.unit_price_brl) AS unit_price_brl
+                  FROM lead_portal_purchase p
+                  JOIN flow_submission_image_package pack ON pack.id = p.package_id
+                  JOIN flow_submissions sub ON sub.id = pack.submission_id
+                  LEFT JOIN lead_portal_flow flow ON flow.slug = sub.flow_slug
+                  LEFT JOIN experiment exp ON exp.lead_portal_flow_id = flow.id
+                  LEFT JOIN experiment flow_exp ON flow.experiment_id = flow_exp.id
+                 WHERE p.id = ? AND p.package_id = ?
+                """, (rs, rowNum) -> {
+                    Long experimentId = rs.getLong("experiment_id");
+                    Map<String, Object> experiment = new LinkedHashMap<>();
+                    experiment.put("id", experimentId);
+                    experiment.put("name", rs.getString("experiment_name"));
+                    experiment.put("hypothesis", rs.getString("hypothesis"));
+                    experiment.put("singlePain", rs.getString("single_pain"));
+                    experiment.put("funnelPromise", rs.getString("funnel_promise"));
+                    experiment.put("primaryCta", rs.getString("primary_cta"));
+                    experiment.put("unitPriceBrl", rs.getBigDecimal("unit_price_brl"));
+                    Map<String, Object> personalization = new LinkedHashMap<>();
+                    personalization.put("submissionId", rs.getString("submission_id"));
+                    personalization.put("name", rs.getString("submission_name"));
+                    personalization.put("email", rs.getString("submission_email"));
+                    personalization.put("answers", rs.getString("submission_answers"));
+                    return new PurchaseContext(
+                            rs.getLong("purchase_id"),
+                            rs.getLong("package_id"),
+                            experimentId,
+                            rs.getString("buyer_name"),
+                            rs.getString("buyer_email"),
+                            personalization,
+                            experiment);
+                }, purchaseId, packageId);
+    }
+
+    /** Monta payload do template versionado entregue ao worker. */
+    private Map<String, Object> templatePayload(AiPromptSchemaTemplate template) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("templateKey", template.getTemplateKey());
+        payload.put("version", template.getVersion());
+        payload.put("model", template.getOpenAiModel());
+        payload.put("schemaName", template.getSchemaName());
+        payload.put("promptMarkdownContent", template.getPromptMarkdownContent());
+        payload.put("schemaJson", template.getSchemaJson());
+        return payload;
+    }
+
+    /** Normaliza texto nulo para contratos JSON. */
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record PurchaseContext(
+            Long purchaseId,
+            Long packageId,
+            Long experimentId,
+            String buyerName,
+            String buyerEmail,
+            Map<String, Object> personalizationInput,
+            Map<String, Object> experimentPayload) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryStageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/delivery/ProductAiPaidDeliveryStageExecution.java
@@ -1,0 +1,106 @@
+package com.marketinghub.productai.delivery;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Responsabilidade: representar a execução auditável da entrega paga de Produto IA. */
+@Entity
+@Table(name = "product_ai_paid_delivery_stage_execution")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductAiPaidDeliveryStageExecution {
+    @Id
+    @Column(name = "id_job", nullable = false, length = 36)
+    private String idJob;
+
+    @Column(name = "purchase_id", nullable = false)
+    private Long purchaseId;
+
+    @Column(name = "package_id", nullable = false)
+    private Long packageId;
+
+    @Column(name = "experiment_id", nullable = false)
+    private Long experimentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id", nullable = false, insertable = false, updatable = false)
+    private com.marketinghub.experiment.Experiment experiment;
+
+    @Column(name = "pipeline_code", nullable = false, length = 80)
+    private String pipelineCode;
+
+    @Column(name = "stage_code", nullable = false, length = 80)
+    private String stageCode;
+
+    @Column(name = "status", nullable = false, length = 40)
+    private String status;
+
+    @Column(name = "execution_requested_at", nullable = false)
+    private Instant executionRequestedAt;
+
+    @Column(name = "processing_started_at")
+    private Instant processingStartedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "prompt_template_key", length = 191)
+    private String promptTemplateKey;
+
+    @Column(name = "prompt_template_version", length = 40)
+    private String promptTemplateVersion;
+
+    @Column(name = "schema_name", length = 191)
+    private String schemaName;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "schema_json", columnDefinition = "LONGTEXT")
+    private String schemaJson;
+
+    @Column(name = "openai_request_body", columnDefinition = "LONGTEXT")
+    private String openAiRequestBody;
+
+    @Column(name = "openai_response_body", columnDefinition = "LONGTEXT")
+    private String openAiResponseBody;
+
+    @Column(name = "functional_output", columnDefinition = "LONGTEXT")
+    private String functionalOutput;
+
+    @Column(name = "artifact_url", length = 1024)
+    private String artifactUrl;
+
+    @Column(name = "openai_model", length = 120)
+    private String openAiModel;
+
+    @Column(name = "service_tier", length = 40)
+    private String serviceTier;
+
+    @Column(name = "input_tokens")
+    private Integer inputTokens;
+
+    @Column(name = "output_tokens")
+    private Integer outputTokens;
+
+    @Column(name = "cost_usd", precision = 12, scale = 6)
+    private BigDecimal costUsd;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/productai/ProductAiPaidDeliveryStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/productai/ProductAiPaidDeliveryStageExecutionRepository.java
@@ -1,0 +1,23 @@
+package com.marketinghub.repository.jpa.productai;
+
+import com.marketinghub.productai.delivery.ProductAiPaidDeliveryStageExecution;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: persistir execuções da entrega paga de Produto IA. */
+public interface ProductAiPaidDeliveryStageExecutionRepository
+        extends JpaRepository<ProductAiPaidDeliveryStageExecution, String> {
+
+    /** Busca execução pelo identificador externo do job. */
+    Optional<ProductAiPaidDeliveryStageExecution> findTopByIdJobOrderByExecutionRequestedAtDesc(String idJob);
+
+    /** Busca execução ativa mais recente de uma compra. */
+    Optional<ProductAiPaidDeliveryStageExecution> findTopByPurchaseIdOrderByExecutionRequestedAtDesc(Long purchaseId);
+
+    /** Lista pendências de etapa para consumo do worker. */
+    List<ProductAiPaidDeliveryStageExecution> findTop20ByPipelineCodeAndStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+            String pipelineCode,
+            String stageCode,
+            String status);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-product-ai-paid-delivery.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-03-product-ai-paid-delivery.yaml
@@ -1,0 +1,163 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-03-product-ai-paid-delivery-001
+      author: codex
+      preConditions:
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: product_ai_paid_delivery_stage_execution
+      changes:
+        - createTable:
+            tableName: product_ai_paid_delivery_stage_execution
+            columns:
+              - column:
+                  name: id_job
+                  type: varchar(36)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: purchase_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: package_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: pipeline_code
+                  type: varchar(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: varchar(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar(40)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: execution_requested_at
+                  type: datetime(6)
+                  defaultValueComputed: CURRENT_TIMESTAMP(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: processing_started_at
+                  type: datetime(6)
+              - column:
+                  name: completed_at
+                  type: datetime(6)
+              - column:
+                  name: prompt_template_key
+                  type: varchar(191)
+              - column:
+                  name: prompt_template_version
+                  type: varchar(40)
+              - column:
+                  name: schema_name
+                  type: varchar(191)
+              - column:
+                  name: prompt
+                  type: longtext
+              - column:
+                  name: schema_json
+                  type: longtext
+              - column:
+                  name: openai_request_body
+                  type: longtext
+              - column:
+                  name: openai_response_body
+                  type: longtext
+              - column:
+                  name: functional_output
+                  type: longtext
+              - column:
+                  name: artifact_url
+                  type: varchar(1024)
+              - column:
+                  name: openai_model
+                  type: varchar(120)
+              - column:
+                  name: service_tier
+                  type: varchar(40)
+              - column:
+                  name: input_tokens
+                  type: int
+              - column:
+                  name: output_tokens
+                  type: int
+              - column:
+                  name: cost_usd
+                  type: decimal(12,6)
+              - column:
+                  name: error_message
+                  type: longtext
+        - createIndex:
+            tableName: product_ai_paid_delivery_stage_execution
+            indexName: idx_product_ai_paid_delivery_pending
+            columns:
+              - column:
+                  name: pipeline_code
+              - column:
+                  name: stage_code
+              - column:
+                  name: status
+              - column:
+                  name: execution_requested_at
+        - createIndex:
+            tableName: product_ai_paid_delivery_stage_execution
+            indexName: idx_product_ai_paid_delivery_purchase
+            columns:
+              - column:
+                  name: purchase_id
+        - addForeignKeyConstraint:
+            baseTableName: product_ai_paid_delivery_stage_execution
+            baseColumnNames: experiment_id
+            constraintName: fk_product_ai_paid_delivery_experiment
+            referencedTableName: experiment
+            referencedColumnNames: id
+
+  - changeSet:
+      id: 2026-07-03-product-ai-paid-delivery-template-001
+      author: codex
+      preConditions:
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO ai_prompt_schema_template (
+                template_key, pipeline_code, stage_code, version, openai_model, schema_name,
+                prompt_markdown_content, schema_json, active, created_at, updated_at
+              )
+              SELECT
+                'product-ai.personalizedsample.v1.paid-delivery.v1',
+                'personalizedsample.v1',
+                'paid-delivery',
+                'v1',
+                'gpt-5.2',
+                'product_ai_personalized_sample_paid_delivery_v1',
+                'Você gera a entrega paga de um Produto IA do tipo AI_PERSONALIZED_SAMPLE. Use os dados do experimento, comprador e respostas de personalização para criar uma especificação visual exclusiva, clara e entregável. Separe preview gratuito de produto pago. Responda apenas JSON válido aderente ao schema.',
+                '{"type":"object","additionalProperties":false,"required":["title","personalizedVisualBrief","deliveryText","artifactPlan","customerInstructions"],"properties":{"title":{"type":"string"},"personalizedVisualBrief":{"type":"string"},"deliveryText":{"type":"string"},"artifactPlan":{"type":"array","items":{"type":"string"}},"customerInstructions":{"type":"string"}}}',
+                TRUE,
+                CURRENT_TIMESTAMP(6),
+                CURRENT_TIMESTAMP(6)
+              WHERE NOT EXISTS (
+                SELECT 1 FROM ai_prompt_schema_template
+                WHERE template_key = 'product-ai.personalizedsample.v1.paid-delivery.v1'
+              );

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1245,3 +1245,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-07-03-mois-sales-library-two-dossier-pipelines.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-07-03-product-ai-paid-delivery.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.gerasalespage.v1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,10 +18,10 @@ import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecut
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -38,11 +39,22 @@ class GeraSalesPageStageServiceTest {
     private GeraSalesPagePublicationAuditService publicationAuditService;
     @Mock
     private ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
-    @Mock
-    private ObjectMapper objectMapper;
 
-    @InjectMocks
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     private GeraSalesPageStageService service;
+
+    /** Inicializa service com ObjectMapper real para validar parsing do quality review. */
+    @BeforeEach
+    void setUp() {
+        service = new GeraSalesPageStageService(
+                experimentRepository,
+                executionRepository,
+                templateRepository,
+                publicationAuditService,
+                promptSchemaUsageService,
+                objectMapper);
+    }
 
     /** Deve substituir execuções antigas e criar uma primeira etapa nova. */
     @Test
@@ -83,6 +95,42 @@ class GeraSalesPageStageServiceTest {
                 GeraSalesPageStageCode.OFFER_BRIEF.code(),
                 newExecution.getValue().getIdJob());
         assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+    }
+
+    /** Deve bloquear a publicação quando a revisão comercial reprova a página. */
+    @Test
+    void receiveResultShouldFailQualityReviewWhenNotApproved() {
+        GeraSalesPageStageExecution execution = GeraSalesPageStageExecution.builder()
+                .idJob("review-job")
+                .experimentId(55L)
+                .stageCode(GeraSalesPageStageCode.CHECKOUT_QUALITY_REVIEW.code())
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .executionRequestedAt(Instant.now())
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("review-job"))
+                .thenReturn(Optional.of(execution));
+
+        service.receiveResult(
+                "review-job",
+                new GeraSalesPageResultRequest(
+                        55L,
+                        GeraSalesPageStageCode.CHECKOUT_QUALITY_REVIEW.code(),
+                        "{\"approved\":false,\"blockers\":[\"amostra e produto pago estão confusos\"],\"recommendation\":\"refazer\"}",
+                        "{\"raw\":true}",
+                        120,
+                        80,
+                        java.math.BigDecimal.valueOf(0.01),
+                        "openai-job",
+                        null,
+                        null));
+
+        assertThat(execution.getStatus()).isEqualTo("FALHA");
+        assertThat(execution.getErrorMessage()).contains("Quality review reprovou");
+        assertThat(execution.getErrorDetail()).contains("amostra e produto pago");
+        verify(publicationAuditService, never()).snapshotPublication(any());
+        verify(executionRepository, never()).findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                55L,
+                GeraSalesPageStageCode.PUBLICATION_PACKAGE.code());
     }
 
     /** Cria template mínimo de prompt/schema para etapa de teste. */

--- a/docs/canonical/product-ai-worker-canon.v1.md
+++ b/docs/canonical/product-ai-worker-canon.v1.md
@@ -1,0 +1,45 @@
+# Product AI Worker Canon v1
+
+## Decisão
+
+Produtos IA vendidos ao cliente devem ser executados por módulo externo próprio: `product-ai-worker`.
+
+O backend principal continua sendo a fonte de verdade para:
+
+- fila `pending`;
+- prompt/schema versionados em banco;
+- auditoria de request e response;
+- cálculo autoritativo de custo OpenAI;
+- vínculo com compra, experimento, hipótese e nicho;
+- marcação de entrega concluída.
+
+O worker não acessa banco e não carrega prompt/schema local.
+
+## Pipeline inicial
+
+Nome: `personalizedsample.v1`
+
+Etapa inicial: `paid-delivery`
+
+Objetivo: gerar a entrega paga personalizada após compra aprovada de experimento `AI_PERSONALIZED_SAMPLE`.
+
+Endpoint interno:
+
+`/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions`
+
+Contratos:
+
+- `POST /approved-purchase`
+- `GET /pending`
+- `POST /{idJob}/recebeRequest`
+- `POST /{idJob}/recebeResponse`
+
+## Regra OpenAI
+
+Toda chamada OpenAI do Product AI Worker deve usar 3 tentativas:
+
+1. Flex
+2. Flex
+3. Standard/default
+
+O custo persistido deve ser calculado pelo backend a partir do modelo, tokens e service tier.

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -105,6 +105,8 @@ Quando uma hipotese criada pelo sistema ja possuir nicho/contexto, dor principal
 
 Depois que o experimento `AI_PERSONALIZED_SAMPLE` existir, a publicacao de campanha deve continuar bloqueada ate o backend criar ou reaproveitar o funil canonico de coleta pelo endpoint `POST /api/product-ai/experiments/{experimentId}/personalized-sample-funnel`. Esse funil deve ser um `LeadPortalFlow` aprovado e vinculado ao experimento, coletando no minimo nome, e-mail, WhatsApp, negocio/projeto, contexto atual, objetivo visual e dados de personalizacao. Sem esses dados, o produto nao tem insumo suficiente para prometer amostra exclusiva.
 
+Depois da compra aprovada, a entrega paga do `AI_PERSONALIZED_SAMPLE` deve ser executada pelo módulo externo `product-ai-worker`, no pipeline versionado `personalizedsample.v1` e etapa `paid-delivery`. O backend deve enfileirar a entrega, entregar prompt/schema versionados pelo `pending`, receber `recebeRequest` antes da chamada OpenAI, receber `recebeResponse` com saída funcional, tokens, service tier e artefato, calcular o custo autoritativo e marcar a compra como entregue. E proibido vender Produto IA dependendo de entrega manual ou de worker que acesse banco diretamente.
+
 Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.
 
 Padroes externos, como os dossies da Biblioteca de Paginas de Vendas, podem ser usados como insumo de briefing e aprendizado. Eles nao podem substituir a geracao rastreavel de hipotese, dor, mecanismo, prova, oferta e experimento pelo sistema.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -86,3 +86,13 @@
 - Pacotes protegidos: `com.marketinghub.pipelines.salespagepatterns.v1` e `com.marketinghub.pipelines.warmupecosystem.v1`.
 - Aplicação: reforço ArchUnit para existência dos dois códigos canônicos e bloqueio de dependência direta entre os pipelines.
 - Backend permanece como fonte de verdade de contratos, pendências, callbacks e custos; inteligência principal permanece no worker.
+
+## 2026-07-03 — Product AI Worker — personalizedsample.v1
+
+- Módulo executor: `product-ai-worker`.
+- Pipeline nomeado: `personalizedsample.v1`.
+- Etapa inicial: `paid-delivery`.
+- Pacotes protegidos: núcleo `com.marketinghub.productaiworker.core` e etapa concreta `com.marketinghub.productaiworker.personalizedsample.v1.paiddelivery`.
+- Ponto inicial canônico: `/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions/pending`.
+- Aplicação: protocolo padrão módulo aplicado no executor novo, com ArchUnit bloqueando banco direto, prompt/schema local e dependência do núcleo em etapa concreta/infra.
+- Backend permanece como fonte de verdade para contrato, prompt/schema em banco, custo autoritativo, compra aprovada e marcação de entrega.

--- a/lead-portal-payments-service/src/main/java/com/marketinghub/payments/config/ProductAiDeliveryProperties.java
+++ b/lead-portal-payments-service/src/main/java/com/marketinghub/payments/config/ProductAiDeliveryProperties.java
@@ -1,0 +1,44 @@
+package com.marketinghub.payments.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: configurar a notificação de entrega paga de Produto IA ao backend. */
+@Component
+@ConfigurationProperties(prefix = "product-ai.delivery")
+public class ProductAiDeliveryProperties {
+    private boolean enabled = true;
+    private String backendBaseUrl = "http://191.252.181.168";
+    private String approvedPurchasePath =
+            "/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions/approved-purchase";
+
+    /** Indica se a notificação ao backend está ativa. */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /** Define se a notificação ao backend está ativa. */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** Retorna a URL base do backend principal. */
+    public String getBackendBaseUrl() {
+        return backendBaseUrl;
+    }
+
+    /** Define a URL base do backend principal. */
+    public void setBackendBaseUrl(String backendBaseUrl) {
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    /** Retorna o caminho do endpoint de compra aprovada. */
+    public String getApprovedPurchasePath() {
+        return approvedPurchasePath;
+    }
+
+    /** Define o caminho do endpoint de compra aprovada. */
+    public void setApprovedPurchasePath(String approvedPurchasePath) {
+        this.approvedPurchasePath = approvedPurchasePath;
+    }
+}

--- a/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/CheckoutService.java
+++ b/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/CheckoutService.java
@@ -45,6 +45,7 @@ public class CheckoutService {
     private final PaymentProperties paymentProperties;
     private final PremiumDeliveryService premiumDeliveryService;
     private final DigitalProductPostPurchaseEmailService digitalProductPostPurchaseEmailService;
+    private final ProductAiPaidDeliveryBackendClient productAiPaidDeliveryBackendClient;
 
     public CheckoutService(MercadoPagoClient mercadoPagoClient,
                            LeadPortalPackageGateway packageGateway,
@@ -52,7 +53,8 @@ public class CheckoutService {
                            MercadoPagoProperties mercadoPagoProperties,
                            PaymentProperties paymentProperties,
                            PremiumDeliveryService premiumDeliveryService,
-                           DigitalProductPostPurchaseEmailService digitalProductPostPurchaseEmailService) {
+                           DigitalProductPostPurchaseEmailService digitalProductPostPurchaseEmailService,
+                           ProductAiPaidDeliveryBackendClient productAiPaidDeliveryBackendClient) {
         this.mercadoPagoClient = mercadoPagoClient;
         this.packageGateway = packageGateway;
         this.purchaseRepository = purchaseRepository;
@@ -60,6 +62,7 @@ public class CheckoutService {
         this.paymentProperties = paymentProperties;
         this.premiumDeliveryService = premiumDeliveryService;
         this.digitalProductPostPurchaseEmailService = digitalProductPostPurchaseEmailService;
+        this.productAiPaidDeliveryBackendClient = productAiPaidDeliveryBackendClient;
     }
 
     public Optional<MercadoPagoPaymentDetails> fetchPayment(String paymentId) {
@@ -185,6 +188,7 @@ public class CheckoutService {
             } catch (Exception ex) {
                 log.error("Falha ao registrar entrega premium para a compra {}", saved.getId(), ex);
             }
+            productAiPaidDeliveryBackendClient.notifyApprovedPurchase(saved);
         }
         return saved;
     }

--- a/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/ProductAiPaidDeliveryBackendClient.java
+++ b/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/ProductAiPaidDeliveryBackendClient.java
@@ -1,0 +1,47 @@
+package com.marketinghub.payments.service;
+
+import com.marketinghub.payments.config.ProductAiDeliveryProperties;
+import com.marketinghub.payments.model.LeadPortalPurchase;
+import java.net.URI;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/** Responsabilidade: notificar o backend principal sobre compras aprovadas de Produto IA. */
+@Service
+public class ProductAiPaidDeliveryBackendClient {
+    private static final Logger log = LoggerFactory.getLogger(ProductAiPaidDeliveryBackendClient.class);
+
+    private final RestClient restClient;
+    private final ProductAiDeliveryProperties properties;
+
+    /** Inicializa o cliente com RestClient e propriedades de endpoint. */
+    public ProductAiPaidDeliveryBackendClient(RestClient restClient, ProductAiDeliveryProperties properties) {
+        this.restClient = restClient;
+        this.properties = properties;
+    }
+
+    /** Envia compra aprovada ao backend para enfileirar entrega paga quando aplicável. */
+    public void notifyApprovedPurchase(LeadPortalPurchase purchase) {
+        if (!properties.isEnabled() || purchase == null || purchase.getId() == null || purchase.getPackageId() == null) {
+            return;
+        }
+        URI uri = URI.create(properties.getBackendBaseUrl() + properties.getApprovedPurchasePath());
+        try {
+            restClient.post()
+                    .uri(uri)
+                    .body(Map.of("purchaseId", purchase.getId(), "packageId", purchase.getPackageId()))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception ex) {
+            log.error(
+                    "Falha ao notificar entrega Produto IA purchaseId={} packageId={} endpoint={}",
+                    purchase.getId(),
+                    purchase.getPackageId(),
+                    uri,
+                    ex);
+        }
+    }
+}

--- a/lead-portal-payments-service/src/main/resources/application.yml
+++ b/lead-portal-payments-service/src/main/resources/application.yml
@@ -67,6 +67,12 @@ digital-product:
       experiment51-product-name: ${DIGITAL_PRODUCT_EXP51_PRODUCT_NAME:Mapa de Recorrência 7D}
       experiment51-delivery-page-url: ${DIGITAL_PRODUCT_EXP51_DELIVERY_PAGE_URL:https://pagamentopalf.site/obrigado-exp51-mapa-recorrencia-7d.html}
       experiment51-download-url: ${DIGITAL_PRODUCT_EXP51_DOWNLOAD_URL:https://pagamentopalf.site/downloads/mapa-recorrencia-7d-entrega-v0-7xQ9mR4pL2.zip}
+
+product-ai:
+  delivery:
+    enabled: ${PRODUCT_AI_DELIVERY_ENABLED:true}
+    backend-base-url: ${PRODUCT_AI_DELIVERY_BACKEND_BASE_URL:http://191.252.181.168}
+    approved-purchase-path: ${PRODUCT_AI_DELIVERY_APPROVED_PURCHASE_PATH:/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions/approved-purchase}
 ---
 spring:
   config:

--- a/lead-portal-payments-service/src/test/java/com/marketinghub/payments/service/CheckoutServiceTest.java
+++ b/lead-portal-payments-service/src/test/java/com/marketinghub/payments/service/CheckoutServiceTest.java
@@ -52,6 +52,9 @@ class CheckoutServiceTest {
     @Mock
     private DigitalProductPostPurchaseEmailService digitalProductPostPurchaseEmailService;
 
+    @Mock
+    private ProductAiPaidDeliveryBackendClient productAiPaidDeliveryBackendClient;
+
     private PaymentProperties paymentProperties;
     private MercadoPagoProperties mercadoPagoProperties;
     private CheckoutService checkoutService;
@@ -67,7 +70,8 @@ class CheckoutServiceTest {
                 mercadoPagoProperties,
                 paymentProperties,
                 premiumDeliveryService,
-                digitalProductPostPurchaseEmailService);
+                digitalProductPostPurchaseEmailService,
+                productAiPaidDeliveryBackendClient);
     }
 
     @Test
@@ -435,6 +439,7 @@ class CheckoutServiceTest {
         assertThat(purchase.getBuyerEmail()).isEqualTo("submission@example.com");
         assertThat(purchase.getStatus()).isEqualTo(PurchaseStatus.APPROVED);
         assertThat(purchase.getPaymentApprovedAt()).isEqualTo(approvalDate);
+        verify(productAiPaidDeliveryBackendClient).notifyApprovedPurchase(purchase);
     }
 
     @Test

--- a/product-ai-worker/Dockerfile
+++ b/product-ai-worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+COPY target/app.jar /app/app.jar
+
+EXPOSE 8095
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/product-ai-worker/docker-compose.yml
+++ b/product-ai-worker/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  product-ai-worker:
+    image: ghcr.io/paulofor/marketing-hub/product-ai-worker:latest
+    container_name: product-ai-worker
+    restart: unless-stopped
+    ports:
+      - "${PRODUCT_AI_WORKER_PORT:-8095}:8095"
+    environment:
+      SERVER_PORT: 8095
+      PRODUCT_AI_WORKER_ENABLED: ${PRODUCT_AI_WORKER_ENABLED:-true}
+      PRODUCT_AI_BACKEND_BASE_URL: ${PRODUCT_AI_BACKEND_BASE_URL:-http://191.252.181.168}
+      PRODUCT_AI_PENDING_LIMIT: ${PRODUCT_AI_PENDING_LIMIT:-10}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}

--- a/product-ai-worker/pom.xml
+++ b/product-ai-worker/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>product-ai-worker</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>product-ai-worker</name>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <finalName>app</finalName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/ProductAiWorkerApplication.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/ProductAiWorkerApplication.java
@@ -1,0 +1,18 @@
+package com.marketinghub.productaiworker;
+
+import com.marketinghub.productaiworker.config.ProductAiWorkerProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/** Responsabilidade: iniciar o módulo executor de Produtos IA. */
+@SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties(ProductAiWorkerProperties.class)
+public class ProductAiWorkerApplication {
+    /** Inicia a aplicação Spring Boot do worker. */
+    public static void main(String[] args) {
+        SpringApplication.run(ProductAiWorkerApplication.class, args);
+    }
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/config/ProductAiWorkerProperties.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/config/ProductAiWorkerProperties.java
@@ -1,0 +1,63 @@
+package com.marketinghub.productaiworker.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Responsabilidade: parametrizar endpoints e limites operacionais do Product AI Worker. */
+@ConfigurationProperties(prefix = "product-ai-worker")
+public class ProductAiWorkerProperties {
+    private boolean enabled = true;
+    private String backendBaseUrl = "http://191.252.181.168";
+    private int pendingLimit = 10;
+    private String openAiBaseUrl = "https://api.openai.com/v1";
+    private String openAiApiKey;
+
+    /** Indica se o processamento periódico está ativo. */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /** Define se o processamento periódico está ativo. */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** Retorna URL base do backend principal. */
+    public String getBackendBaseUrl() {
+        return backendBaseUrl;
+    }
+
+    /** Define URL base do backend principal. */
+    public void setBackendBaseUrl(String backendBaseUrl) {
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    /** Retorna limite de pendências processadas por ciclo. */
+    public int getPendingLimit() {
+        return pendingLimit;
+    }
+
+    /** Define limite de pendências processadas por ciclo. */
+    public void setPendingLimit(int pendingLimit) {
+        this.pendingLimit = pendingLimit;
+    }
+
+    /** Retorna URL base da OpenAI. */
+    public String getOpenAiBaseUrl() {
+        return openAiBaseUrl;
+    }
+
+    /** Define URL base da OpenAI. */
+    public void setOpenAiBaseUrl(String openAiBaseUrl) {
+        this.openAiBaseUrl = openAiBaseUrl;
+    }
+
+    /** Retorna chave OpenAI usada pelo worker. */
+    public String getOpenAiApiKey() {
+        return openAiApiKey;
+    }
+
+    /** Define chave OpenAI usada pelo worker. */
+    public void setOpenAiApiKey(String openAiApiKey) {
+        this.openAiApiKey = openAiApiKey;
+    }
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/core/StageContext.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/core/StageContext.java
@@ -1,0 +1,16 @@
+package com.marketinghub.productaiworker.core;
+
+import java.util.Map;
+
+/** Responsabilidade: transportar uma execução pendente sem acoplar o núcleo a uma etapa concreta. */
+public record StageContext(
+        String idJob,
+        Long purchaseId,
+        Long packageId,
+        Long experimentId,
+        String pipelineCode,
+        String stageCode,
+        Map<String, Object> buyer,
+        Map<String, Object> personalizationInput,
+        Map<String, Object> experiment,
+        Map<String, Object> promptSchemaTemplate) {}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/core/StageProcessor.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/core/StageProcessor.java
@@ -1,0 +1,13 @@
+package com.marketinghub.productaiworker.core;
+
+/** Responsabilidade: definir o contrato de processamento de uma etapa do Product AI Worker. */
+public interface StageProcessor {
+    /** Retorna o código do pipeline atendido pelo processor. */
+    String pipelineCode();
+
+    /** Retorna o código da etapa atendida pelo processor. */
+    String stageCode();
+
+    /** Processa uma execução pendente e reporta o resultado ao backend. */
+    void process(StageContext context);
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiBackendClient.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiBackendClient.java
@@ -1,0 +1,68 @@
+package com.marketinghub.productaiworker.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.productaiworker.config.ProductAiWorkerProperties;
+import com.marketinghub.productaiworker.core.StageContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/** Responsabilidade: consumir pendências e enviar callbacks ao backend principal. */
+@Component
+public class ProductAiBackendClient {
+    private static final String BASE_PATH =
+            "/api/internal/product-ai/personalizedsample/v1/paid-delivery/stage-executions";
+
+    private final RestClient restClient;
+    private final ProductAiWorkerProperties properties;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o cliente HTTP com propriedades do backend. */
+    public ProductAiBackendClient(RestClient.Builder builder, ProductAiWorkerProperties properties, ObjectMapper objectMapper) {
+        this.restClient = builder.baseUrl(properties.getBackendBaseUrl()).build();
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Lista entregas pagas pendentes pelo endpoint canônico pending. */
+    public List<StageContext> pending() {
+        StageContext[] response = restClient.get()
+                .uri(BASE_PATH + "/pending")
+                .retrieve()
+                .body(StageContext[].class);
+        if (response == null) {
+            return List.of();
+        }
+        return Arrays.stream(response).limit(Math.max(1, properties.getPendingLimit())).toList();
+    }
+
+    /** Registra o request bruto enviado à OpenAI. */
+    public void receiveRequest(String idJob, Map<String, Object> payload) {
+        restClient.post()
+                .uri(BASE_PATH + "/{idJob}/recebeRequest", idJob)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    /** Registra resposta ou erro da etapa. */
+    public void receiveResponse(String idJob, Map<String, Object> payload) {
+        restClient.post()
+                .uri(BASE_PATH + "/{idJob}/recebeResponse", idJob)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    /** Converte objeto em JSON para auditoria de payload bruto. */
+    public String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Falha ao serializar payload do Product AI Worker", ex);
+        }
+    }
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiOpenAiClient.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiOpenAiClient.java
@@ -1,0 +1,96 @@
+package com.marketinghub.productaiworker.infra;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.productaiworker.config.ProductAiWorkerProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/** Responsabilidade: chamar OpenAI seguindo a regra de tentativas Flex, Flex e Standard. */
+@Component
+public class ProductAiOpenAiClient {
+    private final RestClient restClient;
+    private final ProductAiWorkerProperties properties;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa cliente HTTP da OpenAI. */
+    public ProductAiOpenAiClient(RestClient.Builder builder, ProductAiWorkerProperties properties, ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        this.restClient = builder.baseUrl(properties.getOpenAiBaseUrl()).build();
+    }
+
+    /** Executa chamada Responses API com fallback de service tier na terceira tentativa. */
+    public OpenAiCallResult generate(
+            String model,
+            String prompt,
+            String schemaJson,
+            BiConsumer<String, Map<String, Object>> requestObserver) {
+        RuntimeException lastError = null;
+        List<String> tiers = List.of("flex", "flex", "default");
+        for (String tier : tiers) {
+            Map<String, Object> request = requestBody(model, prompt, schemaJson, tier);
+            try {
+                requestObserver.accept(tier, request);
+                OpenAiResponse response = restClient.post()
+                        .uri("/responses")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getOpenAiApiKey())
+                        .body(request)
+                        .retrieve()
+                        .body(OpenAiResponse.class);
+                return new OpenAiCallResult(tier, request, response);
+            } catch (RuntimeException ex) {
+                lastError = ex;
+            }
+        }
+        throw lastError != null ? lastError : new IllegalStateException("OpenAI não retornou resposta");
+    }
+
+    /** Monta corpo da Responses API com schema recebido do backend. */
+    /** Monta corpo da Responses API com schema recebido do backend. */
+    private Map<String, Object> requestBody(String model, String prompt, String schemaJson, String serviceTier) {
+        return Map.of(
+                "model", model,
+                "input", prompt,
+                "service_tier", serviceTier,
+                "text", Map.of(
+                        "format", Map.of(
+                                "type", "json_schema",
+                                "name", "product_ai_paid_delivery",
+                                "schema", parseSchema(schemaJson),
+                                "strict", true)));
+    }
+
+    /** Converte schema textual do backend em objeto JSON para a OpenAI. */
+    private Object parseSchema(String schemaJson) {
+        try {
+            return objectMapper.readValue(
+                    StringUtils.hasText(schemaJson) ? schemaJson : "{\"type\":\"object\"}",
+                    Object.class);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Schema JSON inválido recebido do backend", ex);
+        }
+    }
+
+    /** Resultado consolidado da chamada à OpenAI. */
+    public record OpenAiCallResult(String serviceTier, Map<String, Object> requestBody, OpenAiResponse response) {}
+
+    /** Resposta mínima da OpenAI usada pelo worker. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiResponse(
+            String id,
+            @JsonProperty("output_text") String outputText,
+            Usage usage) {}
+
+    /** Uso de tokens retornado pela OpenAI. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Usage(
+            @JsonProperty("input_tokens") Integer inputTokens,
+            @JsonProperty("output_tokens") Integer outputTokens) {}
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiPipelineWorker.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/infra/ProductAiPipelineWorker.java
@@ -1,0 +1,59 @@
+package com.marketinghub.productaiworker.infra;
+
+import com.marketinghub.productaiworker.config.ProductAiWorkerProperties;
+import com.marketinghub.productaiworker.core.StageContext;
+import com.marketinghub.productaiworker.core.StageProcessor;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: orquestrar o consumo periódico de etapas pendentes do Product AI Worker. */
+@Component
+public class ProductAiPipelineWorker {
+    private static final Logger log = LoggerFactory.getLogger(ProductAiPipelineWorker.class);
+
+    private final ProductAiWorkerProperties properties;
+    private final ProductAiBackendClient backendClient;
+    private final Map<String, StageProcessor> processors;
+
+    /** Inicializa o worker com catálogo de processors plugáveis. */
+    public ProductAiPipelineWorker(
+            ProductAiWorkerProperties properties,
+            ProductAiBackendClient backendClient,
+            java.util.List<StageProcessor> processors) {
+        this.properties = properties;
+        this.backendClient = backendClient;
+        this.processors = processors.stream()
+                .collect(Collectors.toMap(this::key, Function.identity()));
+    }
+
+    /** Processa pendências em intervalo fixo definido no executor. */
+    @Scheduled(fixedDelayString = "60000", initialDelayString = "15000")
+    public void processPending() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        for (StageContext context : backendClient.pending()) {
+            StageProcessor processor = processors.get(key(context.pipelineCode(), context.stageCode()));
+            if (processor == null) {
+                log.warn("Nenhum processor registrado para {}/{}", context.pipelineCode(), context.stageCode());
+                continue;
+            }
+            processor.process(context);
+        }
+    }
+
+    /** Monta chave de catálogo para um processor. */
+    private String key(StageProcessor processor) {
+        return key(processor.pipelineCode(), processor.stageCode());
+    }
+
+    /** Monta chave de catálogo para pipeline e etapa. */
+    private String key(String pipelineCode, String stageCode) {
+        return pipelineCode + "/" + stageCode;
+    }
+}

--- a/product-ai-worker/src/main/java/com/marketinghub/productaiworker/personalizedsample/v1/paiddelivery/PaidDeliveryProcessor.java
+++ b/product-ai-worker/src/main/java/com/marketinghub/productaiworker/personalizedsample/v1/paiddelivery/PaidDeliveryProcessor.java
@@ -1,0 +1,94 @@
+package com.marketinghub.productaiworker.personalizedsample.v1.paiddelivery;
+
+import com.marketinghub.productaiworker.core.StageContext;
+import com.marketinghub.productaiworker.core.StageProcessor;
+import com.marketinghub.productaiworker.infra.ProductAiBackendClient;
+import com.marketinghub.productaiworker.infra.ProductAiOpenAiClient;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: executar a entrega paga do pipeline personalizedsample.v1. */
+@Component
+public class PaidDeliveryProcessor implements StageProcessor {
+    private static final String PIPELINE_CODE = "personalizedsample.v1";
+    private static final String STAGE_CODE = "paid-delivery";
+
+    private final ProductAiBackendClient backendClient;
+    private final ProductAiOpenAiClient openAiClient;
+
+    /** Inicializa processor com clientes de backend e OpenAI. */
+    public PaidDeliveryProcessor(ProductAiBackendClient backendClient, ProductAiOpenAiClient openAiClient) {
+        this.backendClient = backendClient;
+        this.openAiClient = openAiClient;
+    }
+
+    /** Retorna o código do pipeline executado por esta etapa. */
+    @Override
+    public String pipelineCode() {
+        return PIPELINE_CODE;
+    }
+
+    /** Retorna o código da etapa executada. */
+    @Override
+    public String stageCode() {
+        return STAGE_CODE;
+    }
+
+    /** Processa uma entrega paga personalizada usando prompt/schema recebidos do backend. */
+    @Override
+    public void process(StageContext context) {
+        String prompt = renderPrompt(context);
+        String schemaJson = stringTemplateValue(context, "schemaJson");
+        String model = stringTemplateValue(context, "model");
+        try {
+            ProductAiOpenAiClient.OpenAiCallResult result = openAiClient.generate(
+                    model,
+                    prompt,
+                    schemaJson,
+                    (tier, requestBody) -> backendClient.receiveRequest(context.idJob(), Map.of(
+                            "prompt", prompt,
+                            "schemaJson", schemaJson,
+                            "requestBodyJson", backendClient.toJson(requestBody),
+                            "openAiModel", model,
+                            "serviceTier", tier)));
+            ProductAiOpenAiClient.OpenAiResponse response = result.response();
+            backendClient.receiveResponse(context.idJob(), responsePayload(model, result.serviceTier(), response));
+        } catch (Exception ex) {
+            Map<String, Object> errorPayload = new LinkedHashMap<>();
+            errorPayload.put("errorMessage", ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName());
+            backendClient.receiveResponse(context.idJob(), errorPayload);
+        }
+    }
+
+    /** Renderiza prompt final com dados comerciais e respostas do usuário. */
+    private String renderPrompt(StageContext context) {
+        return stringTemplateValue(context, "promptMarkdownContent")
+                + "\n\nExperimento:\n" + backendClient.toJson(context.experiment())
+                + "\n\nComprador:\n" + backendClient.toJson(context.buyer())
+                + "\n\nDados de personalização coletados no funil:\n"
+                + backendClient.toJson(context.personalizationInput());
+    }
+
+    /** Monta payload de resposta para o backend. */
+    private Map<String, Object> responsePayload(
+            String model,
+            String serviceTier,
+            ProductAiOpenAiClient.OpenAiResponse response) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("responseBodyJson", backendClient.toJson(response));
+        payload.put("functionalOutputJson", response != null ? response.outputText() : null);
+        payload.put("artifactUrl", null);
+        payload.put("openAiModel", model);
+        payload.put("serviceTier", serviceTier);
+        payload.put("inputTokens", response != null && response.usage() != null ? response.usage().inputTokens() : null);
+        payload.put("outputTokens", response != null && response.usage() != null ? response.usage().outputTokens() : null);
+        return payload;
+    }
+
+    /** Lê valor textual do template enviado pelo backend. */
+    private String stringTemplateValue(StageContext context, String key) {
+        Object value = context.promptSchemaTemplate() != null ? context.promptSchemaTemplate().get(key) : null;
+        return value != null ? value.toString() : "";
+    }
+}

--- a/product-ai-worker/src/main/resources/application.yml
+++ b/product-ai-worker/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+server:
+  port: ${SERVER_PORT:8095}
+
+spring:
+  application:
+    name: product-ai-worker
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,loggers
+
+product-ai-worker:
+  enabled: ${PRODUCT_AI_WORKER_ENABLED:true}
+  backend-base-url: ${PRODUCT_AI_BACKEND_BASE_URL:http://191.252.181.168}
+  pending-limit: ${PRODUCT_AI_PENDING_LIMIT:10}
+  open-ai-base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
+  open-ai-api-key: ${OPENAI_API_KEY:}

--- a/product-ai-worker/src/test/java/com/marketinghub/productaiworker/ProductAiWorkerArchitectureTest.java
+++ b/product-ai-worker/src/test/java/com/marketinghub/productaiworker/ProductAiWorkerArchitectureTest.java
@@ -1,0 +1,44 @@
+package com.marketinghub.productaiworker;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/** Responsabilidade: proteger isolamento arquitetural do Product AI Worker. */
+@AnalyzeClasses(packages = "com.marketinghub.productaiworker", importOptions = ImportOption.DoNotIncludeTests.class)
+class ProductAiWorkerArchitectureTest {
+
+    /** Garante que o worker não acessa banco diretamente. */
+    @ArchTest
+    static final ArchRule workerMustNotUseDatabase =
+            noClasses()
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "jakarta.persistence..",
+                            "javax.persistence..",
+                            "org.springframework.jdbc..",
+                            "org.springframework.data.jpa..")
+                    .because("[ARQUITETURA] Product AI Worker deve consumir apenas APIs do backend, nunca banco direto");
+
+    /** Garante que prompt/schema não sejam carregados de arquivo local. */
+    @ArchTest
+    static final ArchRule workerMustNotLoadLocalPromptSchema =
+            noClasses()
+                    .that().resideInAPackage("..personalizedsample..")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "org.springframework.core.io..",
+                            "java.nio.file..")
+                    .because("[ARQUITETURA] Prompt/schema do Product AI Worker devem vir do backend pelo pending");
+
+    /** Garante que o núcleo genérico não conhece a etapa concreta nem OpenAI. */
+    @ArchTest
+    static final ArchRule coreMustNotDependOnConcreteStageOrOpenAi =
+            noClasses()
+                    .that().resideInAPackage("..core..")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "..personalizedsample..",
+                            "..infra..")
+                    .because("[ARQUITETURA] Núcleo do Product AI Worker deve permanecer genérico e plugável");
+}


### PR DESCRIPTION
## Resumo

- Cria o novo módulo `product-ai-worker` com pipeline `personalizedsample.v1` e etapa `paid-delivery`.
- Adiciona backend canônico para entrega paga de Produto IA: `approved-purchase`, `pending`, `recebeRequest` e `recebeResponse`.
- Faz o `lead-portal-payments-service` notificar o backend quando uma compra for aprovada.
- Bloqueia avanço do GeraSalesPage quando o quality review retorna `approved=false`.
- Adiciona workflow, Dockerfile, compose e documentação do novo worker.

## Impacto

A venda de `AI_PERSONALIZED_SAMPLE` passa a ter fila e executor próprios, sem entrega manual e sem worker acessando banco. O backend permanece como fonte de verdade para prompt/schema, auditoria, custo e marcação de entrega.

## Validação

- `backend/ads-service`: `../mvnw -q -Dtest=GeraSalesPageStageServiceTest test`
- `backend/ads-service`: `../mvnw -q -Dtest=ArquiteturaTest test`
- `backend/ads-service`: `../mvnw -q -DskipTests package`
- `backend/ads-service`: `../mvnw -q -DskipTests liquibase:validate -Dliquibase.url=offline:mysql?version=5.7 -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml`
- `lead-portal-payments-service`: `mvn -q test`
- `product-ai-worker`: `mvn -B test package -DskipTests=false`
- `git diff --check`

Docker build local não foi executado porque este ambiente não tem daemon Docker disponível.