### PR TITLE
[codex] Documenta funil de amostra personalizada

### DIFF
--- a/docs/canonical/product-types-canon.v1.md
+++ b/docs/canonical/product-types-canon.v1.md
@@ -107,6 +107,26 @@ Depois que o experimento `AI_PERSONALIZED_SAMPLE` existir, a publicacao de campa
 
 A pagina de venda aprovada pelo GeraSalesPage para `AI_PERSONALIZED_SAMPLE` deve ser publicada dentro desse mesmo `LeadPortalFlow` de coleta, com formulario gerenciado pelo Lead Portal. O link de campanha deve apontar para esse funil-pagina unico. E proibido publicar uma pagina separada que trate o funil como checkout direto ou que pule a coleta de dados de personalizacao.
 
+O valor central de `AI_PERSONALIZED_SAMPLE` e vender uma solucao aplicada a realidade do lead, nao vender "IA", template generico ou PDF estatico. A amostra gratuita deve provar a personalizacao com um recorte pequeno e util; o produto pago deve entregar a versao completa tambem personalizada, usando os dados capturados no Lead Portal. Se a amostra for personalizada e a entrega paga for generica, o funil quebra a promessa, reduz valor percebido e aumenta risco de frustracao.
+
+Funil canonico recomendado para o primeiro teste:
+
+```text
+Anuncio
+→ Lead Portal com promessa e formulario curto
+→ Amostra personalizada gratuita
+→ E-mail 1: entrega da amostra e oferta leve
+→ E-mail 2: follow-up de conversao
+→ Checkout
+→ Entrega paga personalizada
+```
+
+Para o primeiro experimento, a sequencia deve ser simples: dois e-mails sao suficientes para validar interesse, clique e compra sem aumentar complexidade operacional. Sequencias maiores so devem ser usadas depois, quando houver evidencia de abertura, clique, resposta ou interesse sem compra.
+
+O produto pago deve ser uma entrega hibrida personalizada: estrutura-base padronizada para escalar, com conteudo final adaptado aos dados do lead. A entrega deve conter diagnostico, plano ou materiais aplicaveis ao contexto declarado, separando claramente o que foi recebido como amostra gratuita e o que foi liberado apos pagamento.
+
+Exemplo canonico de aplicacao: para manicures em domicilio, a amostra gratuita pode ser uma `Agenda Blindada 7D` parcial com diagnostico da agenda e 1 ou 2 mensagens personalizadas. A compra deve entregar o `Kit Personalizado Agenda Blindada 7D`, com diagnostico completo, plano dos proximos 7 dias, mensagens de confirmacao, cobranca de sinal, reagendamento, atraso e cliente que some, adaptadas ao tom escolhido e aos dados de agenda informados.
+
 Os prompts ativos do GeraSalesPage devem receber contexto suficiente para diferenciar venda direta de funil de personalização. Para `AI_PERSONALIZED_SAMPLE`, o destino comercial da página deve ser o funil-pagina do Lead Portal, deixando claro para o worker que a primeira ação pública é coleta de dados, não checkout direto. O quality review deve aceitar formulário somente nesse subtipo e deve bloquear qualquer ambiguidade entre amostra gratuita, produto pago, preço e entrega paga.
 
 Para `AI_PERSONALIZED_SAMPLE`, a pagina publicada dentro do Lead Portal nunca deve embutir o proprio Lead Portal, flow ou funil em `iframe`. O backend deve remover iframe autorreferente antes de publicar e os prompts/schemas ativos devem instruir o worker a usar bloco de formulario gerenciado, nao iframe, para evitar recursao visual e perda de experiencia do lead.

--- a/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
+++ b/docs/implementacao/experimentos/plano-experimentos-produto-ia-visual-personalizado.md
@@ -88,16 +88,46 @@ Campos mínimos do funil:
 - dados de personalização;
 - preferências visuais.
 
