### PR TITLE
[codex] Endurece dossiê comercial da biblioteca MOIS

### DIFF
--- a/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/pipelines/dossie/v1/dossiersynthesis/DossierDossierSynthesisProcessor.java
@@ -7,8 +7,10 @@ import com.marketinghub.pipelines.dossie.v1.StageProcessor;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Executa a etapa síntese final do dossiê gerando uma entrega de negócio ou bloqueando saída fraca. */
 public class DossierDossierSynthesisProcessor implements StageProcessor {
@@ -28,19 +30,21 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
     public StageResult process(StageContext context) {
         Map<String, Object> auditEvidence = DossierStageSupport.evidenceFor(context, STAGE_NAME);
         List<String> stageResponses = stageResponses(context);
-        if (!hasBusinessEvidence(stageResponses)) {
+        BusinessEvidenceGate gate = evaluateBusinessEvidence(stageResponses);
+        Map<String, Object> enrichedEvidence = enrichedEvidence(auditEvidence, gate);
+        if (!gate.approved()) {
             DossierDossierSynthesisOutput blockedOutput = new DossierDossierSynthesisOutput(
                     context.dossierId(),
                     "BLOCKED_INSUFFICIENT_CONTEXT",
                     OBJECTIVE,
-                    "Não foi possível gerar um dossiê comercial confiável porque o backend/etapas anteriores entregaram apenas metadados operacionais, sem evidências de produto, promessa, prova, risco e recomendação.",
+                    "Não foi possível gerar um dossiê comercial confiável porque as etapas anteriores não provaram todos os pilares mínimos: produto/público, dor-promessa-mecanismo, prova, fonte/aquecimento, oferta/risco e recomendação.",
                     stageResponses,
                     List.of(
-                            "Reexecutar o dossiê após corrigir as etapas anteriores para retornarem evidências comerciais estruturadas.",
-                            "Garantir que a etapa final receba produto, promessa, público, fontes qualificadas, sinais de aquecimento e riscos.",
+                            "Reexecutar o dossiê após corrigir as etapas anteriores para retornarem evidências comerciais estruturadas e rastreáveis.",
+                            "Garantir que a etapa final receba produto, público, promessa, mecanismo, prova, fontes qualificadas, sinais de aquecimento, oferta/risco e recomendação.",
                             "Não usar este resultado para decisão de oferta enquanto o gate estiver bloqueado."),
                     "BLOCKED",
-                    auditEvidence);
+                    enrichedEvidence);
             return StageResult.failed(
                     INSUFFICIENT_CONTEXT_ERROR,
                     Map.of(STAGE_NAME, blockedOutput),
@@ -58,7 +62,7 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
                         "Transformar os sinais de dor, prova e mecanismo em hipótese de oferta.",
                         "Registrar decisão comercial no relatório da página."),
                 "APPROVED",
-                auditEvidence);
+                enrichedEvidence);
         return StageResult.done(Map.of(STAGE_NAME, output), List.of(finalArtifact(context, output)));
     }
 
@@ -85,22 +89,43 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
         return List.of();
     }
 
