### PR TITLE
[codex] fix facebook campaign stop reason schema

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-facebook-campaign-stop-reason-varchar.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-facebook-campaign-stop-reason-varchar.yaml
@@ -17,3 +17,31 @@ databaseChangeLog:
             sql: |
               ALTER TABLE facebook_ads_campaign
               MODIFY stop_reason VARCHAR(100) NULL;
+  - changeSet:
+      id: 2026-07-04-facebook-campaign-stop-reason-varchar-repair
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - columnExists:
+            tableName: facebook_ads_campaign
+            columnName: stop_reason
+        - sqlCheck:
+            expectedResult: 0
+            sql: |
+              SELECT COUNT(*)
+              FROM information_schema.columns
+              WHERE table_schema = DATABASE()
+                AND table_name = 'facebook_ads_campaign'
+                AND column_name = 'stop_reason'
+                AND data_type = 'varchar'
+                AND character_maximum_length >= 100
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE facebook_ads_campaign
+              MODIFY stop_reason VARCHAR(100) NULL;

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignStopReasonChangelogTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignStopReasonChangelogTest.java
@@ -1,0 +1,52 @@
+package com.marketinghub.facebookads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Valida o contrato Liquibase que mantém os motivos de parada de campanha como texto extensível.
+ */
+class FacebookCampaignStopReasonChangelogTest {
+
+    private static final Path CHANGELOG_DIR = Path.of("src/main/resources/db/changelog");
+    private static final Path MASTER_CHANGELOG = CHANGELOG_DIR.resolve("db.changelog-master.yaml");
+    private static final String STOP_REASON_CHANGESET =
+            "changesets/2026-06-12-facebook-campaign-stop-reason-varchar.yaml";
+
+    /** Confirma que o changelog mestre inclui o reparo com caminho relativo ao próprio changelog. */
+    @Test
+    void masterChangelogIncludesRepairWithRelativePath() throws IOException {
+        String master = Files.readString(MASTER_CHANGELOG);
+
+        assertThat(master)
+                .contains("file: " + STOP_REASON_CHANGESET)
+                .containsSubsequence(
+                        "file: " + STOP_REASON_CHANGESET,
+                        "relativeToChangelogFile: true"
+                );
+    }
+
+    /** Confirma que o reparo converte stop_reason para VARCHAR e roda apenas em MySQL. */
+    @Test
+    void repairChangesetConvertsStopReasonToVarcharOnMysql() throws IOException {
+        String changeset = Files.readString(CHANGELOG_DIR.resolve(STOP_REASON_CHANGESET));
+
+        assertThat(changeset)
+                .contains("databaseChangeLog:")
+                .contains("id: 2026-07-04-facebook-campaign-stop-reason-varchar-repair")
+                .contains("dbms:")
+                .contains("type: mysql")
+                .contains("tableName: facebook_ads_campaign")
+                .contains("columnName: stop_reason")
+                .contains("data_type = 'varchar'")
+                .contains("character_maximum_length >= 100")
+                .contains("splitStatements: true")
+                .contains("stripComments: true")
+                .contains("ALTER TABLE facebook_ads_campaign")
+                .contains("MODIFY stop_reason VARCHAR(100) NULL;");
+    }
+}

--- a/docs/melhorias/experimentos.md
+++ b/docs/melhorias/experimentos.md
@@ -42,6 +42,8 @@ Antes de escalar ou lançar o experimento 56, a prioridade passou a ser corrigir
 
 Após a publicação da correção de CTA/tracking, o experimento 55 ficou `PAUSED` no Hub, mas a campanha Meta vinculada continuou ativa porque a pausa administrativa não criava solicitação operacional para o worker. A correção sistêmica é fazer `updateStatus(PAUSED)` registrar `stop_requested_at` nas campanhas Facebook vinculadas com motivo `ADMIN_EXPERIMENT_PAUSED`, mantendo o backend como fonte da decisão e o worker como executor da pausa na Meta.
 
+Após o deploy dessa correção, a nova pausa expôs um bloqueio de schema: `facebook_ads_campaign.stop_reason` ainda estava como `ENUM` no banco real, rejeitando o motivo `ADMIN_EXPERIMENT_PAUSED`. O reparo necessário é garantir via Liquibase incremental que a coluna fique como `VARCHAR(100)`, porque motivos de parada são contrato operacional extensível e não devem depender de enum físico antigo em produção.
+
 ### Hipótese de melhoria
 
 Se o visitante enxergar prova visual e for conduzido para uma ação de menor atrito antes do checkout, a perda entre visualização da página e intenção deve diminuir. O próximo julgamento do 55 deve separar:


### PR DESCRIPTION
## O que mudou

- Adiciona um changeset Liquibase incremental no changelog já incluído de `facebook_ads_campaign.stop_reason` para reparar produção quando a coluna ainda estiver como `ENUM`.
- Mantém `stop_reason` como `VARCHAR(100)`, permitindo motivos operacionais novos como `ADMIN_EXPERIMENT_PAUSED`.
- Adiciona teste de contrato para garantir que o changelog segue MySQL, `splitStatements`, `stripComments` e está incluído pelo master com caminho relativo.
- Registra o aprendizado do experimento 55 em `docs/melhorias/experimentos.md`.

## Causa-raiz

O backend passou a gerar parada operacional para pausa administrativa do experimento, mas o schema real de produção ainda rejeitava o novo motivo porque `facebook_ads_campaign.stop_reason` permanecia como `ENUM`. O Liquibase antigo já existia, mas podia estar marcado como executado antes da definição final da coluna.

## Impacto

Depois do deploy, a pausa do experimento 55 poderá registrar `ADMIN_EXPERIMENT_PAUSED` em `stop_reason`, gerar `stop_requested_at` e liberar o worker para pausar a campanha real na Meta.

## Validação

`mvn -f backend/ads-service/pom.xml -Dtest=FacebookCampaignStopReasonChangelogTest,ExperimentServiceTest,FacebookCampaignStopServiceTest test`