### PR TITLE
[codex] Enforce commercial contract sales gate

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignDestinationPolicy.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignDestinationPolicy.java
@@ -45,6 +45,10 @@ public class ExperimentCampaignDestinationPolicy {
             return List.of();
         }
         List<String> missing = new ArrayList<>();
+        if (!hasCompleteCommercialContract(experiment)) {
+            missing.add("commercialContract");
+            return List.copyOf(missing);
+        }
         Optional<GeraSalesPagePublicationAudit> salesPagePublication =
                 latestSalesPagePublication(experiment != null ? experiment.getId() : null);
         if (!hasCompletedGeraSalesPagePipeline(experiment != null ? experiment.getId() : null)
@@ -110,6 +114,17 @@ public class ExperimentCampaignDestinationPolicy {
                 && html.contains("page_load_metric")
                 && html.contains("section_view_time")
                 && html.contains("checkout_click");
+    }
+
+    /** Confirma se a etapa Oferta deixou um contrato comercial mínimo para venda. */
+    public boolean hasCompleteCommercialContract(Experiment experiment) {
+        return experiment != null
+                && StringUtils.hasText(experiment.getSinglePain())
+                && StringUtils.hasText(experiment.getFreeReward())
+                && StringUtils.hasText(experiment.getFunnelPromise())
+                && StringUtils.hasText(experiment.getPrimaryCta())
+                && experiment.getUnitPrice() != null
+                && experiment.getUnitPrice().signum() > 0;
     }
 
     /** Normaliza URL para comparação de destino sem depender de barra final. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -91,6 +91,7 @@ public class ExperimentReadinessService {
         long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
         boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
         boolean purchaseIntent = campaignDestinationPolicy.requiresSalesPageBeforePurchase(experiment);
+        boolean hasCommercialContract = campaignDestinationPolicy.hasCompleteCommercialContract(experiment);
         boolean hasGeraSalesPagePipeline = campaignDestinationPolicy.hasCompletedGeraSalesPagePipeline(experimentId);
         Optional<GeraSalesPagePublicationAudit> salesPagePublication =
                 campaignDestinationPolicy.latestSalesPagePublication(experimentId);
@@ -133,7 +134,16 @@ public class ExperimentReadinessService {
             ));
         }
 
-        if (purchaseIntent && (!hasGeraSalesPagePipeline || salesPagePublication.isEmpty())) {
+        if (purchaseIntent && !hasCommercialContract) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.GERA_SALES_PAGE,
+                    "Contrato comercial incompleto",
+                    "Experimentos com intenção de compra precisam da etapa Oferta preenchida antes de página, criativos e campanha.",
+                    "Complete dor única, prova/preview, promessa, CTA e preço para o sistema gerar a página de venda como fonte soberana.",
+                    List.of()
+            ));
+        }
+        if (purchaseIntent && hasCommercialContract && (!hasGeraSalesPagePipeline || salesPagePublication.isEmpty())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,
                     "Página de venda não foi criada pelo pipeline",
@@ -142,7 +152,7 @@ public class ExperimentReadinessService {
                     List.of()
             ));
         }
-        if (purchaseIntent && salesPagePublication.isPresent()
+        if (purchaseIntent && hasCommercialContract && salesPagePublication.isPresent()
                 && !campaignDestinationPolicy.hasAdDestinationPointingToSalesPage(experiment, salesPagePublication.get())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,
@@ -152,7 +162,7 @@ public class ExperimentReadinessService {
                     List.of()
             ));
         }
-        if (purchaseIntent && salesPagePublication.isPresent()
+        if (purchaseIntent && hasCommercialContract && salesPagePublication.isPresent()
                 && !campaignDestinationPolicy.hasRequiredSalesPageAnalyticsCollectors(salesPagePublication.get())) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.GERA_SALES_PAGE,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -898,10 +898,15 @@ public class ExperimentService {
         return experiment;
     }
 
-    /** Bloqueia venda low-ticket quando página, destino ou métricas não estão prontos para tráfego. */
+    /** Bloqueia venda quando contrato, página, destino ou métricas não estão prontos para tráfego. */
     private void ensureLowTicketSalesPageWasBuiltByPipeline(Experiment experiment) {
-        if (experiment.getExperimentType() != ExperimentType.LOW_TICKET_PRODUCT) {
+        if (!requiresSalesPageBeforePurchase(experiment)) {
             return;
+        }
+        if (!hasCompleteCommercialContract(experiment)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento com intenção de compra exige contrato comercial completo da etapa Oferta antes da campanha.");
         }
         boolean pipelineCompleted = geraSalesPageStageExecutionRepository
                 .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
@@ -912,23 +917,41 @@ public class ExperimentService {
         if (!pipelineCompleted) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
-                    "Experimento low-ticket exige página de venda criada pelo GeraSalesPage v1 antes da campanha.");
+                    "Experimento com intenção de compra exige página de venda criada pelo GeraSalesPage v1 antes da campanha.");
         }
         GeraSalesPagePublicationAudit publication = geraSalesPagePublicationAuditRepository
                 .findTopByExperimentIdOrderByPublishedAtDesc(experiment.getId())
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.CONFLICT,
-                        "Experimento low-ticket exige página de venda publicada e auditada pelo GeraSalesPage v1 antes da campanha."));
+                        "Experimento com intenção de compra exige página de venda publicada e auditada pelo GeraSalesPage v1 antes da campanha."));
         if (!hasAdDestinationPointingToSalesPage(experiment, publication)) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
