### PR TITLE
[codex] Corrige serialização da resposta final dos dossiês MOIS

### DIFF
--- a/docs/registros/mois2.md
+++ b/docs/registros/mois2.md
@@ -45,3 +45,11 @@
 > ```md
 > ## YYYY-MM-DD HH:mm:ss UTC-3
 > ```
+
+## 2026-07-05 20:27:59 UTC-3
+- problema identificado: a resposta final da síntese dos dossiês MOIS podia chegar ao backend como representação técnica de record (`DossierDossierSynthesisOutput[...]`) em vez de JSON funcional limpo.
+- causa-raiz: o worker `mois-sales-library-worker` usava `String.valueOf(result.output())` ao montar o callback de resposta local do pipeline `warmupecosystem.v1`, contaminando `resposta_final` com formato técnico.
+- correção aplicada: o client do backend do dossiê MOIS v1 passou a serializar `StageResult.output()` com `ObjectMapper`, preservando a saída funcional como JSON consumível por preflight, oferta, página, criativos e relatório.
+- prevenção de recorrência: adicionado teste de regressão garantindo que `DossierDossierSynthesisOutput` seja enviado como JSON e não como `record.toString()`.
+- documentos lidos para tratar a situação:
+  - `docs/registros/mois2.md`

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClient.java
@@ -1,5 +1,7 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.pipelines.dossie.v1.StageContext;
 import com.marketinghub.pipelines.dossie.v1.StageResult;
 import com.marketinghub.pipelines.dossie.v1.StageResult.OpenAiInteraction;
@@ -16,10 +18,12 @@ import org.springframework.web.client.RestClient;
 @Slf4j
 public class DossierV1BackendClient {
     private final RestClient restClient;
+    private final ObjectMapper objectMapper;
 
     /** Cria o cliente do pipeline usando o RestClient configurado com a URL base do backend. */
-    public DossierV1BackendClient(RestClient restClient) {
+    public DossierV1BackendClient(RestClient restClient, ObjectMapper objectMapper) {
         this.restClient = restClient;
+        this.objectMapper = objectMapper;
     }
 
     /** Busca trabalhos pendentes da etapa informada no endpoint pending canônico do backend. */
@@ -185,8 +189,14 @@ public class DossierV1BackendClient {
         }
     }
 
-    /** Serializa de forma simples o resultado da etapa para o contrato textual do backend. */
+    /** Serializa a saída funcional da etapa como JSON limpo para o contrato textual do backend. */
     public String responseFrom(StageResult result) {
-        return String.valueOf(result.output());
+        try {
+            return objectMapper.writeValueAsString(result.output());
+        } catch (JsonProcessingException ex) {
+            log.warn("MOIS dossie v1 failed to serialize functional stage output. status={}, output={}",
+                    result == null ? null : result.status(), result == null ? null : result.output(), ex);
+            throw new IllegalStateException("Falha ao serializar saída funcional da etapa MOIS dossiê v1", ex);
+        }
     }
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClientTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/DossierV1BackendClientTest.java
@@ -1,0 +1,36 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.pipelines.dossie.v1.StageResult;
+import com.marketinghub.pipelines.dossie.v1.dossiersynthesis.DossierDossierSynthesisOutput;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+/** Valida os contratos HTTP montados pelo cliente do backend do dossiê MOIS v1. */
+class DossierV1BackendClientTest {
+
+    /** Garante que a saída funcional tipada seja enviada como JSON, não como record.toString(). */
+    @Test
+    void deveSerializarSaidaFuncionalComoJsonLimpo() {
+        DossierV1BackendClient client = new DossierV1BackendClient(RestClient.builder().build(), new ObjectMapper());
+        DossierDossierSynthesisOutput output = new DossierDossierSynthesisOutput(
+                123L,
+                "DONE",
+                "priorizar promessa de economia de tempo",
+                "O produto resolve dor operacional clara.",
+                List.of("evidencia comercial"),
+                List.of("testar criativo com prova"),
+                "APPROVED",
+                Map.of("source", "dossie"));
+
+        String response = client.responseFrom(StageResult.done(Map.of("dossier-synthesis", output), List.of()));
+
+        assertThat(response).contains("\"dossierId\":123");
+        assertThat(response).contains("\"businessDecision\":\"priorizar promessa de economia de tempo\"");
+        assertThat(response).doesNotContain("DossierDossierSynthesisOutput[");
+    }
+}


### PR DESCRIPTION
## Escopo

- Corrige `DossierV1BackendClient` para serializar `StageResult.output()` como JSON funcional limpo.
- Impede que a síntese final do dossiê MOIS seja enviada ao backend como `DossierDossierSynthesisOutput[...]`.
- Adiciona teste de regressão cobrindo a serialização da saída `DossierDossierSynthesisOutput`.
- Registra o aprendizado operacional em `docs/registros/mois2.md`.

## Causa-raiz

O worker `mois-sales-library-worker` montava a resposta local do pipeline `warmupecosystem.v1` com `String.valueOf(result.output())`. Para saídas tipadas, isso gravava uma representação técnica de Java em vez de um JSON comercial consumível.

## Impacto

Os próximos dossiês passam a preservar uma resposta final mais útil para decisão de campanha, oferta, página, criativos, preflight e relatório comercial.

## Validação

- `mvn -q -Dtest=DossierV1BackendClientTest,DossierV1RunnerTest test`
- `mvn -q test` em `mois-sales-library-worker`
- `git diff --check`

Observação: o push local falhou com `403`, então a branch e o PR foram publicados pelo conector GitHub.