### PR TITLE
[codex] Corrige pacotes de amostra com imagem no Lead Portal

### DIFF
--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowImagePromptService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowImagePromptService.java
@@ -16,11 +16,15 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+/**
+ * Monta prompts de imagem do Lead Portal a partir do fluxo, respostas do formulário e imagem enviada.
+ */
 @Service
 public class FlowImagePromptService {
 
     private static final int DEFAULT_BATCH_SIZE = 6;
     private static final String DEFAULT_IMAGE_MODEL = "gpt-image-1";
+    private static final int DEFAULT_REFERENCE_IMAGE_FREE_IMAGES = 1;
     private static final String DEFAULT_TEMPLATE = String.join("\n",
             "Gere materiais de divulgação premium em português para {{profissional}}, um(a) {{atividade}} que atua em {{local}}.",
             "Requisitos obrigatórios:",
@@ -33,6 +37,14 @@ public class FlowImagePromptService {
             "Dados coletados no formulário. Use-os para definir copy, cenário, elementos visuais e público-alvo:",
             "{{dados_json}}",
             "");
+    private static final String DEFAULT_REFERENCE_IMAGE_TEMPLATE = String.join("\n",
+            "Gere uma amostra visual personalizada premium em português usando a imagem enviada pelo lead como referência principal.",
+            "Preserve a estrutura, proporções e elementos importantes da foto original. Aplique somente as melhorias solicitadas nas respostas do formulário.",
+            "A saída deve funcionar como prévia gratuita de alto valor, mostrando transformação realista e desejável sem prometer reforma completa.",
+            "",
+            "Dados coletados no formulário:",
+            "{{dados_json}}",
+            "");
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{\\s*([a-zA-Z0-9_.-]+)\\s*\\}\\}");
 
     private final SimpleImageBriefingMapper briefingMapper;
@@ -43,12 +55,17 @@ public class FlowImagePromptService {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Cria o prompt de geração de imagem quando o fluxo possui briefing suficiente para o worker.
+     */
     public Optional<FlowImagePrompt> buildPrompt(Flow flow, FlowSubmission submission) {
-        if (!hasReferenceImage(submission)) {
-            Optional<SimpleImageBriefing> simpleBriefing = briefingMapper.map(flow.slug(), submission);
-            if (simpleBriefing.isPresent()) {
-                return simpleBriefing.map(briefing -> buildSimpleFormPrompt(flow, briefing));
-            }
+        if (hasReferenceImage(submission)) {
+            return buildReferenceImagePrompt(flow, submission);
+        }
+
+        Optional<SimpleImageBriefing> simpleBriefing = briefingMapper.map(flow.slug(), submission);
+        if (simpleBriefing.isPresent()) {
+            return simpleBriefing.map(briefing -> buildSimpleFormPrompt(flow, briefing));
         }
 
         if (!StringUtils.hasText(flow.prompt()) && !StringUtils.hasText(flow.model())) {
@@ -60,6 +77,25 @@ public class FlowImagePromptService {
                 flow.model(),
                 null,
                 null));
+    }
+
+    /**
+     * Monta prompt para fluxos em que a foto enviada deve guiar a amostra personalizada.
+     */
+    private Optional<FlowImagePrompt> buildReferenceImagePrompt(Flow flow, FlowSubmission submission) {
+        if (!hasReferenceImageConfiguration(flow)) {
+            return Optional.empty();
+        }
+
+        int batchSize = resolveBatchSize(flow.imageBatchSize());
+        String template = firstText(flow.imagePromptTemplate(), flow.prompt(), DEFAULT_REFERENCE_IMAGE_TEMPLATE);
+        String prompt = renderTemplate(template, submission, batchSize);
+        if (!StringUtils.hasText(prompt)) {
+            prompt = renderTemplate(DEFAULT_REFERENCE_IMAGE_TEMPLATE, submission, batchSize);
+        }
+        prompt = appendReferenceImageInstructions(prompt, submission);
+        String model = firstText(flow.imagePromptModel(), flow.model(), DEFAULT_IMAGE_MODEL);
+        return Optional.of(new FlowImagePrompt(prompt, model, batchSize, DEFAULT_REFERENCE_IMAGE_FREE_IMAGES));
     }
 
     private FlowImagePrompt buildSimpleFormPrompt(Flow flow, SimpleImageBriefing briefing) {
@@ -82,6 +118,17 @@ public class FlowImagePromptService {
         }
         return StringUtils.hasText(submission.storedFileName())
                 || StringUtils.hasText(submission.originalFileName());
+    }
+
+    private boolean hasReferenceImageConfiguration(Flow flow) {
+        if (flow == null) {
+            return false;
+        }
+        return StringUtils.hasText(flow.imagePromptTemplate())
+                || StringUtils.hasText(flow.prompt())
+                || StringUtils.hasText(flow.imagePromptModel())
+                || StringUtils.hasText(flow.model())
+                || flow.imageBatchSize() != null;
     }
 
     private String serializeBriefing(SimpleImageBriefing briefing) {
@@ -125,6 +172,22 @@ public class FlowImagePromptService {
         return buffer.toString().trim();
     }
 
+    private String renderTemplate(String template, FlowSubmission submission, int batchSize) {
+        if (!StringUtils.hasText(template)) {
+            return null;
+        }
+        Map<String, String> variables = buildSubmissionTemplateVariables(submission, batchSize);
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String replacement = variables.getOrDefault(key, "");
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString().trim();
+    }
+
     private Map<String, String> buildTemplateVariables(SimpleImageBriefing briefing, int batchSize) {
         Map<String, String> variables = new LinkedHashMap<>();
         variables.put("slug", safeOrDefault(briefing.flowSlug(), ""));
@@ -143,6 +206,52 @@ public class FlowImagePromptService {
         flattenAnswers("respostas", briefing.answers(), variables);
         flattenAnswers("answers", briefing.answers(), variables);
         return variables;
+    }
+
+    private Map<String, String> buildSubmissionTemplateVariables(FlowSubmission submission, int batchSize) {
+        Map<String, String> variables = new LinkedHashMap<>();
+        variables.put("slug", safeOrDefault(submission.flowSlug(), ""));
+        variables.put("nome", safeOrDefault(submission.name(), ""));
+        variables.put("name", safeOrDefault(submission.name(), ""));
+        variables.put("email", safeOrDefault(submission.email(), ""));
+        variables.put("image_key", safeOrDefault(submission.imageQuestionKey(), ""));
+        variables.put("stored_file_name", safeOrDefault(submission.storedFileName(), ""));
+        variables.put("original_file_name", safeOrDefault(submission.originalFileName(), ""));
+        variables.put("content_type", safeOrDefault(submission.contentType(), ""));
+        variables.put("batch_size", Integer.toString(batchSize));
+        variables.put("dados_json", serializeSubmission(submission));
+        addAnswerAliases(submission.answers(), variables);
+        flattenAnswers("respostas", submission.answers(), variables);
+        flattenAnswers("answers", submission.answers(), variables);
+        return variables;
+    }
+
+    private String serializeSubmission(FlowSubmission submission) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("nome", submission.name());
+        payload.put("email", submission.email());
+        payload.put("imageQuestionKey", submission.imageQuestionKey());
+        payload.put("originalFileName", submission.originalFileName());
+        payload.put("respostas", submission.answers());
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            return payload.entrySet().stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue())
+                    .collect(Collectors.joining("\n"));
+        }
+    }
+
+    private String appendReferenceImageInstructions(String prompt, FlowSubmission submission) {
+        String basePrompt = StringUtils.hasText(prompt) ? prompt.trim() : DEFAULT_REFERENCE_IMAGE_TEMPLATE;
+        return String.join("\n",
+                basePrompt,
+                "",
+                "Instrução obrigatória sobre a imagem de referência:",
+                "- Use a foto enviada pelo lead como referência visual principal.",
+                "- Não ignore a imagem original; preserve composição, perspectiva e elementos estruturais relevantes.",
+                "- Gere uma amostra personalizada coerente com as respostas do formulário.",
+                "- Arquivo original recebido: " + safeOrDefault(submission.originalFileName(), "imagem enviada pelo lead") + ".");
     }
 
     private void addAnswerAliases(Map<String, Object> answers, Map<String, String> target) {
@@ -228,6 +337,18 @@ public class FlowImagePromptService {
 
     private String safeOrDefault(String value, String fallback) {
         return StringUtils.hasText(value) ? value.trim() : fallback;
+    }
+
+    private String firstText(String... candidates) {
+        if (candidates == null) {
+            return null;
+        }
+        for (String candidate : candidates) {
+            if (StringUtils.hasText(candidate)) {
+                return candidate.trim();
+            }
+        }
+        return null;
     }
 
     private String buildFallbackPrompt(SimpleImageBriefing briefing, int batchSize) {

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
@@ -29,6 +29,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * Registra submissões públicas do Lead Portal, arquivos enviados e pacotes de imagem derivados do fluxo.
+ */
 @Service
 public class FlowSubmissionService {
 
@@ -85,6 +88,9 @@ public class FlowSubmissionService {
         this.imagePipelineEnabled = imagePipelineEnabled;
     }
 
+    /**
+     * Cria uma submissão do fluxo público e inicia o pacote de imagem quando o fluxo exige amostra visual.
+     */
     public FlowSubmission create(String slug, FlowSubmissionRequest request, MultipartFile imageFile) {
         Flow flow = flowService.get(slug);
         validateRequiredQuestions(flow, request, imageFile);
@@ -274,26 +280,25 @@ public class FlowSubmissionService {
                 .orElse(null);
     }
 
+    /**
+     * Cria o pacote de imagem que será consumido pelo worker quando houver configuração funcional no fluxo.
+     */
     private void registerImagePackage(Flow flow, FlowSubmission submission, boolean hasImage) {
-        if (!imagePipelineEnabled) {
+        Optional<FlowImagePrompt> promptSpec = imagePromptService.buildPrompt(flow, submission);
+        if (promptSpec.isEmpty()) {
+            log.info("Skipping image package for submission {} in flow {} because there is no prompt/template.",
+                    submission.id(), flow.slug());
+            return;
+        }
+        if (!imagePipelineEnabled && !shouldCreateImagePackageForFlow(flow, hasImage)) {
             log.info(
                     "Image pipeline disabled. Submission {} from flow {} will only register lead data.",
                     submission.id(),
                     flow.slug());
             return;
         }
-        Optional<FlowImagePrompt> promptSpec = imagePromptService.buildPrompt(flow, submission);
-        if (promptSpec.isEmpty() && !hasImage) {
-            log.info("Skipping image package for submission {} in flow {} because there is no prompt/template.",
-                    submission.id(), flow.slug());
-            return;
-        }
 
-        FlowImagePrompt spec = promptSpec.orElseGet(() -> new FlowImagePrompt(
-                Optional.ofNullable(flow.prompt()).orElse(""),
-                flow.model(),
-                null,
-                null));
+        FlowImagePrompt spec = promptSpec.get();
 
         FlowSubmissionImagePackageEntity imagePackage = new FlowSubmissionImagePackageEntity();
         imagePackage.setSubmissionId(submission.id());
@@ -313,6 +318,18 @@ public class FlowSubmissionService {
 
         FlowSubmissionImagePackageEntity savedPackage = imagePackageRepository.save(imagePackage);
         statusHistoryService.recordStatusChange(savedPackage.getId(), FlowSubmissionImagePackageEntity.Status.RECENT, null);
+    }
+
+    /**
+     * Permite amostras com foto de referência mesmo quando a flag global legada permanece desligada.
+     */
+    private boolean shouldCreateImagePackageForFlow(Flow flow, boolean hasImage) {
+        if (!hasImage || flow == null) {
+            return false;
+        }
+        return StringUtils.hasText(flow.imagePromptTemplate())
+                || StringUtils.hasText(flow.imagePromptModel())
+                || flow.imageBatchSize() != null;
     }
 
     private String normalizeCampaignCode(String value) {

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
@@ -177,6 +177,86 @@ class FlowSubmissionControllerTest {
     }
 
     @Test
+    void submissionWithReferenceImageCreatesPackageWhenFlowHasImagePrompt() throws Exception {
+        Flow visualSampleFlow = new Flow(
+                "decoraia-express",
+                "DecoraIA Express",
+                "Amostra personalizada por foto",
+                null,
+                null,
+                null,
+                "gpt-image-1.5",
+                "Transforme o ambiente de {{nome}} com estilo {{estilo}}. Dados: {{dados_json}}",
+                3,
+                List.of(
+                        new FlowQuestion(
+                                "Nome",
+                                "nome",
+                                FlowQuestionType.TEXT,
+                                true,
+                                "", null,
+                                List.of()),
+                        new FlowQuestion(
+                                "E-mail",
+                                "email",
+                                FlowQuestionType.EMAIL,
+                                true,
+                                "", null,
+                                List.of()),
+                        new FlowQuestion(
+                                "Estilo desejado",
+                                "estilo",
+                                FlowQuestionType.TEXT,
+                                true,
+                                "", null,
+                                List.of()),
+                        new FlowQuestion(
+                                "Foto do ambiente",
+                                "foto_ambiente",
+                                FlowQuestionType.IMAGE_UPLOAD,
+                                true,
+                                "", null,
+                                List.of())),
+                null, null, null, null);
+        flowService.save(visualSampleFlow);
+
+        Map<String, Object> payload = Map.of(
+                "name", "Cliente Premium",
+                "email", "cliente.premium@example.com",
+                "imageKey", "foto_ambiente",
+                "answers",
+                Map.of(
+                        "nome", "Cliente Premium",
+                        "email", "cliente.premium@example.com",
+                        "estilo", "moderno aconchegante"));
+
+        MockMultipartFile payloadPart = new MockMultipartFile(
+                "payload", "payload", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(payload));
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image", "sala.png", MediaType.IMAGE_PNG_VALUE, "conteudo".getBytes());
+
+        mockMvc.perform(multipart("/api/flows/decoraia-express/submissions")
+                        .file(payloadPart)
+                        .file(imagePart))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.flowSlug").value("decoraia-express"));
+
+        assertThat(imagePackageRepository.findAll())
+                .hasSize(1)
+                .first()
+                .satisfies(pack -> {
+                    assertThat(pack.getStatus()).isEqualTo("RECENT");
+                    assertThat(pack.getModel()).isEqualTo("gpt-image-1.5");
+                    assertThat(pack.getPlannedOutputs()).isEqualTo(3);
+                    assertThat(pack.getFreeImages()).isEqualTo(1);
+                    assertThat(pack.getPrompt())
+                            .contains("moderno aconchegante")
+                            .contains("foto enviada pelo lead")
+                            .contains("sala.png");
+                });
+    }
+
+    @Test
     void acceptsMultipartWithoutPayloadAndPersistsCustomFields() throws Exception {
         MockMultipartFile imagePart = new MockMultipartFile(
                 "image", "referencia.png", MediaType.IMAGE_PNG_VALUE, "conteudo".getBytes());

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowImagePromptServiceTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowImagePromptServiceTest.java
@@ -147,7 +147,7 @@ class FlowImagePromptServiceTest {
     }
 
     @Test
-    void shouldSkipPromptWhenSubmissionHasReferenceImage() {
+    void shouldBuildPromptWhenSubmissionHasReferenceImage() {
         Flow flow = new Flow(
                 "formulario-simples-personal-trainer",
                 "Formulário simples",
@@ -175,7 +175,11 @@ class FlowImagePromptServiceTest {
                 null);
 
         Optional<FlowImagePrompt> prompt = service.buildPrompt(flow, submission);
-        assertTrue(prompt.isEmpty());
+        assertTrue(prompt.isPresent());
+        assertEquals(Integer.valueOf(6), prompt.get().plannedOutputs());
+        assertEquals(Integer.valueOf(1), prompt.get().freeImages());
+        assertTrue(prompt.get().prompt().contains("Template: João"));
+        assertTrue(prompt.get().prompt().contains("foto enviada pelo lead"));
+        assertTrue(prompt.get().prompt().contains("upload.png"));
     }
 }
-


### PR DESCRIPTION
## O que muda

- Faz o Lead Portal criar pacote de imagem para fluxos com foto de referência quando o fluxo tem configuração de geração de imagem, mesmo com a flag global legada desligada.
- Atualiza o prompt para tratar a foto enviada pelo lead como referência visual obrigatória.
- Define 1 imagem gratuita para fluxos com foto de referência, preservando o restante como pacote pago.
- Adiciona testes cobrindo o fluxo DecoraIA/amostra personalizada e o contrato de prompt com imagem.

## Causa-raiz

O formulário público salvava o lead e a imagem, mas não criava `flow_submission_image_package` porque `lead-portal.image-pipeline.enabled` ficava desligado por padrão. Além disso, quando havia imagem de referência, o montador de prompt pulava o caminho de template, impedindo o worker de receber instrução adequada para Produto IA personalizado.

## Impacto

Depois do merge, submissões como DecoraIA Express entram na fila automática de imagem com prompt rastreável, permitindo seguir para amostra visual, e-mail e oferta paga antes de liberar campanha.

## Validação

- `mvn -q -Dtest=FlowSubmissionControllerTest,FlowImagePromptServiceTest test`
- `mvn -q test`
- `git diff --check`

Observação: o push local falhou por permissão 403 do token do checkout; a branch foi publicada via conector GitHub.