### PR TITLE
[codex] Melhora layout da tela de planejamento

### DIFF
--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -1,0 +1,44 @@
+.commercial-planning-page {
+  min-width: 0;
+}
+
+.commercial-planning-workspace {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.commercial-planning-sidebar,
+.commercial-planning-main {
+  min-width: 0;
+}
+
+.commercial-planning-plan-item {
+  min-width: 0;
+}
+
+.commercial-planning-plan-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-plan-status {
+  flex: 0 0 auto;
+}
+
+.commercial-planning-plan-action {
+  display: -webkit-box;
+  margin-top: 0.25rem;
+  overflow: hidden;
+  color: inherit;
+  opacity: 0.78;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+@media (max-width: 1199.98px) {
+  .commercial-planning-workspace {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -23,6 +23,7 @@ import {
   useSimulateCommercialPlan,
   useUpdateCommercialPlan,
 } from "../../api/planning/useCommercialPlans";
+import "./CommercialPlanningPage.css";
 
 const emptyForm: SaveCommercialPlanPayload = {
   name: "",
@@ -315,7 +316,7 @@ export default function CommercialPlanningPage() {
   }
 
   return (
-    <div className="d-flex flex-column gap-4">
+    <div className="commercial-planning-page d-flex flex-column gap-4">
       <header className="d-flex flex-column flex-xl-row justify-content-between gap-3">
         <div>
           <PageTitle>Planejamento</PageTitle>
@@ -338,8 +339,8 @@ export default function CommercialPlanningPage() {
         </div>
       ) : null}
 
-      <section className="row g-3">
-        <div className="col-12 col-xl-4">
+      <section className="commercial-planning-workspace">
+        <aside className="commercial-planning-sidebar">
           <div className="card border-0 shadow-sm h-100">
             <div className="card-body">
               <h2 className="h6 mb-3">Planos de Primeira Venda</h2>
@@ -358,16 +359,20 @@ export default function CommercialPlanningPage() {
                   <button
                     type="button"
                     key={plan.id}
-                    className={`list-group-item list-group-item-action px-0 ${selectedPlan?.id === plan.id ? "active" : ""}`}
+                    className={`commercial-planning-plan-item list-group-item list-group-item-action px-0 ${selectedPlan?.id === plan.id ? "active" : ""}`}
                     onClick={() => setSelectedId(plan.id)}
                   >
-                    <div className="d-flex justify-content-between gap-2">
-                      <strong>{plan.name}</strong>
-                      <span className={`badge ${planStatusClass(plan.status)}`}>
+                    <div className="d-flex align-items-start justify-content-between gap-2">
+                      <strong className="commercial-planning-plan-name">
+                        {plan.name}
+                      </strong>
+                      <span
+                        className={`commercial-planning-plan-status badge ${planStatusClass(plan.status)}`}
+                      >
                         {planStatusLabel(plan.status)}
                       </span>
                     </div>
-                    <small>
+                    <small className="commercial-planning-plan-action">
                       {plan.nextAction || "Defina a próxima ação comercial"}
                     </small>
                   </button>
@@ -375,9 +380,9 @@ export default function CommercialPlanningPage() {
               </div>
             </div>
           </div>
-        </div>
+        </aside>
 
-        <div className="col-12 col-xl-8">
+        <main className="commercial-planning-main">
           <div className="card border-0 shadow-sm h-100">
             <div className="card-body">
               {selectedPlan ? (
@@ -828,7 +833,7 @@ export default function CommercialPlanningPage() {
               )}
             </div>
           </div>
-        </div>
+        </main>
       </section>
 
       <section className="card border-0 shadow-sm">


### PR DESCRIPTION
## O que mudou

- Reduzi a largura da coluna lateral da tela de Planejamento para remover o excesso de espaço em branco à esquerda.
- Dei mais área útil ao painel principal de análise do plano.
- Adicionei CSS específico da página para limitar textos longos da lista de planos sem alterar backend ou contratos.

## Por que

A tela estava usando uma coluna lateral grande demais para o volume real de informação. Isso deixava o conteúdo principal comprimido e criava percepção de espaço vazio do lado esquerdo.

## Validação

- `npm run typecheck`
- `NODE_ENV=test npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx`
- `npm run build`

Observação: o ambiente estava com `npm omit=dev`; instalei as dependências com `npm install --include=dev` para executar os checks locais.