### PR TITLE
[codex] Normalize generated creative CTA values

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeGenerationService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeGenerationService.java
@@ -21,6 +21,8 @@ import org.springframework.util.StringUtils;
 @Service
 public class CreativeGenerationService {
     private static final Logger log = LoggerFactory.getLogger(CreativeGenerationService.class);
+    private static final int META_CALL_TO_ACTION_MAX_LENGTH = 32;
+    private static final String DEFAULT_META_CALL_TO_ACTION = "LEARN_MORE";
 
     private final CreativeGenerationBackendClient backendClient;
     private final CreativeChatGptClient textClient;
@@ -99,7 +101,7 @@ public class CreativeGenerationService {
             request.setHeadline(plan.headline());
             request.setPrimaryText(plan.primaryText());
             request.setDescription(plan.description());
-            request.setCta(plan.ctaText());
+            request.setCta(normalizeMetaCallToAction(plan.ctaText()));
             request.setFormat(StringUtils.hasText(plan.format()) ? plan.format() : "IMAGE");
             request.setImageUrl(imageUrl);
             request.setStatus(CreativeStatus.DRAFT);
@@ -120,6 +122,7 @@ public class CreativeGenerationService {
             if (creative.getStatus() == null) {
                 creative.setStatus(CreativeStatus.DRAFT);
             }
+            creative.setCta(normalizeMetaCallToAction(creative.getCta()));
         }
         return creatives;
     }
@@ -165,6 +168,18 @@ public class CreativeGenerationService {
             return dto.getCreativeImagePrompt();
         }
         return "Crie uma imagem de anúncio para Meta Ads alinhada ao texto: " + creative.getPrimaryText();
+    }
+
+    /** Normaliza CTA livre para o tipo canônico aceito pelo backend e pela Meta. */
+    private String normalizeMetaCallToAction(String value) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        String normalized = value.trim();
+        if (normalized.length() <= META_CALL_TO_ACTION_MAX_LENGTH) {
+            return normalized;
+        }
+        return DEFAULT_META_CALL_TO_ACTION;
     }
 
     /** Extrai a mensagem raiz para gravar erro operacional legível no backend. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeGenerationServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeGenerationServiceTest.java
@@ -34,6 +34,7 @@ class CreativeGenerationServiceTest {
         CreateCreativeRequest generated = new CreateCreativeRequest();
         generated.setHeadline("Headline");
         generated.setPrimaryText("Texto principal");
+        generated.setCta("Gerar minha amostra personalizada");
         generated.setStatus(CreativeStatus.DRAFT);
 
         when(backendClient.listPending(5)).thenReturn(List.of(experiment));
@@ -54,6 +55,7 @@ class CreativeGenerationServiceTest {
         ArgumentCaptor<CreateCreativeRequest> captor = ArgumentCaptor.forClass(CreateCreativeRequest.class);
         verify(backendClient).createCreative(org.mockito.ArgumentMatchers.eq(49L), captor.capture());
         assertThat(captor.getValue().getImageUrl()).isEqualTo("/assets/creative.jpg");
+        assertThat(captor.getValue().getCta()).isEqualTo("LEARN_MORE");
         verify(backendClient).markCompleted(49L);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -8,7 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 /**
- * Creative linked to an experiment.
+ * Responsabilidade: representar um criativo vinculado a um experimento.
  */
 @Entity
 @Table(name = "creative")
