### PR TITLE
[codex] documenta bloqueio de página sem acentuação

### DIFF
--- a/docs/canonical/gerasalespage-arquitetura-canon.v1.md
+++ b/docs/canonical/gerasalespage-arquitetura-canon.v1.md
@@ -25,6 +25,7 @@ O GeraSalesPage v1 é um pipeline independente para gerar página de vendas dire
 - O worker não carrega prompt/schema local para este pipeline.
 - Toda chamada OpenAI deve registrar request, response bruto, modelo, tokens, custo e erro quando houver.
 - A revisão de checkout deve bloquear liberação para tráfego quando checkout, promessa, preço, garantia ou CTA estiverem incoerentes.
+- A revisão de qualidade deve bloquear HTML público com português sem acentuação em termos comuns de venda, atendimento e entrega, como `nao`, `voce`, `informacao`, `producao`, `pendencia` e `endereco`, pois isso reduz confiança antes do checkout e invalida a página para tráfego pago.
 - Experimento `LOW_TICKET_PRODUCT` só pode ser liberado para campanha quando a etapa final `sales-page-publication-package` estiver `CONCLUIDO`; URL de página preenchida manualmente não substitui a conclusão do pipeline.
 - A liberação de campanha low-ticket também exige snapshot auditado da página publicada em banco. O link do anúncio deve apontar para essa página de venda, nunca direto para checkout; o checkout permanece apenas dentro dos CTAs da página.
 - O HTML publicável da página de venda deve conter os coletores `page_view`, `page_load_metric`, `section_view_time` e `checkout_click`. Página sem qualquer um desses coletores deve ser republicada antes de receber tráfego pago.


### PR DESCRIPTION
## O que mudou

- Adiciona ao cânone do GeraSalesPage v1 uma regra para bloquear HTML público com português sem acentuação em termos comuns de venda, atendimento e entrega.

## Por que mudou

A página de venda do experimento 54 apresentou textos como `nao`, `voce`, `informacao`, `producao`, `pendencia` e `endereco`. Esse tipo de falha reduz confiança antes do checkout e não pode ser liberado para tráfego pago.

## Causa-raiz

O gate comercial do GeraSalesPage cobria coerência de checkout, promessa, preço, garantia, CTA e publicação, mas não tratava acentuação básica como critério bloqueante de qualidade comercial.

## Orientação de implementação futura

- Corrigir a página publicada afetada.
- Ajustar prompt e quality review do GeraSalesPage para reprovar português sem acentuação.
- Criar teste automático que falhe quando o HTML público contiver termos comuns sem acento.

## Validação

- `git diff --check`
- Revisão manual do diff documental
