### PR TITLE
[codex] Corrige CTA e tracking do experimento 55

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -445,6 +445,10 @@ public class ExperimentFunnelService {
             validateRequiredLandingAnalyticsField(request.sessionId(), "sessionId é obrigatório para checkout_click");
             validateRequiredLandingAnalyticsField(request.pageUrl(), "pageUrl é obrigatório para checkout_click");
         }
+        if ("form_start".equalsIgnoreCase(eventType) || "form_submit".equalsIgnoreCase(eventType)) {
+            validateRequiredLandingAnalyticsField(request.sessionId(), "sessionId é obrigatório para eventos de formulário");
+            validateRequiredLandingAnalyticsField(request.pageUrl(), "pageUrl é obrigatório para eventos de formulário");
+        }
     }
 
     /**
@@ -563,6 +567,12 @@ public class ExperimentFunnelService {
         }
         if ("page_load_metric".equalsIgnoreCase(eventType)) {
             return ExperimentFunnelStage.VISUALIZACAO_FORM;
+        }
+        if ("form_start".equalsIgnoreCase(eventType)) {
+            return ExperimentFunnelStage.VISUALIZACAO_FORM;
+        }
+        if ("form_submit".equalsIgnoreCase(eventType)) {
+            return ExperimentFunnelStage.ENVIO_FORM;
         }
         if ("checkout_click".equalsIgnoreCase(eventType) && isLowTicketProduct(experiment)) {
             return ExperimentFunnelStage.ACESSO_CHECKOUT;

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -191,6 +191,78 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, saved.getSource());
     }
 
+    /**
+     * Valida que início do formulário vira sinal de visualização qualificada do formulário.
+     */
+    @Test
+    void registerLandingPageAnalyticsSavesFormStartAsFormVisualization() {
+        Experiment experiment = Experiment.builder().id(55L).build();
+        when(experimentRepository.findFirstByLeadPortalFlowSlug("product-ai-exp-55-personalized-sample"))
+                .thenReturn(Optional.of(experiment));
+        when(eventRepository.save(any(ExperimentFunnelEvent.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.registerLandingPageAnalyticsEvent("product-ai-exp-55-personalized-sample",
+                new RegisterLandingPageAnalyticsEventRequest(
+                        "form-start-1",
+                        "form_start",
+                        "visitor-1",
+                        "session-1",
+                        null,
+                        null,
+                        null,
+                        "https://oportunidadebrasil.shop/flows/product-ai-exp-55-personalized-sample",
+                        Instant.parse("2026-07-04T12:00:00Z"),
+                        "JUnit",
+                        "mobile",
+                        "android",
+                        390,
+                        844));
+
+        ArgumentCaptor<ExperimentFunnelEvent> eventCaptor = ArgumentCaptor.forClass(ExperimentFunnelEvent.class);
+        verify(eventRepository).save(eventCaptor.capture());
+
+        ExperimentFunnelEvent saved = eventCaptor.getValue();
+        assertEquals(experiment, saved.getExperiment());
+        assertEquals(ExperimentFunnelStage.VISUALIZACAO_FORM, saved.getStage());
+        assertEquals(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, saved.getSource());
+    }
+
+    /**
+     * Valida que envio do formulário vira sinal de envio no funil para diagnóstico do experimento.
+     */
+    @Test
+    void registerLandingPageAnalyticsSavesFormSubmitAsFormSubmission() {
+        Experiment experiment = Experiment.builder().id(55L).build();
+        when(experimentRepository.findFirstByLeadPortalFlowSlug("product-ai-exp-55-personalized-sample"))
+                .thenReturn(Optional.of(experiment));
+        when(eventRepository.save(any(ExperimentFunnelEvent.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.registerLandingPageAnalyticsEvent("product-ai-exp-55-personalized-sample",
+                new RegisterLandingPageAnalyticsEventRequest(
+                        "form-submit-1",
+                        "form_submit",
+                        "visitor-1",
+                        "session-1",
+                        null,
+                        null,
+                        null,
+                        "https://oportunidadebrasil.shop/flows/product-ai-exp-55-personalized-sample",
+                        Instant.parse("2026-07-04T12:01:00Z"),
+                        "JUnit",
+                        "mobile",
+                        "android",
+                        390,
+                        844));
+
+        ArgumentCaptor<ExperimentFunnelEvent> eventCaptor = ArgumentCaptor.forClass(ExperimentFunnelEvent.class);
+        verify(eventRepository).save(eventCaptor.capture());
+
+        ExperimentFunnelEvent saved = eventCaptor.getValue();
+        assertEquals(experiment, saved.getExperiment());
+        assertEquals(ExperimentFunnelStage.ENVIO_FORM, saved.getStage());
+        assertEquals(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE, saved.getSource());
+    }
+
 
 
     /**

--- a/docs/melhorias/experimentos.md
+++ b/docs/melhorias/experimentos.md
@@ -1,0 +1,60 @@
+# Melhorias de experimentos
+
+## Referência de análise
+
+Este documento consolida aprendizados e decisões de melhoria para experimentos de marketing digital do Marketing Hub.
+
+### Fontes prioritárias
+
+- Relatórios Markdown em `docs/relatorios/experimentos/`.
+- Registros históricos em `docs/registros/experimentos.md` e `docs/registros/diario.md`.
+- Métricas persistidas do funil, analytics e campanhas.
+- Evidências de página, CTA, checkout, submissão e eventos públicos.
+
+## Diagnóstico consolidado recente
+
+Nos experimentos recentes, o gargalo principal apareceu depois do clique: alguns anúncios geraram CTR aceitável e clique barato, mas a passagem de visualização da página para intenção real de compra ou envio de formulário ficou muito baixa.
+
+Leitura prática:
+
+- O topo do funil já demonstrou capacidade de atrair atenção em alguns nichos.
+- A página intermediária ainda precisa provar valor antes de pedir checkout.
+- CTA frio direto para compra tende a desperdiçar tráfego quando a promessa exige demonstração visual ou personalização.
+- Tracking incompleto reduz a capacidade de diferenciar problema de criativo, página, formulário ou checkout.
+
+## Experimento 55
+
+### Problema identificado
+
+O experimento 55 tinha campanha com entrega ativa no ecossistema Meta, mas sem clique e sem evento útil de funil. Na análise da página, o CTA principal podia apontar para a própria URL do fluxo, criando risco de loop em vez de conduzir claramente ao formulário.
+
+### Decisão aplicada
+
+Antes de escalar ou lançar o experimento 56, a prioridade passou a ser corrigir o fluxo do 55:
+
+- transformar links autorreferentes da página em rolagem para o formulário;
+- registrar `form_start` quando o usuário começa a preencher;
+- registrar `form_submit` quando o formulário é enviado;
+- manter `page_view` e `page_load_metric` como sinais de saúde da página;
+- preservar o relatório do funil com dados persistidos, não apenas logs.
+
+### Hipótese de melhoria
+
+Se o visitante enxergar prova visual e for conduzido para uma ação de menor atrito antes do checkout, a perda entre visualização da página e intenção deve diminuir. O próximo julgamento do 55 deve separar:
+
+- problema de anúncio, se continuar sem clique;
+- problema de página/CTA, se houver clique mas não houver `form_start`;
+- problema de formulário, se houver `form_start` mas não houver `form_submit`;
+- problema de oferta/checkout, se houver submissão mas não houver avanço para compra.
+
+## Próximos testes recomendados
+
+- Manter orçamento baixo até haver clique e eventos úteis.
+- Usar CTAs de menor atrito:
+  - "ver exemplo preenchido";
+  - "gerar minha amostra";
+  - "ver antes/depois".
+- Colocar prova visual antes do checkout.
+- Só levar ao checkout depois de demonstrar valor concreto.
+- Não lançar o experimento 56 até validar que o gargalo de página/formulário do 55 foi corrigido.
+

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
@@ -270,6 +270,22 @@ public class FlowController {
                       .then(function(response){ debugLog('fetch concluído', {eventId: payload.eventId, eventType: eventType, status: response.status}); })
                       .catch(function(error){ debugLog('fetch falhou', {eventId: payload.eventId, eventType: eventType, error: error && error.message ? error.message : String(error)}); });
                   };
+                  const resolveFormTarget = function(){
+                    return document.querySelector('form');
+                  };
+                  const isSelfReferentialLink = function(anchor){
+                    if (!anchor || !anchor.href) return false;
+                    try {
+                      const targetUrl = new URL(anchor.href, window.location.href);
+                      const currentUrl = new URL(window.location.href);
+                      const targetPath = targetUrl.pathname.replace(/\\/$/, '');
+                      const currentPath = currentUrl.pathname.replace(/\\/$/, '');
+                      if (targetUrl.origin === currentUrl.origin && targetPath === currentPath) return true;
+                      return targetPath.endsWith('/flows/' + slugValue) || targetPath.endsWith('/flows/' + slugValue + '/page');
+                    } catch (error) {
+                      return false;
+                    }
+                  };
                   const startTracking = function(){
                     debugLog('tracking iniciado', {slug: slugValue});
                     sendEvent('page_view', null, null);
@@ -304,6 +320,28 @@ public class FlowController {
                     const trackedSections = document.querySelectorAll('section[id], [data-section-id], [data-track-section]');
                     debugLog('seções monitoradas', {count: trackedSections.length});
                     trackedSections.forEach(function(el){ observer.observe(el); });
+                    document.addEventListener('click', function(event){
+                      const anchor = event.target && event.target.closest ? event.target.closest('a[href]') : null;
+                      if (!anchor || !isSelfReferentialLink(anchor)) return;
+                      const formTarget = resolveFormTarget();
+                      if (!formTarget) return;
+                      event.preventDefault();
+                      formTarget.scrollIntoView({behavior:'smooth', block:'start'});
+                    }, true);
+                    const startedForms = new WeakSet();
+                    const trackFormStart = function(event){
+                      const form = event.target && event.target.closest ? event.target.closest('form') : null;
+                      if (!form || startedForms.has(form)) return;
+                      startedForms.add(form);
+                      sendEvent('form_start', null, null);
+                    };
+                    document.addEventListener('input', trackFormStart, true);
+                    document.addEventListener('change', trackFormStart, true);
+                    document.addEventListener('submit', function(event){
+                      const form = event.target && event.target.tagName && event.target.tagName.toLowerCase() === 'form' ? event.target : null;
+                      if (!form) return;
+                      sendEvent('form_submit', null, null);
+                    }, true);
                     window.addEventListener('beforeunload', function(){
                       const now = performance.now();
                       debugLog('beforeunload processando seções visíveis', {count: visibleSince.size});

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -282,7 +282,10 @@ class FlowControllerTest {
                 .andExpect(content().string(containsString("screenWidth")))
                 .andExpect(content().string(containsString("page_load_metric")))
                 .andExpect(content().string(containsString("loadDurationMs")))
-                .andExpect(content().string(containsString("resourceErrorCount")));
+                .andExpect(content().string(containsString("resourceErrorCount")))
+                .andExpect(content().string(containsString("isSelfReferentialLink")))
+                .andExpect(content().string(containsString("form_start")))
+                .andExpect(content().string(containsString("form_submit")));
     }
 
     /**

--- a/lead-portal/frontend/src/api.ts
+++ b/lead-portal/frontend/src/api.ts
@@ -189,6 +189,50 @@ export async function registerFlowRenderComplete(
   }
 }
 
+export interface FlowPageAnalyticsPayload {
+  eventId: string;
+  eventType: string;
+  visitorId?: string | null;
+  sessionId?: string | null;
+  sectionId?: string | null;
+  visibleMs?: number | null;
+  elapsedMs?: number | null;
+  pageUrl?: string | null;
+  occurredAt?: string | null;
+  userAgent?: string | null;
+  deviceType?: string | null;
+  operatingSystem?: string | null;
+  screenWidth?: number | null;
+  screenHeight?: number | null;
+  loadDurationMs?: number | null;
+  domContentLoadedMs?: number | null;
+  firstContentfulPaintMs?: number | null;
+  resourceErrorCount?: number | null;
+  connectionType?: string | null;
+}
+
+export async function registerFlowPageAnalytics(
+  slug: string,
+  payload: FlowPageAnalyticsPayload
+): Promise<void> {
+  const normalizedSlug = slug?.trim();
+  if (!normalizedSlug) {
+    throw new Error("Slug do fluxo é obrigatório");
+  }
+  const response = await fetch(
+    buildUrl(`/flows/${encodeURIComponent(normalizedSlug)}/page-analytics`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    }
+  );
+  if (!response.ok) {
+    const message = await extractError(response);
+    throw new Error(message);
+  }
+}
+
 async function extractError(response: Response): Promise<string> {
   try {
     const body = await response.json();

--- a/lead-portal/frontend/src/components/FlowForm.tsx
+++ b/lead-portal/frontend/src/components/FlowForm.tsx
@@ -13,12 +13,14 @@ type AnswerValue = string | string[] | File | null;
 interface FlowFormProps {
   flow: LeadPortalFlow;
   campaignCode?: string | null;
+  onStarted?: () => void;
   onSubmitted?: (result: FlowSubmissionResponse) => void;
 }
 
 export default function FlowForm({
   flow,
   campaignCode,
+  onStarted,
   onSubmitted,
 }: FlowFormProps) {
   const {
@@ -48,6 +50,7 @@ export default function FlowForm({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submissionResult, setSubmissionResult] =
     useState<FlowSubmissionResponse | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
 
   const visibleQuestions = useMemo(() => {
     if (!contactFollowUpConfig) {
@@ -76,6 +79,7 @@ export default function FlowForm({
     setErrors({});
     setSubmitError(null);
     setSubmissionResult(null);
+    setHasStarted(false);
   }, [initialAnswers]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -171,6 +175,10 @@ export default function FlowForm({
   };
 
   const updateAnswer = (question: FlowQuestion, value: AnswerValue) => {
+    if (!hasStarted) {
+      setHasStarted(true);
+      onStarted?.();
+    }
     setAnswers((current) => {
       const next = {
         ...current,

--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import {
   API_BASE_URL,
   fetchLeadPortalFlow,
+  registerFlowPageAnalytics,
   registerFlowRenderComplete,
   submitFlowSubmission,
 } from "../api";
@@ -29,15 +30,36 @@ export default function FlowPage() {
   const campaignCode = useCampaignCode();
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [hasTrackedRenderComplete, setHasTrackedRenderComplete] = useState(false);
+  const [hasTrackedFormStart, setHasTrackedFormStart] = useState(false);
   const [submissionResult, setSubmissionResult] = useState<FlowSubmissionResponse | null>(null);
 
   useEffect(() => {
     setHasSubmitted(false);
     setHasTrackedRenderComplete(false);
+    setHasTrackedFormStart(false);
     setSubmissionResult(null);
   }, [slug]);
 
+  const trackFormEvent = (eventType: "form_start" | "form_submit") => {
+    if (!resolvedFlowSlug) {
+      return;
+    }
+    const eventPayload = buildFlowPageAnalyticsPayload(eventType);
+    registerFlowPageAnalytics(resolvedFlowSlug, eventPayload).catch((trackError) => {
+      console.warn(`Falha ao registrar ${eventType} do fluxo`, trackError);
+    });
+  };
+
+  const handleFormStarted = () => {
+    if (hasTrackedFormStart) {
+      return;
+    }
+    setHasTrackedFormStart(true);
+    trackFormEvent("form_start");
+  };
+
   const handleSubmissionComplete = (result: FlowSubmissionResponse) => {
+    trackFormEvent("form_submit");
     setSubmissionResult(result);
     setHasSubmitted(true);
   };
@@ -292,6 +314,7 @@ export default function FlowPage() {
         <FlowForm
           flow={flowForForm}
           campaignCode={campaignCode}
+          onStarted={handleFormStarted}
           onSubmitted={handleSubmissionComplete}
         />
       </div>
@@ -628,7 +651,7 @@ function attachCustomTemplateBridgeToDocument(
 
   const handleAnchorClick = (event: MouseEvent) => {
     const target = event.target as Element | null;
-    const anchor = target?.closest?.('a[href^="#"]') as HTMLAnchorElement | null;
+    const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
     if (!anchor) {
       return;
     }
@@ -637,6 +660,20 @@ function attachCustomTemplateBridgeToDocument(
     }
     const href = anchor.getAttribute("href");
     if (!href || href === "#") {
+      return;
+    }
+    if (isSelfReferentialFlowLink(anchor, options.flowSlug)) {
+      const formTarget = resolveManagedFormTarget(doc, options.formSpec);
+      if (!formTarget) {
+        return;
+      }
+      event.preventDefault();
+      const behaviorAttr = anchor.getAttribute("data-scroll-behavior");
+      const behavior: ScrollBehavior = behaviorAttr === "auto" ? "auto" : "smooth";
+      scrollToElement(formTarget, behavior);
+      return;
+    }
+    if (!href.startsWith("#")) {
       return;
     }
     const anchorTargetId = href.slice(1);
@@ -654,6 +691,32 @@ function attachCustomTemplateBridgeToDocument(
   };
 
   doc.addEventListener("click", handleAnchorClick, true);
+
+  const startedForms = new WeakSet<HTMLFormElement>();
+  const trackTemplateFormEvent = (eventType: "form_start" | "form_submit") => {
+    registerFlowPageAnalytics(options.flowSlug, buildFlowPageAnalyticsPayload(eventType)).catch((trackError) => {
+      console.warn(`Falha ao registrar ${eventType} do template`, trackError);
+    });
+  };
+
+  const handleFormStart = (event: Event) => {
+    const target = event.target as Element | null;
+    const form = target?.closest?.("form") as HTMLFormElement | null;
+    if (!form) {
+      return;
+    }
+    if (options.rootElement && !options.rootElement.contains(form)) {
+      return;
+    }
+    if (startedForms.has(form)) {
+      return;
+    }
+    startedForms.add(form);
+    trackTemplateFormEvent("form_start");
+  };
+
+  doc.addEventListener("input", handleFormStart, true);
+  doc.addEventListener("change", handleFormStart, true);
 
   const handleFormSubmit = async (event: Event) => {
     const target = event.target as HTMLFormElement | null;
@@ -675,6 +738,7 @@ function attachCustomTemplateBridgeToDocument(
     try {
       const parsed = parseTemplateSubmissionPayload(target, options.campaignCode);
       const response = await submitFlowSubmission(options.flowSlug, parsed.payload, parsed.image);
+      trackTemplateFormEvent("form_submit");
       target.dataset.leadPortalSubmitted = "true";
       writeManagedTemplateFeedback(
         target,
@@ -725,8 +789,86 @@ function attachCustomTemplateBridgeToDocument(
 
   return () => {
     doc.removeEventListener("click", handleAnchorClick, true);
+    doc.removeEventListener("input", handleFormStart, true);
+    doc.removeEventListener("change", handleFormStart, true);
     doc.removeEventListener("submit", handleFormSubmit, true);
   };
+}
+
+function buildFlowPageAnalyticsPayload(eventType: "form_start" | "form_submit") {
+  const now = new Date().toISOString();
+  return {
+    eventId: typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+    eventType,
+    visitorId: getVisitorIdCookie(),
+    sessionId: resolveLeadPortalSessionId(),
+    pageUrl: window.location.href,
+    occurredAt: now,
+    userAgent: navigator.userAgent,
+    deviceType: resolveDeviceType(),
+    operatingSystem: resolveOperatingSystem(),
+    screenWidth: Math.round(window.innerWidth || document.documentElement.clientWidth || screen.width || 0),
+    screenHeight: Math.round(window.innerHeight || document.documentElement.clientHeight || screen.height || 0),
+  };
+}
+
+function resolveLeadPortalSessionId() {
+  const key = "mh_lp_react_session";
+  const current = sessionStorage.getItem(key);
+  if (current) {
+    return current;
+  }
+  const created = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  sessionStorage.setItem(key, created);
+  return created;
+}
+
+function resolveDeviceType() {
+  const userAgent = navigator.userAgent || "";
+  const isTablet = /ipad|tablet/i.test(userAgent) || (/android/i.test(userAgent) && !/mobile/i.test(userAgent));
+  if (isTablet) {
+    return "tablet";
+  }
+  return /mobi|iphone|ipod|android/i.test(userAgent) ? "mobile" : "desktop";
+}
+
+function resolveOperatingSystem() {
+  const userAgent = navigator.userAgent || "";
+  if (/iphone|ipad|ipod/i.test(userAgent)) {
+    return "ios";
+  }
+  if (/android/i.test(userAgent)) {
+    return "android";
+  }
+  return "other";
+}
+
+function isSelfReferentialFlowLink(anchor: HTMLAnchorElement, flowSlug: string) {
+  try {
+    const targetUrl = new URL(anchor.href, window.location.href);
+    const currentUrl = new URL(window.location.href);
+    const normalizedTargetPath = targetUrl.pathname.replace(/\/$/, "");
+    const normalizedCurrentPath = currentUrl.pathname.replace(/\/$/, "");
+    if (targetUrl.origin === currentUrl.origin && normalizedTargetPath === normalizedCurrentPath) {
+      return true;
+    }
+    return normalizedTargetPath.endsWith(`/flows/${flowSlug}`)
+      || normalizedTargetPath.endsWith(`/flows/${flowSlug}/page`);
+  } catch {
+    return false;
+  }
+}
+
+function resolveManagedFormTarget(doc: Document, formSpec?: CustomTemplateFormSpec) {
+  if (formSpec?.formId) {
+    const byId = doc.getElementById(formSpec.formId);
+    if (byId) {
+      return byId;
+    }
+  }
+  return doc.querySelector("form");
 }
 
 function toggleTemplateSubmitButtons(form: HTMLFormElement, isSubmitting: boolean) {


### PR DESCRIPTION
## O que mudou

- Corrige CTAs autorreferentes do Lead Portal para rolar até o formulário em vez de manter o usuário em loop na mesma página.
- Adiciona tracking explícito de `form_start` e `form_submit` no frontend React e na landing standalone servida pelo Lead Portal.
- Ajusta o backend principal para aceitar esses eventos de analytics e registrá-los no funil do experimento.
- Registra a decisão e o aprendizado em `docs/melhorias/experimentos.md`.

## Por que

A análise do experimento 55 indicou que o próximo aprendizado depende de separar claramente problema de criativo, página, formulário e checkout. Sem `form_start` e `form_submit`, o funil não distingue visitante que viu a página de visitante que tentou avançar.

## Impacto

O experimento 55 passa a gerar sinais mais acionáveis antes de qualquer escala de orçamento ou lançamento do experimento 56.

## Validação

- `mvn -Dtest=ExperimentFunnelServiceRenderCompleteTest test` em `backend/ads-service`
- `mvn -Dtest=FlowControllerTest,FlowEngagementControllerTest test` em `lead-portal/backend`
- `npm run build` em `lead-portal/frontend`

Observação: o build frontend exigiu instalar devDependencies explicitamente porque o ambiente estava com `NODE_ENV=production` e `npm config omit=dev`.