### PR TITLE
[codex] Bloqueia tráfego frio direto para compra

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignDestinationPolicy.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignDestinationPolicy.java
@@ -1,0 +1,126 @@
+package com.marketinghub.experiment.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Centraliza a política de destino de campanha para impedir tráfego frio direto para compra.
+ */
+@Service
+public class ExperimentCampaignDestinationPolicy {
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+
+    private final GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
+    private final GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
+
+    /** Cria a política usando as auditorias canônicas do GeraSalesPage. */
+    public ExperimentCampaignDestinationPolicy(
+            GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository,
+            GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository) {
+        this.geraSalesPageStageExecutionRepository = geraSalesPageStageExecutionRepository;
+        this.geraSalesPagePublicationAuditRepository = geraSalesPagePublicationAuditRepository;
+    }
+
+    /** Informa se o experimento tem intenção de compra e precisa de página intermediária auditada. */
+    public boolean requiresSalesPageBeforePurchase(Experiment experiment) {
+        return experiment != null
+                && (experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT
+                || experiment.getCampaignObjective() == ExperimentCampaignObjective.SALES);
+    }
+
+    /** Lista violações da regra de destino para campanhas com intenção de compra. */
+    public List<String> missingConfiguration(Experiment experiment) {
+        if (!requiresSalesPageBeforePurchase(experiment)) {
+            return List.of();
+        }
+        List<String> missing = new ArrayList<>();
+        Optional<GeraSalesPagePublicationAudit> salesPagePublication =
+                latestSalesPagePublication(experiment != null ? experiment.getId() : null);
+        if (!hasCompletedGeraSalesPagePipeline(experiment != null ? experiment.getId() : null)
+                || salesPagePublication.isEmpty()) {
+            missing.add("geraSalesPagePipeline");
+            return List.copyOf(missing);
+        }
+        GeraSalesPagePublicationAudit publication = salesPagePublication.get();
+        if (!hasAdDestinationPointingToSalesPage(experiment, publication)) {
+            missing.add("salesPageAdDestination");
+        }
+        if (!hasRequiredSalesPageAnalyticsCollectors(publication)) {
+            missing.add("salesPageAnalyticsCollectors");
+        }
+        return List.copyOf(missing);
+    }
+
+    /** Busca a página de venda publicada mais recente do experimento. */
+    public Optional<GeraSalesPagePublicationAudit> latestSalesPagePublication(Long experimentId) {
+        if (experimentId == null) {
+            return Optional.empty();
+        }
+        return geraSalesPagePublicationAuditRepository.findTopByExperimentIdOrderByPublishedAtDesc(experimentId);
+    }
+
+    /** Verifica a conclusão da etapa final que publica a página de venda canônica. */
+    public boolean hasCompletedGeraSalesPagePipeline(Long experimentId) {
+        if (experimentId == null) {
+            return false;
+        }
+        return geraSalesPageStageExecutionRepository
+                .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experimentId, GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
+                .map(com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution::getStatus)
+                .map(STATUS_COMPLETED::equalsIgnoreCase)
+                .orElse(false);
+    }
+
+    /** Confirma que o anúncio levará para a página de venda auditada, não para o checkout. */
+    public boolean hasAdDestinationPointingToSalesPage(
+            Experiment experiment,
+            GeraSalesPagePublicationAudit publication) {
+        if (experiment == null || publication == null) {
+            return false;
+        }
+        String destinationUrl = normalizeUrl(experiment.getFollowUpActionUrl());
+        String salesPageUrl = normalizeUrl(publication.getSalesPageUrl());
+        String checkoutUrl = normalizeUrl(publication.getCheckoutUrl());
+        return StringUtils.hasText(destinationUrl)
+                && StringUtils.hasText(salesPageUrl)
+                && destinationUrl.equals(salesPageUrl)
+                && (!StringUtils.hasText(checkoutUrl) || !destinationUrl.equals(checkoutUrl));
+    }
+
+    /** Confirma que a página publicada possui todos os coletores mínimos de venda. */
+    public boolean hasRequiredSalesPageAnalyticsCollectors(GeraSalesPagePublicationAudit publication) {
+        if (publication == null || !StringUtils.hasText(publication.getHtml())) {
+            return false;
+        }
+        String html = publication.getHtml();
+        return html.contains("data-mh-sales-page-analytics")
+                && html.contains("page_view")
+                && html.contains("page_load_metric")
+                && html.contains("section_view_time")
+                && html.contains("checkout_click");
+    }
+
+    /** Normaliza URL para comparação de destino sem depender de barra final. */
+    private String normalizeUrl(String url) {
+        if (!StringUtils.hasText(url)) {
+            return "";
+        }
+        String normalized = url.trim().toLowerCase(Locale.ROOT);
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -8,7 +8,6 @@ import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
-import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.targeting.TargetingElement;
@@ -16,11 +15,8 @@ import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
-import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
-import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +43,7 @@ public class ExperimentReadinessService {
     );
 
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    private final ExperimentCampaignDestinationPolicy campaignDestinationPolicy;
     private static final List<TargetingElementType> PUBLISHABLE_TARGETING_TYPES = List.of(
             TargetingElementType.INTEREST,
             TargetingElementType.JOB_TITLE,
@@ -64,22 +61,17 @@ public class ExperimentReadinessService {
     );
 
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
-    private final GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
-    private final GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
-
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
                                       GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
-                                      GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository,
-                                      GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository) {
+                                      ExperimentCampaignDestinationPolicy campaignDestinationPolicy) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
-        this.geraSalesPageStageExecutionRepository = geraSalesPageStageExecutionRepository;
-        this.geraSalesPagePublicationAuditRepository = geraSalesPagePublicationAuditRepository;
+        this.campaignDestinationPolicy = campaignDestinationPolicy;
     }
 
     /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
@@ -98,9 +90,10 @@ public class ExperimentReadinessService {
                 : PUBLISHABLE_TARGETING_TYPES;
         long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
         boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
-        boolean lowTicket = isLowTicketProduct(experiment);
-        boolean hasGeraSalesPagePipeline = hasCompletedGeraSalesPagePipeline(experimentId);
-        Optional<GeraSalesPagePublicationAudit> salesPagePublication = latestSalesPagePublication(experimentId);
+        boolean purchaseIntent = campaignDestinationPolicy.requiresSalesPageBeforePurchase(experiment);
+        boolean hasGeraSalesPagePipeline = campaignDestinationPolicy.hasCompletedGeraSalesPagePipeline(experimentId);
+        Optional<GeraSalesPagePublicationAudit> salesPagePublication =
+                campaignDestinationPolicy.latestSalesPagePublication(experimentId);
 
         List<ExperimentReadinessIssueDto> issues = new ArrayList<>();
         if (!hasCreatives) {
@@ -112,7 +105,7 @@ public class ExperimentReadinessService {
                     List.of()
             ));
         }
-        if (!lowTicket && !hasLeadPortalFlow) {
+        if (!purchaseIntent && !hasLeadPortalFlow) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.LEAD_PORTAL_FLOW,
                     "Sem fluxo do portal do lead",
@@ -140,17 +133,17 @@ public class ExperimentReadinessService {
             ));
         }
 