-    /** Verifica se as respostas anteriores contêm sinais de negócio além de metadados operacionais. */
-    private boolean hasBusinessEvidence(List<String> stageResponses) {
-        if (stageResponses.size() < 3) {
-            return false;
+    /** Avalia se as respostas anteriores sustentam conclusão comercial comparável e acionável. */
+    private BusinessEvidenceGate evaluateBusinessEvidence(List<String> stageResponses) {
+        if (stageResponses.size() < 4) {
+            return new BusinessEvidenceGate(false, List.of(), List.of("historico_minimo_de_etapas"));
         }
         String joined = String.join(" ", stageResponses).toLowerCase();
-        boolean hasBusinessMarkers = joined.contains("promessa")
-                || joined.contains("público")
-                || joined.contains("publico")
-                || joined.contains("evidência")
-                || joined.contains("evidencia")
-                || joined.contains("recomendação")
-                || joined.contains("recomendacao")
-                || joined.contains("risco")
-                || joined.contains("prova");
-        return hasBusinessMarkers;
+        List<String> matchedCategories = requiredCommercialCategories().entrySet().stream()
+                .filter(entry -> entry.getValue().stream().anyMatch(joined::contains))
+                .map(Map.Entry::getKey)
+                .toList();
+        List<String> missingCategories = requiredCommercialCategories().keySet().stream()
+                .filter(category -> !matchedCategories.contains(category))
+                .toList();
+        boolean approved = matchedCategories.size() >= 6
+                && matchedCategories.containsAll(Set.of("produto_publico", "dor_promessa_mecanismo", "prova", "fonte_aquecimento", "recomendacao"));
+        return new BusinessEvidenceGate(approved, matchedCategories, missingCategories);
+    }
+
+    /** Define os pilares mínimos que impedem um dossiê operacional genérico de virar conclusão comercial. */
+    private Map<String, List<String>> requiredCommercialCategories() {
+        return Map.of(
+                "produto_publico", List.of("produto", "público", "publico", "persona", "cliente", "produtor", "marca"),
+                "dor_promessa_mecanismo", List.of("dor", "promessa", "mecanismo", "resultado", "transformação", "transformacao"),
+                "prova", List.of("prova", "evidência", "evidencia", "depoimento", "autoridade", "case", "review"),
+                "fonte_aquecimento", List.of("fonte", "canal", "youtube", "instagram", "afiliado", "review", "aquecimento", "comunidade"),
+                "oferta_risco", List.of("oferta", "preço", "preco", "garantia", "checkout", "cta", "risco", "objeção", "objecao"),
+                "recomendacao", List.of("recomendação", "recomendacao", "próximo teste", "proximo teste", "avançar", "avancar", "descartar"),
+                "oportunidade_adaptacao", List.of("adaptar", "oportunidade", "criativo", "funil", "landing", "campanha"));
+    }
+
+    /** Enriquece a evidência de auditoria com o resultado objetivo do gate comercial. */
+    private Map<String, Object> enrichedEvidence(Map<String, Object> auditEvidence, BusinessEvidenceGate gate) {
+        Map<String, Object> enriched = new LinkedHashMap<>(auditEvidence);
+        enriched.put("commercialEvidenceGateApproved", gate.approved());
+        enriched.put("commercialEvidenceCategoriesFound", gate.matchedCategories());
+        enriched.put("commercialEvidenceCategoriesMissing", gate.missingCategories());
+        return Map.copyOf(enriched);
     }
 
     /** Cria o artefato final separado dos metadados técnicos de auditoria. */
@@ -110,5 +135,9 @@ public class DossierDossierSynthesisProcessor implements StageProcessor {
                 "dossie/v1/" + context.dossierId() + "/" + STAGE_NAME + "/final",
                 output.finalConclusion(),
                 Instant.now());
+    }
+
+    /** Representa o resultado do gate comercial aplicado antes da síntese final. */
+    private record BusinessEvidenceGate(boolean approved, List<String> matchedCategories, List<String> missingCategories) {
     }
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/pipelines/dossie/v1/PipelineWorkerTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/pipelines/dossie/v1/PipelineWorkerTest.java
@@ -68,15 +68,37 @@ class PipelineWorkerTest {
         PipelineWorker worker = new PipelineWorker(processorsCanonicos());
         StageContext context = new StageContext(10L, 20L, "workspace-mois", "dossier-synthesis", Map.of(
                 "previousStageResponses", List.of(
-                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, promessa=resultado claro para o público}",
-                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, evidência=prova social e autoridade}",
-                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, recomendação=avançar com risco controlado}")));
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, produto=curso de beleza, público=mulheres maduras}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, dor=baixa autoestima, promessa=resultado visual, mecanismo=diagnóstico personalizado}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, evidência=prova social e autoridade em reviews externos}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, fonte=YouTube, canal=Instagram, aquecimento=comunidade}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, oferta=kit premium, garantia=7 dias, CTA=gerar amostra}",
+                        "{auditDecision=ok, inputKeys=[jobId], stageExecutionId=20, recomendação=avançar com risco controlado e adaptar criativo}")));
 
         StageResult result = worker.execute(context);
 
         assertThat(result.status()).isEqualTo("DONE");
         assertThat(result.errorMessage()).isNull();