-                    "Experimento low-ticket exige que o link do anúncio aponte para a página de venda publicada, não para o checkout direto.");
+                    "Experimento com intenção de compra exige que o link do anúncio aponte para a página de venda publicada, não para o checkout direto.");
         }
         if (!hasRequiredSalesPageAnalyticsCollectors(publication)) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
-                    "Experimento low-ticket exige página de venda com coletores page_view, page_load_metric, section_view_time e checkout_click antes da campanha.");
+                    "Experimento com intenção de compra exige página de venda com coletores page_view, page_load_metric, section_view_time e checkout_click antes da campanha.");
         }
+    }
+
+    /** Informa se o experimento precisa de página de venda antes do checkout. */
+    private boolean requiresSalesPageBeforePurchase(Experiment experiment) {
+        return experiment != null
+                && (experiment.getExperimentType() == ExperimentType.LOW_TICKET_PRODUCT
+                || experiment.getCampaignObjective() == ExperimentCampaignObjective.SALES);
+    }
+
+    /** Confirma se a etapa Oferta preencheu o contrato comercial mínimo de venda. */
+    private boolean hasCompleteCommercialContract(Experiment experiment) {
+        return experiment != null
+                && StringUtils.hasText(experiment.getSinglePain())
+                && StringUtils.hasText(experiment.getFreeReward())
+                && StringUtils.hasText(experiment.getFunnelPromise())
+                && StringUtils.hasText(experiment.getPrimaryCta())
+                && experiment.getUnitPrice() != null
+                && experiment.getUnitPrice().signum() > 0;
     }
 
     /** Confirma que o destino do anúncio é a página auditada e não o checkout. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -194,6 +194,11 @@ public class ExperimentController {
     /** Bloqueia liberação de tráfego frio com intenção de compra direto para checkout. */
     private void ensurePurchaseIntentDoesNotBypassSalesPage(Long id) {
         List<String> missing = campaignDestinationPolicy.missingConfiguration(service.get(id));
+        if (missing.contains("commercialContract")) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Experimento com intenção de compra exige contrato comercial completo da etapa Oferta antes da página e da campanha.");
+        }
         if (missing.contains("geraSalesPagePipeline")) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
