### PR TITLE
[codex] Bloqueia GeraSalesPage sem acentuação

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -23,8 +23,11 @@ import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -42,6 +45,10 @@ public class GeraSalesPagePublicationAuditService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final Pattern IFRAME_BLOCK_PATTERN =
             Pattern.compile("(?is)<iframe\\b[^>]*>.*?</iframe>");
+    private static final Pattern COMMON_UNACCENTED_PORTUGUESE_PATTERN = Pattern.compile(
+            "(?iu)(?<![\\p{L}])(" 
+                    + "nao|voce|informacao|producao|pendencia|endereco|proximo|almoco|atencao|solucao"
+                    + ")(?![\\p{L}@-])");
 
     private final ExperimentRepository experimentRepository;
     private final GeraSalesPageStageExecutionRepository executionRepository;
@@ -137,6 +144,7 @@ public class GeraSalesPagePublicationAuditService {
                 packagePayload.get("publicUrl"),
                 packagePayload.get("publishedUrl"),
                 packagePayload.get("pageUrl"));
+        validatePublicPortugueseAccentuation(experiment, publicationExecution, html);
         PersonalizedSamplePublication personalizedSamplePublication =
                 publishPersonalizedSampleSalesPageIfNeeded(experiment, html);
         boolean personalizedSampleSalesPage = personalizedSamplePublication != null;
@@ -175,6 +183,39 @@ public class GeraSalesPagePublicationAuditService {
             return StringUtils.hasText(checkoutUrl) ? checkoutUrl : null;
         }
         return StringUtils.hasText(checkoutUrl) ? checkoutUrl : experiment.getFollowUpActionUrl();
+    }
+
+    /** Bloqueia publicacao de pagina publica com termos comerciais comuns sem acentuacao. */
+    private void validatePublicPortugueseAccentuation(
+            Experiment experiment,
+            GeraSalesPageStageExecution publicationExecution,
+            String html) {
+        Set<String> unaccentedTerms = findCommonUnaccentedPortugueseTerms(html);
+        if (unaccentedTerms.isEmpty()) {
+            return;
+        }
+        String terms = String.join(", ", unaccentedTerms);
+        log.warn(
+                "GeraSalesPage bloqueou HTML publico sem acentuacao: experimentId={}, idJob={}, termos={}",
+                experiment.getId(),
+                publicationExecution.getIdJob(),
+                terms);
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "GeraSalesPage bloqueou a publicacao por portugues sem acentuacao em termos comuns: " + terms);
+    }
+
+    /** Localiza termos comuns sem acento preservando a ordem em que aparecem no HTML. */
+    private Set<String> findCommonUnaccentedPortugueseTerms(String html) {
+        Set<String> terms = new LinkedHashSet<>();
+        if (!StringUtils.hasText(html)) {
+            return terms;
+        }
+        Matcher matcher = COMMON_UNACCENTED_PORTUGUESE_PATTERN.matcher(html);
+        while (matcher.find()) {
+            terms.add(matcher.group(1).toLowerCase(Locale.ROOT));
+        }
+        return terms;
     }
 
     /** Publica pagina low-ticket standalone no Lead Portal e usa essa URL como destino oficial da campanha. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-04-gera-sales-page-product-ai-templates-v3.yaml
@@ -63,3 +63,47 @@ databaseChangeLog:
                 schema_json = VALUES(schema_json),
                 active = true,
                 updated_at = CURRENT_TIMESTAMP;
+  - changeSet:
+      id: 2026-07-05-gera-sales-page-accentuation-templates-v4-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ai_prompt_schema_template
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ai_prompt_schema_template
+              SET active = false, updated_at = CURRENT_TIMESTAMP
+              WHERE pipeline_code = 'gera-sales-page-v1'
+                AND stage_code IN (
+                  'sales-page-html',
+                  'sales-page-checkout-quality-review',
+                  'sales-page-publication-package'
+                );
+
+              INSERT INTO ai_prompt_schema_template
+                (template_key, pipeline_code, stage_code, version, openai_model, schema_name, prompt_markdown_content, schema_json, active, created_at, updated_at)
+              VALUES
+                ('gera-sales-page-v1:sales-page-html:v4', 'gera-sales-page-v1', 'sales-page-html', 'v4', 'gpt-5.5', 'gera_sales_page_v1_html',
+                 'Você é desenvolvedor front-end de landing de vendas. Gere a etapa sales-page-html do GeraSalesPage v1 em HTML responsivo e português brasileiro profissional, com acentuação correta em todo texto público, incluindo títulos, botões, bullets, placeholders e mensagens de formulário. É proibido entregar termos comuns sem acento como nao, voce, informacao, producao, pendencia, endereco, proximo, almoco, atencao ou solucao. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, os CTAs devem apontar para o bloco de formulário gerenciado; não crie checkout direto como primeira ação, não crie campos próprios fora do formulário gerenciado e nunca use iframe para carregar o Lead Portal, flow ou a própria URL do funil. Explique amostra, preço e entrega paga com clareza. Se salesPageDestination=DIRECT_CHECKOUT, use a URL de checkout real e não crie formulário. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["html","checkoutUrl","notes"],"properties":{"html":{"type":"string"},"checkoutUrl":{"type":"string"},"notes":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-checkout-quality-review:v4', 'gera-sales-page-v1', 'sales-page-checkout-quality-review', 'v4', 'gpt-5.5', 'gera_sales_page_v1_checkout_quality_review',
+                 'Você é auditor comercial. Revise a página do GeraSalesPage v1 como material que receberá tráfego pago. Bloqueie sempre que o HTML público tiver português brasileiro sem acentuação em termos comuns de venda, atendimento ou entrega, incluindo nao, voce, informacao, producao, pendencia, endereco, proximo, almoco, atencao e solucao. Esse erro reduz confiança antes do checkout e invalida a página para mídia paga. Se salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, aprove formulário e CTA para coleta de personalização, mas bloqueie se a página confundir amostra gratuita, compra paga, preço, entrega completa ou limites da amostra. Bloqueie sempre que houver iframe apontando para Lead Portal, flow, funil ou para a própria página. Não exija checkout direto nesse caso. Se salesPageDestination=DIRECT_CHECKOUT, bloqueie se CTA não apontar para checkout real ou se houver formulário obrigatório. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["approved","blockers","recommendation"],"properties":{"approved":{"type":"boolean"},"blockers":{"type":"array","items":{"type":"string"}},"recommendation":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-publication-package:v4', 'gera-sales-page-v1', 'sales-page-publication-package', 'v4', 'gpt-5.5', 'gera_sales_page_v1_publication_package',
+                 'Você é responsável por empacotar a página para publicação. Antes de retornar readyForTraffic=true, revise o HTML final e bloqueie qualquer português brasileiro sem acentuação em texto público, como nao, voce, informacao, producao, pendencia, endereco, proximo, almoco, atencao ou solucao. Para salesPageDestination=LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, mantenha HTML publicável no funil-página, CTAs para o formulário gerenciado, clareza de amostra gratuita, produto pago, preço e entrega; o checklist deve confirmar acentuação correta, ausência de checkout direto como primeira ação e ausência de iframe para Lead Portal, flow ou a própria página. Para checkout real, mantenha checkoutUrl e checklist de liberação para mídia paga. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["readyForTraffic","html","checkoutUrl","releaseChecklist"],"properties":{"readyForTraffic":{"type":"boolean"},"html":{"type":"string"},"checkoutUrl":{"type":"string"},"releaseChecklist":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+              ON DUPLICATE KEY UPDATE
+                prompt_markdown_content = VALUES(prompt_markdown_content),
+                schema_json = VALUES(schema_json),
+                active = true,
+                updated_at = CURRENT_TIMESTAMP;

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.gerasalespage.v1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Valida o snapshot historico de publicacoes do GeraSalesPage v1. */
 @ExtendWith(MockitoExtension.class)
