### PR TITLE
Avoid blocking Lead Portal submissions on image upload

### DIFF
--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/config/LeadPortalAsyncConfig.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/config/LeadPortalAsyncConfig.java
@@ -1,0 +1,25 @@
+package com.marketinghub.leadportal.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/** Responsabilidade: configurar executores assíncronos usados pelo Lead Portal. */
+@Configuration
+public class LeadPortalAsyncConfig {
+
+    /** Cria o executor dedicado ao upload de imagens sem bloquear a resposta do formulário. */
+    @Bean(name = "leadPortalImageUploadExecutor")
+    @ConditionalOnMissingBean(name = "leadPortalImageUploadExecutor")
+    public Executor leadPortalImageUploadExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("lead-portal-image-upload-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,6 +69,7 @@ public class FlowSubmissionService {
     private final FlowSubmissionImagePackageStatusHistoryService statusHistoryService;
     private final FlowImagePromptService imagePromptService;
     private final ExperimentFunnelTrackingClient trackingClient;
+    private final Executor imageUploadExecutor;
     private final boolean imagePipelineEnabled;
 
     public FlowSubmissionService(
@@ -77,6 +80,7 @@ public class FlowSubmissionService {
             FlowSubmissionImagePackageStatusHistoryService statusHistoryService,
             FlowImagePromptService imagePromptService,
             ExperimentFunnelTrackingClient trackingClient,
+            @Qualifier("leadPortalImageUploadExecutor") Executor imageUploadExecutor,
             @Value("${lead-portal.image-pipeline.enabled:false}") boolean imagePipelineEnabled) {
         this.flowService = flowService;
         this.repository = repository;
@@ -85,6 +89,7 @@ public class FlowSubmissionService {
         this.statusHistoryService = statusHistoryService;
         this.imagePromptService = imagePromptService;
         this.trackingClient = trackingClient;
+        this.imageUploadExecutor = imageUploadExecutor;
         this.imagePipelineEnabled = imagePipelineEnabled;
     }
 
@@ -100,8 +105,9 @@ public class FlowSubmissionService {
         String originalFileName = null;
         String contentType = null;
         boolean hasImage = imageFile != null && !imageFile.isEmpty();
+        boolean asyncImagePackage = hasImage && shouldCreateImagePackageForFlow(flow, true);
 
-        if (hasImage) {
+        if (hasImage && !asyncImagePackage) {
             storedFileName = fileStorageService.store(imageFile, id.toString());
             originalFileName = imageFile.getOriginalFilename();
             contentType = imageFile.getContentType();
@@ -123,8 +129,12 @@ public class FlowSubmissionService {
                 normalizeCampaignCode(request.getCampaignCode()));
 
         repository.save(com.marketinghub.leadportal.entity.FlowSubmissionEntity.fromModel(submission));
-        registerImagePackage(flow, submission, hasImage);
         notifyExperimentFunnel(flow, submission);
+        if (asyncImagePackage) {
+            scheduleImageUploadAndPackage(flow, submission, imageFile);
+        } else {
+            registerImagePackage(flow, submission, hasImage);
+        }
         return submission;
     }
 
@@ -318,6 +328,62 @@ public class FlowSubmissionService {
 
         FlowSubmissionImagePackageEntity savedPackage = imagePackageRepository.save(imagePackage);
         statusHistoryService.recordStatusChange(savedPackage.getId(), FlowSubmissionImagePackageEntity.Status.RECENT, null);
+    }
+
+    /** Agenda upload da foto e criação do pacote sem prender a confirmação enviada ao lead. */
+    private void scheduleImageUploadAndPackage(Flow flow, FlowSubmission submission, MultipartFile imageFile) {
+        try {
+            byte[] imageBytes = imageFile.getBytes();
+            String originalFileName = imageFile.getOriginalFilename();
+            String contentType = imageFile.getContentType();
+            imageUploadExecutor.execute(() ->
+                    uploadImageAndRegisterPackage(flow, submission, imageBytes, originalFileName, contentType));
+        } catch (Exception ex) {
+            log.error(
+                    "Falha ao preparar upload assíncrono da imagem. flow={}, submissionId={}",
+                    flow.slug(),
+                    submission.id(),
+                    ex);
+        }
+    }
+
+    /** Faz o upload da imagem, atualiza a submissão e cria o pacote para o AI Worker. */
+    private void uploadImageAndRegisterPackage(
+            Flow flow,
+            FlowSubmission submission,
+            byte[] imageBytes,
+            String originalFileName,
+            String contentType) {
+        try {
+            String storedFileName = fileStorageService.store(
+                    imageBytes, submission.id().toString(), originalFileName, contentType);
+            repository.findById(submission.id()).ifPresent(entity -> {
+                entity.setStoredFileName(storedFileName);
+                entity.setOriginalFileName(originalFileName);
+                entity.setContentType(contentType);
+                repository.save(entity);
+            });
+
+            FlowSubmission submissionWithImage = new FlowSubmission(
+                    submission.id(),
+                    submission.flowSlug(),
+                    submission.name(),
+                    submission.email(),
+                    submission.answers(),
+                    submission.imageQuestionKey(),
+                    storedFileName,
+                    originalFileName,
+                    contentType,
+                    submission.createdAt(),
+                    submission.campaignCode());
+            registerImagePackage(flow, submissionWithImage, true);
+        } catch (Exception ex) {
+            log.error(
+                    "Falha no upload assíncrono da imagem da submissão. flow={}, submissionId={}",
+                    flow.slug(),
+                    submission.id(),
+                    ex);
+        }
     }
 
     /**

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
@@ -20,6 +20,7 @@ import com.marketinghub.leadportal.service.ExperimentFunnelTrackingClient.Tracki
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
@@ -41,10 +44,21 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class FlowSubmissionControllerTest {
+
+    /** Responsabilidade: executar tarefas assíncronas de imagem no mesmo thread durante testes de controller. */
+    @TestConfiguration
+    static class DirectExecutorTestConfig {
+
+        /** Cria executor direto para tornar determinística a criação de pacote de imagem nos testes. */
+        @Bean(name = "leadPortalImageUploadExecutor")
+        Executor leadPortalImageUploadExecutor() {
+            return Runnable::run;
+        }
+    }
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Contexto

Durante a validacao premium do fluxo DecoraIA Express, a pagina publica carregou e o AI Worker conseguiu processar pacote anterior, mas novas submissoes reais com foto ficaram presas ate timeout no cliente e nao chegaram a persistir o lead. Isso bloqueia a publicacao da campanha, porque o usuario pode enviar a foto e nao entrar no funil de amostra.

## Causa-raiz

O Lead Portal fazia upload da imagem para storage de forma sincrona antes de salvar a submissao. Quando o upload fica lento ou indisponivel, a experiencia do cliente falha antes do lead existir no banco.

## Solucao

- Persiste a submissao imediatamente para fluxos que criam pacote de imagem.
- Executa upload da imagem e criacao do pacote em executor assíncrono dedicado.
- Mantem o comportamento sincrono para fluxos que nao usam pacote de imagem.
- Adiciona executor configuravel e teste com executor direto para manter determinismo.

## Validacao

- `cd lead-portal/backend && mvn -q -Dtest=FlowSubmissionControllerTest test`
- `git diff --check`

Depois do merge, vou repetir o teste publico ponta a ponta com foto, acompanhar pacote no AI Worker, validar registro de envio de e-mail e so entao liberar a campanha.