### PR TITLE
[codex] Normalize MOIS salespagepatterns OpenAI response

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/shared/DossierOpenAiTextResponseExtractor.java
@@ -1,65 +1,14 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1.shared;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.util.StringUtils;
+import com.marketinghub.moissaleslibraryworker.pipelines.shared.service.OpenAiTextResponseExtractor;
 
 /** Utilitário responsável por extrair a resposta funcional limpa dos envelopes OpenAI do dossiê de produto. */
 public final class DossierOpenAiTextResponseExtractor {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     /** Impede instanciação porque o extrator não mantém estado por execução. */
     private DossierOpenAiTextResponseExtractor() {}
 
-    /** Retorna o campo text do response OpenAI quando existir; caso contrário preserva o response bruto. */
+    /** Delega a extração para o utilitário compartilhado entre pipelines MOIS. */
     public static String extract(String rawResponse) {
-        if (!StringUtils.hasText(rawResponse)) {
-            return rawResponse;
-        }
-        try {
-            JsonNode root = OBJECT_MAPPER.readTree(rawResponse);
-            String extracted = extractFromRoot(root);
-            return StringUtils.hasText(extracted) ? extracted : rawResponse;
-        } catch (JsonProcessingException ex) {
-            return rawResponse;
-        }
-    }
-
-    /** Busca o texto funcional nos formatos raiz usados pela Responses API e por mensagens diretas. */
-    private static String extractFromRoot(JsonNode root) {
-        String directOutput = extractFromOutput(root.path("output"));
-        if (StringUtils.hasText(directOutput)) {
-            return directOutput;
-        }
-        return extractFromContent(root.path("content"));
-    }
-
-    /** Varre a lista output da OpenAI procurando o primeiro conteúdo textual da mensagem. */
-    private static String extractFromOutput(JsonNode output) {
-        if (!output.isArray()) {
-            return null;
-        }
-        for (JsonNode outputItem : output) {
-            String text = extractFromContent(outputItem.path("content"));
-            if (StringUtils.hasText(text)) {
-                return text;
-            }
-        }
-        return null;
-    }
-
-    /** Varre a lista content da OpenAI procurando o primeiro campo text preenchido. */
-    private static String extractFromContent(JsonNode content) {
-        if (!content.isArray()) {
-            return null;
-        }
-        for (JsonNode contentItem : content) {
-            JsonNode textNode = contentItem.path("text");
-            if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
-                return textNode.asText();
-            }
-        }
-        return null;
+        return OpenAiTextResponseExtractor.extract(rawResponse);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/salespagepatterns/v1/pagepatternextraction/service/SalesPagePatternsPagePatternExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/salespagepatterns/v1/pagepatternextraction/service/SalesPagePatternsPagePatternExtractionService.java
@@ -1,8 +1,5 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.pending.SalesPagePatternsPagePatternExtractionPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.pending.SalesPagePatternsPagePatternExtractionPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.pending.SalesPagePatternsPagePatternExtractionPendingResponse;
@@ -10,6 +7,7 @@ import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pa
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.receberequest.SalesPagePatternsPagePatternExtractionRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.receberesponse.SalesPagePatternsPagePatternExtractionRecebeResponseRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.receberesponse.SalesPagePatternsPagePatternExtractionRecebeResponseResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.shared.service.OpenAiTextResponseExtractor;
 import com.marketinghub.moissaleslibraryworker.pipelines.shared.service.PipelinePromptSchemaTemplatePayload;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
@@ -24,11 +22,9 @@ import java.util.Map;
 import java.util.UUID;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
-import lombok.extern.slf4j.Slf4j;
 
 /** Publica pendências e callbacks da extração de padrões do pipeline salespagepatterns.v1. */
 @Service
-@Slf4j
 public class SalesPagePatternsPagePatternExtractionService {
     private static final String PIPELINE_CODE = "salespagepatterns.v1";
     private static final String STAGE_CODE = "page-pattern-extraction";
@@ -42,7 +38,6 @@ public class SalesPagePatternsPagePatternExtractionService {
     private final DossierProductContextGateway productContextGateway;
     private final AiPromptSchemaTemplateRepository templateRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /** Cria o service com os repositórios canônicos de página e auditoria do pipeline. */
     public SalesPagePatternsPagePatternExtractionService(
@@ -107,7 +102,7 @@ public class SalesPagePatternsPagePatternExtractionService {
         page.setSalesPagePatternsUpdatedAt(now);
         salesPageRepository.save(page);
         savePipelineAudit(productKey, jobId, STAGE_CODE, status, null, request.response(),
-                extractOpenAiTextResponse(request.response()), null, null, null, request.promptTemplateKey(),
+                OpenAiTextResponseExtractor.extract(request.response()), null, null, null, request.promptTemplateKey(),
                 request.promptTemplateVersion(), request.schemaName(), request, request.descricaoErro());
         accumulateCosts(pageId, request.custo());
         return new SalesPagePatternsPagePatternExtractionRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, null);
@@ -249,22 +244,4 @@ public class SalesPagePatternsPagePatternExtractionService {
         return value == null || value.isBlank();
     }
 
-    /** Extrai o texto funcional de respostas OpenAI sem depender do pipeline de aquecimento. */
-    private String extractOpenAiTextResponse(String response) {
-        if (response == null || response.isBlank()) {
-            return null;
-        }
-        try {
-            JsonNode root = objectMapper.readTree(response);
-            JsonNode outputText = root.path("output_text");
-            if (!outputText.isMissingNode() && !outputText.asText().isBlank()) {
-                return outputText.asText();
-            }
-        } catch (JsonProcessingException ex) {
-            log.warn("Falha ao extrair output_text de salespagepatterns.v1; mantendo response bruto. stageCode={}, responseLength={}",
-                    STAGE_CODE, response.length(), ex);
-            return response;
-        }
-        return response;
-    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/shared/service/OpenAiTextResponseExtractor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/shared/service/OpenAiTextResponseExtractor.java
@@ -1,0 +1,69 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.shared.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+
+/** Utilitário compartilhado para extrair texto funcional limpo de envelopes da OpenAI. */
+public final class OpenAiTextResponseExtractor {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /** Impede instanciação porque o extrator não mantém estado por execução. */
+    private OpenAiTextResponseExtractor() {}
+
+    /** Retorna o campo text/output_text quando existir; caso contário preserva o response bruto. */
+    public static String extract(String rawResponse) {
+        if (!StringUtils.hasText(rawResponse)) {
+            return rawResponse;
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(rawResponse);
+            String extracted = extractFromRoot(root);
+            return StringUtils.hasText(extracted) ? extracted : rawResponse;
+        } catch (JsonProcessingException ex) {
+            return rawResponse;
+        }
+    }
+
+    /** Busca o texto funcional nos formatos raiz usados pela Responses API. */
+    private static String extractFromRoot(JsonNode root) {
+        JsonNode outputText = root.path("output_text");
+        if (outputText.isTextual() && StringUtils.hasText(outputText.asText())) {
+            return outputText.asText();
+        }
+        String directOutput = extractFromOutput(root.path("output"));
+        if (StringUtils.hasText(directOutput)) {
+            return directOutput;
+        }
+        return extractFromContent(root.path("content"));
+    }
+
+    /** Varre a lista output da OpenAI procurando o primeiro conteúdo textual da mensagem. */
+    private static String extractFromOutput(JsonNode output) {
+        if (!output.isArray()) {
+            return null;
+        }
+        for (JsonNode outputItem : output) {
+            String text = extractFromContent(outputItem.path("content"));
+            if (StringUtils.hasText(text)) {
+                return text;
+            }
+        }
+        return null;
+    }
+
+    /** Varre a lista content da OpenAI procurando o primeiro campo text preenchido. */
+    private static String extractFromContent(JsonNode content) {
+        if (!content.isArray()) {
+            return null;
+        }
+        for (JsonNode contentItem : content) {
+            JsonNode textNode = contentItem.path("text");
+            if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
+                return textNode.asText();
+            }
+        }
+        return null;
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/salespagepatterns/v1/pagepatternextraction/service/SalesPagePatternsPagePatternExtractionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/moissaleslibraryworker/pipelines/salespagepatterns/v1/pagepatternextraction/service/SalesPagePatternsPagePatternExtractionServiceTest.java
@@ -1,0 +1,83 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.moissaleslibraryworker.pipelines.salespagepatterns.v1.pagepatternextraction.service.receberesponse.SalesPagePatternsPagePatternExtractionRecebeResponseRequest;
+import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
+import com.marketinghub.repository.jpa.mois.dossieproduto.DossierProductContextGateway;
+import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
+import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Testa os callbacks da etapa de extração de padrões de página de venda. */
+@ExtendWith(MockitoExtension.class)
+class SalesPagePatternsPagePatternExtractionServiceTest {
+    @Mock
+    private MoisSalesPageRepository salesPageRepository;
+
+    @Mock
+    private PipelineDossieProdutoRepository pipelineDossieProdutoRepository;
+
+    @Mock
+    private DossierProductContextGateway productContextGateway;
+
+    @Mock
+    private AiPromptSchemaTemplateRepository templateRepository;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private SalesPagePatternsPagePatternExtractionService service;
+
+    /** Garante que a resposta funcional limpa seja persistida separada do envelope bruto da OpenAI. */
+    @Test
+    void shouldPersistCleanFinalResponseFromResponsesApiEnvelope() {
+        MoisSalesPage page = new MoisSalesPage();
+        page.setId(401L);
+        when(salesPageRepository.findById(401L)).thenReturn(Optional.of(page));
+        String rawResponse = """
+                {
+                  "id": "resp_salespagepatterns",
+                  "output": [
+                    {
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "{\\\"headlinePattern\\\":\\\"dor concreta + mecanismo específico\\\"}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        service.recebeResponse(
+                "401",
+                "job-401",
+                new SalesPagePatternsPagePatternExtractionRecebeResponseRequest(
+                        rawResponse, 120, 80, null, "gpt-5-mini", null, "template-key", "v1", "schema-name"));
+
+        ArgumentCaptor<PipelineDossieProduto> pipelineCaptor = ArgumentCaptor.forClass(PipelineDossieProduto.class);
+        verify(pipelineDossieProdutoRepository).save(pipelineCaptor.capture());
+        PipelineDossieProduto pipeline = pipelineCaptor.getValue();
+        assertThat(pipeline.getResponse()).isEqualTo(rawResponse);
+        assertThat(pipeline.getRespostaFinal())
+                .isEqualTo("{\"headlinePattern\":\"dor concreta + mecanismo específico\"}");
+        assertThat(pipeline.getPipelineCode()).isEqualTo("salespagepatterns.v1");
+        verify(salesPageRepository).save(any(MoisSalesPage.class));
+    }
+}


### PR DESCRIPTION
## O que mudou

- Centraliza a extração de texto funcional de responses OpenAI em `OpenAiTextResponseExtractor` compartilhado dos pipelines MOIS.
- Faz o `salespagepatterns.v1/page-pattern-extraction` gravar `resposta_final` com o texto limpo de `output[].content[].text`, preservando `response` como envelope bruto de auditoria.
- Mantém o extrator legado de `dossieproduto.v1` como delegação para o utilitário compartilhado, sem acoplar `salespagepatterns.v1` a outro pipeline.
- Adiciona teste de regressão do callback `salespagepatterns.v1` com envelope real da Responses API.

## Causa-raiz

O callback de `salespagepatterns.v1` extraía apenas `output_text` na raiz. Quando a OpenAI retornava o formato real `output[].content[].text`, o backend salvava o envelope bruto em `resposta_final`, reduzindo a utilidade do dossiê como evidência comercial para o preflight de experimentos.

## Impacto

Os dossiês de padrões de página passam a alimentar oferta, página, criativos e funil com texto funcional limpo, sem contaminar a evidência comercial com metadados técnicos.

## Validação

- `../mvnw -Dtest=SalesPagePatternsPagePatternExtractionServiceTest,DossierOpenAiTextResponseExtractorTest,BackendExperimentRunControllerTest,ExperimentReadinessServiceTest test`
- `../mvnw -Dtest=ArquiteturaTest test`
- `git diff --check`

## Observação

O registro operacional em `docs/registros/mois1.md` foi preparado e validado localmente, mas não entrou neste PR porque o push local falhou com 403 e o conector disponível não oferece append seguro para esse arquivo grande.