-        assertThat(String.valueOf(result.output())).contains("OBJECTIVE_FULFILLED");
+        assertThat(String.valueOf(result.output())).contains("OBJECTIVE_FULFILLED", "commercialEvidenceGateApproved=true");
+    }
+
+    /** Garante que palavras comerciais soltas não aprovam a síntese sem pilares rastreáveis. */
+    @Test
+    void deveBloquearSinteseFinalComTermosComerciaisGenericos() {
+        PipelineWorker worker = new PipelineWorker(processorsCanonicos());
+        StageContext context = new StageContext(10L, 20L, "workspace-mois", "dossier-synthesis", Map.of(
+                "previousStageResponses", List.of(
+                        "Promessa parece boa para o público.",
+                        "Existe prova e risco.",
+                        "Recomendação: avançar.",
+                        "O relatório operacional foi concluído.")));
+
+        StageResult result = worker.execute(context);
+
+        assertThat(result.status()).isEqualTo("FAILED");
+        assertThat(result.errorMessage()).contains("Dossiê final bloqueado");
+        assertThat(String.valueOf(result.output()))
+                .contains("BLOCKED_INSUFFICIENT_CONTEXT", "commercialEvidenceGateApproved=false", "fonte_aquecimento");
     }
 
     /** Garante bloqueio explícito quando o backend enviar etapa sem processor registrado no executor. */
@@ -96,8 +118,11 @@ class PipelineWorkerTest {
             return new StageContext(10L, 20L, "workspace-mois", processor.stageName(), Map.of(
                     "previousStageResponses", List.of(
                             "Produto resolve dor clara do público com promessa específica.",
-                            "Evidência externa indica prova social e autoridade.",
-                            "Recomendação: avançar com risco controlado.")));
+                            "Mecanismo de diagnóstico personalizado sustenta a transformação prometida.",
+                            "Fonte externa em YouTube e Instagram indica aquecimento e comunidade ativa.",
+                            "Evidência externa indica prova social, autoridade e reviews.",
+                            "Oferta possui CTA direto, garantia e risco controlado.",
+                            "Recomendação: avançar com oportunidade de adaptar criativo e funil.")));
         }
         return new StageContext(10L, 20L, "workspace-mois", processor.stageName(), Map.of("origem", "teste"));
     }


### PR DESCRIPTION
## O que mudou

- Endurece a etapa final `dossier-synthesis` do `mois-sales-library-worker`.
- O dossiê agora só conclui quando as etapas anteriores entregam pilares comerciais mínimos: produto/público, dor-promessa-mecanismo, prova, fonte/aquecimento, oferta/risco e recomendação.
- A saída passa a registrar o resultado do gate (`commercialEvidenceGateApproved`, categorias encontradas e categorias ausentes).
- Adiciona teste que bloqueia termos comerciais genéricos e teste que aprova somente evidência comercial completa.

## Causa-raiz

A síntese final aceitava poucas respostas contendo palavras soltas como `prova`, `risco` ou `recomendação`. Isso permitia que relatórios operacionais ou genéricos fossem marcados como concluídos, sem gerar inteligência útil para campanha, funil, criativo ou oferta.

## Impacto

Dossiês fracos passam a ficar bloqueados como contexto insuficiente em vez de virarem conclusão comercial. Isso protege decisões de marketing contra relatório genérico e força o pipeline a entregar evidências reais antes de orientar investimento em mídia ou adaptação de oferta.

## Validação

- `mvn -q -f mois-sales-library-worker/pom.xml test`
- `git diff --check`