-        if (lowTicket && (!hasGeraSalesPagePipeline || salesPagePublication.isEmpty())) {
+        if (purchaseIntent && (!hasGeraSalesPagePipeline || salesPagePublication.isEmpty())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,
                     "Página de venda não foi criada pelo pipeline",
-                    "Experimentos low-ticket só podem ser liberados quando o GeraSalesPage v1 concluir e auditar a publicação da página de venda.",
+                    "Experimentos com intenção de compra só podem ser liberados quando o GeraSalesPage v1 concluir e auditar a publicação da página de venda.",
                     "Execute ou refaça o GeraSalesPage v1 e use a página de venda gerada pelo pipeline.",
                     List.of()
             ));
         }
-        if (lowTicket && salesPagePublication.isPresent()
-                && !hasAdDestinationPointingToSalesPage(experiment, salesPagePublication.get())) {
+        if (purchaseIntent && salesPagePublication.isPresent()
+                && !campaignDestinationPolicy.hasAdDestinationPointingToSalesPage(experiment, salesPagePublication.get())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,
                     "Link do anúncio não aponta para a página de venda",
@@ -159,8 +152,8 @@ public class ExperimentReadinessService {
                     List.of()
             ));
         }
-        if (lowTicket && salesPagePublication.isPresent()
-                && !hasRequiredSalesPageAnalyticsCollectors(salesPagePublication.get())) {
+        if (purchaseIntent && salesPagePublication.isPresent()
+                && !campaignDestinationPolicy.hasRequiredSalesPageAnalyticsCollectors(salesPagePublication.get())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,
                     "Página de venda sem coletores de métricas",
@@ -170,7 +163,7 @@ public class ExperimentReadinessService {
             ));
         }
 
