### PR TITLE
[codex] Publish GeraSalesPage standalone low-ticket pages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -19,6 +19,7 @@ import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationStageAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -46,6 +47,7 @@ public class GeraSalesPagePublicationAuditService {
     private final GeraSalesPageStageExecutionRepository executionRepository;
     private final GeraSalesPagePublicationAuditRepository publicationRepository;
     private final GeraSalesPagePublicationStageAuditRepository publicationStageRepository;
+    private final LeadPortalFlowRepository leadPortalFlowRepository;
     private final LeadPortalFlowPublisher leadPortalFlowPublisher;
     private final LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
     private final ObjectMapper objectMapper;
@@ -56,6 +58,7 @@ public class GeraSalesPagePublicationAuditService {
             GeraSalesPageStageExecutionRepository executionRepository,
             GeraSalesPagePublicationAuditRepository publicationRepository,
             GeraSalesPagePublicationStageAuditRepository publicationStageRepository,
+            LeadPortalFlowRepository leadPortalFlowRepository,
             LeadPortalFlowPublisher leadPortalFlowPublisher,
             LeadPortalPublicUrlResolver leadPortalPublicUrlResolver,
             ObjectMapper objectMapper) {
@@ -63,6 +66,7 @@ public class GeraSalesPagePublicationAuditService {
         this.executionRepository = executionRepository;
         this.publicationRepository = publicationRepository;
         this.publicationStageRepository = publicationStageRepository;
+        this.leadPortalFlowRepository = leadPortalFlowRepository;
         this.leadPortalFlowPublisher = leadPortalFlowPublisher;
         this.leadPortalPublicUrlResolver = leadPortalPublicUrlResolver;
         this.objectMapper = objectMapper;
@@ -140,6 +144,11 @@ public class GeraSalesPagePublicationAuditService {
             html = personalizedSamplePublication.html();
             salesPageUrl = personalizedSamplePublication.salesPageUrl();
             checkoutUrl = null;
+        } else {
+            DirectCheckoutPublication directCheckoutPublication =
+                    publishDirectCheckoutSalesPage(experiment, html);
+            html = directCheckoutPublication.html();
+            salesPageUrl = directCheckoutPublication.salesPageUrl();
         }
         Instant publishedAt = publicationExecution.getCompletedAt() != null
                 ? publicationExecution.getCompletedAt()
@@ -166,6 +175,62 @@ public class GeraSalesPagePublicationAuditService {
             return StringUtils.hasText(checkoutUrl) ? checkoutUrl : null;
         }
         return StringUtils.hasText(checkoutUrl) ? checkoutUrl : experiment.getFollowUpActionUrl();
+    }
+
+    /** Publica pagina low-ticket standalone no Lead Portal e usa essa URL como destino oficial da campanha. */
+    private DirectCheckoutPublication publishDirectCheckoutSalesPage(
+            Experiment experiment,
+            String html) {
+        if (!StringUtils.hasText(html)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "GeraSalesPage v1 exige HTML final para publicar pagina de venda standalone.");
+        }
+        LeadPortalFlow flow = upsertDirectCheckoutFlow(experiment, html);
+        try {
+            leadPortalFlowPublisher.publish(flow);
+        } catch (LeadPortalPublicationException ex) {
+            log.error("Falha ao publicar pagina GeraSalesPage standalone: experimentId={}, flowId={}, slug={}",
+                    experiment.getId(), flow.getId(), flow.getSlug(), ex);
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_GATEWAY,
+                    "Falha ao publicar pagina de venda standalone.",
+                    ex);
+        }
+        String publicUrl = leadPortalPublicUrlResolver.resolve(flow);
+        if (!StringUtils.hasText(publicUrl)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Lead Portal nao retornou URL publica para a pagina de venda standalone.");
+        }
+        experiment.setLeadPortalFlow(flow);
+        experiment.setSchemaFirstLeadPortalEnabled(true);
+        experiment.setFollowUpActionUrl(publicUrl);
+        return new DirectCheckoutPublication(publicUrl, html);
+    }
+
+    /** Cria ou atualiza o fluxo publico usado exclusivamente como pagina de venda standalone. */
+    private LeadPortalFlow upsertDirectCheckoutFlow(Experiment experiment, String html) {
+        String slug = "exp-" + experiment.getId() + "-gerasalespage-v1";
+        LeadPortalFlow flow = leadPortalFlowRepository.findBySlug(slug).orElseGet(() -> LeadPortalFlow.builder()
+                .name("GeraSalesPage v1 - Experimento " + experiment.getId())
+                .slug(slug)
+                .description("Pagina de venda standalone gerada automaticamente pelo GeraSalesPage v1.")
+                .prompt("Pipeline: gera-sales-page-v1/publication-package")
+                .schemaFirst(true)
+                .experiment(experiment)
+                .marketNiche(experiment.getNiche())
+                .build());
+        flow.setCustomFormHtml(html.trim());
+        flow.setSchemaFirst(true);
+        flow.setApproved(true);
+        if (flow.getApprovedAt() == null) {
+            flow.setApprovedAt(Instant.now());
+        }
+        flow.setModel("GERA_SALES_PAGE_V1_STANDALONE");
+        flow.setExperiment(experiment);
+        flow.setMarketNiche(experiment.getNiche());
+        return leadPortalFlowRepository.save(flow);
     }
 
     /** Publica a pagina aprovada dentro do funil canonico quando o produto exige personalizacao. */
