### PR TITLE
[codex] Add CNAE audience experiment links

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/ExperimentMetaAudience.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/ExperimentMetaAudience.java
@@ -1,0 +1,71 @@
+package com.marketinghub.metaaudience;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.niche.MarketNiche;
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Representa o uso planejado de uma audiência CNAE em um experimento comercial. */
+@Entity
+@Table(
+        name = "experiment_meta_audience",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_experiment_meta_audience",
+                columnNames = {"experiment_id", "meta_audience_id", "meta_audience_segment_id"}))
+@Getter
+@Setter
+public class ExperimentMetaAudience {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "meta_audience_id", nullable = false)
+    private MetaAudience metaAudience;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "meta_audience_segment_id", nullable = false)
+    private MetaAudienceSegment metaAudienceSegment;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_niche_id", nullable = false)
+    private MarketNiche marketNiche;
+
+    @Column(name = "activation_status", nullable = false, length = 32)
+    private String activationStatus;
+
+    @Column(name = "channel", length = 64)
+    private String channel;
+
+    @Lob
+    @Column(name = "pain_angle")
+    private String painAngle;
+
+    @Lob
+    @Column(name = "promise")
+    private String promise;
+
+    @Lob
+    @Column(name = "offer")
+    private String offer;
+
+    @Lob
+    @Column(name = "decision_snapshot_json")
+    private String decisionSnapshotJson;
+
+    @Lob
+    @Column(name = "analysis_summary")
+    private String analysisSummary;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/controller/MetaAudienceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/controller/MetaAudienceController.java
@@ -3,6 +3,8 @@ package com.marketinghub.metaaudience.controller;
 import com.marketinghub.metaaudience.service.BackendMetaAudienceService;
 import com.marketinghub.metaaudience.service.internalComplete.MetaAudienceSyncCompleteRequest;
 import com.marketinghub.metaaudience.service.internalPending.MetaAudiencePendingResponse;
+import com.marketinghub.metaaudience.service.linkExperiment.ExperimentMetaAudienceResponse;
+import com.marketinghub.metaaudience.service.linkExperiment.LinkMetaAudienceExperimentRequest;
 import com.marketinghub.metaaudience.service.requestAudience.MetaAudienceRequest;
 import com.marketinghub.metaaudience.service.requestAudience.MetaAudienceResponse;
 import java.util.List;
