### PR TITLE
[codex] Corrige pausa operacional do experimento 55

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -13,6 +13,8 @@ import com.marketinghub.experiment.*;
 import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
+import com.marketinghub.experiment.funnel.ExperimentFunnelStandbyService;
+import com.marketinghub.facebookads.FacebookCampaignStopReason;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
@@ -83,6 +85,7 @@ public class ExperimentService {
     private final CurrencyConversionService currencyConversionService;
     private final ExperimentAiPromptSchemaUsageService promptSchemaUsageService;
     private final ProductAiExperimentPreparationService productAiExperimentPreparationService;
+    private final ExperimentFunnelStandbyService experimentFunnelStandbyService;
 
     public ExperimentService(ExperimentRepository repository,
                              ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository,
@@ -109,7 +112,8 @@ public class ExperimentService {
                              ObjectMapper objectMapper,
                              CurrencyConversionService currencyConversionService,
                              ExperimentAiPromptSchemaUsageService promptSchemaUsageService,
-                             ProductAiExperimentPreparationService productAiExperimentPreparationService) {
+                             ProductAiExperimentPreparationService productAiExperimentPreparationService,
+                             ExperimentFunnelStandbyService experimentFunnelStandbyService) {
         this.repository = repository;
         this.promiseGenerationRequestRepository = promiseGenerationRequestRepository;
         this.nicheRepository = nicheRepository;
@@ -136,6 +140,7 @@ public class ExperimentService {
         this.currencyConversionService = currencyConversionService;
         this.promptSchemaUsageService = promptSchemaUsageService;
         this.productAiExperimentPreparationService = productAiExperimentPreparationService;
+        this.experimentFunnelStandbyService = experimentFunnelStandbyService;
     }
 
     /**
@@ -549,7 +554,7 @@ public class ExperimentService {
     }
 
     /**
-     * Updates the status of an experiment.
+     * Atualiza o status do experimento e solicita pausa operacional das campanhas Meta quando aplicável.
      */
     @Transactional
     public Experiment updateStatus(Long id, ExperimentStatus status) {
@@ -563,6 +568,13 @@ public class ExperimentService {
             }
         }
         exp.setStatus(status);
+        if (status == ExperimentStatus.PAUSED) {
+            experimentFunnelStandbyService.requestFacebookCampaignStops(
+                    exp.getId(),
+                    FacebookCampaignStopReason.ADMIN_EXPERIMENT_PAUSED,
+                    "pausa administrativa do experimento"
+            );
+        }
         return exp;
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookCampaignStopReason.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookCampaignStopReason.java
@@ -4,6 +4,7 @@ package com.marketinghub.facebookads;
  * Motivos que disparam uma solicitação automática de pausa para uma campanha Facebook.
  */
 public enum FacebookCampaignStopReason {
+    ADMIN_EXPERIMENT_PAUSED,
     FIRST_FORM_SUBMISSION_STANDBY,
     FORM_ZERO_CONVERSION_RULE_OF_THREE,
     LOW_TICKET_ZERO_PURCHASE_STATISTICAL_FINANCIAL,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -26,6 +26,7 @@ import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.facebookads.BudgetMode;
 import com.marketinghub.facebookads.FacebookAdStatus;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookCampaignStopReason;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
@@ -693,6 +694,66 @@ class ExperimentServiceTest {
         assertThat(paused.getFacebookReleaseRequestedAt()).isNotNull();
         assertThat(paused.getFacebookReleaseRequestedAt().toEpochMilli())
                 .isEqualTo(releaseTimestamp.toEpochMilli());
+    }
+
+    @Test
+    void updateStatusPausedRequestsStopForLinkedFacebookCampaigns() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Pause Stop").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("APS").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("HPS")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150_PAUSE_STOP")
+                .name("Lean-Startup 150 Pause Stop")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("ExpPauseStop");
+        req.setHypothesis("H");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150_PAUSE_STOP");
+        req.setJourneyTemplateId(createJourneyTemplate().getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow(niche));
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        Experiment experiment = service.create(req);
+        experimentRepository.save(experiment);
+
+        FacebookAccount facebookAccount = facebookAccountRepository.save(FacebookAccount.builder()
+                .name("Conta Facebook Pause")
+                .adAccountId("act_pause")
+                .build());
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("campaign-pause-stop");
+        campaign.setExternalId("meta-pause-stop");
+        campaign.setAdAccountId("act_pause");
+        campaign.setExperiment(experiment);
+        campaign.setFacebookAccount(facebookAccount);
+        campaign.setName("Campanha para pausar");
+        campaign.setObjective("OUTCOME_LEADS");
+        campaign.setStatus(FacebookAdStatus.ACTIVE);
+        campaign.setBudgetMode(BudgetMode.CAMPAIGN);
+        facebookAdsCampaignRepository.save(campaign);
+
+        service.updateStatus(experiment.getId(), ExperimentStatus.PAUSED);
+
+        FacebookAdsCampaign stored = facebookAdsCampaignRepository.findById(campaign.getId()).orElseThrow();
+        assertThat(stored.getStopRequestedAt()).isNotNull();
+        assertThat(stored.getStopCompletedAt()).isNull();
+        assertThat(stored.getStopLastError()).isNull();
+        assertThat(stored.getStopReason()).isEqualTo(FacebookCampaignStopReason.ADMIN_EXPERIMENT_PAUSED);
     }
 
     @Test

--- a/docs/melhorias/experimentos.md
+++ b/docs/melhorias/experimentos.md
@@ -38,6 +38,10 @@ Antes de escalar ou lançar o experimento 56, a prioridade passou a ser corrigir
 - manter `page_view` e `page_load_metric` como sinais de saúde da página;
 - preservar o relatório do funil com dados persistidos, não apenas logs.
 
+### Correção operacional complementar
+
+Após a publicação da correção de CTA/tracking, o experimento 55 ficou `PAUSED` no Hub, mas a campanha Meta vinculada continuou ativa porque a pausa administrativa não criava solicitação operacional para o worker. A correção sistêmica é fazer `updateStatus(PAUSED)` registrar `stop_requested_at` nas campanhas Facebook vinculadas com motivo `ADMIN_EXPERIMENT_PAUSED`, mantendo o backend como fonte da decisão e o worker como executor da pausa na Meta.
+
 ### Hipótese de melhoria
 
 Se o visitante enxergar prova visual e for conduzido para uma ação de menor atrito antes do checkout, a perda entre visualização da página e intenção deve diminuir. O próximo julgamento do 55 deve separar:
@@ -57,4 +61,3 @@ Se o visitante enxergar prova visual e for conduzido para uma ação de menor at
 - Colocar prova visual antes do checkout.
 - Só levar ao checkout depois de demonstrar valor concreto.
 - Não lançar o experimento 56 até validar que o gargalo de página/formulário do 55 foi corrigido.
-


### PR DESCRIPTION
## Resumo

- Faz a pausa administrativa do experimento (`updateStatus(PAUSED)`) gerar solicitação operacional de parada para campanhas Facebook vinculadas.
- Adiciona o motivo `ADMIN_EXPERIMENT_PAUSED` para diferenciar pausa manual de reprovações automáticas do funil.
- Cobre o cenário com teste integrado e registra o aprendizado em `docs/melhorias/experimentos.md`.

## Causa-raiz

O experimento 55 ficou `PAUSED` no Hub, mas a campanha Meta continuou ativa porque a mudança administrativa de status não preenchia `stop_requested_at`. Assim, o Facebook Ads Worker consultava `/api/facebook-campaigns/stop-requests` e recebia lista vazia.

## Impacto

Depois do deploy, ao pausar/repausar o experimento 55 pelo Hub, a campanha vinculada entra na fila do worker para pausa real na Meta. Isso evita gasto ativo quando o experimento já foi pausado administrativamente.

## Validação

- `mvn -Dtest=ExperimentServiceTest,FacebookCampaignStopServiceTest test`