### PR TITLE
Fix AI Worker creative generation contract

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeGenerationService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeGenerationService.java
@@ -21,8 +21,11 @@ import org.springframework.util.StringUtils;
 @Service
 public class CreativeGenerationService {
     private static final Logger log = LoggerFactory.getLogger(CreativeGenerationService.class);
+    private static final int CREATIVE_TEXT_MAX_LENGTH = 255;
     private static final int META_CALL_TO_ACTION_MAX_LENGTH = 32;
     private static final String DEFAULT_META_CALL_TO_ACTION = "LEARN_MORE";
+    private static final String IMAGE_TEXT_GUARD =
+            "Nao incluir texto, letras, numeros, palavras, logotipos ou interface legivel dentro da imagem.";
 
     private final CreativeGenerationBackendClient backendClient;
     private final CreativeChatGptClient textClient;
@@ -94,15 +97,16 @@ public class CreativeGenerationService {
         }
         List<CreateCreativeRequest> result = new ArrayList<>();
         for (PipelineAdCreativePlan plan : plans) {
-            String prompt = buildPipelineImagePrompt(plan);
-            String imageUrl = imageClient.generateImage(prompt, null,
-                    "pipeline-creative-experiment-" + dto.getId() + "-" + plan.variantKey());
             CreateCreativeRequest request = new CreateCreativeRequest();
             request.setHeadline(plan.headline());
             request.setPrimaryText(plan.primaryText());
             request.setDescription(plan.description());
             request.setCta(normalizeMetaCallToAction(plan.ctaText()));
             request.setFormat(StringUtils.hasText(plan.format()) ? plan.format() : "IMAGE");
+            normalizeCreativeContract(request);
+            String prompt = buildPipelineImagePrompt(plan, request);
+            String imageUrl = imageClient.generateImage(prompt, null,
+                    "pipeline-creative-experiment-" + dto.getId() + "-" + plan.variantKey());
             request.setImageUrl(imageUrl);
             request.setStatus(CreativeStatus.DRAFT);
             result.add(request);
@@ -117,12 +121,12 @@ public class CreativeGenerationService {
                 .limit(Math.max(1, quantity))
                 .toList();
         for (CreateCreativeRequest creative : creatives) {
+            normalizeCreativeContract(creative);
             String prompt = defaultImagePrompt(dto, creative);
             creative.setImageUrl(imageClient.generateImage(prompt, null, "creative-experiment-" + dto.getId()));
             if (creative.getStatus() == null) {
                 creative.setStatus(CreativeStatus.DRAFT);
             }
-            creative.setCta(normalizeMetaCallToAction(creative.getCta()));
         }
         return creatives;
     }
@@ -147,27 +151,42 @@ public class CreativeGenerationService {
     }
 
     /** Monta o prompt visual final de um criativo do pipeline. */
-    private String buildPipelineImagePrompt(PipelineAdCreativePlan plan) {
+    private String buildPipelineImagePrompt(PipelineAdCreativePlan plan, CreateCreativeRequest creative) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("Crie uma imagem de anúncio para Meta Ads. ");
         if (plan.imageBriefing() != null && StringUtils.hasText(plan.imageBriefing().visualBriefing())) {
             prompt.append(plan.imageBriefing().visualBriefing()).append(' ');
         }
-        if (StringUtils.hasText(plan.primaryText())) {
-            prompt.append("Mensagem do anúncio: ").append(plan.primaryText()).append(' ');
+        if (StringUtils.hasText(creative.getPrimaryText())) {
+            prompt.append("Mensagem do anúncio: ").append(creative.getPrimaryText()).append(' ');
         }
-        if (StringUtils.hasText(plan.headline())) {
-            prompt.append("Headline: ").append(plan.headline()).append(' ');
+        if (StringUtils.hasText(creative.getHeadline())) {
+            prompt.append("Headline: ").append(creative.getHeadline()).append(' ');
         }
+        prompt.append(IMAGE_TEXT_GUARD);
         return prompt.toString().trim();
+    }
+
+    /** Normaliza o criativo para respeitar o contrato persistivel do backend e da Meta. */
+    private void normalizeCreativeContract(CreateCreativeRequest creative) {
+        if (creative == null) {
+            return;
+        }
+        creative.setHeadline(limitText(creative.getHeadline(), CREATIVE_TEXT_MAX_LENGTH));
+        creative.setPrimaryText(limitText(creative.getPrimaryText(), CREATIVE_TEXT_MAX_LENGTH));
+        creative.setDescription(limitText(creative.getDescription(), CREATIVE_TEXT_MAX_LENGTH));
+        creative.setCta(normalizeMetaCallToAction(creative.getCta()));
     }
 
     /** Define o prompt de imagem do modo padrão usando prompt customizado ou texto do criativo. */
     private String defaultImagePrompt(ExperimentDto dto, CreateCreativeRequest creative) {
         if (StringUtils.hasText(dto.getCreativeImagePrompt())) {
-            return dto.getCreativeImagePrompt();
+            return dto.getCreativeImagePrompt().trim() + " " + IMAGE_TEXT_GUARD;
         }
-        return "Crie uma imagem de anúncio para Meta Ads alinhada ao texto: " + creative.getPrimaryText();
+        return "Crie uma imagem de anúncio para Meta Ads alinhada ao texto: "
+                + creative.getPrimaryText()
+                + " "
+                + IMAGE_TEXT_GUARD;
     }
 
     /** Normaliza CTA livre para o tipo canônico aceito pelo backend e pela Meta. */
@@ -180,6 +199,22 @@ public class CreativeGenerationService {
             return normalized;
         }
         return DEFAULT_META_CALL_TO_ACTION;
+    }
+
+    /** Limita texto em fronteira de palavra para impedir falha de persistencia por coluna curta. */
+    private String limitText(String value, int maxLength) {
+        if (!StringUtils.hasText(value) || value.length() <= maxLength) {
+            return value;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() <= maxLength) {
+            return trimmed;
+        }
+        int boundary = trimmed.lastIndexOf(' ', maxLength);
+        if (boundary < maxLength / 2) {
+            boundary = maxLength;
+        }
+        return trimmed.substring(0, boundary).trim();
     }
 
     /** Extrai a mensagem raiz para gravar erro operacional legível no backend. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeGenerationServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeGenerationServiceTest.java
@@ -59,6 +59,52 @@ class CreativeGenerationServiceTest {
         verify(backendClient).markCompleted(49L);
     }
 
+    /**
+     * Garante que textos longos gerados pela IA sejam ajustados antes do envio ao backend.
+     */
+    @Test
+    void shouldNormalizeGeneratedCreativeTextBeforeSaving() {
+        CreativeGenerationBackendClient backendClient = mock(CreativeGenerationBackendClient.class);
+        CreativeChatGptClient textClient = mock(CreativeChatGptClient.class);
+        CreativeImageClient imageClient = mock(CreativeImageClient.class);
+        CreativeGenerationService service =
+                new CreativeGenerationService(backendClient, textClient, imageClient, new ObjectMapper());
+        ExperimentDto experiment = pendingExperiment();
+        experiment.setCreativeImagePrompt(null);
+        CreateCreativeRequest generated = new CreateCreativeRequest();
+        generated.setHeadline(repeat("Headline longa", 30));
+        generated.setPrimaryText(repeat("Texto principal persuasivo", 30));
+        generated.setDescription(repeat("Descricao complementar", 30));
+        generated.setCta("Gerar minha amostra personalizada agora");
+
+        when(backendClient.listPending(5)).thenReturn(List.of(experiment));
+        when(textClient.generateCreatives(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq(1)))
+                .thenReturn(new CreativeChatGptClient.Generation(List.of(generated), null, null));
+        when(imageClient.generateImage(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn("/assets/creative.jpg");
+
+        CreativeGenerationService.ProcessingSummary summary = service.processPending(5);
+
+        assertThat(summary.failed()).isZero();
+        ArgumentCaptor<CreateCreativeRequest> creativeCaptor = ArgumentCaptor.forClass(CreateCreativeRequest.class);
+        verify(backendClient).createCreative(org.mockito.ArgumentMatchers.eq(49L), creativeCaptor.capture());
+        CreateCreativeRequest saved = creativeCaptor.getValue();
+        assertThat(saved.getHeadline()).hasSizeLessThanOrEqualTo(255);
+        assertThat(saved.getPrimaryText()).hasSizeLessThanOrEqualTo(255);
+        assertThat(saved.getDescription()).hasSizeLessThanOrEqualTo(255);
+        assertThat(saved.getCta()).isEqualTo("LEARN_MORE");
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(imageClient).generateImage(
+                promptCaptor.capture(),
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.anyString());
+        assertThat(promptCaptor.getValue()).contains(saved.getPrimaryText());
+        assertThat(promptCaptor.getValue()).contains("Nao incluir texto, letras, numeros");
+    }
+
     /** Cria um experimento pendente mínimo para o cenário de teste. */
     private ExperimentDto pendingExperiment() {
         ExperimentDto dto = new ExperimentDto();
@@ -70,5 +116,10 @@ class CreativeGenerationServiceTest {
         dto.setCreativesToGenerate(1);
         dto.setCreativeImagePrompt("Prompt visual");
         return dto;
+    }
+
+    /** Repete um texto de base para montar entradas maiores que o contrato persistivel. */
+    private String repeat(String text, int times) {
+        return String.join(" ", java.util.Collections.nCopies(times, text));
     }
 }

--- a/docs/registros/experimento-56-creative-contract.md
+++ b/docs/registros/experimento-56-creative-contract.md
@@ -1,0 +1,22 @@
+# Experimento 56 - contrato de texto de criativos
+
+Data: 2026-07-05
+
+## Problema
+
+O experimento 56 ficou sem criativos aprovaveis porque o AI Worker gerou um `primaryText` maior que o contrato persistivel do backend. O banco usa `creative.primary_text VARCHAR(255)`, e o modo `DEFAULT` enviava a resposta da IA para o backend sem reforcar esse limite.
+
+## Causa-raiz
+
+O prompt orientava limites de copy, mas o worker confiava na aderencia da resposta do modelo. Quando a IA devolveu texto maior, o backend falhou ao persistir com `Data too long for column 'primary_text'`.
+
+## Correção aplicada
+
+- Normalizar `headline`, `primaryText` e `description` para ate 255 caracteres antes do envio ao backend.
+- Manter CTA livre longo como `LEARN_MORE`, preservando compatibilidade com o tipo aceito pela Meta.
+- Aplicar a normalizacao tanto no modo `DEFAULT` quanto no modo `PIPELINE_ADS`.
+- Adicionar teste de regressao cobrindo resposta longa da IA antes do salvamento.
+
+## Prevenção
+
+Nenhum fluxo de criativo deve depender apenas do prompt para cumprir contrato de persistencia/publicacao. A saida de IA precisa ser validada e ajustada no worker antes de chamar o backend.


### PR DESCRIPTION
## Resumo
- Corrige o AI Worker para normalizar `headline`, `primaryText` e `description` para o limite persistível de 255 caracteres antes de chamar o backend.
- Mantém CTA livre longo como `LEARN_MORE`, compatível com backend/Meta.
- Aplica o contrato tanto no modo `DEFAULT` quanto no `PIPELINE_ADS`.
- Adiciona guarda no prompt de imagem para evitar texto legível dentro do criativo gerado.
- Registra a causa-raiz do experimento 56 em `docs/registros`.

## Causa-raiz
O modo `DEFAULT` confiava apenas no prompt para cumprir o contrato do banco. Quando a IA retornou `primaryText` maior que `creative.primary_text VARCHAR(255)`, o backend falhou com `Data too long for column 'primary_text'` e o experimento ficou sem criativo aprovado.

## Validação
- `backend/ads-service`: `mvn -DskipTests install` para disponibilizar o snapshot local usado pelo ai-worker.
- `ai-worker`: `mvn -Dtest=CreativeGenerationServiceTest test` passou.
- `ai-worker`: `mvn test` passou com 200 testes, 0 falhas, 2 skipped.

## Reprocessamento operacional
- Experimento 56 reprocessado após a correção.
- Criativo aprovado: `207`.
- Readiness do experimento 56 sem issues: página, público e criativo OK.

Observação: a fila de campanhas prontas ainda retornou vazia após o criativo aprovado, então qualquer próximo bloqueio não parece mais ser geração de criativo; deve ser checado como gate operacional separado.