### PR TITLE
[codex] Allow sales page for personalized sample funnels

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java
@@ -12,9 +12,11 @@ import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
 import com.marketinghub.productai.ProductAiSubtype;
 import jakarta.persistence.EntityNotFoundException;
+import java.net.URI;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -60,7 +62,7 @@ public class GeraSalesPageStageService {
         this.objectMapper = objectMapper;
     }
 
-    /** Inicia o pipeline na primeira etapa, bloqueando experimento sem checkout real. */
+    /** Inicia o pipeline na primeira etapa, bloqueando experimento sem destino comercial válido. */
     @Transactional
     public GeraSalesPageStartResponse start(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId)
@@ -279,13 +281,55 @@ public class GeraSalesPageStageService {
                 && !url.contains("#checkout");
     }
 
-    /** Bloqueia início ou rebuild sem checkout real persistido no experimento. */
+    /** Bloqueia início ou rebuild sem checkout real ou funil de amostra personalizada aprovado. */
     private void validateCheckoutUrl(Experiment experiment) {
+        if (usesPersonalizedSampleFunnelAsDestination(experiment)) {
+            return;
+        }
         if (!isRealCheckoutUrl(resolveCheckoutUrl(experiment))) {
             throw new ResponseStatusException(
                     HttpStatus.CONFLICT,
                     "GeraSalesPage v1 exige URL real de checkout antes de iniciar.");
         }
+    }
+
+    /** Confirma que Produto IA personalizado usa o funil aprovado do Lead Portal como primeiro destino. */
+    private boolean usesPersonalizedSampleFunnelAsDestination(Experiment experiment) {
+        if (experiment == null || experiment.getProductAiSubtype() != ProductAiSubtype.AI_PERSONALIZED_SAMPLE) {
+            return false;
+        }
+        if (experiment.getLeadPortalFlow() == null
+                || !experiment.getLeadPortalFlow().isApproved()
+                || !StringUtils.hasText(experiment.getLeadPortalFlow().getSlug())) {
+            return false;
+        }
+        String destinationPath = destinationPath(experiment.getFollowUpActionUrl());
+        String expectedPath = "/flows/" + experiment.getLeadPortalFlow().getSlug().trim().toLowerCase(Locale.ROOT);
+        return expectedPath.equals(destinationPath);
+    }
+
+    /** Extrai o caminho da URL pública para comparar com o slug do funil. */
+    private String destinationPath(String url) {
+        if (!StringUtils.hasText(url)) {
+            return "";
+        }
+        try {
+            return normalizeUrl(URI.create(url.trim()).getPath());
+        } catch (IllegalArgumentException ex) {
+            return "";
+        }
+    }
+
+    /** Normaliza caminho ou URL removendo espaços, caixa e barra final. */
+    private String normalizeUrl(String url) {
+        if (!StringUtils.hasText(url)) {
+            return "";
+        }
+        String normalized = url.trim().toLowerCase(Locale.ROOT);
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
     }
 
     /** Resolve o checkout interno priorizando auditoria anterior quando followUpActionUrl já virou página. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -183,6 +183,38 @@ class ExperimentReadinessServiceTest {
     }
 
     @Test
+    void shouldAllowPersonalizedSampleProductAiCampaignAfterGeraSalesPagePublishesLeadPortalFunnel() {
+        Experiment experiment = buildExperiment(57L, 30L);
+        experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);
+        experiment.setCampaignObjective(ExperimentCampaignObjective.SALES);
+        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        experiment.setLeadPortalFlow(productAiFlow(
+                "nome",
+                "email",
+                "whatsapp",
+                "negocio_projeto",
+                "contexto_atual",
+                "objetivo_visual",
+                "dados_personalizacao"));
+        experiment.getLeadPortalFlow().setSlug("decoraia-express-exp-57");
+        experiment.setFollowUpActionUrl("https://oportunidadebrasil.shop/flows/decoraia-express-exp-57");
+        experiment.getNiche().setFacebookPixelId("pixel-exp57");
+        completeCommercialContract(experiment);
+
+        when(creativeRepository.existsByExperimentIdAndStatus(57L, CreativeStatus.READY)).thenReturn(true);
+        mockPublishableSelection(57L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(57L);
+        mockSalesPageAudit(
+                57L,
+                "https://oportunidadebrasil.shop/flows/decoraia-express-exp-57",
+                null,
+                trackedSalesPageHtml());
+
+        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
+        assertThat(service.isReadyForCampaign(experiment)).isTrue();
+    }
+
+    @Test
     void shouldAllowLowTicketCampaignOnlyAfterGeraSalesPagePublicationPackage() {
         Experiment experiment = buildExperiment(53L, 63L);
         experiment.setExperimentType(ExperimentType.LOW_TICKET_PRODUCT);

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageServiceTest.java
@@ -12,6 +12,8 @@ import com.marketinghub.experiment.service.ExperimentAiPromptSchemaUsageService;
 import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageExecution;
+import com.marketinghub.leadportal.LeadPortalFlow;
+import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPageStageExecutionRepository;
@@ -97,6 +99,56 @@ class GeraSalesPageStageServiceTest {
                 GeraSalesPageStageCode.OFFER_BRIEF.code(),
                 newExecution.getValue().getIdJob());
         assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+    }
+
+    /** Deve permitir Produto IA personalizado quando o destino é o funil aprovado de amostra. */
+    @Test
+    void startShouldAllowPersonalizedSampleFunnelWithoutDirectCheckout() {
+        Experiment experiment = new Experiment();
+        experiment.setId(57L);
+        experiment.setProductAiSubtype(ProductAiSubtype.AI_PERSONALIZED_SAMPLE);
+        experiment.setFollowUpActionUrl("https://oportunidadebrasil.shop/flows/decoraia-express-exp-57");
+        experiment.setLeadPortalFlow(LeadPortalFlow.builder()
+                .id(39L)
+                .slug("decoraia-express-exp-57")
+                .approved(true)
+                .build());
+        completeCommercialContract(experiment);
+
+        when(experimentRepository.findById(57L)).thenReturn(Optional.of(experiment));
+        AiPromptSchemaTemplate activeTemplate = template(GeraSalesPageStageCode.OFFER_BRIEF.code());
+        when(templateRepository.findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
+                "gera-sales-page-v1", GeraSalesPageStageCode.OFFER_BRIEF.code()))
+                .thenReturn(Optional.of(activeTemplate));
+        when(executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                57L,
+                GeraSalesPageStageCode.OFFER_BRIEF.code()))
+                .thenReturn(Optional.empty());
+        when(executionRepository.save(any(GeraSalesPageStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GeraSalesPageStartResponse response = service.start(57L);
+
+        assertThat(response.stageCode()).isEqualTo(GeraSalesPageStageCode.OFFER_BRIEF.code());
+        verify(promptSchemaUsageService).linkSalesPageTemplate(
+                57L,
+                activeTemplate,
+                GeraSalesPageStageCode.OFFER_BRIEF.code(),
+                response.jobid());
+    }
+
+    /** Deve continuar bloqueando venda direta sem checkout real. */
+    @Test
+    void startShouldRejectDirectSalesPageWithoutCheckout() {
+        Experiment experiment = new Experiment();
+        experiment.setId(58L);
+        experiment.setFollowUpActionUrl("#checkout");
+        completeCommercialContract(experiment);
+        when(experimentRepository.findById(58L)).thenReturn(Optional.of(experiment));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.start(58L))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("checkout");
     }
 
     /** Deve bloquear o início quando a etapa Oferta ainda não preencheu contrato comercial. */

--- a/docs/canonical/trafego-frio-compra-direta-canon.v1.md
+++ b/docs/canonical/trafego-frio-compra-direta-canon.v1.md
@@ -6,10 +6,13 @@ Todo experimento com intenção de compra, identificado por `experimentType = LO
 
 O anúncio não pode apontar diretamente para checkout, link de pagamento ou outro destino de compra.
 
+Para Produto IA `AI_PERSONALIZED_SAMPLE`, o destino intermediário aprovado é o funil-página do Lead Portal vinculado ao experimento. Nesse caso, o GeraSalesPage v1 pode iniciar sem URL de checkout real quando `follow_up_action_url` apontar exatamente para o funil aprovado de coleta da amostra personalizada. A publicação da campanha continua bloqueada até o GeraSalesPage v1 concluir e auditar a página dentro desse funil.
+
 ## Critérios obrigatórios
 
 - O GeraSalesPage v1 precisa concluir a etapa `publication-package` e registrar auditoria da página publicada antes da liberação para Facebook Ads.
 - `follow_up_action_url` deve ser a URL da página de venda auditada, não a URL de checkout.
+- Em `AI_PERSONALIZED_SAMPLE`, `follow_up_action_url` deve ser a URL pública do `LeadPortalFlow` aprovado que receberá a página auditada e o formulário gerenciado de personalização.
 - O checkout deve existir apenas como CTA dentro da página, depois de promessa, prova, mecanismo, objeções e percepção de valor.
 - A página precisa conter coletores mínimos `page_view`, `page_load_metric`, `section_view_time` e `checkout_click`.
 - O backend deve bloquear tanto a liberação manual quanto a fila `/api/facebook-campaigns/experiments-ready` quando essa regra não for cumprida.

--- a/docs/melhorias/experimentos.md
+++ b/docs/melhorias/experimentos.md
@@ -26,6 +26,8 @@ Leitura prática:
 
 Decisão de melhoria aplicada em 2026-07-04: todo experimento com intenção de compra deve passar por página de venda auditada antes de checkout. A regra vale para `LOW_TICKET_PRODUCT` e para qualquer campanha futura com `campaignObjective = SALES`.
 
+Interpretação aplicada em 2026-07-05: Produto IA `AI_PERSONALIZED_SAMPLE` não precisa ter checkout real antes da página quando o primeiro passo comercial é a amostra personalizada. Nesse caso, o GeraSalesPage v1 usa o funil aprovado do Lead Portal como destino intermediário, publica a página dentro dele e só depois a campanha pode ser liberada.
+
 Impacto esperado:
 
 - impedir liberação manual de experimento que mande anúncio direto para checkout;

--- a/docs/registros/experimentos-decoraia-express-2026-07-05.md
+++ b/docs/registros/experimentos-decoraia-express-2026-07-05.md
@@ -3,3 +3,4 @@
 - Decisão: o piloto `DecoraIA Express` deve usar o tipo existente Produto IA com subtipo `AI_PERSONALIZED_SAMPLE`, sem criar módulo ou categoria comercial nova.
 - Correção aplicada: quando o contexto do experimento indicar DecoraIA, decoração ou ambiente por foto, o backend cria o funil do Lead Portal com upload obrigatório da foto do ambiente, ambiente a transformar, incômodo principal, objetivo visual, orçamento aproximado, dados de personalização e preferências visuais.
 - Prevenção de recorrência: teste de controller valida que o funil especializado usa `IMAGE_UPLOAD` obrigatório para `foto_ambiente`, preservando o fluxo rastreável do Marketing Hub para o piloto visual.
+- Ajuste de campanha: o GeraSalesPage v1 pode iniciar para `AI_PERSONALIZED_SAMPLE` usando o funil aprovado do Lead Portal como destino intermediário, sem exigir checkout real antes da amostra. A campanha continua bloqueada até existir publicação auditada do GeraSalesPage dentro desse funil.


### PR DESCRIPTION
## O que muda

- Permite que o GeraSalesPage v1 inicie para Produto IA `AI_PERSONALIZED_SAMPLE` quando o destino inicial for o funil aprovado do Lead Portal.
- Mantém o bloqueio para venda direta sem checkout real.
- Adiciona testes para o fluxo DecoraIA/amostra personalizada e para prontidão de campanha após publicação auditada.
- Atualiza o cânone e registros de marketing para deixar claro que a campanha continua bloqueada até o GeraSalesPage publicar a página dentro do funil.

## Causa-raiz

O fluxo Produto IA personalizado usa amostra antes da compra. O backend já tinha o Lead Portal como destino correto, mas o GeraSalesPage ainda exigia checkout real antes de iniciar, tratando o funil de amostra como se fosse venda direta.

## Impacto

Depois do merge, o próximo passo operacional é iniciar/refazer o GeraSalesPage v1 do experimento DecoraIA Express. A campanha só deve ser liberada depois da publicação auditada da página no funil.

## Validação

- `../mvnw -Dtest=GeraSalesPageStageServiceTest,ExperimentReadinessServiceTest test`
- `git diff --check`

Observação: `spotless:check` não rodou porque o POM do `ads-service` não expõe plugin com prefixo `spotless`.