+## Funil de valor para `AI_PERSONALIZED_SAMPLE`
+
+O experimento precisa deixar claro que a personalizacao e parte da entrega inteira. A amostra gratuita e uma prova pequena do mecanismo; o produto pago e a versao completa personalizada. Nao deve haver amostra personalizada seguida de produto final generico.
+
+Fluxo recomendado para o primeiro teste:
+
+```text
+Anuncio
+→ Lead Portal com formulario curto
+→ Amostra personalizada gerada por IA
+→ E-mail 1: entrega da amostra + oferta leve
+→ E-mail 2: follow-up de conversao
+→ Checkout
+→ Produto final personalizado
+```
+
+O primeiro e-mail deve entregar a amostra, reforcar o principal diagnostico e apresentar a oferta paga sem pressao. O segundo e-mail deve sair depois de aproximadamente 24 horas, reativar a dor, mostrar aplicacao pratica e chamar para o checkout. Quatro ou mais e-mails so fazem sentido em uma otimizacao posterior, quando o funil ja tiver sinais de abertura, clique ou resposta sem compra.
+
+O valor oferecido nao deve ser "usar IA". O valor deve ser reduzir esforco e dor com uma solucao aplicada ao contexto do lead. A entrega paga deve usar uma base padrao para escalar, mas adaptar diagnostico, plano, mensagens, ativos ou recomendacoes aos dados capturados no Lead Portal.
+
+Exemplo de referencia:
+
+- nicho: manicures autonomas que atendem em domicilio;
+- dor: faltas, atrasos, cancelamentos e deslocamentos perdidos;
+- amostra gratuita: `Agenda Blindada 7D` parcial com diagnostico e 1 ou 2 mensagens personalizadas;
+- produto pago: `Kit Personalizado Agenda Blindada 7D`;
+- entrega paga: diagnostico completo da agenda, plano dos proximos 7 dias, mensagens para confirmar horario, cobrar sinal, reagendar, lidar com atraso e cliente que some, no tom escolhido pela lead.
+
 ## Desenho experimental inicial
 
 Fluxo:
 
 ```text
 Anuncio
-→ Pagina/formulario com promessa unica
-→ Entrada minima do lead
+→ Lead Portal com promessa unica e formulario curto
 → Amostra personalizada gerada por IA
-→ Oferta paga para pacote completo
+→ E-mail de entrega com oferta leve
+→ E-mail de follow-up
+→ Checkout
+→ Entrega paga personalizada
 → Compra/nao compra
 ```
 


### PR DESCRIPTION
## O que mudou

- Detalha no cânone de tipos de produto que `AI_PERSONALIZED_SAMPLE` deve entregar amostra gratuita personalizada e produto final pago também personalizado.
- Define o funil recomendado do primeiro teste: anúncio, Lead Portal, amostra, 2 e-mails, checkout e entrega paga personalizada.
- Atualiza o plano de experimentos de Produto IA com a lógica de valor, sequência mínima de e-mails e exemplo de manicure em domicílio com `Agenda Blindada 7D`.

## Por que mudou

A conversa definiu que o produto final não pode ser genérico quando a amostra é personalizada. A promessa comercial do subtipo depende de entregar uma solução aplicada à realidade do lead, não apenas um template ou PDF estático.

## Alternativas avaliadas

1. Documentar só no plano de implementação: menor esforço, mas deixaria o cânone incompleto.
2. Alterar código agora: poderia antecipar implementação sem pedido explícito e misturar escopo.
3. Atualizar cânone e plano documental: melhor equilíbrio para registrar a decisão de produto e orientar implementação futura sem mudar runtime.

Escolha: alternativa 3, porque preserva a decisão estratégica no documento canônico e no plano operacional, mantendo o PR restrito ao que foi solicitado.

## Validação

- `git diff --check`
- Comparação remota confirmou apenas 2 arquivos Markdown alterados.