### PR TITLE
[codex] Add R2 timeouts for lead portal image flow

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/leadportal/image/LeadPortalStorageConfig.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/leadportal/image/LeadPortalStorageConfig.java
@@ -1,9 +1,11 @@
 package com.marketinghub.worker.leadportal.image;
 
 import java.net.URI;
+import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -11,9 +13,18 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
+/**
+ * Responsabilidade: configurar o cliente S3 compartilhado pelo AI Worker para arquivos do Lead Portal.
+ */
 @Configuration
 public class LeadPortalStorageConfig {
 
+    private static final Duration API_CALL_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration API_CALL_ATTEMPT_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * Cria o cliente R2 com timeouts para impedir que downloads/uploads de imagem prendam o ciclo do worker.
+     */
     @Bean
     @ConditionalOnMissingBean(name = "leadPortalS3Client")
     public S3Client leadPortalS3Client(LeadPortalStorageProperties properties) {
@@ -21,12 +32,17 @@ public class LeadPortalStorageConfig {
                 AwsBasicCredentials.create(properties.getAccessKeyId(), properties.getSecretAccessKey());
 
         S3Configuration configuration = S3Configuration.builder().pathStyleAccessEnabled(true).build();
+        ClientOverrideConfiguration timeoutConfiguration = ClientOverrideConfiguration.builder()
+                .apiCallTimeout(API_CALL_TIMEOUT)
+                .apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
+                .build();
 
         S3ClientBuilder builder =
                 S3Client.builder()
                         .credentialsProvider(StaticCredentialsProvider.create(credentials))
                         .region(Region.of(properties.getRegion()))
-                        .serviceConfiguration(configuration);
+                        .serviceConfiguration(configuration)
+                        .overrideConfiguration(timeoutConfiguration);
 
         if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
             builder = builder.endpointOverride(URI.create(properties.getEndpoint()));

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/config/StorageConfig.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/config/StorageConfig.java
@@ -1,8 +1,10 @@
 package com.marketinghub.leadportal.config;
 
 import java.net.URI;
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -10,21 +12,35 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
+/**
+ * Responsabilidade: configurar o cliente S3 usado pelo Lead Portal para acessar o storage R2.
+ */
 @Configuration
 public class StorageConfig {
 
+    private static final Duration API_CALL_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration API_CALL_ATTEMPT_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * Cria o cliente R2 com timeout explícito para evitar travamento no envio de fotos.
+     */
     @Bean
     public S3Client r2S3Client(StorageProperties properties) {
         AwsBasicCredentials credentials =
                 AwsBasicCredentials.create(properties.getAccessKeyId(), properties.getSecretAccessKey());
 
         S3Configuration s3Configuration = S3Configuration.builder().pathStyleAccessEnabled(true).build();
+        ClientOverrideConfiguration timeoutConfiguration = ClientOverrideConfiguration.builder()
+                .apiCallTimeout(API_CALL_TIMEOUT)
+                .apiCallAttemptTimeout(API_CALL_ATTEMPT_TIMEOUT)
+                .build();
 
         S3ClientBuilder builder =
                 S3Client.builder()
                         .credentialsProvider(StaticCredentialsProvider.create(credentials))
                         .region(Region.of(properties.getRegion()))
-                        .serviceConfiguration(s3Configuration);
+                        .serviceConfiguration(s3Configuration)
+                        .overrideConfiguration(timeoutConfiguration);
 
         if (properties.getEndpoint() != null && !properties.getEndpoint().isBlank()) {
             builder.endpointOverride(URI.create(properties.getEndpoint()));


### PR DESCRIPTION
## O que mudou
- Adiciona timeout total de 20s e timeout por tentativa de 10s no cliente S3/R2 do Lead Portal.
- Aplica o mesmo limite no cliente S3/R2 usado pelo AI Worker para baixar/subir imagens do funil de amostra.
- Inclui comentários de responsabilidade nas classes Java alteradas.

## Por quê
Durante a validação premium do experimento DecoraIA Express, o envio com foto ficou sem resposta HTTP por 40s. A submissão e o pacote foram criados depois, mas tarde demais para uma experiência aceitável. A causa operacional provável é chamada R2 sem timeout explícito no caminho síncrono de upload/download.

## Validação
- `mvn -q -Dtest=FlowSubmissionControllerTest,FlowImagePromptServiceTest test` em `lead-portal/backend`.
- `git diff --check`.

## Limitação
- O teste local do `ai-worker` não rodou porque o Maven tentou baixar `com.marketinghub:ads-service:0.0.1-SNAPSHOT` do GitHub Packages e recebeu `401 Unauthorized` neste ambiente.