### PR TITLE
[codex] retry creative image transport failures

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -400,18 +400,27 @@ public class CreativeImageClient {
      * Identifica falhas transitórias da OpenAI que merecem nova tentativa em outro tier.
      */
     private boolean isTransientOpenAiFailure(RuntimeException ex) {
-        String message = ex.getMessage();
-        if (message == null) {
-            return false;
+        StringBuilder details = new StringBuilder();
+        Throwable current = ex;
+        while (current != null) {
+            if (current.getMessage() != null) {
+                details.append(' ').append(current.getMessage());
+            }
+            details.append(' ').append(current.getClass().getName());
+            current = current.getCause();
         }
-        String normalized = message.toLowerCase(Locale.ROOT);
+        String normalized = details.toString().toLowerCase(Locale.ROOT);
         return normalized.contains("429")
                 || normalized.contains("408")
                 || normalized.contains("5xx")
                 || normalized.contains("rate_limit")
                 || normalized.contains("too many requests")
                 || normalized.contains("temporarily unavailable")
-                || normalized.contains("timeout");
+                || normalized.contains("timeout")
+                || normalized.contains("connection prematurely closed")
+                || normalized.contains("prematurecloseexception")
+                || normalized.contains("connection reset")
+                || normalized.contains("webclientrequestexception");
     }
 
     /**

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -250,6 +250,47 @@ class CreativeImageClientTest {
         assertThat(payloads.get(2)).doesNotContainKey("service_tier");
     }
 
+    /**
+     * Deve tentar novamente quando a conexão com a OpenAI fecha antes da resposta.
+     */
+    @Test
+    void retriesPrematureClosedConnectionBeforeFailingCreativeGeneration() {
+        String imagePayload;
+        try {
+            imagePayload = Base64.getEncoder().encodeToString(createSolidPng(64, 64));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        String successBody = "{\"output\":[{\"type\":\"image_generation_call\",\"result\":\"" + imagePayload + "\"}]}";
+        AtomicInteger calls = new AtomicInteger();
+        ExchangeFunction exchange = request -> {
+            int attempt = calls.incrementAndGet();
+            if (attempt == 1) {
+                return Mono.error(new RuntimeException("Connection prematurely closed BEFORE response"));
+            }
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(successBody)
+                    .build());
+        };
+        CreativeImageClient retryClient = new CreativeImageClient(
+                WebClient.builder().exchangeFunction(exchange),
+                backendAssetClient,
+                optimizer,
+                "key",
+                "http://openai",
+                "gpt-image-2",
+                "gpt-5.5",
+                "flex",
+                900);
+        when(backendAssetClient.uploadImage(any(), any(), any(), any(), any())).thenReturn("/uploads/retry.jpg");
+
+        String result = retryClient.generateImage("prompt", null, "creative-experiment-55");
+
+        assertThat(result).isEqualTo("/uploads/retry.jpg");
+        assertThat(calls).hasValue(2);
+    }
+
 
     /**
      * Garante que ausência de credencial OpenAI falhe em vez de retornar URL nula.


### PR DESCRIPTION
## O que mudou

- O `ai-worker` agora trata falhas transitórias de transporte da OpenAI como retryable ao gerar imagens de criativos.
- A detecção passa a analisar a cadeia de causas e cobre `connection prematurely closed`, `PrematureCloseException`, `connection reset` e `WebClientRequestException`.
- Adicionado teste unitário simulando conexão fechada antes da resposta e validando nova tentativa bem-sucedida.

## Por quê

Ao reprocessar os criativos do experimento 55, a falha anterior de CTA longo foi superada, mas a geração abortou na primeira imagem por `Connection prematurely closed BEFORE response`. A causa-raiz era que esse tipo de falha de transporte não entrava na política de retry já existente.

## Validação

- `mvn -Dtest=CreativeImageClientTest test` no `ai-worker`: passou, 8 testes.
- `mvn -Dtest=CreativeServiceTest#normalizesLongCallToActionBeforePersisting test` no `backend/ads-service`: passou, 1 teste.
- Também foi necessário `mvn -DskipTests install` no `backend/ads-service` para instalar a dependência local `ads-service` antes de rodar o teste do `ai-worker`.

## Observação

O registro local em `docs/registros/experimentos.md` foi atualizado no checkout, mas o ambiente não tinha `gh` nem credencial Git HTTPS para empurrar o commit local completo. O PR contém a correção executável e o teste de recorrência.