### PR TITLE
[codex] Corrige collation dos candidatos MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -658,11 +658,14 @@ public class MoisSalesLibraryService {
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
                 LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
                 LEFT JOIN (
-                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    SELECT workspace_id,
+                           CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci AS reference_url,
+                           MAX(id) AS latest_reference_id
                     FROM mois_collected_reference
                     WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
-                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
-                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                    GROUP BY workspace_id, CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id
+                   AND cr_latest.reference_url = CONVERT(p.url_canonical USING utf8mb4) COLLATE utf8mb4_unicode_ci
                 LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
                 WHERE p.workspace_id = ?
                 """ + warmupCondition;
@@ -865,11 +868,14 @@ public class MoisSalesLibraryService {
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
                 LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
                 LEFT JOIN (
-                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    SELECT workspace_id,
+                           CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci AS reference_url,
+                           MAX(id) AS latest_reference_id
                     FROM mois_collected_reference
                     WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
-                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
-                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                    GROUP BY workspace_id, CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id
+                   AND cr_latest.reference_url = CONVERT(p.url_canonical USING utf8mb4) COLLATE utf8mb4_unicode_ci
                 LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
                 WHERE p.id = ? LIMIT 1
                 """, this::mapSalesPageResponse, pageId);
@@ -1909,11 +1915,14 @@ public class MoisSalesLibraryService {
                 FROM mois_sales_page p
                 LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
                 LEFT JOIN (
-                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    SELECT workspace_id,
+                           CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci AS reference_url,
+                           MAX(id) AS latest_reference_id
                     FROM mois_collected_reference
                     WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
-                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
-                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                    GROUP BY workspace_id, CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id
+                   AND cr_latest.reference_url = CONVERT(p.url_canonical USING utf8mb4) COLLATE utf8mb4_unicode_ci
                 LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
                 WHERE p.workspace_id = ?
                   AND p.source = 'HOTMART'
@@ -1926,9 +1935,9 @@ public class MoisSalesLibraryService {
                   AND NOT EXISTS (
                       SELECT 1
                       FROM pipeline_dossieproduto pd
-                      WHERE pd.id_externo = CAST(p.id AS CHAR)
+                      WHERE pd.id_externo COLLATE utf8mb4_unicode_ci = CONVERT(CAST(p.id AS CHAR) USING utf8mb4) COLLATE utf8mb4_unicode_ci
                         AND pd.versao_pipeline = 'v1'
-                        AND pd.pipeline_code = ?
+                        AND pd.pipeline_code COLLATE utf8mb4_unicode_ci = CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci
                         AND pd.status IN ('INICIADO', 'AGUARDANDO_RETORNO_MODULO', 'CONCLUIDO')
                   )
                 ORDER BY COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) DESC,

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -241,7 +241,7 @@ class MoisSalesLibraryServiceTest {
         verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("LEFT JOIN mois_sales_page_market_warmup_summary mws")
-                .contains("cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical")
+                .contains("cr_latest.reference_url = CONVERT(p.url_canonical USING utf8mb4) COLLATE utf8mb4_unicode_ci")
                 .contains("COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature")
                 .contains("ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?");
     }
@@ -548,6 +548,25 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.pipelineCode()).isEqualTo("warmupecosystem.v1");
         org.assertj.core.api.Assertions.assertThat(response.items().get(0).pageId()).isEqualTo(401L);
         org.assertj.core.api.Assertions.assertThat(response.items().get(0).hotmartTemperature()).isEqualByComparingTo("127.07");
+    }
+
+    /**
+     * Garante que a consulta de candidatos evita conflito de collation no MySQL 5.7.
+     */
+    @Test
+    void shouldNormalizeCollationWhenListingHotProductDossierCandidates() {
+        given(jdbcTemplate.query(contains("pipeline_dossieproduto pd"), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq("warmupecosystem.v1"), eq(10)))
+                .willReturn(List.of());
+
+        service.listHotProductDossierCandidates("workspace-001", BigDecimal.valueOf(80), 10);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(BigDecimal.valueOf(80)), eq("warmupecosystem.v1"), eq(10));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("CONVERT(COALESCE(sales_page_url, product_url) USING utf8mb4) COLLATE utf8mb4_unicode_ci")
+                .contains("cr_latest.reference_url = CONVERT(p.url_canonical USING utf8mb4) COLLATE utf8mb4_unicode_ci")
+                .contains("pd.id_externo COLLATE utf8mb4_unicode_ci = CONVERT(CAST(p.id AS CHAR) USING utf8mb4) COLLATE utf8mb4_unicode_ci")
+                .contains("pd.pipeline_code COLLATE utf8mb4_unicode_ci = CONVERT(? USING utf8mb4) COLLATE utf8mb4_unicode_ci");
     }
 
     /**


### PR DESCRIPTION
## O que mudou

- Normaliza comparações por URL entre `mois_collected_reference` e `mois_sales_page` usando `utf8mb4_unicode_ci`.
- Normaliza a comparação de `pipeline_dossieproduto.id_externo` e `pipeline_code` na consulta de candidatos quentes.
- Adiciona teste de regressão para impedir que a seleção dos dossiês volte a usar comparação textual sem collation explícita.

## Causa-raiz

O enfileiramento dos produtos quentes dependia de consultas que comparavam textos vindos de tabelas/expressões com collations diferentes no MySQL. Em produção isso podia gerar erro 500 antes de enfileirar os dossiês, mesmo quando as páginas eram elegíveis.

## Impacto

A biblioteca volta a conseguir listar e enfileirar produtos quentes para os pipelines `warmupecosystem.v1` e `salespagepatterns.v1`, destravando a geração de dossiês comerciais úteis.

## Validação

- `mvn -q -f backend/ads-service/pom.xml -Dtest=MoisSalesLibraryServiceTest test`
- `git diff --check`