+import com.marketinghub.experiment.service.ExperimentReadinessService;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.facebookads.dto.ExperimentReadyForAdSetDto;
@@ -42,6 +43,7 @@ public class FacebookAdSetExperimentService {
     private final MarketNicheMapper marketNicheMapper;
     private final HypothesisMapper hypothesisMapper;
     private final TargetingElementMapper targetingElementMapper;
+    private final ExperimentReadinessService readinessService;
 
     /**
      * Inicializa o serviço com repositórios e mapeadores usados para montar o contrato do worker.
@@ -52,7 +54,8 @@ public class FacebookAdSetExperimentService {
                                           ExperimentMapper experimentMapper,
                                           MarketNicheMapper marketNicheMapper,
                                           HypothesisMapper hypothesisMapper,
-                                          TargetingElementMapper targetingElementMapper) {
+                                          TargetingElementMapper targetingElementMapper,
+                                          ExperimentReadinessService readinessService) {
         this.experimentRepository = experimentRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.targetingElementRepository = targetingElementRepository;
@@ -60,6 +63,7 @@ public class FacebookAdSetExperimentService {
         this.marketNicheMapper = marketNicheMapper;
         this.hypothesisMapper = hypothesisMapper;
         this.targetingElementMapper = targetingElementMapper;
+        this.readinessService = readinessService;
     }
 
     /**
@@ -112,6 +116,9 @@ public class FacebookAdSetExperimentService {
      * Converte um experimento em contrato de ad set quando existe pacote de segmentação publicável.
      */
     private ExperimentReadyForAdSetDto toReadyForAdSetDto(Experiment experiment) {
+        if (!readinessService.isReadyForCampaign(experiment)) {
+            return null;
+        }
         TargetingPackageDto targeting = buildTargetingPackage(experiment);
         if (targeting == null) {
             return null;

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -92,6 +92,18 @@ public class GeraSalesPagePublicationAuditService {
                 .toList();
     }
 
+    /** Retorna o checkout auditado mais recente para rebuild sem confundir com a URL pública da página. */
+    @Transactional(readOnly = true)
+    public String latestCheckoutUrl(Long experimentId) {
+        if (experimentId == null) {
+            return null;
+        }
+        return publicationRepository.findTopByExperimentIdOrderByPublishedAtDesc(experimentId)
+                .map(GeraSalesPagePublicationAudit::getCheckoutUrl)
+                .filter(StringUtils::hasText)
+                .orElse(null);
+    }
+
     /** Cria snapshots para publicacoes antigas que ainda possuem execucoes auditaveis no banco. */
     private void backfillMissingSnapshots(Experiment experiment) {
         executionRepository.findByExperimentIdAndStageCodeAndStatusOrderByExecutionRequestedAtAsc(

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -65,6 +65,7 @@ public class GeraSalesPageStageService {
     public GeraSalesPageStartResponse start(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        validateCommercialContract(experiment);
         validateCheckoutUrl(experiment);
         GeraSalesPageStageExecution execution = enqueue(experimentId, GeraSalesPageStageCode.OFFER_BRIEF.code());
         return new GeraSalesPageStartResponse(experimentId, execution.getStageCode(), idJobText(execution), execution.getStatus());
@@ -75,6 +76,7 @@ public class GeraSalesPageStageService {
     public GeraSalesPageStartResponse rebuild(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        validateCommercialContract(experiment);
         validateCheckoutUrl(experiment);
         List<GeraSalesPageStageExecution> executions =
                 executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(experimentId);
@@ -210,7 +212,7 @@ public class GeraSalesPageStageService {
         payload.put("campaignAngle", parseJsonOrText(experiment.getCampaignAngle()));
         payload.put("adCopy", parseJsonOrText(experiment.getAdCopy()));
         payload.put("adImageBriefing", parseJsonOrText(experiment.getAdImageBriefing()));
-        payload.put("checkoutUrl", experiment.getFollowUpActionUrl());
+        payload.put("checkoutUrl", resolveCheckoutUrl(experiment));
         payload.put("productAiSubtype", experiment.getProductAiSubtype());
         payload.put("salesPageDestination", salesPageDestination(experiment));
         payload.put("unitPrice", experiment.getUnitPrice());
@@ -279,10 +281,33 @@ public class GeraSalesPageStageService {
 
     /** Bloqueia início ou rebuild sem checkout real persistido no experimento. */
     private void validateCheckoutUrl(Experiment experiment) {
-        if (!isRealCheckoutUrl(experiment.getFollowUpActionUrl())) {
+        if (!isRealCheckoutUrl(resolveCheckoutUrl(experiment))) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
-                    "GeraSalesPage v1 exige followUpActionUrl com URL real de checkout antes de iniciar.");
+                    "GeraSalesPage v1 exige URL real de checkout antes de iniciar.");
+        }
+    }
+
+    /** Resolve o checkout interno priorizando auditoria anterior quando followUpActionUrl já virou página. */
+    private String resolveCheckoutUrl(Experiment experiment) {
+        String auditedCheckoutUrl = publicationAuditService.latestCheckoutUrl(experiment.getId());
+        if (StringUtils.hasText(auditedCheckoutUrl)) {
+            return auditedCheckoutUrl;
+        }
+        return experiment.getFollowUpActionUrl();
+    }
+
+    /** Bloqueia página de venda sem contrato comercial mínimo da etapa Oferta. */
+    private void validateCommercialContract(Experiment experiment) {
+        if (!StringUtils.hasText(experiment.getSinglePain())
+                || !StringUtils.hasText(experiment.getFreeReward())
+                || !StringUtils.hasText(experiment.getFunnelPromise())
+                || !StringUtils.hasText(experiment.getPrimaryCta())
+                || experiment.getUnitPrice() == null
+                || experiment.getUnitPrice().signum() <= 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "GeraSalesPage v1 exige contrato comercial completo: dor, prova/preview, promessa, CTA e preço.");
         }
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -143,6 +144,7 @@ class ExperimentReadinessServiceTest {
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
         experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc");
         experiment.getNiche().setFacebookPixelId("pixel-exp56");
+        completeCommercialContract(experiment);
 
         when(creativeRepository.existsByExperimentIdAndStatus(56L, CreativeStatus.READY)).thenReturn(true);
         mockPublishableSelection(56L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
@@ -164,6 +166,7 @@ class ExperimentReadinessServiceTest {
         experiment.setCampaignObjective(ExperimentCampaignObjective.SALES);
         experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=sales-direct");
         experiment.getNiche().setFacebookPixelId("pixel-exp60");
+        completeCommercialContract(experiment);
 
         when(creativeRepository.existsByExperimentIdAndStatus(60L, CreativeStatus.READY)).thenReturn(true);
         mockPublishableSelection(60L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
@@ -185,6 +188,7 @@ class ExperimentReadinessServiceTest {
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
         experiment.setFollowUpActionUrl("https://pagamentopalf.site/sales-page-exp53.html");
         experiment.getNiche().setFacebookPixelId("pixel-exp53");
+        completeCommercialContract(experiment);
 
         when(creativeRepository.existsByExperimentIdAndStatus(53L, CreativeStatus.READY)).thenReturn(true);
         mockPublishableSelection(53L, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);
@@ -197,6 +201,21 @@ class ExperimentReadinessServiceTest {
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
+    }
+
+    @Test
+    void shouldRequireCommercialContractBeforeSalesPageForPurchaseIntent() {
+        Experiment experiment = buildExperiment(56L, 66L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc");
+        experiment.getNiche().setFacebookPixelId("pixel-exp56");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(56L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(56L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("commercialContract");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
     }
 
     /** Simula uma seleção de público aprovada e identificável pela Meta. */
@@ -315,6 +334,15 @@ class ExperimentReadinessServiceTest {
         experiment.setHypothesisRef(hypothesis);
         experiment.setCreativeApproved(true);
         return experiment;
+    }
+
+    /** Preenche o contrato comercial mínimo gerado pela etapa Oferta. */
+    private void completeCommercialContract(Experiment experiment) {
+        experiment.setSinglePain("Cliente some depois da manutenção");
+        experiment.setFreeReward("Preview visual da agenda preenchida");
+        experiment.setFunnelPromise("Enxergar riscos e encaixes em 7 dias");
+        experiment.setPrimaryCta("Comprar o Mapa 7D");
+        experiment.setUnitPrice(BigDecimal.valueOf(29.90));
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
@@ -11,6 +11,7 @@ import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
+import com.marketinghub.experiment.service.ExperimentReadinessService;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.facebookads.dto.ExperimentReadyForAdSetDto;
@@ -48,6 +49,8 @@ class FacebookAdSetExperimentServiceTest {
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
     @Mock
     private TargetingElementRepository targetingElementRepository;
+    @Mock
+    private ExperimentReadinessService readinessService;
 
     private FacebookAdSetExperimentService service;
 
@@ -69,7 +72,8 @@ class FacebookAdSetExperimentServiceTest {
                 experimentMapper,
                 marketNicheMapper,
                 hypothesisMapper,
-                targetingElementMapper);
+                targetingElementMapper,
+                readinessService);
     }
 
     /**
@@ -148,6 +152,7 @@ class FacebookAdSetExperimentServiceTest {
 
         when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
                 .thenReturn(List.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(true);
 
         TargetingElement interest = TargetingElement.builder()
                 .id(1L)
@@ -223,6 +228,7 @@ class FacebookAdSetExperimentServiceTest {
 
         when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
                 .thenReturn(List.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(true);
         when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.INTEREST, hypothesisId))
                 .thenReturn(List.of());
 
@@ -291,6 +297,7 @@ class FacebookAdSetExperimentServiceTest {
 
         when(experimentRepository.findForAdSetTargetingById(13L, ExperimentPlatform.FACEBOOK))
                 .thenReturn(Optional.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(true);
         when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(13L))
                 .thenReturn(List.of(
                         ExperimentTargetingSelection.builder()
@@ -350,6 +357,7 @@ class FacebookAdSetExperimentServiceTest {
 
         when(experimentRepository.findForAdSetTargetingById(38L, ExperimentPlatform.FACEBOOK))
                 .thenReturn(Optional.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(true);
         when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(38L))
                 .thenReturn(List.of(
                         ExperimentTargetingSelection.builder()
@@ -391,6 +399,7 @@ class FacebookAdSetExperimentServiceTest {
 
         when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
                 .thenReturn(List.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(true);
         TargetingElement interest = TargetingElement.builder()
                 .id(9L)
                 .niche(niche)
@@ -415,5 +424,33 @@ class FacebookAdSetExperimentServiceTest {
                 .extracting(TargetingElementDto::getMetaId)
                 .containsExactly("6003139266461");
         assertThat(result.getFirst().getTargeting().getJobTitles()).isEmpty();
+    }
+
+    /**
+     * Garante que o endpoint não expõe adset quando o readiness bloqueia contrato, página ou campanha.
+     */
+    @Test
+    void listExperimentsReadySkipsExperimentBlockedByReadinessGate() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(5L);
+
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(UUID.randomUUID());
+        hypothesis.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(56L);
+        experiment.setNiche(niche);
+        experiment.setHypothesisRef(hypothesis);
+        experiment.setStatus(ExperimentStatus.PLANNED);
+        experiment.setPlatform(ExperimentPlatform.FACEBOOK);
+
+        when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
+                .thenReturn(List.of(experiment));
+        when(readinessService.isReadyForCampaign(experiment)).thenReturn(false);
+
+        List<ExperimentReadyForAdSetDto> result = service.listExperimentsReadyForAdSets();
+
+        assertThat(result).isEmpty();
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -62,6 +63,7 @@ class GeraSalesPageStageServiceTest {
         Experiment experiment = new Experiment();
         experiment.setId(53L);
         experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc");
+        completeCommercialContract(experiment);
         GeraSalesPageStageExecution previous = GeraSalesPageStageExecution.builder()
                 .idJob("old-job")
                 .experimentId(53L)
@@ -95,6 +97,19 @@ class GeraSalesPageStageServiceTest {
                 GeraSalesPageStageCode.OFFER_BRIEF.code(),
                 newExecution.getValue().getIdJob());
         assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+    }
+
+    /** Deve bloquear o início quando a etapa Oferta ainda não preencheu contrato comercial. */
+    @Test
+    void rebuildShouldRejectExperimentWithoutCommercialContract() {
+        Experiment experiment = new Experiment();
+        experiment.setId(56L);
+        experiment.setFollowUpActionUrl("https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=abc");
+        when(experimentRepository.findById(56L)).thenReturn(Optional.of(experiment));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.rebuild(56L))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("contrato comercial completo");
     }
 
     /** Deve bloquear a publicação quando a revisão comercial reprova a página. */
@@ -148,5 +163,14 @@ class GeraSalesPageStageServiceTest {
                 .createdAt(Instant.now())
                 .updatedAt(Instant.now())
                 .build();
+    }
+
+    /** Preenche o contrato comercial mínimo exigido antes da página de vendas. */
+    private void completeCommercialContract(Experiment experiment) {
+        experiment.setSinglePain("Cliente some depois da manutenção");
+        experiment.setFreeReward("Preview visual da agenda preenchida");
+        experiment.setFunnelPromise("Enxergar riscos e encaixes em 7 dias");
+        experiment.setPrimaryCta("Comprar o Mapa 7D");
+        experiment.setUnitPrice(BigDecimal.valueOf(29.90));
     }
 }

--- a/frontend/src/api/useFacebookCampaignExperiments.ts
+++ b/frontend/src/api/useFacebookCampaignExperiments.ts
@@ -24,6 +24,13 @@ export interface ExperimentSummary {
   id: number;
   name: string;
   hypothesis: string;
+  singlePain?: string | null;
+  freeReward?: string | null;
+  funnelPromise?: string | null;
+  primaryCta?: string | null;
+  experimentType?: string | null;
+  campaignObjective?: string | null;
+  followUpActionUrl?: string | null;
   kpiTargetCpl: number | null;
   startDate: string | null;
   endDate: string | null;

--- a/frontend/src/api/useFacebookReadyExperiments.ts
+++ b/frontend/src/api/useFacebookReadyExperiments.ts
@@ -6,6 +6,13 @@ export interface FacebookReadyExperiment {
   id: number;
   name: string;
   hypothesis: string;
+  singlePain?: string | null;
+  freeReward?: string | null;
+  funnelPromise?: string | null;
+  primaryCta?: string | null;
+  experimentType?: string | null;
+  campaignObjective?: string | null;
+  followUpActionUrl?: string | null;
   kpiTargetCpl: number | null;
   startDate: string | null;
   endDate: string | null;

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
@@ -176,6 +176,64 @@
   color: var(--bs-success-text-emphasis);
 }
 
+.experiments-ready-flow {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.experiments-ready-flow__step {
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  background-color: var(--bs-body-bg);
+}
+
+.experiments-ready-flow__icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+}
+
+.experiments-ready-flow__step strong {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--bs-emphasis-color);
+}
+
+.experiments-ready-flow__step small {
+  display: block;
+  color: var(--bs-secondary-color);
+  line-height: 1.35;
+}
+
+.experiments-ready-flow__step--done {
+  border-color: var(--bs-success-border-subtle);
+}
+
+.experiments-ready-flow__step--done .experiments-ready-flow__icon {
+  background-color: var(--bs-success-bg-subtle);
+  color: var(--bs-success-text-emphasis);
+}
+
+.experiments-ready-flow__step--current {
+  border-color: var(--bs-warning-border-subtle);
+  background-color: var(--bs-warning-bg-subtle);
+}
+
+.experiments-ready-flow__step--current .experiments-ready-flow__icon {
+  background-color: var(--bs-warning-border-subtle);
+  color: var(--bs-warning-text-emphasis);
+}
+
 .experiments-ready-pending {
   margin-top: 2rem;
   display: flex;

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   CalendarDays,
   CheckCircle2,
+  FileText,
   FlaskConical,
   Flag,
   Gauge,
@@ -20,6 +21,17 @@ import "./FacebookExperimentsReadyPage.css";
 import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
 import { MissingConfigurationList } from "./MissingConfigurationList";
 
+interface CommercialFlowExperiment {
+  singlePain?: string | null;
+  freeReward?: string | null;
+  funnelPromise?: string | null;
+  primaryCta?: string | null;
+  experimentType?: string | null;
+  campaignObjective?: string | null;
+  followUpActionUrl?: string | null;
+  missingConfiguration: string[];
+}
+
 function formatCurrency(value: number | null) {
   if (value === null) return "Sem KPI";
   return new Intl.NumberFormat("pt-BR", {
@@ -34,6 +46,72 @@ function formatDate(value: string | null) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleDateString("pt-BR");
+}
+
+function commercialFlowSteps(experiment: CommercialFlowExperiment) {
+  const missing = new Set(experiment.missingConfiguration);
+  const pageMissing =
+    missing.has("geraSalesPagePipeline") ||
+    missing.has("salesPageAdDestination") ||
+    missing.has("salesPageAnalyticsCollectors");
+  const contractMissing = missing.has("commercialContract");
+  const ready = experiment.missingConfiguration.length === 0;
+
+  return [
+    {
+      label: "Contrato comercial",
+      status: contractMissing ? "current" : "done",
+      detail: contractMissing
+        ? "Completar Oferta: dor, prova/preview, promessa, CTA e preço."
+        : "Oferta preenchida e usada como fonte do funil.",
+    },
+    {
+      label: "Página de venda",
+      status: contractMissing ? "pending" : pageMissing ? "current" : "done",
+      detail: pageMissing
+        ? "Gerar, auditar e apontar o anúncio para a página, não para o checkout."
+        : "Página GeraSalesPage auditada ou sem bloqueio pendente.",
+    },
+    {
+      label: "Campanha",
+      status: ready ? "done" : contractMissing || pageMissing ? "pending" : "current",
+      detail: ready
+        ? "Pronto para o worker publicar."
+        : "Resolver criativo, público, pixel e demais pendências antes de mídia.",
+    },
+  ];
+}
+
+function CommercialFlowGuide({
+  experiment,
+}: {
+  experiment: CommercialFlowExperiment;
+}) {
+  const steps = commercialFlowSteps(experiment);
+  return (
+    <div className="experiments-ready-flow" aria-label="Fluxo comercial">
+      {steps.map((step) => (
+        <div
+          key={step.label}
+          className={`experiments-ready-flow__step experiments-ready-flow__step--${step.status}`}
+        >
+          <span className="experiments-ready-flow__icon">
+            {step.status === "done" ? (
+              <CheckCircle2 size={15} />
+            ) : step.status === "current" ? (
+              <FileText size={15} />
+            ) : (
+              <ListChecks size={15} />
+            )}
+          </span>
+          <span>
+            <strong>{step.label}</strong>
+            <small>{step.detail}</small>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export default function FacebookExperimentsReadyPage() {
@@ -215,6 +293,7 @@ export default function FacebookExperimentsReadyPage() {
                   </>
                 )}
               </div>
+              <CommercialFlowGuide experiment={experiment} />
               <div className="d-flex justify-content-end">
                 <Link
                   className="btn btn-link p-0"
@@ -301,6 +380,7 @@ export default function FacebookExperimentsReadyPage() {
                     className="mb-0"
                   />
                 </div>
+                <CommercialFlowGuide experiment={experiment} />
 
                 <dl className="experiments-ready-pending__meta">
                   <div>

--- a/frontend/src/pages/facebook/missingConfigurationLabels.ts
+++ b/frontend/src/pages/facebook/missingConfigurationLabels.ts
@@ -4,6 +4,11 @@ export interface MissingConfigurationInfo {
 }
 
 const missingConfigurationInfo: Record<string, MissingConfigurationInfo> = {
+  commercialContract: {
+    label: "Completar contrato comercial da etapa Oferta",
+    helperText:
+      "Venda low-ticket precisa de dor única, prova/preview, promessa, CTA e preço antes de página, criativos e campanha.",
+  },
   creativeApproval: { label: "Aprovar pelo menos um criativo" },
   landingDestination: { label: "Aprovar a landing para definir URL de destino" },
   geraSalesPagePipeline: {


### PR DESCRIPTION
## O que mudou

- Torna o contrato comercial da etapa Oferta um gate obrigatório para experimentos `LOW_TICKET_PRODUCT` ou objetivo `SALES`.
- Bloqueia GeraSalesPage, liberação manual para Facebook e exposição de adsets ao worker quando o contrato, página auditada, destino ou coletores não estão prontos.
- Mantém checkout como ação interna da página ao reutilizar o checkout auditado em rebuilds do GeraSalesPage.
- Atualiza a tela de experimentos para campanha com orientação visual: contrato comercial, página de venda e campanha.

## Causa-raiz

O sistema já gerava contrato comercial, mas ainda permitia caminhos operacionais em que o experimento avançava para página/campanha sem tratar esse contrato como fonte soberana e gate obrigatório.

## Validação

- `./mvnw -f ads-service/pom.xml -Dtest=ExperimentReadinessServiceTest,FacebookAdSetExperimentServiceTest,GeraSalesPageStageServiceTest,ExperimentControllerReleasePolicyTest test`
- `npm run typecheck`
- `npm run build`

Observação: para validar o frontend foi necessário rodar `npm ci --include=dev`, porque o primeiro `npm ci` do ambiente instalou sem devDependencies.