@@ -47,7 +47,7 @@ public class Creative {
     @Column(name = "description")
     private String description;
 
-    @Column(name = "call_to_action")
+    @Column(name = "call_to_action", length = 32)
     private String cta;
 
     @Column(name = "destination_url")

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -48,6 +48,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class CreativeService {
+    private static final int META_CALL_TO_ACTION_MAX_LENGTH = 32;
+    private static final String DEFAULT_META_CALL_TO_ACTION = "LEARN_MORE";
 
     private final CreativeRepository repository;
     private final ExperimentRepository experimentRepository;
@@ -74,7 +76,7 @@ public class CreativeService {
                     .primaryText(request.getPrimaryText())
                     .imageUrl(request.getImageUrl())
                     .description(request.getDescription())
-                    .cta(request.getCta())
+                    .cta(normalizeMetaCallToAction(request.getCta()))
                     .destinationUrl(request.getDestinationUrl())
                     .leadGenFormId(request.getLeadGenFormId())
                     .instagramUserId(request.getInstagramUserId())
@@ -111,7 +113,7 @@ public class CreativeService {
         creative.setPrimaryText(request.getPrimaryText());
         creative.setImageUrl(request.getImageUrl());
         creative.setDescription(request.getDescription());
-        creative.setCta(request.getCta());
+        creative.setCta(normalizeMetaCallToAction(request.getCta()));
         creative.setDestinationUrl(request.getDestinationUrl());
         creative.setLeadGenFormId(request.getLeadGenFormId());
         creative.setInstagramUserId(request.getInstagramUserId());
@@ -119,6 +121,20 @@ public class CreativeService {
         Creative saved = repository.save(creative);
         refreshExperimentApproval(saved.getExperiment());
         return saved;
+    }
+
+    /**
+     * Mantem o CTA compatível com a coluna e com o tipo canônico aceito pela Meta.
+     */
+    private String normalizeMetaCallToAction(String value) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        String normalized = value.trim();
+        if (normalized.length() <= META_CALL_TO_ACTION_MAX_LENGTH) {
+            return normalized;
+        }
+        return DEFAULT_META_CALL_TO_ACTION;
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -153,6 +153,24 @@ class CreativeServiceTest {
         assertThat(afterApproval.isCreativeApproved()).isTrue();
     }
 
+    /** Garante que CTAs livres longos não quebram o limite físico da coluna. */
+    @Test
+    void normalizesLongCallToActionBeforePersisting() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+
+        CreateCreativeRequest createRequest = new CreateCreativeRequest();
+        createRequest.setHeadline("Headline");
+        createRequest.setPrimaryText("Primary");
+        createRequest.setImageUrl("/img.png");
+        createRequest.setCta("Gerar minha amostra personalizada");
+        createRequest.setStatus(CreativeStatus.DRAFT);
+
+        Creative creative = service.create(exp.getId(), createRequest);
+
+        assertThat(creative.getCta()).isEqualTo("LEARN_MORE");
+    }
+
     @Test
     void deletingLastApprovedCreativeResetsFlag() {
         MarketNiche niche = fixtures.createAndSaveNiche();


### PR DESCRIPTION
## Resumo

- Normaliza CTAs livres maiores que o limite físico de `creative.call_to_action` para `LEARN_MORE`.
- Aplica a proteção no `ai-worker` antes de enviar o criativo e no backend antes de persistir.
- Alinha a entidade `Creative` ao schema real da coluna `call_to_action` com `length = 32`.
- Adiciona testes cobrindo o CTA que quebrou a geração do experimento 55: `Gerar minha amostra personalizada`.

## Causa-raiz

A geração de criativo podia produzir CTA textual livre com mais de 32 caracteres. A coluna real no MySQL é `VARCHAR(32)`, então o backend retornava erro ao persistir e o criativo era descartado. O problema apareceu no experimento 55 com o CTA `Gerar minha amostra personalizada`.

## Impacto

A geração de criativos deixa de falhar por CTA longo. Para CTAs acima do limite, o sistema usa o CTA canônico de Meta Ads `LEARN_MORE`, preservando a campanha e evitando erro 500.

## Validação

- `../mvnw -q -Dtest=CreativeServiceTest test`
- `mvn -q -Dtest=CreativeGenerationServiceTest test`
- `../mvnw -q -Dtest=ArquiteturaTest test`
- `mvn -q test` no `ai-worker`
- `../mvnw -q test` no backend
- `git diff --check`