@@ -188,6 +190,33 @@ class GeraSalesPagePublicationAuditServiceTest {
         Map<?, ?> formSpec = (Map<?, ?>) customPayload.get("formSpec");
         assertThat(formSpec.get("formId")).isEqualTo("lead-portal-personalized-sample-form");
         assertThat((List<?>) formSpec.get("fields")).hasSize(2);
+    }
+
+    /** Deve bloquear HTML publico com termos comerciais comuns em portugues sem acentuacao. */
+    @Test
+    void shouldBlockPublicationWithCommonUnaccentedPortugueseTerms() {
+        Experiment experiment = new Experiment();
+        experiment.setId(53L);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/checkout");
+        GeraSalesPageStageExecution publication = execution(
+                "job-publication",
+                GeraSalesPageStageCode.PUBLICATION_PACKAGE.code(),
+                "{\"html\":\"<html><body><h1>Voce nao precisa perder o almoco</h1>"
+                        + "<p>Receba informacao no proximo endereco.</p></body></html>\","
+                        + "\"checkoutUrl\":\"https://mp.test/checkout\"}",
+                Instant.parse("2026-07-01T10:10:00Z"));
+
+        when(publicationRepository.existsByPublicationJobId("job-publication")).thenReturn(false);
+        when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L))
+                .thenReturn(List.of(publication));
+
+        assertThatThrownBy(() -> service.snapshotPublication(publication))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("voce")
+                .hasMessageContaining("nao")
+                .hasMessageContaining("informacao")
+                .hasMessageContaining("endereco");
     }
 
     /** Cria execução concluída mínima para snapshot de teste. */


### PR DESCRIPTION
## O que mudou

- Adiciona trava no backend para bloquear publicação do GeraSalesPage quando o HTML final contém termos comuns em português sem acentuação.
- Versiona templates v4 do GeraSalesPage para reforçar acentuação obrigatória nas etapas de HTML, quality review e publication package.
- Adiciona teste unitário cobrindo bloqueio com termos como `voce`, `nao`, `informacao`, `proximo`, `almoco` e `endereco`.

## Causa-raiz

A regra estava apenas documentada: o prompt/quality review ainda podia deixar passar HTML público com português sem acentuação, e a publicação não tinha uma trava final antes de salvar/publicar a página.

## Validação

- `../mvnw -Dtest=GeraSalesPagePublicationAuditServiceTest test`
- `git diff origin/main...HEAD --check` no commit local equivalente
