### PR TITLE
[codex] Corrige sincronismo de status Facebook Ads

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -239,7 +239,7 @@ public class FacebookAdsCampaignController {
                 throw new ResponseStatusException(HttpStatus.CONFLICT,
                         "Facebook campaign already belongs to another experiment: " + req.id());
             }
-            existingCampaign.get().setStatus(resolveCampaignPublicationStatus(req.status()));
+            reconcileExistingCampaignPublication(existingCampaign.get(), req);
             experiment.setStatus(ExperimentStatus.RUNNING);
             return;
         }
@@ -300,6 +300,86 @@ public class FacebookAdsCampaignController {
     // Resolve o status canônico da campanha após confirmação de publicação completa pelo worker.
     private FacebookAdStatus resolveCampaignPublicationStatus(FacebookAdStatus status) {
         return status != null ? status : FacebookAdStatus.ACTIVE;
+    }
+
+    // Reconcilia status de publicação quando o worker reporta novamente uma campanha já persistida.
+    private void reconcileExistingCampaignPublication(FacebookAdsCampaign campaign, CreateCampaignRequest req) {
+        campaign.setStatus(resolveCampaignPublicationStatus(req.status()));
+        if (req.adSet() != null && StringUtils.hasText(req.adSet().id())) {
+            adSetRepository.findById(req.adSet().id())
+                    .ifPresent(adSet -> adSet.setStatus(resolveCampaignPublicationStatus(req.adSet().status())));
+        }
+        for (CreateCampaignRequest.Ad adRequest : resolveAdRequests(req)) {
+            if (adRequest == null || !StringUtils.hasText(adRequest.id())) {
+                continue;
+            }
+            adRepository.findById(adRequest.id())
+                    .ifPresent(ad -> ad.setStatus(resolveCampaignPublicationStatus(adRequest.status())));
+        }
+    }
+
+    /**
+     * Atualiza o status de campanha, ad sets e anúncios com o retrato efetivo recebido da Meta.
+     */
+    @PostMapping("/{campaignId}/status-sync")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Transactional
+    public void syncStatus(
+            @PathVariable String campaignId,
+            @RequestBody CampaignStatusSyncRequest request) {
+        FacebookAdsCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Facebook campaign not found: " + campaignId));
+        campaign.setStatus(resolveMetaStatus(request.status(), request.effectiveStatus(), campaign.getStatus()));
+        if (request.adSets() != null) {
+            for (CampaignStatusSyncRequest.AdSetStatus adSetStatus : request.adSets()) {
+                if (adSetStatus == null || !StringUtils.hasText(adSetStatus.id())) {
+                    continue;
+                }
+                adSetRepository.findById(adSetStatus.id())
+                        .ifPresent(adSet -> adSet.setStatus(resolveMetaStatus(
+                                adSetStatus.status(),
+                                adSetStatus.effectiveStatus(),
+                                adSet.getStatus())));
+            }
+        }
+        if (request.ads() != null) {
+            for (CampaignStatusSyncRequest.AdStatus adStatus : request.ads()) {
+                if (adStatus == null || !StringUtils.hasText(adStatus.id())) {
+                    continue;
+                }
+                adRepository.findById(adStatus.id())
+                        .ifPresent(ad -> ad.setStatus(resolveMetaStatus(
+                                adStatus.status(),
+                                adStatus.effectiveStatus(),
+                                ad.getStatus())));
+            }
+        }
+    }
+
+    // Resolve o status vindo da Meta preferindo o status efetivo quando ele estiver disponível.
+    private FacebookAdStatus resolveMetaStatus(String status, String effectiveStatus, FacebookAdStatus fallback) {
+        FacebookAdStatus effective = parseFacebookStatus(effectiveStatus);
+        if (effective != null) {
+            return effective;
+        }
+        FacebookAdStatus configured = parseFacebookStatus(status);
+        if (configured != null) {
+            return configured;
+        }
+        return fallback != null ? fallback : FacebookAdStatus.ACTIVE;
+    }
+
+    // Converte texto de status da Meta para o enum interno quando existir correspondência.
+    private FacebookAdStatus parseFacebookStatus(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return FacebookAdStatus.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**
@@ -834,6 +914,17 @@ public class FacebookAdsCampaignController {
             BigDecimal spend) {}
 
     public record CampaignMetricsErrorRequest(String message) {}
+
+    public record CampaignStatusSyncRequest(
+            String status,
+            String effectiveStatus,
+            List<AdSetStatus> adSets,
+            List<AdStatus> ads) {
+
+        public record AdSetStatus(String id, String status, String effectiveStatus) {}
+
+        public record AdStatus(String id, String status, String effectiveStatus) {}
+    }
 
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -513,7 +513,15 @@ class FacebookAdsCampaignControllerTest {
         existingCampaign.setId("cmp-existente");
         existingCampaign.setExperiment(experiment);
         existingCampaign.setStatus(FacebookAdStatus.PAUSED);
+        var existingAdSet = new FacebookAdsAdSet();
+        existingAdSet.setId("adset-existente");
+        existingAdSet.setStatus(FacebookAdStatus.PAUSED);
+        var existingAd = new FacebookAdsAd();
+        existingAd.setId("ad-existente");
+        existingAd.setStatus(FacebookAdStatus.PAUSED);
         when(campaignRepository.findById("cmp-existente")).thenReturn(Optional.of(existingCampaign));
+        when(adSetRepository.findById("adset-existente")).thenReturn(Optional.of(existingAdSet));
+        when(adRepository.findById("ad-existente")).thenReturn(Optional.of(existingAd));
 
         String payload = """
             {
@@ -524,7 +532,17 @@ class FacebookAdsCampaignControllerTest {
               "status": "ACTIVE",
               "budgetMode": "CAMPAIGN",
               "experimentId": 37,
-              "facebookAccountId": 88
+              "facebookAccountId": 88,
+              "adSet": {
+                "id": "adset-existente",
+                "status": "ACTIVE"
+              },
+              "ads": [
+                {
+                  "id": "ad-existente",
+                  "status": "ACTIVE"
+                }
+              ]
             }
             """;
 
@@ -534,8 +552,56 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(status().isCreated());
 
         assertThat(existingCampaign.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
+        assertThat(existingAdSet.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
+        assertThat(existingAd.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
         assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.RUNNING);
         verify(campaignRepository, never()).save(any());
+    }
+
+    @Test
+    void syncStatusUpdatesCampaignAdSetAndAdsFromMetaSnapshot() throws Exception {
+        var campaign = new FacebookAdsCampaign();
+        campaign.setId("cmp-sync");
+        campaign.setStatus(FacebookAdStatus.PAUSED);
+        var adSet = new FacebookAdsAdSet();
+        adSet.setId("adset-sync");
+        adSet.setStatus(FacebookAdStatus.PAUSED);
+        var ad = new FacebookAdsAd();
+        ad.setId("ad-sync");
+        ad.setStatus(FacebookAdStatus.PAUSED);
+        when(campaignRepository.findById("cmp-sync")).thenReturn(Optional.of(campaign));
+        when(adSetRepository.findById("adset-sync")).thenReturn(Optional.of(adSet));
+        when(adRepository.findById("ad-sync")).thenReturn(Optional.of(ad));
+
+        String payload = """
+            {
+              "status": "ACTIVE",
+              "effectiveStatus": "ACTIVE",
+              "adSets": [
+                {
+                  "id": "adset-sync",
+                  "status": "ACTIVE",
+                  "effectiveStatus": "ACTIVE"
+                }
+              ],
+              "ads": [
+                {
+                  "id": "ad-sync",
+                  "status": "ACTIVE",
+                  "effectiveStatus": "ACTIVE"
+                }
+              ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/facebook-campaigns/cmp-sync/status-sync")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isAccepted());
+
+        assertThat(campaign.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
+        assertThat(adSet.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
+        assertThat(ad.getStatus()).isEqualTo(FacebookAdStatus.ACTIVE);
     }
 
     @Test

--- a/docs/registros/facebook-ads-status-sync-2026-07-05.md
+++ b/docs/registros/facebook-ads-status-sync-2026-07-05.md
@@ -1,0 +1,6 @@
+# 2026-07-05 — Sincronismo de status Facebook Ads com a Meta
+
+- Problema: campanhas podiam aparecer ativas na Meta enquanto ad set e anúncios permaneciam `PAUSED` no painel do Marketing Hub.
+- Causa-raiz: o backend, ao receber novamente uma campanha já persistida, atualizava só o status da campanha; além disso, o sync periódico de métricas não reconciliava `status/effective_status` dos filhos na Meta.
+- Correção aplicada: o callback de publicação reconcilia campanha, ad set e anúncios existentes; o Facebook Ads Worker passa a consultar o retrato efetivo da Meta e enviar `POST /api/facebook-campaigns/{campaignId}/status-sync`.
+- Prevenção de recorrência: testes cobrem o callback idempotente, o endpoint de status e o mapeamento do snapshot de status da Meta.

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -64,6 +64,10 @@
 - Após a publicação completa da campanha/ad set/criativo/anúncio na Meta, o worker deve confirmar
   sucesso ao backend em `POST /api/facebook-campaigns` com `status=ACTIVE`, permitindo que o backend
   atualize `facebook_ads_campaign.status` e `experiment.status` no mesmo contrato.
+- Na sincronização periódica de métricas, o worker também deve consultar `status` e `effective_status`
+  de campanha, ad sets e anúncios na Graph API e reportar o retrato ao backend em
+  `POST /api/facebook-campaigns/{campaignId}/status-sync`; o painel deve refletir a Meta, não somente
+  o status salvo no momento da publicação.
 - Na criação de criativos (`POST /adcreatives`), `call_to_action.type` deve ser sempre um enum técnico aceito pela Meta
   (ex.: `LEARN_MORE`, `SIGN_UP`, `SHOP_NOW`) e nunca o texto comercial do botão. Labels comerciais vindos do criativo
   devem ser normalizados antes do envio, usando fallback seguro (`LEARN_MORE` para destino web e `SIGN_UP` para lead form).

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -218,6 +218,14 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    criados, já em `ACTIVE`, permitindo que o experimento comece a rodar sem
    ativação manual no Gerenciador de Anúncios.
 
+No ciclo periódico de métricas, o worker também consulta `status` e
+`effective_status` da campanha, dos conjuntos de anúncios e dos anúncios na
+Graph API e envia o snapshot ao backend por
+`POST /api/facebook-campaigns/{campaignId}/status-sync`. Com isso, o painel
+administrativo passa a refletir o estado efetivo da Meta mesmo quando a
+publicação inicial foi repetida ou quando algum filho teve status alterado fora
+do Marketing Hub.
+
 As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 `/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como
 "nenhum experimento disponível" para evitar falhas no agendamento. Quando não

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsService.java
@@ -40,6 +40,7 @@ public class FacebookCampaignMetricsService {
     private final FacebookAccessTokenManager accessTokenManager;
     private final WebClient backendClient;
     private final FacebookWorkerConfigurationClient configurationClient;
+    private final FacebookCampaignStatusSnapshotClient statusSnapshotClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
     private final AtomicBoolean configurationUnavailableWarningLogged = new AtomicBoolean(false);
@@ -50,12 +51,14 @@ public class FacebookCampaignMetricsService {
     public FacebookCampaignMetricsService(FacebookAdsService facebookAdsService,
                                           FacebookAccessTokenManager accessTokenManager,
                                           FacebookWorkerConfigurationClient configurationClient,
+                                          FacebookCampaignStatusSnapshotClient statusSnapshotClient,
                                           WebClient.Builder builder,
                                           @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
                                           @Value("${backend.api-prefix:/api}") String apiPrefix) {
         this.facebookAdsService = facebookAdsService;
         this.accessTokenManager = accessTokenManager;
         this.configurationClient = configurationClient;
+        this.statusSnapshotClient = statusSnapshotClient;
         this.backendClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
@@ -96,6 +99,7 @@ public class FacebookCampaignMetricsService {
      */
     private void processTarget(CampaignMetricsSyncTarget target) {
         try {
+            syncStatusSnapshot(target.campaignId());
             JsonNode insights = facebookAdsService.getCampaignInsights(target.campaignId(), buildInsightsQuery());
             JsonNode data = insights.path("data");
             if (!data.isArray() || data.isEmpty()) {
@@ -123,6 +127,57 @@ public class FacebookCampaignMetricsService {
             LOGGER.warn("Unexpected error while syncing metrics for campaign {}: {}", target.campaignId(), ex.getMessage(), ex);
             reportMetricsError(target.campaignId(), "Unexpected error: " + ex.getMessage());
         }
+    }
+
+    /**
+     * Consulta status efetivo na Meta e envia o retrato ao backend para manter o painel coerente.
+     */
+    private void syncStatusSnapshot(String campaignId) {
+        try {
+            JsonNode snapshot = statusSnapshotClient.fetch(campaignId, facebookAdsService.getCurrentAccessToken());
+            if (snapshot == null || snapshot.isNull()) {
+                return;
+            }
+            CampaignStatusSyncRequest payload = mapStatusSnapshot(snapshot);
+            sendStatusSync(campaignId, payload);
+        } catch (Exception ex) {
+            LOGGER.warn("Could not sync Facebook status snapshot for campaign {}: {}", campaignId, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Converte o retrato bruto da Meta em contrato enxuto de status para o backend.
+     */
+    private CampaignStatusSyncRequest mapStatusSnapshot(JsonNode snapshot) {
+        List<CampaignStatusSyncRequest.AdSetStatus> adSets = new java.util.ArrayList<>();
+        List<CampaignStatusSyncRequest.AdStatus> ads = new java.util.ArrayList<>();
+        JsonNode adSetData = snapshot.path("adsets").path("data");
+        if (adSetData.isArray()) {
+            for (JsonNode adSetNode : adSetData) {
+                String adSetId = adSetNode.path("id").asText(null);
+                adSets.add(new CampaignStatusSyncRequest.AdSetStatus(
+                    adSetId,
+                    adSetNode.path("status").asText(null),
+                    adSetNode.path("effective_status").asText(null)
+                ));
+                JsonNode adData = adSetNode.path("ads").path("data");
+                if (adData.isArray()) {
+                    for (JsonNode adNode : adData) {
+                        ads.add(new CampaignStatusSyncRequest.AdStatus(
+                            adNode.path("id").asText(null),
+                            adNode.path("status").asText(null),
+                            adNode.path("effective_status").asText(null)
+                        ));
+                    }
+                }
+            }
+        }
+        return new CampaignStatusSyncRequest(
+            snapshot.path("status").asText(null),
+            snapshot.path("effective_status").asText(null),
+            adSets,
+            ads
+        );
     }
 
     /**
@@ -247,6 +302,23 @@ public class FacebookCampaignMetricsService {
     }
 
     /**
+     * Envia ao backend o status efetivo sincronizado da campanha e seus filhos.
+     */
+    private void sendStatusSync(String campaignId, CampaignStatusSyncRequest payload) {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/" + campaignId + "/status-sync");
+        backendClient.post()
+            .uri(url)
+            .bodyValue(payload)
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, response -> response.createException().flatMap(e -> {
+                LOGGER.warn("Backend rejected status sync for campaign {}: status={} message={}", campaignId, response.statusCode(), e.getMessage());
+                return Mono.error(e);
+            }))
+            .toBodilessEntity()
+            .block();
+    }
+
+    /**
      * Registra no backend uma falha de sincronização de métricas da campanha.
      */
     private void reportMetricsError(String campaignId, String message) {
@@ -334,4 +406,15 @@ public class FacebookCampaignMetricsService {
             BigDecimal spend) {}
 
     public record CampaignMetricsErrorRequest(String message) {}
+
+    public record CampaignStatusSyncRequest(
+            String status,
+            String effectiveStatus,
+            List<AdSetStatus> adSets,
+            List<AdStatus> ads) {
+
+        public record AdSetStatus(String id, String status, String effectiveStatus) {}
+
+        public record AdStatus(String id, String status, String effectiveStatus) {}
+    }
 }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignStatusSnapshotClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignStatusSnapshotClient.java
@@ -1,0 +1,48 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Consulta na Graph API o status efetivo de campanhas e seus filhos. */
+@Component
+public class FacebookCampaignStatusSnapshotClient {
+    private final WebClient webClient;
+    private final String apiVersion;
+
+    /** Inicializa o client com a base e versão configuradas da Graph API. */
+    public FacebookCampaignStatusSnapshotClient(
+            WebClient.Builder builder,
+            @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String baseUrl,
+            @Value("${facebook.graph-api.version:v23.0}") String apiVersion) {
+        this.webClient = builder.baseUrl(baseUrl).build();
+        this.apiVersion = normalizeVersion(apiVersion);
+    }
+
+    /** Busca campanha, ad sets e anúncios com status configurado e efetivo. */
+    public JsonNode fetch(String campaignId, String accessToken) {
+        String fields = "status,effective_status,adsets{status,effective_status,ads{status,effective_status}}";
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/" + apiVersion + "/" + campaignId)
+                        .queryParam("fields", fields)
+                        .queryParam("access_token", accessToken)
+                        .build())
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+    }
+
+    /** Normaliza a versão da Graph API para o formato esperado pela URL. */
+    private String normalizeVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return "v23.0";
+        }
+        String trimmed = version.trim();
+        if (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        return trimmed.startsWith("v") ? trimmed : "v" + trimmed;
+    }
+}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsServiceTest.java
@@ -64,12 +64,56 @@ class FacebookCampaignMetricsServiceTest {
         assertThat(payload.spend()).isEqualByComparingTo(new BigDecimal("25.00"));
     }
 
+    /** Garante que o retrato de status da Meta inclui campanha, ad set e anúncios. */
+    @Test
+    void mapStatusSnapshotCopiesCampaignChildrenStatus() throws Exception {
+        FacebookCampaignMetricsService service = service();
+        JsonNode row = objectMapper.readTree("""
+                {
+                  "id": "cmp-1",
+                  "status": "ACTIVE",
+                  "effective_status": "ACTIVE",
+                  "adsets": {
+                    "data": [
+                      {
+                        "id": "adset-1",
+                        "status": "ACTIVE",
+                        "effective_status": "ACTIVE",
+                        "ads": {
+                          "data": [
+                            {
+                              "id": "ad-1",
+                              "status": "ACTIVE",
+                              "effective_status": "ACTIVE"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        Method method = FacebookCampaignMetricsService.class.getDeclaredMethod("mapStatusSnapshot", JsonNode.class);
+        method.setAccessible(true);
+        FacebookCampaignMetricsService.CampaignStatusSyncRequest payload =
+                (FacebookCampaignMetricsService.CampaignStatusSyncRequest) method.invoke(service, row);
+
+        assertThat(payload.status()).isEqualTo("ACTIVE");
+        assertThat(payload.effectiveStatus()).isEqualTo("ACTIVE");
+        assertThat(payload.adSets()).hasSize(1);
+        assertThat(payload.adSets().get(0).id()).isEqualTo("adset-1");
+        assertThat(payload.ads()).hasSize(1);
+        assertThat(payload.ads().get(0).id()).isEqualTo("ad-1");
+    }
+
     /** Cria o serviço com dependências simuladas para testar apenas o mapeamento local. */
     private FacebookCampaignMetricsService service() {
         return new FacebookCampaignMetricsService(
                 mock(FacebookAdsService.class),
                 mock(FacebookAccessTokenManager.class),
                 mock(FacebookWorkerConfigurationClient.class),
+                mock(FacebookCampaignStatusSnapshotClient.class),
                 WebClient.builder(),
                 "http://backend.test",
                 "/api"

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignStatusSnapshotClientTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignStatusSnapshotClientTest.java
@@ -1,0 +1,52 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import com.marketinghub.facebookadsworker.testsupport.FailFastMockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Testa a consulta de status efetivo de campanhas na Graph API. */
+class FacebookCampaignStatusSnapshotClientTest {
+    private FailFastMockWebServer facebook;
+
+    /** Sobe o servidor HTTP simulado da Graph API. */
+    @BeforeEach
+    void setUp() throws Exception {
+        facebook = new FailFastMockWebServer();
+        facebook.start();
+    }
+
+    /** Encerra o servidor HTTP simulado da Graph API. */
+    @AfterEach
+    void tearDown() throws Exception {
+        facebook.shutdown();
+    }
+
+    /** Garante que o campo expandido de ad sets/anúncios é codificado na URL. */
+    @Test
+    void fetchEncodesExpandedStatusFields() throws Exception {
+        facebook.enqueueResponse(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"id\":\"cmp-1\",\"status\":\"ACTIVE\",\"effective_status\":\"ACTIVE\"}"));
+        FacebookCampaignStatusSnapshotClient client = new FacebookCampaignStatusSnapshotClient(
+                WebClient.builder(),
+                facebook.url("/").toString(),
+                "v23.0");
+
+        client.fetch("cmp-1", "token");
+
+        RecordedRequest request = facebook.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath())
+                .contains("/v23.0/cmp-1")
+                .contains("fields=status,effective_status,adsets%7Bstatus,effective_status,ads%7Bstatus,effective_status%7D%7D")
+                .contains("access_token=token");
+    }
+}


### PR DESCRIPTION
## O que mudou

- Backend reconcilia campanha, ad set e anúncios quando recebe callback repetido de publicação.
- Novo endpoint `POST /api/facebook-campaigns/{campaignId}/status-sync` para persistir `status/effective_status` vindo da Meta.
- Facebook Ads Worker passa a buscar snapshot de status da Meta no ciclo de métricas e reportar ao backend.
- Documentação do worker e registro operacional da correção foram atualizados.

## Causa-raiz

O backend aceitava retry de campanha existente atualizando só `facebook_ads_campaign.status`. Os filhos (`facebook_ads_ad_set` e `facebook_ads_ad`) podiam continuar com status antigo, e o sync periódico de métricas não reconciliava o status efetivo da Meta.

## Validação

- `../mvnw -Dtest=FacebookAdsCampaignControllerTest test` em `backend/ads-service`
- `mvn -Dtest=FacebookCampaignMetricsServiceTest,FacebookCampaignStatusSnapshotClientTest test` em `facebook-ads-worker`
- `git diff --check origin/main`