### PR TITLE
[codex] Fix meta audience decision snapshot capacity

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/metaaudience/ExperimentMetaAudience.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metaaudience/ExperimentMetaAudience.java
@@ -56,7 +56,7 @@ public class ExperimentMetaAudience {
     private String offer;
 
     @Lob
-    @Column(name = "decision_snapshot_json")
+    @Column(name = "decision_snapshot_json", columnDefinition = "MEDIUMTEXT")
     private String decisionSnapshotJson;
 
     @Lob

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-experiment-meta-audience-snapshot-mediumtext.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-experiment-meta-audience-snapshot-mediumtext.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-04-02-experiment-meta-audience-snapshot-mediumtext
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_meta_audience
+        - columnExists:
+            tableName: experiment_meta_audience
+            columnName: decision_snapshot_json
+        - sqlCheck:
+            expectedResult: 0
+            sql: |
+              SELECT COUNT(*)
+              FROM information_schema.columns
+              WHERE table_schema = DATABASE()
+                AND table_name = 'experiment_meta_audience'
+                AND column_name = 'decision_snapshot_json'
+                AND data_type = 'mediumtext'
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_meta_audience
+                MODIFY COLUMN decision_snapshot_json MEDIUMTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,6 +3,9 @@ databaseChangeLog:
       file: changesets/2026-07-04-experiment-meta-audience.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-04-experiment-meta-audience-snapshot-mediumtext.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/metaaudience/service/BackendMetaAudienceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/metaaudience/service/BackendMetaAudienceServiceTest.java
@@ -91,6 +91,41 @@ class BackendMetaAudienceServiceTest {
         assertThat(response.decisionSnapshotJson()).contains("uniqueEmails");
     }
 
+    /** Deve preservar snapshot grande para manter a evidência usada na decisão do piloto CNAE. */
+    @Test
+    void linkExperimentPreservesLargeDecisionSnapshot() {
+        MarketNiche niche = niche(10L);
+        MetaAudience audience = audience(20L, niche);
+        MetaAudienceSegment segment = segment(30L, audience, niche);
+        Experiment experiment = experiment(40L, niche);
+        String largeSnapshot = "{\"evidences\":\"" + "volume-cnae-".repeat(7000) + "\"}";
+
+        when(audienceRepository.findById(20L)).thenReturn(Optional.of(audience));
+        when(experimentRepository.findById(40L)).thenReturn(Optional.of(experiment));
+        when(segmentRepository.findById(30L)).thenReturn(Optional.of(segment));
+        when(experimentAudienceRepository.findByExperimentIdAndMetaAudienceIdAndMetaAudienceSegmentId(40L, 20L, 30L))
+                .thenReturn(Optional.empty());
+        when(experimentAudienceRepository.save(any(ExperimentMetaAudience.class))).thenAnswer(invocation -> {
+            ExperimentMetaAudience saved = invocation.getArgument(0);
+            saved.setId(51L);
+            return saved;
+        });
+
+        ExperimentMetaAudienceResponse response = service.linkExperiment(new LinkMetaAudienceExperimentRequest(
+                20L,
+                30L,
+                40L,
+                "Meta Ads",
+                "agenda lotada no WhatsApp",
+                "organizar agenda sem perder cliente",
+                "produto low-ticket",
+                "PLANNED",
+                largeSnapshot));
+
+        assertThat(response.decisionSnapshotJson()).isEqualTo(largeSnapshot);
+        assertThat(response.decisionSnapshotJson().length()).isGreaterThan(65_535);
+    }
+
     /** Deve bloquear vínculo quando a audiência e o experimento pertencem a nichos diferentes. */
     @Test
     void linkExperimentRejectsDifferentNiches() {


### PR DESCRIPTION
## O que mudou

- Aumenta `experiment_meta_audience.decision_snapshot_json` para `MEDIUMTEXT` via Liquibase incremental MySQL 5.7.
- Alinha a entidade `ExperimentMetaAudience` ao tipo canônico da coluna.
- Adiciona teste garantindo que snapshots grandes do piloto CNAE sejam preservados, em vez de exigir snapshot enxuto manual.

## Por que

Durante o piloto CNAE, o vínculo experimento-audiência falhou quando o snapshot completo da decisão ficou maior que a capacidade prática da coluna. A causa-raiz é capacidade insuficiente para evidências de decisão/auditoria do plano CNAE.

## Impacto

O sistema passa a suportar snapshots mais completos para análise de nicho > hipótese > experimento > análise, sem transformar o backend em executor operacional. A mudança é somente leitura/escrita/persistência.

## Validação

- `mvn -Dtest=BackendMetaAudienceServiceTest,MetaAudienceArchitectureTest,ArquiteturaTest test`
- Resultado: 93 testes passaram.
- Validação adicional: changelog mestre sem `include` relativo de `changesets/...` sem `relativeToChangelogFile: true`.