@@ -422,5 +487,9 @@ public class GeraSalesPagePublicationAuditService {
 
     /** Resultado interno da publicacao no funil Produto IA personalizado. */
     private record PersonalizedSamplePublication(String salesPageUrl, String html) {
+    }
+
+    /** Resultado interno da publicacao standalone para venda direta low-ticket. */
+    private record DirectCheckoutPublication(String salesPageUrl, String html) {
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
@@ -21,6 +21,7 @@ import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationStageAuditRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
+import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,8 @@ class GeraSalesPagePublicationAuditServiceTest {
     private GeraSalesPagePublicationAuditRepository publicationRepository;
     @Mock
     private GeraSalesPagePublicationStageAuditRepository publicationStageRepository;
+    @Mock
+    private LeadPortalFlowRepository leadPortalFlowRepository;
     @Mock
     private LeadPortalFlowPublisher leadPortalFlowPublisher;
     @Mock
@@ -74,6 +77,15 @@ class GeraSalesPagePublicationAuditServiceTest {
         when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
         when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L))
                 .thenReturn(List.of(offer, publication));
+        when(leadPortalFlowRepository.findBySlug("exp-53-gerasalespage-v1")).thenReturn(Optional.empty());
+        when(leadPortalFlowRepository.save(any(LeadPortalFlow.class)))
+                .thenAnswer(invocation -> {
+                    LeadPortalFlow flow = invocation.getArgument(0);
+                    flow.setId(53L);
+                    return flow;
+                });
+        when(leadPortalPublicUrlResolver.resolve(any(LeadPortalFlow.class)))
+                .thenReturn("https://oportunidadebrasil.shop/flows/exp-53-gerasalespage-v1");
         when(publicationRepository.save(any(GeraSalesPagePublicationAudit.class)))
                 .thenAnswer(invocation -> {
                     GeraSalesPagePublicationAudit audit = invocation.getArgument(0);
@@ -86,10 +98,17 @@ class GeraSalesPagePublicationAuditServiceTest {
         ArgumentCaptor<GeraSalesPagePublicationAudit> audit =
                 ArgumentCaptor.forClass(GeraSalesPagePublicationAudit.class);
         verify(publicationRepository).save(audit.capture());
+        ArgumentCaptor<LeadPortalFlow> flow = ArgumentCaptor.forClass(LeadPortalFlow.class);
+        verify(leadPortalFlowPublisher).publish(flow.capture());
         ArgumentCaptor<List<GeraSalesPagePublicationStageAudit>> stages = ArgumentCaptor.forClass(List.class);
         verify(publicationStageRepository).saveAll(stages.capture());
+        assertThat(flow.getValue().getSlug()).isEqualTo("exp-53-gerasalespage-v1");
+        assertThat(flow.getValue().getCustomFormHtml()).contains("Venda");
+        assertThat(experiment.getFollowUpActionUrl())
+                .isEqualTo("https://oportunidadebrasil.shop/flows/exp-53-gerasalespage-v1");
         assertThat(audit.getValue().getPublicationJobId()).isEqualTo("job-publication");
-        assertThat(audit.getValue().getSalesPageUrl()).isEqualTo("https://pagamentopalf.site/sales-page-exp53.html");
+        assertThat(audit.getValue().getSalesPageUrl())
+                .isEqualTo("https://oportunidadebrasil.shop/flows/exp-53-gerasalespage-v1");
         assertThat(audit.getValue().getCheckoutUrl()).isEqualTo("https://mp.test/checkout");
         assertThat(audit.getValue().getHtml()).contains("Venda");
         assertThat(stages.getValue()).hasSize(2);

--- a/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
+++ b/docs/registros/experimentos-2026-07-02-analytics-sales-page.md
@@ -18,3 +18,10 @@
 - Sintoma pós-deploy: o backend subia saudável, mas o bootstrap registrava `Cannot add foreign key constraint` ao tentar criar FKs de `gera_sales_page_publication_audit.publication_job_id` e `gera_sales_page_publication_stage_audit.id_job` para `gera_sales_page_stage_execution.id_job`.
 - Causa-raiz confirmada via MCP/banco: as tabelas de auditoria foram criadas com `utf8mb4_unicode_ci`, enquanto `gera_sales_page_stage_execution.id_job` estava em `utf8mb4_general_ci`; no MySQL 5.7, FK entre `VARCHAR` com collation diferente é recusada. O changeset original estava `MARK_RAN`, deixando índices e FKs de job incompletos.
 - Correção aplicada: novo changelog alinha a collation das colunas-filhas para `utf8mb4_general_ci`, recria os índices previstos e adiciona as FKs de job de forma idempotente.
+
+## 2026-07-05 — Publicação standalone low-ticket no GeraSalesPage
+
+- Problema: o experimento 56 concluiu a página no GeraSalesPage, mas a publicação manteve `salesPageUrl`/destino da campanha apontando para checkout Mercado Pago.
+- Causa-raiz: a publicação final tinha tratamento especial apenas para Produto IA personalizado; no low-ticket comum, o snapshot auditava o pacote e fazia fallback para `followUpActionUrl`, que ainda era a URL interna de checkout usada para montar a página.
+- Correção aplicada: a etapa final do GeraSalesPage agora publica o HTML aprovado como fluxo standalone no Lead Portal, grava a URL pública como `salesPageUrl` e `followUpActionUrl`, mantendo `checkoutUrl` separado para os botões da página.
+- Prevenção de recorrência: teste unitário cobre página de venda direta com checkout separado e garante que a campanha passa a usar a URL pública do Lead Portal, não o checkout frio.


### PR DESCRIPTION
## O que muda

- Publica a página final do GeraSalesPage low-ticket como fluxo standalone no Lead Portal.
- Atualiza `salesPageUrl` e `followUpActionUrl` para a URL pública da página, mantendo `checkoutUrl` separado para os botões internos.
- Adiciona teste cobrindo venda direta com checkout separado.
- Registra a causa-raiz em `docs/registros`.

## Causa-raiz

A publicação final tinha regra específica para Produto IA personalizado, mas no low-ticket comum fazia fallback para `followUpActionUrl`. No experimento 56, esse campo ainda era o checkout Mercado Pago usado como insumo da página, então o destino da campanha continuava frio para checkout.

## Validação

- `mvn -B -Dtest=GeraSalesPagePublicationAuditServiceTest,GeraSalesPageStageServiceTest,ExperimentReadinessServiceTest,ExperimentServiceTest,FacebookAdsCampaignControllerTest test` em `backend/ads-service`: 46 testes, 0 falhas.
- `mvn -B -s settings.xml test` em `ai-worker`: bloqueado antes dos testes por `401 Unauthorized` ao resolver `com.marketinghub:ads-service:0.0.1-SNAPSHOT` no GitHub Packages.

## Observação

Não alterei `gerasalespage.worker.service-tier`: o cânone atual do GeraSalesPage v1 mantém `service_tier=default` para priorizar estabilidade da página de venda.