-        if (!lowTicket && !hasGeraLandingPipeline) {
+        if (!purchaseIntent && !hasGeraLandingPipeline) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_LANDING,
                     "GeraLanding incompleto",
@@ -208,22 +201,7 @@ public class ExperimentReadinessService {
         if (!hasApprovedLandingDestination(experiment)) {
             missing.add("landingDestination");
         }
-        if (isLowTicketProduct(experiment)) {
-            Optional<GeraSalesPagePublicationAudit> salesPagePublication =
-                    latestSalesPagePublication(experiment != null ? experiment.getId() : null);
-            if (!hasCompletedGeraSalesPagePipeline(experiment != null ? experiment.getId() : null)
-                    || salesPagePublication.isEmpty()) {
-                missing.add("geraSalesPagePipeline");
-            } else {
-                GeraSalesPagePublicationAudit publication = salesPagePublication.get();
-                if (!hasAdDestinationPointingToSalesPage(experiment, publication)) {
-                    missing.add("salesPageAdDestination");
-                }
-                if (!hasRequiredSalesPageAnalyticsCollectors(publication)) {
-                    missing.add("salesPageAnalyticsCollectors");
-                }
-            }
-        }
+        missing.addAll(campaignDestinationPolicy.missingConfiguration(experiment));
         if (isLowTicketProduct(experiment) && !hasFacebookPixel(experiment)) {
             missing.add("facebookPixel");
         }
@@ -324,68 +302,6 @@ public class ExperimentReadinessService {
                 .map(question -> question.getDataKey() == null ? "" : question.getDataKey().toLowerCase(Locale.ROOT))
                 .collect(java.util.stream.Collectors.toSet());
         return keys.containsAll(PRODUCT_AI_PERSONALIZED_SAMPLE_REQUIRED_KEYS);
-    }
-
-    /** Verifica a conclusão da etapa final que publica a página de venda canônica. */
-    private boolean hasCompletedGeraSalesPagePipeline(Long experimentId) {
-        if (experimentId == null) {
-            return false;
-        }
-        return geraSalesPageStageExecutionRepository
-                .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
-                        experimentId, GeraSalesPageStageCode.PUBLICATION_PACKAGE.code())
-                .map(com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution::getStatus)
-                .map(STATUS_COMPLETED::equalsIgnoreCase)
-                .orElse(false);
-    }
-
-    /** Busca a página de venda publicada mais recente do experimento. */
-    private Optional<GeraSalesPagePublicationAudit> latestSalesPagePublication(Long experimentId) {
-        if (experimentId == null) {
-            return Optional.empty();
-        }
-        return geraSalesPagePublicationAuditRepository.findTopByExperimentIdOrderByPublishedAtDesc(experimentId);
-    }
-
-    /** Confirma que o anúncio levará para a página de venda auditada, não para o checkout. */
-    private boolean hasAdDestinationPointingToSalesPage(
-            Experiment experiment,
-            GeraSalesPagePublicationAudit publication) {
-        if (experiment == null || publication == null) {
-            return false;
-        }
-        String destinationUrl = normalizeUrl(experiment.getFollowUpActionUrl());
-        String salesPageUrl = normalizeUrl(publication.getSalesPageUrl());
-        String checkoutUrl = normalizeUrl(publication.getCheckoutUrl());
-        return StringUtils.hasText(destinationUrl)
-                && StringUtils.hasText(salesPageUrl)
-                && destinationUrl.equals(salesPageUrl)
-                && (!StringUtils.hasText(checkoutUrl) || !destinationUrl.equals(checkoutUrl));
-    }
-
-    /** Confirma que a página publicada possui todos os coletores mínimos de venda low-ticket. */
-    private boolean hasRequiredSalesPageAnalyticsCollectors(GeraSalesPagePublicationAudit publication) {
-        if (publication == null || !StringUtils.hasText(publication.getHtml())) {
-            return false;
-        }
-        String html = publication.getHtml();
-        return html.contains("data-mh-sales-page-analytics")
-                && html.contains("page_view")
-                && html.contains("page_load_metric")
-                && html.contains("section_view_time")
-                && html.contains("checkout_click");
-    }
-
-    /** Normaliza URL para comparação de destino sem depender de barra final. */
-    private String normalizeUrl(String url) {
-        if (!StringUtils.hasText(url)) {
-            return "";
-        }
-        String normalized = url.trim().toLowerCase(Locale.ROOT);
-        while (normalized.endsWith("/")) {
-            normalized = normalized.substring(0, normalized.length() - 1);
-        }
-        return normalized;
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -8,14 +8,17 @@ import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.experiment.dto.UpdateSelectedSampleEmailRequest;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.experiment.service.ExperimentDiagnosticsService;
+import com.marketinghub.experiment.service.ExperimentCampaignDestinationPolicy;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.experiment.service.ExperimentReadinessService;
 import com.marketinghub.experiment.service.ExperimentPromiseGenerationService;
 import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
 import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsResponse;
 import com.marketinghub.experiment.service.generatepromise.latestdraft.ExperimentPromiseOptionsDraftResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.stream.StreamSupport;
@@ -31,17 +34,20 @@ public class ExperimentController {
     private final ExperimentDiagnosticsService diagnosticsService;
     private final ExperimentReadinessService readinessService;
     private final ExperimentPromiseGenerationService promiseGenerationService;
+    private final ExperimentCampaignDestinationPolicy campaignDestinationPolicy;
 
     /** Inicializa o controller com serviços de experimento, diagnóstico, prontidão e geração de promessas. */
     public ExperimentController(ExperimentService service, ExperimentMapper mapper,
                                 ExperimentDiagnosticsService diagnosticsService,
                                 ExperimentReadinessService readinessService,
-                                ExperimentPromiseGenerationService promiseGenerationService) {
+                                ExperimentPromiseGenerationService promiseGenerationService,
+                                ExperimentCampaignDestinationPolicy campaignDestinationPolicy) {
         this.service = service;
         this.mapper = mapper;
         this.diagnosticsService = diagnosticsService;
         this.readinessService = readinessService;
         this.promiseGenerationService = promiseGenerationService;
+        this.campaignDestinationPolicy = campaignDestinationPolicy;
     }
 
     /** Cria um novo experimento com os dados comerciais informados na tela. */
@@ -181,7 +187,28 @@ public class ExperimentController {
     /** Libera o experimento para publicação no Facebook Ads. */
     @PostMapping("/{id}/facebook-release")
     public ExperimentDto releaseForFacebook(@PathVariable Long id) {
+        ensurePurchaseIntentDoesNotBypassSalesPage(id);
         return mapper.toDto(service.releaseForFacebook(id));
+    }
+
+    /** Bloqueia liberação de tráfego frio com intenção de compra direto para checkout. */
+    private void ensurePurchaseIntentDoesNotBypassSalesPage(Long id) {
+        List<String> missing = campaignDestinationPolicy.missingConfiguration(service.get(id));
+        if (missing.contains("geraSalesPagePipeline")) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento com intenção de compra exige página de venda criada pelo GeraSalesPage v1 antes da campanha.");
+        }
+        if (missing.contains("salesPageAdDestination")) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento com intenção de compra exige que o link do anúncio aponte para a página de venda publicada, não para o checkout direto.");
+        }
+        if (missing.contains("salesPageAnalyticsCollectors")) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento com intenção de compra exige página de venda com coletores page_view, page_load_metric, section_view_time e checkout_click antes da campanha.");
+        }
     }
 
     /** Registra uma solicitação para o AI Worker gerar três opções de contrato de promessa única. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.experiment.service;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
 import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignObjective;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
@@ -26,9 +27,9 @@ import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRe
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -55,8 +56,20 @@ class ExperimentReadinessServiceTest {
     @Mock
     private GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
 
-    @InjectMocks
     private ExperimentReadinessService service;
+
+    @BeforeEach
+    void setUp() {
+        ExperimentCampaignDestinationPolicy campaignDestinationPolicy = new ExperimentCampaignDestinationPolicy(
+                geraSalesPageStageExecutionRepository,
+                geraSalesPagePublicationAuditRepository);
+        service = new ExperimentReadinessService(
+                experimentService,
+                creativeRepository,
+                targetingSelectionRepository,
+                geraLandingStageExecutionRepository,
+                campaignDestinationPolicy);
+    }
 
     @Test
     void shouldReportAllIssuesWhenNothingIsReady() {
@@ -125,143 +138,6 @@ class ExperimentReadinessServiceTest {
     }
 
     @Test
-    void shouldReportTargetingIssueWhenThereIsNoPublishableSelection() {
-        Long experimentId = 11L;
-        Experiment experiment = buildExperiment(experimentId, 19L);
-        LeadPortalFlow flow = new LeadPortalFlow();
-        flow.setApproved(true);
-        experiment.setLeadPortalFlow(flow);
-
-        when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
-        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
-
-        assertThat(summary.hasCompleteTargeting()).isFalse();
-        assertThat(summary.missingTargetingTypes()).containsExactly(
-                TargetingElementType.INTEREST,
-                TargetingElementType.JOB_TITLE,
-                TargetingElementType.BEHAVIOR);
-        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
-                .contains(ExperimentReadinessIssueType.TARGETING);
-    }
-
-    @Test
-    void shouldTreatSavedInterestSelectionAsReady() {
-        Long experimentId = 15L;
-        Experiment experiment = buildExperiment(experimentId, 21L);
-        LeadPortalFlow flow = new LeadPortalFlow();
-        flow.setApproved(true);
-        experiment.setLeadPortalFlow(flow);
-
-        when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
-        mockPublishableSelection(experimentId, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
-
-        assertThat(summary.hasCompleteTargeting()).isTrue();
-        assertThat(summary.missingTargetingTypes()).isEmpty();
-        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
-                .doesNotContain(ExperimentReadinessIssueType.TARGETING);
-    }
-
-    @Test
-    void shouldKeepGeraLandingPendingWhenLatestRequiredStageFailed() {
-        Long experimentId = 48L;
-        Experiment experiment = buildExperiment(experimentId, 22L);
-        LeadPortalFlow flow = new LeadPortalFlow();
-        flow.setApproved(true);
-        experiment.setLeadPortalFlow(flow);
-
-        when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
-        when(geraLandingStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
-                experimentId, "landing-page-wireframe"))
-                .thenReturn(Optional.of(geraLandingExecution("landing-page-wireframe", "CONCLUIDO")));
-        when(geraLandingStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
-                experimentId, "landing-page-copy"))
-                .thenReturn(Optional.of(geraLandingExecution("landing-page-copy", "FALHA")));
-
-        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
-
-        assertThat(summary.hasGeraLandingPipeline()).isFalse();
-        assertThat(summary.geraLandingCompletedStageCount()).isEqualTo(1);
-        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
-                .contains(ExperimentReadinessIssueType.GERA_LANDING);
-    }
-
-    @Test
-    void shouldRequireLandingDestinationInCampaignPendingChecklist() {
-        Experiment experiment = buildExperiment(20L, 30L);
-        experiment.setFollowUpActionUrl(null);
-
-        when(creativeRepository.existsByExperimentIdAndStatus(20L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(20L, TargetingCandidateType.WORK_POSITION, TargetingElementType.JOB_TITLE);
-
-        assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("landingDestination");
-    }
-
-    @Test
-    void shouldBeReadyForCampaignWhenCreativeAndLandingAreReady() {
-        Experiment experiment = buildExperiment(21L, 31L);
-        experiment.setFollowUpActionUrl("https://example.com/landing/21");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(21L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(21L, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);
-
-        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
-        assertThat(service.isReadyForCampaign(experiment)).isTrue();
-    }
-
-    @Test
-    void shouldBlockCampaignWhenSelectionDoesNotHaveOfficialMetaId() {
-        Experiment experiment = buildExperiment(23L, 33L);
-        experiment.setFollowUpActionUrl("https://example.com/landing/23");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(23L, CreativeStatus.READY)).thenReturn(true);
-        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(23L))
-                .thenReturn(List.of(selection(
-                        TargetingCandidateType.INTEREST,
-                        targetingElement(TargetingElementType.INTEREST, ""))));
-
-        assertThat(service.computeMissingConfiguration(experiment)).containsExactly("approvedTargetingPackage");
-        assertThat(service.isReadyForCampaign(experiment)).isFalse();
-    }
-
-    @Test
-    void shouldRequireGeraSalesPagePipelineForLowTicketCampaign() {
-        Experiment experiment = buildExperiment(52L, 62L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp52.html");
-        experiment.getNiche().setFacebookPixelId("pixel-exp52");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(52L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(52L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-
-        assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("geraSalesPagePipeline");
-        assertThat(service.isReadyForCampaign(experiment)).isFalse();
-    }
-
-    @Test
-    // Verifica que low-ticket com pipeline concluído ainda precisa de auditoria da página publicada.
-    void shouldRequirePublishedSalesPageAuditForLowTicketCampaign() {
-        Experiment experiment = buildExperiment(55L, 65L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp55.html");
-        experiment.getNiche().setFacebookPixelId("pixel-exp55");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(55L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(55L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        mockCompletedGeraSalesPagePublication(55L);
-
-        assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("geraSalesPagePipeline");
-        assertThat(service.isReadyForCampaign(experiment)).isFalse();
-    }
-
-    @Test
-    // Verifica que low-ticket não pode enviar o clique do anúncio direto para checkout.
     void shouldRequireAdDestinationToPointToSalesPageForLowTicketCampaign() {
         Experiment experiment = buildExperiment(56L, 66L);
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
@@ -283,104 +159,27 @@ class ExperimentReadinessServiceTest {
     }
 
     @Test
-    // Verifica que low-ticket não publica página antiga sem coletores mínimos de funil.
-    void shouldRequireSalesPageAnalyticsCollectorsForLowTicketCampaign() {
-        Experiment experiment = buildExperiment(57L, 67L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp57.html");
-        experiment.getNiche().setFacebookPixelId("pixel-exp57");
+    void shouldRequireSalesPageDestinationForAnySalesCampaignObjective() {
+        Experiment experiment = buildExperiment(60L, 70L);
+        experiment.setCampaignObjective(ExperimentCampaignObjective.SALES);
+        experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=sales-direct");
+        experiment.getNiche().setFacebookPixelId("pixel-exp60");
 
-        when(creativeRepository.existsByExperimentIdAndStatus(57L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(57L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        mockCompletedGeraSalesPagePublication(57L);
+        when(creativeRepository.existsByExperimentIdAndStatus(60L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(60L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(60L);
         mockSalesPageAudit(
-                57L,
-                "https://pagamentopalf.site/sales-page-exp57.html",
-                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=def",
-                "<html><body><a href=\"https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=def\">Comprar</a></body></html>");
+                60L,
+                "https://pagamentopalf.site/sales-page-exp60.html",
+                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=sales-direct",
+                trackedSalesPageHtml());
 
         assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("salesPageAnalyticsCollectors");
+                .containsExactly("salesPageAdDestination");
         assertThat(service.isReadyForCampaign(experiment)).isFalse();
     }
 
     @Test
-    // Verifica que low-ticket sem pixel não entra na fila de campanha de venda.
-    void shouldRequireFacebookPixelForLowTicketCampaign() {
-        Experiment experiment = buildExperiment(54L, 64L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp54.html");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(54L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(54L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        mockCompletedGeraSalesPagePublication(54L);
-        mockSalesPageAudit(
-                54L,
-                "https://pagamentopalf.site/sales-page-exp54.html",
-                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp54",
-                trackedSalesPageHtml());
-
-        assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("facebookPixel");
-        assertThat(service.isReadyForCampaign(experiment)).isFalse();
-    }
-
-    @Test
-    // Verifica que Produto IA personalizado não publica sem coleta prévia dos dados do lead.
-    void shouldRequirePersonalizedSampleFunnelForProductAiCampaign() {
-        Experiment experiment = buildExperiment(58L, 68L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp58.html");
-        experiment.getNiche().setFacebookPixelId("pixel-exp58");
-
-        when(creativeRepository.existsByExperimentIdAndStatus(58L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(58L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        mockCompletedGeraSalesPagePublication(58L);
-        mockSalesPageAudit(
-                58L,
-                "https://pagamentopalf.site/sales-page-exp58.html",
-                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp58",
-                trackedSalesPageHtml());
-
-        assertThat(service.computeMissingConfiguration(experiment))
-                .containsExactly("productAiPersonalizedSampleFunnel");
-        assertThat(service.isReadyForCampaign(experiment)).isFalse();
-    }
-
-    @Test
-    // Verifica que Produto IA personalizado completo exige funil aprovado com campos mínimos de personalização.
-    void shouldAllowPersonalizedSampleCampaignWhenFunnelCollectsRequiredData() {
-        Experiment experiment = buildExperiment(59L, 69L);
-        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
-        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
-        experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp59.html");
-        experiment.getNiche().setFacebookPixelId("pixel-exp59");
-        experiment.setLeadPortalFlow(productAiFlow(
-                "nome",
-                "email",
-                "whatsapp",
-                "negocio_projeto",
-                "contexto_atual",
-                "objetivo_visual",
-                "dados_personalizacao",
-                "preferencias_visuais"));
-
-        when(creativeRepository.existsByExperimentIdAndStatus(59L, CreativeStatus.READY)).thenReturn(true);
-        mockPublishableSelection(59L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
-        mockCompletedGeraSalesPagePublication(59L);
-        mockSalesPageAudit(
-                59L,
-                "https://pagamentopalf.site/sales-page-exp59.html",
-                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp59",
-                trackedSalesPageHtml());
-
-        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
-        assertThat(service.isReadyForCampaign(experiment)).isTrue();
-    }
-
-    @Test
-    // Verifica que low-ticket completo com página e pixel pode ser publicado.
     void shouldAllowLowTicketCampaignOnlyAfterGeraSalesPagePublicationPackage() {
         Experiment experiment = buildExperiment(53L, 63L);
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
@@ -399,7 +198,6 @@ class ExperimentReadinessServiceTest {
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
-
 
     /** Simula uma seleção de público aprovada e identificável pela Meta. */
     private void mockPublishableSelection(Long experimentId, TargetingCandidateType candidateType, TargetingElementType elementType) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerReleasePolicyTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerReleasePolicyTest.java
@@ -1,0 +1,46 @@
+package com.marketinghub.experiment.web;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.mapper.ExperimentMapper;
+import com.marketinghub.experiment.service.ExperimentCampaignDestinationPolicy;
+import com.marketinghub.experiment.service.ExperimentDiagnosticsService;
+import com.marketinghub.experiment.service.ExperimentPromiseGenerationService;
+import com.marketinghub.experiment.service.ExperimentReadinessService;
+import com.marketinghub.experiment.service.ExperimentService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Valida a política de bloqueio no endpoint administrativo de liberação para Facebook Ads.
+ */
+class ExperimentControllerReleasePolicyTest {
+
+    @Test
+    // Garante que o botão de liberação bloqueia tráfego frio com compra direta.
+    void releaseForFacebookRejectsPurchaseIntentBypassingSalesPage() {
+        ExperimentService service = mock(ExperimentService.class);
+        ExperimentCampaignDestinationPolicy policy = mock(ExperimentCampaignDestinationPolicy.class);
+        Experiment experiment = new Experiment();
+        when(service.get(60L)).thenReturn(experiment);
+        when(policy.missingConfiguration(experiment)).thenReturn(List.of("salesPageAdDestination"));
+        ExperimentController controller = new ExperimentController(
+                service,
+                mock(ExperimentMapper.class),
+                mock(ExperimentDiagnosticsService.class),
+                mock(ExperimentReadinessService.class),
+                mock(ExperimentPromiseGenerationService.class),
+                policy);
+
+        assertThatThrownBy(() -> controller.releaseForFacebook(60L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("checkout direto");
+        verify(service, never()).releaseForFacebook(60L);
+    }
+}

--- a/docs/canonical/trafego-frio-compra-direta-canon.v1.md
+++ b/docs/canonical/trafego-frio-compra-direta-canon.v1.md
@@ -1,0 +1,21 @@
+# Tráfego frio não vai direto para compra v1
+
+## Regra mandatória
+
+Todo experimento com intenção de compra, identificado por `experimentType = LOW_TICKET_PRODUCT` ou `campaignObjective = SALES`, deve enviar o tráfego frio primeiro para uma página de venda/intermediação publicada e auditada pelo GeraSalesPage v1.
+
+O anúncio não pode apontar diretamente para checkout, link de pagamento ou outro destino de compra.
+
+## Critérios obrigatórios
+
+- O GeraSalesPage v1 precisa concluir a etapa `publication-package` e registrar auditoria da página publicada antes da liberação para Facebook Ads.
+- `follow_up_action_url` deve ser a URL da página de venda auditada, não a URL de checkout.
+- O checkout deve existir apenas como CTA dentro da página, depois de promessa, prova, mecanismo, objeções e percepção de valor.
+- A página precisa conter coletores mínimos `page_view`, `page_load_metric`, `section_view_time` e `checkout_click`.
+- O backend deve bloquear tanto a liberação manual quanto a fila `/api/facebook-campaigns/experiments-ready` quando essa regra não for cumprida.
+
+## Interpretação de negócio
+
+Tráfego frio direto para compra reduz a chance de educar o visitante, provar valor e medir onde o funil quebra.
+
+A regra protege caixa e aprendizado: primeiro mede atenção e convencimento na página, depois mede intenção de checkout.

--- a/docs/melhorias/experimentos.md
+++ b/docs/melhorias/experimentos.md
@@ -22,6 +22,17 @@ Leitura prática:
 - CTA frio direto para compra tende a desperdiçar tráfego quando a promessa exige demonstração visual ou personalização.
 - Tracking incompleto reduz a capacidade de diferenciar problema de criativo, página, formulário ou checkout.
 
+### Trava sistêmica contra compra direta com tráfego frio
+
+Decisão de melhoria aplicada em 2026-07-04: todo experimento com intenção de compra deve passar por página de venda auditada antes de checkout. A regra vale para `LOW_TICKET_PRODUCT` e para qualquer campanha futura com `campaignObjective = SALES`.
+
+Impacto esperado:
+
+- impedir liberação manual de experimento que mande anúncio direto para checkout;
+- impedir que a fila do Facebook Ads Worker receba experimentos irregulares;
+- forçar prova de valor e coleta de métricas antes da intenção de compra;
+- reduzir desperdício de mídia em tráfego frio sem contexto suficiente para compra.
+
 ## Experimento 55
 
 ### Problema identificado


### PR DESCRIPTION
## O que muda

- Centraliza uma política de destino para campanhas com intenção de compra.
- Bloqueia liberação administrativa quando `LOW_TICKET_PRODUCT` ou `campaignObjective=SALES` aponta direto para checkout.
- Faz a prontidão/fila do Facebook Ads respeitar a mesma regra.
- Registra o cânone da regra e o aprendizado em melhorias de experimentos.

## Por quê

Tráfego frio direto para compra desperdiça mídia e impede leitura correta do funil. A regra força página de venda auditada antes do checkout, com coletores mínimos de funil.

## Validação local

`mvn -f backend/ads-service/pom.xml -Dtest=ExperimentReadinessServiceTest,ExperimentControllerTest,ExperimentServiceTest test`

Resultado local: 61 testes, 0 falhas.