@@ -26,6 +28,30 @@ public class MetaAudienceController {
     @GetMapping("/api/internal/meta-audiences/pending")
     public List<MetaAudiencePendingResponse> pending(@RequestParam(defaultValue = "10") int limit) {
         return service.listPending(limit);
+    }
+
+    /** Lista os planos de audiência CNAE de um nicho. */
+    @GetMapping("/api/meta-audiences/niches/{nicheId}")
+    public List<MetaAudienceResponse> listByNiche(@PathVariable Long nicheId) {
+        return service.listByNiche(nicheId);
+    }
+
+    /** Vincula uma audiência CNAE ao experimento responsável pela validação. */
+    @PostMapping("/api/meta-audiences/experiment-links")
+    public ExperimentMetaAudienceResponse linkExperiment(@RequestBody LinkMetaAudienceExperimentRequest request) {
+        return service.linkExperiment(request);
+    }
+
+    /** Lista audiências CNAE usadas por um experimento. */
+    @GetMapping("/api/meta-audiences/experiments/{experimentId}")
+    public List<ExperimentMetaAudienceResponse> listByExperiment(@PathVariable Long experimentId) {
+        return service.listByExperiment(experimentId);
+    }
+
+    /** Lista vínculos de audiências CNAE dentro de um nicho. */
+    @GetMapping("/api/meta-audiences/niches/{nicheId}/experiment-links")
+    public List<ExperimentMetaAudienceResponse> listExperimentLinksByNiche(@PathVariable Long nicheId) {
+        return service.listExperimentLinksByNiche(nicheId);
     }
 
     /** Recebe o resultado da criação/sincronização da audiência feita pelo worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/BackendMetaAudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/BackendMetaAudienceService.java
@@ -1,12 +1,18 @@
 package com.marketinghub.metaaudience.service;
 
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.metaaudience.ExperimentMetaAudience;
 import com.marketinghub.metaaudience.MetaAudience;
 import com.marketinghub.metaaudience.MetaAudienceSegment;
 import com.marketinghub.metaaudience.service.internalComplete.MetaAudienceSyncCompleteRequest;
 import com.marketinghub.metaaudience.service.internalPending.MetaAudiencePendingResponse;
+import com.marketinghub.metaaudience.service.linkExperiment.ExperimentMetaAudienceResponse;
+import com.marketinghub.metaaudience.service.linkExperiment.LinkMetaAudienceExperimentRequest;
 import com.marketinghub.metaaudience.service.requestAudience.MetaAudienceRequest;
 import com.marketinghub.metaaudience.service.requestAudience.MetaAudienceResponse;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.metaaudience.ExperimentMetaAudienceRepository;
 import com.marketinghub.repository.jpa.metaaudience.MetaAudienceRepository;
 import com.marketinghub.repository.jpa.metaaudience.MetaAudienceSegmentRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
@@ -27,7 +33,9 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendMetaAudienceService {
     private final MetaAudienceRepository audienceRepository;
     private final MetaAudienceSegmentRepository segmentRepository;
+    private final ExperimentMetaAudienceRepository experimentAudienceRepository;
     private final MarketNicheRepository nicheRepository;
+    private final ExperimentRepository experimentRepository;
     private final JdbcTemplate jdbcTemplate;
 
     /** Persiste uma audiência recebida do OPRM sem calcular elegibilidade, nome, recorte ou volume de negócio. */
@@ -79,6 +87,72 @@ public class BackendMetaAudienceService {
                 .toList();
     }
 
+    /** Lista os planos de audiência CNAE já persistidos para um nicho. */
+    @Transactional(readOnly = true)
+    public List<MetaAudienceResponse> listByNiche(Long nicheId) {
+        if (nicheId == null || !nicheRepository.existsById(nicheId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Nicho não encontrado.");
+        }
+        return audienceRepository.findByMarketNicheIdOrderByUpdatedAtDesc(nicheId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /** Vincula uma audiência CNAE e sua parcela funcional ao experimento que validará a hipótese. */
+    @Transactional
+    public ExperimentMetaAudienceResponse linkExperiment(LinkMetaAudienceExperimentRequest request) {
+        validateExperimentLinkRequest(request);
+        MetaAudience audience = audienceRepository.findById(request.metaAudienceId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Audiência não encontrada."));
+        Experiment experiment = experimentRepository.findById(request.experimentId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado."));
+        MetaAudienceSegment segment = loadSegment(request.metaAudienceSegmentId(), audience.getId());
+        validateExperimentAndAudienceNiche(experiment, audience, segment);
+
+        Instant now = Instant.now();
+        ExperimentMetaAudience link = experimentAudienceRepository
+                .findByExperimentIdAndMetaAudienceIdAndMetaAudienceSegmentId(
+                        experiment.getId(), audience.getId(), segment != null ? segment.getId() : null)
+                .orElseGet(ExperimentMetaAudience::new);
+        if (link.getId() == null) {
+            link.setCreatedAt(now);
+        }
+        link.setExperiment(experiment);
+        link.setMetaAudience(audience);
+        link.setMetaAudienceSegment(segment);
+        link.setMarketNiche(audience.getMarketNiche());
+        link.setActivationStatus(defaultStatus(request.activationStatus()));
+        link.setChannel(limit(request.channel(), 64));
+        link.setPainAngle(request.painAngle());
+        link.setPromise(request.promise());
+        link.setOffer(request.offer());
+        link.setDecisionSnapshotJson(request.decisionSnapshotJson());
+        link.setUpdatedAt(now);
+        return toExperimentAudienceResponse(experimentAudienceRepository.save(link));
+    }
+
+    /** Lista as audiências CNAE vinculadas a um experimento. */
+    @Transactional(readOnly = true)
+    public List<ExperimentMetaAudienceResponse> listByExperiment(Long experimentId) {
+        if (experimentId == null || !experimentRepository.existsById(experimentId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado.");
+        }
+        return experimentAudienceRepository.findByExperimentIdOrderByUpdatedAtDesc(experimentId).stream()
+                .map(this::toExperimentAudienceResponse)
+                .toList();
+    }
+
+    /** Lista os vínculos de audiência CNAE feitos dentro de um nicho. */
+    @Transactional(readOnly = true)
+    public List<ExperimentMetaAudienceResponse> listExperimentLinksByNiche(Long nicheId) {
+        if (nicheId == null || !nicheRepository.existsById(nicheId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Nicho não encontrado.");
+        }
+        return experimentAudienceRepository.findByMarketNicheIdOrderByUpdatedAtDesc(nicheId).stream()
+                .map(this::toExperimentAudienceResponse)
+                .toList();
+    }
+
     /** Atualiza o estado persistido da audiência conforme o resultado técnico reportado pelo worker. */
     @Transactional
     public MetaAudienceResponse completeSync(Long id, MetaAudienceSyncCompleteRequest request) {
@@ -110,6 +184,41 @@ public class BackendMetaAudienceService {
         }
     }
 
+    /** Valida os identificadores mínimos para relacionar audiência e experimento. */
+    private void validateExperimentLinkRequest(LinkMetaAudienceExperimentRequest request) {
+        if (request == null || request.metaAudienceId() == null || request.metaAudienceSegmentId() == null
+                || request.experimentId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Audiência, parcela funcional e experimento são obrigatórios para vincular o plano CNAE.");
+        }
+    }
+
+    /** Carrega a parcela funcional e garante que ela pertença à audiência informada. */
+    private MetaAudienceSegment loadSegment(Long segmentId, Long audienceId) {
+        MetaAudienceSegment segment = segmentRepository.findById(segmentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Parcela da audiência não encontrada."));
+        if (!segment.getMetaAudience().getId().equals(audienceId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Parcela funcional não pertence à audiência informada.");
+        }
+        return segment;
+    }
+
+    /** Garante que audiência, parcela e experimento pertencem ao mesmo nicho. */
+    private void validateExperimentAndAudienceNiche(
+            Experiment experiment, MetaAudience audience, MetaAudienceSegment segment) {
+        Long experimentNicheId = experiment.getNiche().getId();
+        Long audienceNicheId = audience.getMarketNiche().getId();
+        if (!experimentNicheId.equals(audienceNicheId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Audiência CNAE e experimento precisam pertencer ao mesmo nicho.");
+        }
+        if (segment != null && !segment.getMarketNiche().getId().equals(audienceNicheId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Parcela funcional precisa pertencer ao mesmo nicho da audiência.");
+        }
+    }
+
     /** Lê os emails persistidos pelo backend para entrega técnica ao worker, sem calcular seleção de público. */
     private List<String> loadEmails(String cnaeCode) {
         return jdbcTemplate.queryForList(
@@ -132,6 +241,33 @@ public class BackendMetaAudienceService {
     private MetaAudienceResponse toResponse(MetaAudience audience) {
         return new MetaAudienceResponse(audience.getId(), audience.getMarketNiche().getId(), audience.getAudienceName(),
                 audience.getEligibilityStatus(), audience.getTotalContacts(), audience.getUniqueEmails());
+    }
+
+    /** Converte o vínculo experimento-audiência em contrato de leitura para a tela e análise. */
+    private ExperimentMetaAudienceResponse toExperimentAudienceResponse(ExperimentMetaAudience link) {
+        MetaAudience audience = link.getMetaAudience();
+        MetaAudienceSegment segment = link.getMetaAudienceSegment();
+        return new ExperimentMetaAudienceResponse(
+                link.getId(),
+                link.getExperiment().getId(),
+                link.getMarketNiche().getId(),
+                audience.getId(),
+                segment != null ? segment.getId() : null,
+                audience.getSourceCnaeCode(),
+                audience.getAudienceName(),
+                segment != null ? segment.getSegmentName() : null,
+                link.getActivationStatus(),
+                link.getChannel(),
+                link.getPainAngle(),
+                link.getPromise(),
+                link.getOffer(),
+                link.getDecisionSnapshotJson(),
+                link.getAnalysisSummary());
+    }
+
+    /** Define o status inicial do plano quando o solicitante não envia um valor explícito. */
+    private String defaultStatus(String status) {
+        return StringUtils.hasText(status) ? limit(status.trim(), 32) : "APPROVED_FOR_EXPERIMENT";
     }
 
     /** Limita textos ao tamanho máximo da coluna de destino. */

--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/linkExperiment/ExperimentMetaAudienceResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/linkExperiment/ExperimentMetaAudienceResponse.java
@@ -1,0 +1,19 @@
+package com.marketinghub.metaaudience.service.linkExperiment;
+
+/** Resposta do vínculo entre experimento e audiência CNAE. */
+public record ExperimentMetaAudienceResponse(
+        Long id,
+        Long experimentId,
+        Long marketNicheId,
+        Long metaAudienceId,
+        Long metaAudienceSegmentId,
+        String cnaeCode,
+        String audienceName,
+        String segmentName,
+        String activationStatus,
+        String channel,
+        String painAngle,
+        String promise,
+        String offer,
+        String decisionSnapshotJson,
+        String analysisSummary) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/linkExperiment/LinkMetaAudienceExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/service/linkExperiment/LinkMetaAudienceExperimentRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.metaaudience.service.linkExperiment;
+
+/** Contrato para vincular uma audiência CNAE planejada a um experimento. */
+public record LinkMetaAudienceExperimentRequest(
+        Long metaAudienceId,
+        Long metaAudienceSegmentId,
+        Long experimentId,
+        String channel,
+        String painAngle,
+        String promise,
+        String offer,
+        String activationStatus,
+        String decisionSnapshotJson) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/ExperimentMetaAudienceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/ExperimentMetaAudienceRepository.java
@@ -1,0 +1,19 @@
+package com.marketinghub.repository.jpa.metaaudience;
+
+import com.marketinghub.metaaudience.ExperimentMetaAudience;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA dos vínculos entre experimentos e audiências Meta Ads por CNAE. */
+public interface ExperimentMetaAudienceRepository extends JpaRepository<ExperimentMetaAudience, Long> {
+    /** Busca vínculo existente para manter a operação idempotente por experimento, audiência e parcela. */
+    Optional<ExperimentMetaAudience> findByExperimentIdAndMetaAudienceIdAndMetaAudienceSegmentId(
+            Long experimentId, Long metaAudienceId, Long metaAudienceSegmentId);
+
+    /** Lista as audiências CNAE vinculadas a um experimento. */
+    List<ExperimentMetaAudience> findByExperimentIdOrderByUpdatedAtDesc(Long experimentId);
+
+    /** Lista os vínculos de audiências CNAE de um nicho. */
+    List<ExperimentMetaAudience> findByMarketNicheIdOrderByUpdatedAtDesc(Long nicheId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/MetaAudienceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/MetaAudienceRepository.java
@@ -9,4 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MetaAudienceRepository extends JpaRepository<MetaAudience, Long> {
     /** Lista audiências prontas para sincronização pelo Facebook Ads Worker. */
     List<MetaAudience> findByEligibilityStatusOrderByUpdatedAtAsc(String status, Pageable pageable);
+
+    /** Lista audiências planejadas para um nicho. */
+    List<MetaAudience> findByMarketNicheIdOrderByUpdatedAtDesc(Long nicheId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/MetaAudienceSegmentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/metaaudience/MetaAudienceSegmentRepository.java
@@ -1,7 +1,11 @@
 package com.marketinghub.repository.jpa.metaaudience;
 
 import com.marketinghub.metaaudience.MetaAudienceSegment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Repositório JPA das parcelas funcionais vinculadas às audiências Meta Ads. */
-public interface MetaAudienceSegmentRepository extends JpaRepository<MetaAudienceSegment, Long> {}
+public interface MetaAudienceSegmentRepository extends JpaRepository<MetaAudienceSegment, Long> {
+    /** Lista as parcelas funcionais de uma audiência. */
+    List<MetaAudienceSegment> findByMetaAudienceIdOrderByUpdatedAtDesc(Long metaAudienceId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-experiment-meta-audience.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-experiment-meta-audience.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-04-01-experiment-meta-audience
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_meta_audience
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_meta_audience (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                experiment_id BIGINT NOT NULL,
+                meta_audience_id BIGINT NOT NULL,
+                meta_audience_segment_id BIGINT NOT NULL,
+                market_niche_id BIGINT NOT NULL,
+                activation_status VARCHAR(32) NOT NULL,
+                channel VARCHAR(64) NULL,
+                pain_angle TEXT NULL,
+                promise TEXT NULL,
+                offer TEXT NULL,
+                decision_snapshot_json TEXT NULL,
+                analysis_summary TEXT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_experiment_meta_audience PRIMARY KEY (id),
+                CONSTRAINT fk_experiment_meta_audience_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id),
+                CONSTRAINT fk_experiment_meta_audience_audience FOREIGN KEY (meta_audience_id) REFERENCES meta_audience(id),
+                CONSTRAINT fk_experiment_meta_audience_segment FOREIGN KEY (meta_audience_segment_id) REFERENCES meta_audience_segment(id),
+                CONSTRAINT fk_experiment_meta_audience_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id),
+                CONSTRAINT uk_experiment_meta_audience UNIQUE (experiment_id, meta_audience_id, meta_audience_segment_id)
+              );
+              CREATE INDEX idx_experiment_meta_audience_experiment ON experiment_meta_audience (experiment_id, updated_at);
+              CREATE INDEX idx_experiment_meta_audience_niche ON experiment_meta_audience (market_niche_id, updated_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -508,29 +508,65 @@ databaseChangeLog:
   - include:
       file: V20250825__sales_funnel_multichannel.xml
       relativeToChangelogFile: true
+
   - include:
-      file: V20250825__sales_funnel_template.xml
+      file: V20250901__link_experiment_sales_funnel.xml
+      relativeToChangelogFile: true
+
+  - include:
+      file: V2026_10_01__experiment_journey_template.sql
+      relativeToChangelogFile: true
+
+  - include:
+      file: V2026_10_02__experiment_journey_template_not_null.sql
+      relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-10-30-facebook-release-reset.yaml
+      relativeToChangelogFile: true
+
+  - include:
+      file: V2025_08_06__create_chat_tables.sql
       relativeToChangelogFile: true
   - include:
-      file: V20250905__rename_hypothesis_value_proposition.sql
+      file: V2025_08_14__add_unique_mechanism_to_hypothesis.sql
       relativeToChangelogFile: true
   - include:
-      file: V20250910__create_experiment_pipeline_job.sql
+      file: V2025_09_15__create_chat_dialog_table.sql
       relativeToChangelogFile: true
   - include:
-      file: V20250915__journey_step_form_fields.sql
+      file: V2025_09_16__add_mechanism_to_hypothesis.sql
       relativeToChangelogFile: true
   - include:
-      file: V20250920__add_selected_email_to_experiment.sql
+      file: V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
       relativeToChangelogFile: true
   - include:
-      file: V20250925__journey_template.sql
+      file: V2025_09_21__add_generated_at_to_hypothesis.sql
       relativeToChangelogFile: true
   - include:
-      file: V20251001__social_calendar.sql
+      file: V2025_09_22__allow_null_premise_angle.sql
       relativeToChangelogFile: true
   - include:
-      file: V20251005__add_selected_journey_to_experiment.sql
+      file: changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: V2025_09_26__relax_hypothesis_constraints.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2025_09_27__add_active_to_prompt_descriptions.sql
+      relativeToChangelogFile: true
+
+  - include:
+      file: V2025_09_28__drop_version_from_prompt_tables.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2025_09_29__link_hypothesis_prompt_attribute_description.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2025_09_30__create_creative_table.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2025_10_05__create_facebook_ads_tables.sql
       relativeToChangelogFile: true
   - include:
       file: V2025_10_06__add_audiences_to_generate_to_niche.sql
@@ -539,55 +575,97 @@ databaseChangeLog:
       file: V2025_10_10__move_audience_approval.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_15__event_campaign.sql
+      file: V2025_10_15__create_journey_tables.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_20__manual_media_plan.sql
+      file: V2025_10_20__journey_execution_runtime.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_01__add_budget_and_schedule_to_campaign.sql
+      file: V2025_10_21__rename_journey_event_value_column.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_10__create_experiment_sample_email.sql
+      file: V2025_10_29__increase_journey_step_stimulus_length.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_12_01__add_selected_sample_email_to_experiment.sql
+      file: V2025_10_30__create_asset_table.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_01_01__add_creative_variants.sql
+      file: V2025_11_05__widen_asset_provider.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_02_01__social_calendar_visual_plan.sql
+      file: V2025_12_04__convert_asset_provider_to_varchar.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_02_15__create_facebook_page.sql
+      file: V2026_03_21__ensure_asset_provider_user_upload.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_03_05__rename_fb_page_status.sql
+      file: V2025_11_10__widen_asset_type.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_03_10__facebook_page_permissions.sql
+      file: V2025_11_15__widen_asset_prompt.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_04_15__create_instagram_account.sql
+      file: V2025_11_20__ensure_asset_prompt_longtext.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_04_20__instagram_account_status.sql
+      file: V2025_11_26__extend_creative_with_meta_fields.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_05_01__create_adset.sql
+      file: V2025_11_30__widen_journey_step_stimulus_type.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_05_15__link_creative_to_adset.sql
+      file: V2025_12_05__create_fb_page_table.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_06_20__adset_publication.sql
+      file: V2025_12_10__move_page_id_to_experiment.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_07_10__adset_daily_budget.sql
+      file: V2025_12_20__extend_fb_account_with_token.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_08_01__adset_effective_status.sql
+      file: V2026_01_05__add_fb_account_token_renewal.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_02_15__add_fb_account_business_manager_app_id.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_02_18__experiment_facebook_api_log.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_03_20__extend_fb_account_worker_config.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_01_17__ensure_hypothesis_mechanism_longtext.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_04_10__drop_fb_account_business_manager_app_id.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_04_15__add_fb_account_pixel_owner_business_id.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_05_01__track_fb_worker_config_errors.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_09_12__add_worker_requests_to_experiment.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_05_10__support_lead_forms.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_11_30__add_fb_account_system_user_token.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_05_20__link_experiment_to_fb_page.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_06_01__extend_instagram_account.sql
+      relativeToChangelogFile: true
+  - include:
+      file: V2026_07_05__simplify_instagram_account.sql
       relativeToChangelogFile: true
   - include:
       file: V2026_08_20__add_instagram_account_to_experiment.sql

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-04-experiment-meta-audience.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
       relativeToChangelogFile: true
   - include:
@@ -505,65 +508,29 @@ databaseChangeLog:
   - include:
       file: V20250825__sales_funnel_multichannel.xml
       relativeToChangelogFile: true
-
   - include:
-      file: V20250901__link_experiment_sales_funnel.xml
-      relativeToChangelogFile: true
-
-  - include:
-      file: V2026_10_01__experiment_journey_template.sql
-      relativeToChangelogFile: true
-
-  - include:
-      file: V2026_10_02__experiment_journey_template_not_null.sql
-      relativeToChangelogFile: true
-
-  - include:
-      file: changesets/2026-10-30-facebook-release-reset.yaml
-      relativeToChangelogFile: true
-
-  - include:
-      file: V2025_08_06__create_chat_tables.sql
+      file: V20250825__sales_funnel_template.xml
       relativeToChangelogFile: true
   - include:
-      file: V2025_08_14__add_unique_mechanism_to_hypothesis.sql
+      file: V20250905__rename_hypothesis_value_proposition.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_09_15__create_chat_dialog_table.sql
+      file: V20250910__create_experiment_pipeline_job.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_09_16__add_mechanism_to_hypothesis.sql
+      file: V20250915__journey_step_form_fields.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
+      file: V20250920__add_selected_email_to_experiment.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_09_21__add_generated_at_to_hypothesis.sql
+      file: V20250925__journey_template.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_09_22__allow_null_premise_angle.sql
+      file: V20251001__social_calendar.sql
       relativeToChangelogFile: true
   - include:
-      file: changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
-      relativeToChangelogFile: true
-  - include:
-      file: V2025_09_26__relax_hypothesis_constraints.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2025_09_27__add_active_to_prompt_descriptions.sql
-      relativeToChangelogFile: true
-
-  - include:
-      file: V2025_09_28__drop_version_from_prompt_tables.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2025_09_29__link_hypothesis_prompt_attribute_description.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2025_09_30__create_creative_table.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2025_10_05__create_facebook_ads_tables.sql
+      file: V20251005__add_selected_journey_to_experiment.sql
       relativeToChangelogFile: true
   - include:
       file: V2025_10_06__add_audiences_to_generate_to_niche.sql
@@ -572,97 +539,55 @@ databaseChangeLog:
       file: V2025_10_10__move_audience_approval.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_15__create_journey_tables.sql
+      file: V2025_10_15__event_campaign.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_20__journey_execution_runtime.sql
+      file: V2025_10_20__manual_media_plan.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_21__rename_journey_event_value_column.sql
+      file: V2025_11_01__add_budget_and_schedule_to_campaign.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_29__increase_journey_step_stimulus_length.sql
+      file: V2025_11_10__create_experiment_sample_email.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_10_30__create_asset_table.sql
+      file: V2025_12_01__add_selected_sample_email_to_experiment.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_05__widen_asset_provider.sql
+      file: V2026_01_01__add_creative_variants.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_12_04__convert_asset_provider_to_varchar.sql
+      file: V2026_02_01__social_calendar_visual_plan.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_03_21__ensure_asset_provider_user_upload.sql
+      file: V2026_02_15__create_facebook_page.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_10__widen_asset_type.sql
+      file: V2026_03_05__rename_fb_page_status.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_15__widen_asset_prompt.sql
+      file: V2026_03_10__facebook_page_permissions.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_20__ensure_asset_prompt_longtext.sql
+      file: V2026_04_15__create_instagram_account.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_26__extend_creative_with_meta_fields.sql
+      file: V2026_04_20__instagram_account_status.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_11_30__widen_journey_step_stimulus_type.sql
+      file: V2026_05_01__create_adset.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_12_05__create_fb_page_table.sql
+      file: V2026_05_15__link_creative_to_adset.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_12_10__move_page_id_to_experiment.sql
+      file: V2026_06_20__adset_publication.sql
       relativeToChangelogFile: true
   - include:
-      file: V2025_12_20__extend_fb_account_with_token.sql
+      file: V2026_07_10__adset_daily_budget.sql
       relativeToChangelogFile: true
   - include:
-      file: V2026_01_05__add_fb_account_token_renewal.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_02_15__add_fb_account_business_manager_app_id.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_02_18__experiment_facebook_api_log.yaml
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_03_20__extend_fb_account_worker_config.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_01_17__ensure_hypothesis_mechanism_longtext.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_04_10__drop_fb_account_business_manager_app_id.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_04_15__add_fb_account_pixel_owner_business_id.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_05_01__track_fb_worker_config_errors.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_09_12__add_worker_requests_to_experiment.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_05_10__support_lead_forms.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_11_30__add_fb_account_system_user_token.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_05_20__link_experiment_to_fb_page.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_06_01__extend_instagram_account.sql
-      relativeToChangelogFile: true
-  - include:
-      file: V2026_07_05__simplify_instagram_account.sql
+      file: V2026_08_01__adset_effective_status.sql
       relativeToChangelogFile: true
   - include:
       file: V2026_08_20__add_instagram_account_to_experiment.sql

--- a/backend/ads-service/src/test/java/com/marketinghub/metaaudience/MetaAudienceArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/metaaudience/MetaAudienceArchitectureTest.java
@@ -1,0 +1,47 @@
+package com.marketinghub.metaaudience;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.List;
+
+/** Protege o pacote MetaAudience para permanecer como leitura/escrita no backend. */
+@AnalyzeClasses(packages = "com.marketinghub")
+class MetaAudienceArchitectureTest {
+    private static final String META_AUDIENCE_PACKAGE = "com.marketinghub.metaaudience";
+    private static final String META_AUDIENCE_EXECUTOR_MODULE = "facebook-ads-worker";
+
+    @ArchTest
+    static final ArchRule metaAudienceBackendMustRemainReadWriteOnly = classes()
+            .that()
+            .resideInAPackage(META_AUDIENCE_PACKAGE + "..")
+            .should(notAssumeOperationalExecutionResponsibilityForMetaAudience())
+            .because("[ARQUITETURA] [BACKEND][MetaAudience] o backend deve registrar planos CNAE, expor pending e receber "
+                    + "resultado; a criação/sincronização operacional de públicos pertence ao módulo "
+                    + META_AUDIENCE_EXECUTOR_MODULE);
+
+    /** Garante que o backend MetaAudience não assuma execução operacional do Facebook Ads Worker. */
+    private static ArchCondition<JavaClass> notAssumeOperationalExecutionResponsibilityForMetaAudience() {
+        List<String> forbiddenNames = List.of("Scheduled", "PipelineWorker", "StageProcessor", "StageContext",
+                "StageResult", "StageArtifact", "WebClient", "RestTemplate", "Jsoup", "Playwright", "Selenium");
+        return new ArchCondition<>("[ARQUITETURA] manter MetaAudience backend como leitura/escrita") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                item.getDirectDependenciesFromSelf().stream()
+                        .filter(dependency -> forbiddenNames.stream().anyMatch(name ->
+                                dependency.getTargetClass().getName().contains(name)))
+                        .forEach(dependency -> events.add(SimpleConditionEvent.violated(item,
+                                "[ARQUITETURA] [BACKEND][MetaAudience] " + item.getName()
+                                        + " depende de " + dependency.getTargetClass().getName()
+                                        + "; criação de público, polling e integração externa pertencem ao "
+                                        + META_AUDIENCE_EXECUTOR_MODULE)));
+            }
+        };
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/metaaudience/service/BackendMetaAudienceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/metaaudience/service/BackendMetaAudienceServiceTest.java
@@ -1,0 +1,173 @@
+package com.marketinghub.metaaudience.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.metaaudience.ExperimentMetaAudience;
+import com.marketinghub.metaaudience.MetaAudience;
+import com.marketinghub.metaaudience.MetaAudienceSegment;
+import com.marketinghub.metaaudience.service.linkExperiment.ExperimentMetaAudienceResponse;
+import com.marketinghub.metaaudience.service.linkExperiment.LinkMetaAudienceExperimentRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.metaaudience.ExperimentMetaAudienceRepository;
+import com.marketinghub.repository.jpa.metaaudience.MetaAudienceRepository;
+import com.marketinghub.repository.jpa.metaaudience.MetaAudienceSegmentRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Testa o serviço backend de leitura/escrita de planos de audiência CNAE. */
+@ExtendWith(MockitoExtension.class)
+class BackendMetaAudienceServiceTest {
+    @Mock
+    private MetaAudienceRepository audienceRepository;
+
+    @Mock
+    private MetaAudienceSegmentRepository segmentRepository;
+
+    @Mock
+    private ExperimentMetaAudienceRepository experimentAudienceRepository;
+
+    @Mock
+    private MarketNicheRepository nicheRepository;
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private BackendMetaAudienceService service;
+
+    /** Deve vincular a audiência ao experimento mantendo o mesmo nicho e status padrão. */
+    @Test
+    void linkExperimentPersistsAudienceExperimentRelation() {
+        MarketNiche niche = niche(10L);
+        MetaAudience audience = audience(20L, niche);
+        MetaAudienceSegment segment = segment(30L, audience, niche);
+        Experiment experiment = experiment(40L, niche);
+
+        when(audienceRepository.findById(20L)).thenReturn(Optional.of(audience));
+        when(experimentRepository.findById(40L)).thenReturn(Optional.of(experiment));
+        when(segmentRepository.findById(30L)).thenReturn(Optional.of(segment));
+        when(experimentAudienceRepository.findByExperimentIdAndMetaAudienceIdAndMetaAudienceSegmentId(40L, 20L, 30L))
+                .thenReturn(Optional.empty());
+        when(experimentAudienceRepository.save(any(ExperimentMetaAudience.class))).thenAnswer(invocation -> {
+            ExperimentMetaAudience saved = invocation.getArgument(0);
+            saved.setId(50L);
+            return saved;
+        });
+
+        ExperimentMetaAudienceResponse response = service.linkExperiment(new LinkMetaAudienceExperimentRequest(
+                20L,
+                30L,
+                40L,
+                "Meta Ads",
+                "agenda lotada no WhatsApp",
+                "organizar pedidos sem planilha",
+                "produto low-ticket",
+                null,
+                "{\"uniqueEmails\":97490}"));
+
+        assertThat(response.id()).isEqualTo(50L);
+        assertThat(response.marketNicheId()).isEqualTo(10L);
+        assertThat(response.metaAudienceId()).isEqualTo(20L);
+        assertThat(response.metaAudienceSegmentId()).isEqualTo(30L);
+        assertThat(response.experimentId()).isEqualTo(40L);
+        assertThat(response.activationStatus()).isEqualTo("APPROVED_FOR_EXPERIMENT");
+        assertThat(response.cnaeCode()).isEqualTo("5620104");
+        assertThat(response.decisionSnapshotJson()).contains("uniqueEmails");
+    }
+
+    /** Deve bloquear vínculo quando a audiência e o experimento pertencem a nichos diferentes. */
+    @Test
+    void linkExperimentRejectsDifferentNiches() {
+        MetaAudience audience = audience(20L, niche(10L));
+        Experiment experiment = experiment(40L, niche(11L));
+
+        when(audienceRepository.findById(20L)).thenReturn(Optional.of(audience));
+        when(experimentRepository.findById(40L)).thenReturn(Optional.of(experiment));
+
+        MetaAudienceSegment segment = segment(30L, audience, audience.getMarketNiche());
+        when(segmentRepository.findById(30L)).thenReturn(Optional.of(segment));
+
+        assertThatThrownBy(() -> service.linkExperiment(new LinkMetaAudienceExperimentRequest(
+                        20L, 30L, 40L, null, null, null, null, null, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("mesmo nicho");
+    }
+
+    /** Deve listar vínculos de audiência CNAE por experimento para análise do piloto. */
+    @Test
+    void listByExperimentReturnsLinkedAudiences() {
+        MarketNiche niche = niche(10L);
+        ExperimentMetaAudience link = new ExperimentMetaAudience();
+        link.setId(50L);
+        link.setExperiment(experiment(40L, niche));
+        link.setMarketNiche(niche);
+        link.setMetaAudience(audience(20L, niche));
+        link.setMetaAudienceSegment(segment(30L, link.getMetaAudience(), niche));
+        link.setActivationStatus("RUNNING");
+
+        when(experimentRepository.existsById(40L)).thenReturn(true);
+        when(experimentAudienceRepository.findByExperimentIdOrderByUpdatedAtDesc(40L)).thenReturn(List.of(link));
+
+        List<ExperimentMetaAudienceResponse> response = service.listByExperiment(40L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).activationStatus()).isEqualTo("RUNNING");
+        assertThat(response.get(0).segmentName()).isEqualTo("Dono-operador de marmitas");
+    }
+
+    /** Cria um nicho mínimo para os testes de relacionamento. */
+    private MarketNiche niche(Long id) {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(id);
+        niche.setName("Marmitas");
+        return niche;
+    }
+
+    /** Cria uma audiência CNAE mínima para os testes de plano. */
+    private MetaAudience audience(Long id, MarketNiche niche) {
+        MetaAudience audience = new MetaAudience();
+        audience.setId(id);
+        audience.setMarketNiche(niche);
+        audience.setSourceCnaeCode("5620104");
+        audience.setAudienceName("Marmitas CNAE 5620104");
+        audience.setEligibilityStatus("READY");
+        audience.setTotalContacts(97490L);
+        audience.setUniqueEmails(97490L);
+        return audience;
+    }
+
+    /** Cria uma parcela funcional mínima para os testes de vínculo. */
+    private MetaAudienceSegment segment(Long id, MetaAudience audience, MarketNiche niche) {
+        MetaAudienceSegment segment = new MetaAudienceSegment();
+        segment.setId(id);
+        segment.setMetaAudience(audience);
+        segment.setMarketNiche(niche);
+        segment.setSegmentName("Dono-operador de marmitas");
+        return segment;
+    }
+
+    /** Cria um experimento mínimo para validar o vínculo com audiência. */
+    private Experiment experiment(Long id, MarketNiche niche) {
+        Experiment experiment = new Experiment();
+        experiment.setId(id);
+        experiment.setNiche(niche);
+        experiment.setName("Piloto marmitas");
+        return experiment;
+    }
+}

--- a/docs/swagger/meta-audiences-swagger.yaml
+++ b/docs/swagger/meta-audiences-swagger.yaml
@@ -15,6 +15,57 @@ paths:
       responses:
         '200':
           description: Audiência persistida no backend conforme decisão do OPRM.
+  /api/meta-audiences/niches/{nicheId}:
+    get:
+      summary: Lista planos de audiência CNAE vinculados a um nicho.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Planos de audiência do nicho.
+  /api/meta-audiences/experiment-links:
+    post:
+      summary: Vincula uma audiência CNAE a um experimento.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkMetaAudienceExperimentRequest'
+      responses:
+        '200':
+          description: Vínculo persistido entre experimento e audiência.
+  /api/meta-audiences/experiments/{experimentId}:
+    get:
+      summary: Lista audiências CNAE usadas por um experimento.
+      parameters:
+        - in: path
+          name: experimentId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Audiências vinculadas ao experimento.
+  /api/meta-audiences/niches/{nicheId}/experiment-links:
+    get:
+      summary: Lista vínculos de audiência CNAE por nicho.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Vínculos de audiência e experimento do nicho.
   /api/internal/meta-audiences/pending:
     get:
       summary: Lista audiências prontas para o Facebook Ads Worker criar na Meta.
@@ -62,3 +113,34 @@ components:
         totalContacts: { type: integer, format: int64 }
         uniqueEmails: { type: integer, format: int64 }
         estimatedContacts: { type: integer, format: int64 }
+    LinkMetaAudienceExperimentRequest:
+      type: object
+      required: [metaAudienceId, metaAudienceSegmentId, experimentId]
+      properties:
+        metaAudienceId: { type: integer, format: int64 }
+        metaAudienceSegmentId: { type: integer, format: int64 }
+        experimentId: { type: integer, format: int64 }
+        channel: { type: string }
+        painAngle: { type: string }
+        promise: { type: string }
+        offer: { type: string }
+        activationStatus: { type: string }
+        decisionSnapshotJson: { type: string }
+    ExperimentMetaAudienceResponse:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        experimentId: { type: integer, format: int64 }
+        marketNicheId: { type: integer, format: int64 }
+        metaAudienceId: { type: integer, format: int64 }
+        metaAudienceSegmentId: { type: integer, format: int64 }
+        cnaeCode: { type: string }
+        audienceName: { type: string }
+        segmentName: { type: string }
+        activationStatus: { type: string }
+        channel: { type: string }
+        painAngle: { type: string }
+        promise: { type: string }
+        offer: { type: string }
+        decisionSnapshotJson: { type: string }
+        analysisSummary: { type: string }


### PR DESCRIPTION
## O que mudou

- Adiciona o vínculo `experiment_meta_audience` para conectar plano de audiência CNAE, parcela funcional do nicho e experimento.
- Expõe endpoints de leitura/escrita para listar audiências por nicho, vincular audiência a experimento e consultar vínculos por experimento/nicho.
- Mantém execução operacional fora do backend: o backend registra plano, expõe pending e recebe resultado; criação/sincronização continua no `facebook-ads-worker`.
- Adiciona regra ArchUnit dedicada para proteger `metaaudience` contra responsabilidades operacionais.
- Atualiza Swagger e Liquibase MySQL 5.7 com `DATETIME` e include relativo.

## Por que

O piloto CNAE precisa entrar no fluxo existente `nicho -> hipótese -> experimento -> análise`, sem virar disparo paralelo ou módulo acoplado. O vínculo permite usar a base de e-mails por CNAE como inteligência de segmentação e ativação controlada pelo sistema.

## Validação

- `mvn -Dtest=BackendMetaAudienceServiceTest,MetaAudienceArchitectureTest,ArquiteturaTest test`
- Resultado local: 92 testes passaram.
- `git diff --check`
- Validação de includes relativos no changelog mestre sem pendências.