### PR TITLE
[codex] Fix Product AI funnel iframe publication

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -24,6 +24,8 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -37,6 +39,8 @@ import org.springframework.web.server.ResponseStatusException;
 public class GeraSalesPagePublicationAuditService {
     private static final Logger log = LoggerFactory.getLogger(GeraSalesPagePublicationAuditService.class);
     private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final Pattern IFRAME_BLOCK_PATTERN =
+            Pattern.compile("(?is)<iframe\\b[^>]*>.*?</iframe>");
 
     private final ExperimentRepository experimentRepository;
     private final GeraSalesPageStageExecutionRepository executionRepository;
@@ -166,6 +170,7 @@ public class GeraSalesPagePublicationAuditService {
                     "Produto IA personalizado exige funil Lead Portal aprovado antes da publicacao da pagina.");
         }
         String htmlWithManagedForm = ensureManagedFormAnchor(html);
+        htmlWithManagedForm = removeSelfReferentialLeadPortalIframes(htmlWithManagedForm, flow);
         flow.setCustomFormHtml(buildPersonalizedSampleTemplatePayload(flow, htmlWithManagedForm));
         flow.setSchemaFirst(true);
         flow.setApproved(true);
@@ -189,6 +194,36 @@ public class GeraSalesPagePublicationAuditService {
         String publicUrl = leadPortalPublicUrlResolver.resolve(flow);
         experiment.setFollowUpActionUrl(publicUrl);
         return new PersonalizedSamplePublication(publicUrl, htmlWithManagedForm);
+    }
+
+    /** Remove iframe que aponta para o proprio funil e causaria recursao visual no Lead Portal. */
+    private String removeSelfReferentialLeadPortalIframes(String html, LeadPortalFlow flow) {
+        if (!StringUtils.hasText(html)) {
+            return html;
+        }
+        Matcher matcher = IFRAME_BLOCK_PATTERN.matcher(html);
+        StringBuffer cleaned = new StringBuffer();
+        while (matcher.find()) {
+            String iframe = matcher.group();
+            if (isSelfReferentialLeadPortalIframe(iframe, flow)) {
+                matcher.appendReplacement(cleaned, "");
+            } else {
+                matcher.appendReplacement(cleaned, Matcher.quoteReplacement(iframe));
+            }
+        }
+        matcher.appendTail(cleaned);
+        return cleaned.toString();
+    }
+
+    /** Identifica iframes que tentam embutir o mesmo fluxo publicado pelo Lead Portal. */
+    private boolean isSelfReferentialLeadPortalIframe(String iframe, LeadPortalFlow flow) {
+        String normalized = iframe.toLowerCase(java.util.Locale.ROOT);
+        String slug = flow != null && StringUtils.hasText(flow.getSlug())
+                ? flow.getSlug().toLowerCase(java.util.Locale.ROOT)
+                : "";
+        return (StringUtils.hasText(slug) && normalized.contains(slug))
+                || normalized.contains("/flows/")
+                || normalized.contains("lead-portal");
     }
 
     /** Garante que o runtime publico tenha um form alvo para renderizar as perguntas do Lead Portal. */

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -10,6 +10,7 @@ import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import com.marketinghub.productai.ProductAiSubtype;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -210,9 +211,19 @@ public class GeraSalesPageStageService {
         payload.put("adCopy", parseJsonOrText(experiment.getAdCopy()));
         payload.put("adImageBriefing", parseJsonOrText(experiment.getAdImageBriefing()));
         payload.put("checkoutUrl", experiment.getFollowUpActionUrl());
+        payload.put("productAiSubtype", experiment.getProductAiSubtype());
+        payload.put("salesPageDestination", salesPageDestination(experiment));
         payload.put("unitPrice", experiment.getUnitPrice());
         payload.put("hypothesisFramework", parseJsonOrText(experiment.getHypothesisFrameworkJsonForPending()));
         return payload;
+    }
+
+    /** Classifica o destino comercial para o worker nao confundir funil Produto IA com checkout direto. */
+    private String salesPageDestination(Experiment experiment) {
+        if (experiment.getProductAiSubtype() == ProductAiSubtype.AI_PERSONALIZED_SAMPLE) {
+            return "LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL";
+        }
+        return "DIRECT_CHECKOUT";
     }
 
     /** Monta o bloco de template ativo entregue ao worker. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-04-gera-sales-page-product-ai-templates-v3-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ai_prompt_schema_template
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ai_prompt_schema_template
+              SET active = false, updated_at = CURRENT_TIMESTAMP
+              WHERE pipeline_code = 'gera-sales-page-v1'
+                AND stage_code IN (
+                  'sales-page-offer-brief',
+                  'sales-page-wireframe',
+                  'sales-page-copy',
+                  'sales-page-visual-plan',
+                  'sales-page-html',
+                  'sales-page-checkout-quality-review',
+                  'sales-page-publication-package'
+                );
+
+              INSERT INTO ai_prompt_schema_template
+                (template_key, pipeline_code, stage_code, version, openai_model, schema_name, prompt_markdown_content, schema_json, active, created_at, updated_at)
+              VALUES
+                ('gera-sales-page-v1:sales-page-offer-brief:v3', 'gera-sales-page-v1', 'sales-page-offer-brief', 'v3', 'gpt-5.5', 'gera_sales_page_v1_offer_brief',
+                 'Você é um estrategista de vendas diretas. Gere a etapa sales-page-offer-brief do GeraSalesPage v1. Use experiment.productAiSubtype e experiment.salesPageDestination como fonte soberana do destino. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, a página vende a promessa e conduz o lead ao formulário de personalização antes do checkout; não trate essa URL como checkout direto. Explique claramente amostra gratuita, produto pago, preço e entrega. Se salesPageDestination=DIRECT_CHECKOUT, mantenha venda direta para checkout. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["summary","promise","checkoutUrl","offerStack","risks"],"properties":{"summary":{"type":"string"},"promise":{"type":"string"},"checkoutUrl":{"type":"string"},"offerStack":{"type":"array","items":{"type":"string"}},"risks":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-wireframe:v3', 'gera-sales-page-v1', 'sales-page-wireframe', 'v3', 'gpt-5.5', 'gera_sales_page_v1_wireframe',
+                 'Você é um arquiteto de página de vendas. Gere a etapa sales-page-wireframe do GeraSalesPage v1. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, a página deve conter promessa, prova, explicação da amostra personalizada e bloco de coleta pelo formulário gerenciado antes da compra; os CTAs devem avançar para esse formulário, não para checkout direto. Nunca proponha iframe para embutir o próprio Lead Portal, flow ou funil. Se salesPageDestination=DIRECT_CHECKOUT, foque em checkout. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["sections","primaryCta","checkoutUrl"],"properties":{"sections":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["id","goal","content"],"properties":{"id":{"type":"string"},"goal":{"type":"string"},"content":{"type":"string"}}}},"primaryCta":{"type":"string"},"checkoutUrl":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-copy:v3', 'gera-sales-page-v1', 'sales-page-copy', 'v3', 'gpt-5.5', 'gera_sales_page_v1_copy',
+                 'Você é copywriter de resposta direta. Gere a etapa sales-page-copy do GeraSalesPage v1. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, deixe explícito: a primeira ação é enviar dados para receber uma amostra personalizada; a compra de preço informado libera a entrega paga completa; a amostra não é o produto inteiro. O CTA deve vender o benefício de preencher o formulário. Se salesPageDestination=DIRECT_CHECKOUT, o CTA aponta para checkout. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["headline","subheadline","sections","cta"],"properties":{"headline":{"type":"string"},"subheadline":{"type":"string"},"sections":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["id","title","body"],"properties":{"id":{"type":"string"},"title":{"type":"string"},"body":{"type":"string"}}}},"cta":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-visual-plan:v3', 'gera-sales-page-v1', 'sales-page-visual-plan', 'v3', 'gpt-5.5', 'gera_sales_page_v1_visual_plan',
+                 'Você é diretor de arte de venda direta. Gere a etapa sales-page-visual-plan do GeraSalesPage v1. Para salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, use visuais que materializem personalização, antes/depois, exemplo de amostra e diferença entre preview gratuito e entrega paga. Para checkout direto, use imagens que reduzem objeção, demonstram produto ou aumentam prova. Nunca recomende iframe para o próprio Lead Portal. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["visualDirection","imageBriefs","trustElements"],"properties":{"visualDirection":{"type":"string"},"imageBriefs":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["sectionId","purpose","prompt"],"properties":{"sectionId":{"type":"string"},"purpose":{"type":"string"},"prompt":{"type":"string"}}}},"trustElements":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-html:v3', 'gera-sales-page-v1', 'sales-page-html', 'v3', 'gpt-5.5', 'gera_sales_page_v1_html',
+                 'Você é desenvolvedor front-end de landing de vendas. Gere a etapa sales-page-html do GeraSalesPage v1 em HTML responsivo. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, os CTAs devem apontar para o bloco de formulário gerenciado; não crie checkout direto como primeira ação, não crie campos próprios fora do formulário gerenciado e nunca use iframe para carregar o Lead Portal, flow ou a própria URL do funil. Explique amostra, preço e entrega paga com clareza. Se salesPageDestination=DIRECT_CHECKOUT, use a URL de checkout real e não crie formulário. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["html","checkoutUrl","notes"],"properties":{"html":{"type":"string"},"checkoutUrl":{"type":"string"},"notes":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-checkout-quality-review:v3', 'gera-sales-page-v1', 'sales-page-checkout-quality-review', 'v3', 'gpt-5.5', 'gera_sales_page_v1_checkout_quality_review',
+                 'Você é auditor comercial. Revise a página do GeraSalesPage v1. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, aprove formulário e CTA para coleta de personalização, mas bloqueie se a página confundir amostra gratuita, compra paga, preço, entrega completa ou limites da amostra. Bloqueie sempre que houver iframe apontando para Lead Portal, flow, funil ou para a própria página. Não exija checkout direto nesse caso. Se salesPageDestination=DIRECT_CHECKOUT, bloqueie se CTA não apontar para checkout real ou se houver formulário obrigatório. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["approved","blockers","recommendation"],"properties":{"approved":{"type":"boolean"},"blockers":{"type":"array","items":{"type":"string"}},"recommendation":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-publication-package:v3', 'gera-sales-page-v1', 'sales-page-publication-package', 'v3', 'gpt-5.5', 'gera_sales_page_v1_publication_package',
+                 'Você é responsável por empacotar a página para publicação. Para salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, mantenha HTML publicável no funil-página, CTAs para o formulário gerenciado, clareza de amostra gratuita, produto pago, preço e entrega; o checklist deve confirmar que não há checkout direto como primeira ação e que não existe iframe para Lead Portal, flow ou a própria página. Para checkout real, mantenha checkoutUrl e checklist de liberação para mídia paga. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["readyForTraffic","html","checkoutUrl","releaseChecklist"],"properties":{"readyForTraffic":{"type":"boolean"},"html":{"type":"string"},"checkoutUrl":{"type":"string"},"releaseChecklist":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+              ON DUPLICATE KEY UPDATE
+                prompt_markdown_content = VALUES(prompt_markdown_content),
+                schema_json = VALUES(schema_json),
+                active = true,
+                updated_at = CURRENT_TIMESTAMP;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-03-product-ai-subtype.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
@@ -131,7 +131,9 @@ class GeraSalesPagePublicationAuditServiceTest {
         GeraSalesPageStageExecution publication = execution(
                 "job-publication",
                 GeraSalesPageStageCode.PUBLICATION_PACKAGE.code(),
-                "{\"html\":\"<html><body><main>Venda Produto IA</main></body></html>\",\"checkoutUrl\":\"https://pagamentopalf.site/checkout\"}",
+                "{\"html\":\"<html><body><main>Venda Produto IA</main>"
+                        + "<iframe src='https://oportunidadebrasil.shop/flows/product-ai-exp-55-personalized-sample'></iframe>"
+                        + "</body></html>\",\"checkoutUrl\":\"https://pagamentopalf.site/checkout\"}",
                 Instant.parse("2026-07-01T10:10:00Z"));
 
         when(publicationRepository.existsByPublicationJobId("job-publication")).thenReturn(false);
@@ -162,6 +164,8 @@ class GeraSalesPagePublicationAuditServiceTest {
 
         Map<?, ?> customPayload = objectMapper.readValue(flow.getCustomFormHtml(), Map.class);
         assertThat(customPayload.get("htmlDocument").toString()).contains("Venda Produto IA");
+        assertThat(customPayload.get("htmlDocument").toString()).doesNotContain("<iframe");
+        assertThat(audit.getValue().getHtml()).doesNotContain("<iframe");
         Map<?, ?> formSpec = (Map<?, ?>) customPayload.get("formSpec");
         assertThat(formSpec.get("formId")).isEqualTo("lead-portal-personalized-sample-form");
         assertThat((List<?>) formSpec.get("fields")).hasSize(2);

--- a/docs/canonical/gerasalespage-arquitetura-canon.v1.md
+++ b/docs/canonical/gerasalespage-arquitetura-canon.v1.md
@@ -33,6 +33,7 @@ O GeraSalesPage v1 é um pipeline independente para gerar página de vendas dire
 - Cada página de venda publicada deve gerar um snapshot histórico em banco, associando a versão da página ao job final, HTML/pacote final, prompts renderizados, prompt markdown base, schema JSON, modelo OpenAI, request enviado e resposta bruta de cada etapa usada naquela versão.
 - A troca futura de prompt, schema ou modelo não pode sobrescrever a auditoria das páginas já publicadas; o frontend deve conseguir consultar as versões publicadas e seus prompts/schemas originais por experimento.
 - Cada etapa do GeraSalesPage v1 enfileirada para um experimento deve registrar o template de prompt/schema usado em `experiment_ai_prompt_schema_usage`, com contexto `GERA_SALES_PAGE_V1`, para que o experimento preserve a associação completa entre oferta, página, modelo, prompt e schema.
+- Para `AI_PERSONALIZED_SAMPLE`, o payload de `pending` deve declarar `productAiSubtype` e `salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL`; nesse caso a etapa final publica a pagina dentro do funil Lead Portal, injeta formulario gerenciado e remove qualquer `iframe` que aponte para Lead Portal, flow ou a propria pagina antes de auditar/publicar.
 
 ## Sugestões incorporadas
 

--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -109,6 +109,8 @@ A pagina de venda aprovada pelo GeraSalesPage para `AI_PERSONALIZED_SAMPLE` deve
 
 Os prompts ativos do GeraSalesPage devem receber contexto suficiente para diferenciar venda direta de funil de personalização. Para `AI_PERSONALIZED_SAMPLE`, o destino comercial da página deve ser o funil-pagina do Lead Portal, deixando claro para o worker que a primeira ação pública é coleta de dados, não checkout direto. O quality review deve aceitar formulário somente nesse subtipo e deve bloquear qualquer ambiguidade entre amostra gratuita, produto pago, preço e entrega paga.
 
+Para `AI_PERSONALIZED_SAMPLE`, a pagina publicada dentro do Lead Portal nunca deve embutir o proprio Lead Portal, flow ou funil em `iframe`. O backend deve remover iframe autorreferente antes de publicar e os prompts/schemas ativos devem instruir o worker a usar bloco de formulario gerenciado, nao iframe, para evitar recursao visual e perda de experiencia do lead.
+
 Depois da compra aprovada, a entrega paga do `AI_PERSONALIZED_SAMPLE` deve ser executada pelo módulo externo `product-ai-worker`, no pipeline versionado `personalizedsample.v1` e etapa `paid-delivery`. O backend deve enfileirar a entrega, entregar prompt/schema versionados pelo `pending`, receber `recebeRequest` antes da chamada OpenAI, receber `recebeResponse` com saída funcional, tokens, service tier e artefato, calcular o custo autoritativo e marcar a compra como entregue. E proibido vender Produto IA dependendo de entrega manual ou de worker que acesse banco diretamente.
 
 Criar o mesmo conceito para outro nicho exige nova execucao do fluxo com novo contexto de nicho. Variar um produto para melhora exige nova versao ou novo experimento com variavel primaria declarada.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5611,3 +5611,10 @@
 - Correção aplicada: o sync de métricas passa a avaliar a regra estatístico-financeira low-ticket imediatamente após atualizar gasto/cliques e também aplica uma regra complementar para tráfego caro antes da amostra completa.
 - Regra nova: com `0` compras, pelo menos `5` cliques, custo total acima do `stopLossCpl`, CPC maior ou igual a `10%` do ticket e checkout abaixo de `3%`, o experimento é invalidado por `LOW_TICKET_TRAFFIC_COST_ECONOMICALLY_UNVIABLE`.
 - Prevenção de recorrência: teste de controller cobre a execução da regra low-ticket no POST de métricas, e teste de service cobre o caso de tráfego caro como o experimento 54.
+
+## 2026-07-04 — Produto IA sem iframe autorreferente no funil
+
+- Problema: a página aprovada do experimento 55 podia incluir um `iframe` apontando para o próprio funil do Lead Portal, causando risco de recursão visual e experiência ruim antes da coleta da personalização.
+- Causa-raiz: os templates do GeraSalesPage ainda deixavam margem para o worker tratar o funil-página como recurso a ser embutido, e o backend não removia iframe autorreferente antes da publicação.
+- Correção aplicada: o `pending` do GeraSalesPage agora declara `productAiSubtype` e `salesPageDestination`; os templates `v3` proíbem iframe para Lead Portal/flow/funil; e a publicação de `AI_PERSONALIZED_SAMPLE` remove iframe autorreferente antes de salvar o HTML no `LeadPortalFlow`.
+- Prevenção de recorrência: teste unitário cobre publicação de Produto IA com iframe para o próprio funil e valida que o HTML auditado/publicado fica sem iframe.


### PR DESCRIPTION
## Resumo

- Remove iframe autorreferente do HTML publicado no funil `AI_PERSONALIZED_SAMPLE` antes de salvar/publicar no Lead Portal.
- Envia `productAiSubtype` e `salesPageDestination` no `pending` do GeraSalesPage para o worker diferenciar funil de personalização de checkout direto.
- Adiciona templates `v3` do GeraSalesPage proibindo iframe para Lead Portal/flow/funil.
- Atualiza cânones e registro operacional do experimento.

## Causa-raiz

A página aprovada do experimento 55 podia embutir o próprio funil do Lead Portal em um `iframe`, porque os templates ainda deixavam margem para tratar a URL do funil como recurso embutível e o backend não fazia uma limpeza defensiva antes da publicação.

## Validação

- `../mvnw -q -Dtest=GeraSalesPagePublicationAuditServiceTest,GeraSalesPageStageServiceTest test`
- `../mvnw -q -Dtest=ArquiteturaTest test`
- `../mvnw -q -DskipTests liquibase:validate -Dliquibase.url=offline:mysql?version=5.7 -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml`
- `../mvnw -q test`
- `git diff --check`
- Verificação de includes relativos no changelog mestre
