### PR TITLE
[codex] Adiciona psicologia aplicada a ofertas

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/ad-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/ad-copy.md
@@ -21,6 +21,7 @@ Regras fixas da etapa:
 2.4. `headline`, `description`, `primaryText` e `ctaText` devem conseguir levar naturalmente ao mesmo botão principal: em vendas, compra/checkout; em leads, formulário como “Receber as 3 mensagens” ou o CTA principal recebido.
 2.5. Nenhuma variação pode testar uma promessa/recompensa diferente; a etapa testa ângulos de abertura da mesma promessa única, não novas ofertas.
 3. O anúncio deve falar diretamente com o cliente ideal descrito pelo ângulo de campanha, usando linguagem de reconhecimento imediato.
+3.1. O gancho deve ativar uma cena concreta da rotina, uma dor emocional ou um esforço que o público quer evitar, sem manipulação abusiva ou exagero.
 4. A copy deve filtrar quem é público alvo de quem não é: quem vive aquela dor/situação precisa se sentir chamado; quem não pertence ao público deve perceber que o anúncio não é para ele.
 5. Crie exatamente 3 variações em `primaryTextVariants`, com labels distintos: `dor`, `resultado` e `prova`.
 6. Cada variação deve ter um gancho de abertura diferente, mas preservar a mesma promessa central.
@@ -29,6 +30,7 @@ Regras fixas da etapa:
 9. `lengthVariants.curta` deve ser direta e rápida para mobile.
 10. `lengthVariants.media` deve explicar a promessa com mecanismo e CTA.
 11. `lengthVariants.longa` deve aprofundar dor, resultado, mecanismo, prova e ação sem virar texto de landing.
+11.1. As variações devem vender alivio percebido, facilidade e futuro imaginável, não apenas o formato do material.
 12. `primaryText` é o texto final que será salvo e publicado no campo Primary text do Meta Ads; deve ter no máximo 125 caracteres.
 12.1. As variações em `lengthVariants` são apenas apoio criativo; se alguma passar de 125 caracteres, reescreva `primaryText` como síntese curta, sem copiar a versão longa.
 13. `headline` deve ser curta, clara e específica, sem promessa absoluta, com no máximo 40 caracteres.
@@ -56,5 +58,6 @@ Checklist antes de responder:
 2. A CTA é a mesma ação esperada para a landing: checkout em vendas ou entrega gratuita em leads?
 3. A copy evita promessa absoluta e promessa individual?
 4. A copy evita consultoria/call/acompanhamento se não fizer parte do produto?
-5. O JSON final contém somente `adCopy` e `experimentMetadata` na raiz?
-6. Cada `primaryText` tem até 125 caracteres, cada `headline` até 40 caracteres e cada `description` até 25 caracteres?
+5. A copy reduz carga cognitiva e deixa claro por que clicar exige pouco esforço?
+6. O JSON final contém somente `adCopy` e `experimentMetadata` na raiz?
+7. Cada `primaryText` tem até 125 caracteres, cada `headline` até 40 caracteres e cada `description` até 25 caracteres?

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -45,6 +45,7 @@ Regra central de contrato:
 - Quando `campaignObjective` for `SALES`, escreva como página de venda direta low-ticket: o CTA principal deve comprar/ir ao checkout, `freeReward` deve aparecer como preview/prova visual da oferta e nenhum texto deve prometer entrega gratuita por formulário antes da compra.
 - Quando `campaignObjective` for `LEADS`, escreva como página de captura: o CTA principal pode prometer a entrega gratuita definida em `freeReward`.
 - Narrativa universal obrigatória: quando o wireframe pedir textos de promessa, dor, mecanismo, prova, oferta e ação, escreva seguindo **Dor → Resultado → Mecanismo → Prova → Oferta → Ação**.
+- Psicologia aplicada obrigatoria: a pagina deve ajudar o visitante a reconhecer a propria dor, imaginar uma cena futura melhor, perceber reducao de esforco e sentir que o proximo passo e simples.
 - Especificidade obrigatória: todo texto deve parecer feito para o nicho e para a dor recebidos no contexto; evite frases que serviriam para qualquer mercado.
 - Mecanismo plausível: em passos/cards explicativos, mostre por que a solução funciona de forma simples, sem promessa mágica e sem jargão interno.
 - CTA orientado ao benefício: botões e links devem repetir a ação principal recebida em `primaryCta`. Em `SALES`, use compra/checkout; em `LEADS`, use a recompensa gratuita, como “Receber as 3 mensagens”.
@@ -52,6 +53,7 @@ Regra central de contrato:
 - Clareza de formulário obrigatória: se o wireframe trouxer labels, placeholders, microcopy ou botão do formulário, escreva textos explícitos para `nome`, `email` e CTA, para que o usuário não veja campos vazios sem orientação.
 - CTA visualmente curto e forte: textos de botão devem ser curtos, específicos e com verbo de ação; evite frases longas que quebrem o layout, pareçam link comum ou reduzam a percepção de botão premium.
 - Prova de valor rápida: em listas e cards, prefira frases que conectem item entregue → benefício prático → redução de esforço/dor, sem depender de termos genéricos como “mini-kit”, “amostra” ou “material” isoladamente.
+- Linguagem experiencial: prefira cenas, tarefas, momentos de decisao, perdas de tempo, insegurancas e alivios concretos do nicho, em vez de beneficios abstratos.
 - A etapa copy não decide estrutura, não adiciona seções, não adiciona blocos e não cria metadados.
 - A etapa copy apenas escreve o valor `texto` para ids textuais existentes no wireframe.
 - Princípio de pouco esforço obrigatório: o usuário não quer fazer esforço para entender a comunicação da página; portanto, cada texto deve ser claro em leitura rápida, reduzir carga cognitiva, evitar explicação longa sem necessidade e conduzir naturalmente para o próximo CTA ou próximo passo definido pelo wireframe.
@@ -94,8 +96,9 @@ Regras obrigatórias:
 12. Para botão submit de formulário, use CTA compatível com o que o formulário realmente coleta; com apenas nome/e-mail, nunca sugira personalização profunda, briefing completo, diagnóstico detalhado imediato, prévia genérica ou sistema completo.
 13. Manter continuidade com promessa e CTA do anúncio somente dentro dos campos textuais que o wireframe já pediu, repetindo `funnelPromise`, `freeReward` e `primaryCta` quando estiverem disponíveis.
 14. Antes de responder, revise se H1, subtítulo, CTA do hero e submit contam a mesma história: dor removida, resultado prometido, mecanismo plausível, prova/entrega e ação de baixo esforço.
-15. Se houver conflito entre contexto e wireframe, priorize sempre o wireframe.
-16. Responder somente com JSON válido aderente ao schema da etapa.
+15. Antes de responder, revise se a pagina reduz carga cognitiva: o visitante entende para quem e, qual dor resolve, como funciona, o que recebe e qual proximo passo.
+16. Se houver conflito entre contexto e wireframe, priorize sempre o wireframe.
+17. Responder somente com JSON válido aderente ao schema da etapa.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
@@ -14,6 +14,7 @@ A landing do GeraLanding não deve apenas parecer bonita. Ela precisa cumprir um
 4. oferecer uma microprova concreta do valor da solução;
 5. fazer o visitante sentir que vale a pena avançar para a ação principal: checkout em `SALES` ou e-mail em `LEADS`;
 6. conduzir visualmente para a ação principal sem confusão.
+7. reduzir carga cognitiva e tornar facil imaginar a melhoria concreta depois da acao.
 
 Use as imagens como evidência principal. Avalie o que aparece na tela, não o que provavelmente estava no briefing. Não recompense intenção invisível.
 
@@ -58,6 +59,8 @@ A página deve sustentar a sequência comercial:
 **Dor → Resultado → Mecanismo → Prova → Oferta → Ação**
 
 A landing deve vender primeiro a transformação percebida pelo visitante. O material gratuito, diagnóstico, checklist, plano, template, preview ou amostra deve funcionar como prova de valor e redução de risco, não como um item genérico sem desejo. Em `SALES`, essa prova deve preparar o clique no checkout, não substituir a compra.
+
+Tambem avalie se a pagina aplica psicologia comercial de forma saudavel: reconhecimento imediato da dor, cena concreta da rotina, alivio de esforco, identidade desejada plausivel e futuro facil de visualizar.
 
 ## Critérios de avaliação
 
@@ -152,13 +155,19 @@ Avalie:
 
 Penalize se a página parecer wireframe, template cru, layout monótono, tela genérica, página sem acabamento ou composição visual sem intenção.
 
-### 7. Especificidade do público
+### 7. Reconhecimento psicologico e baixo esforço
+
+A pagina deve fazer o visitante pensar rapidamente: "isso fala de mim", "esse problema me custa algo", "esse caminho parece possivel" e "o proximo passo e simples".
+
+Penalize se a pagina exigir muito esforco mental para entender a oferta, usar linguagem abstrata demais, nao mostrar cena concreta da rotina ou nao conectar dor atual a uma melhoria futura imaginavel.
+
+### 8. Especificidade do público
 
 A página deve parecer feita para um público real.
 
 Penalize se os textos e blocos poderiam servir para qualquer nicho. A dor, a promessa, a prova e a oferta devem conter sinais específicos do mercado, da situação e do desejo do público.
 
-### 8. Coerência entre promessa, prova e CTA
+### 9. Coerência entre promessa, prova e CTA
 
 Quando houver contrato de promessa única, a landing deve preservar a mesma `singlePain`, `freeReward`, `funnelPromise` e `primaryCta` do contrato.
 
@@ -172,7 +181,7 @@ Penalize se:
 - a oferta parece menor do que a promessa;
 - o formulário aparece antes de existir desejo suficiente.
 
-### 9. Responsividade e ausência de falhas técnicas visíveis
+### 10. Responsividade e ausência de falhas técnicas visíveis
 
 Verifique desktop e mobile:
 
@@ -211,6 +220,7 @@ Recomende `APPROVE_FOR_PUBLICATION` somente se todas as condições abaixo forem
 - primeira dobra comunica dor, resultado, mecanismo e CTA;
 - existe prova ou amostra concreta do valor da solução;
 - o formulário/CTA deixa claro o benefício de enviar o e-mail;
+- a pagina reduz carga cognitiva e ajuda o visitante a visualizar a transformacao concreta;
 - a página parece final, confiável e premium;
 - não há artefato técnico, metadado, texto provisório ou layout quebrado;
 - mobile e desktop estão visualmente corretos.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-mechanism.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-mechanism.md
@@ -9,6 +9,7 @@ Regras obrigatórias:
 - Use a dor concluída e o resultado concluído como base principal; não invente um novo problema nem uma nova promessa.
 - O mecanismo precisa explicar por que o resultado pode acontecer de forma concreta, sem parecer mágica, cura, automação total ou garantia absoluta.
 - O mecanismo deve reduzir dor e esforço do nicho, aumentando facilidade, previsibilidade e valor percebido.
+- O mecanismo deve reduzir carga cognitiva: mostrar o caminho em poucos passos claros, com linguagem de rotina, sem exigir que o consumidor entenda tecnologia ou jargao.
 - O mecanismo precisa ser compatível com produto digital apoiado por IA, mas sem depender de acesso direto ao sistema interno do cliente.
 - Não crie prova, preço, bônus, checkout ou oferta final nesta etapa.
 - Não use markdown dentro dos campos.
@@ -18,6 +19,7 @@ Critérios de qualidade:
 - Explique o mecanismo em linguagem simples, comercial e operacional.
 - Mostre passos claros que possam virar módulos, entregáveis ou ativos digitais depois.
 - Deixe explícito o papel da IA como alavanca prática, não como promessa vaga.
+- Mostre por que o caminho parece mais facil do que tentar resolver sozinho.
 - Inclua limites de plausibilidade para impedir promessa exagerada.
 - Preserve o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
 

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
@@ -10,6 +10,7 @@ Regras obrigatórias:
 - A oferta precisa ser um produto digital low-ticket: específico, barato o suficiente para compra de baixo atrito e útil rapidamente.
 - A oferta precisa ser percebida como um pacote de alto valor por preço baixo: muitos itens úteis, complementares e aplicáveis, sem inflar com bônus irrelevantes.
 - A oferta precisa deixar claro o que o cliente recebe, por que isso reduz esforço e como aproxima o resultado desejado.
+- A oferta deve tornar facil imaginar a vida apos a compra: qual tarefa fica mais simples, qual dor diminui, qual decisao fica mais clara e qual identidade desejada se aproxima.
 - Defina uma faixa de preço sugerida ou ancoragem de preço compatível com low-ticket; não crie checkout, cupom, parcelamento ou condição comercial final.
 - A oferta deve conter entregáveis concretos que possam ser produzidos pelo Marketing Hub depois: diagnóstico, roteiro, checklist, template, biblioteca, calculadora simples, prompts, plano ou mini-kit.
 - Quando o público for MEI, autônomo, trabalhador por conta própria, dono-operador ou negócio local, avalie obrigatoriamente se a dor pode ser atacada por uma oferta de presença digital, atendimento e aquisição prática: Google Perfil da Empresa, Instagram, WhatsApp, descrição do negócio, respostas prontas, rotina de postagens, pedido de avaliações, orçamento, follow-up, agenda e recuperação de interessados.
@@ -29,6 +30,7 @@ Critérios de qualidade:
 - A promessa de entrada deve caber em uma compra simples: remover uma dor prática, entregar clareza, reduzir esforço ou gerar um primeiro avanço perceptível.
 - Os passos devem poder virar módulos, entregáveis, checklists, templates ou planos de ação.
 - Os entregáveis devem ser descritos pelo benefício prático, não apenas pelo formato do arquivo.
+- A pilha de valor deve parecer uma solucao de baixo esforco para uma situacao real, nao uma lista decorativa de arquivos.
 - A relação preço/valor deve soar como oportunidade acessível: preço baixo, pacote robusto, aplicação imediata e economia de esforço; não use desconto falso, urgência artificial ou ancoragem enganosa.
 - Mostre o papel da IA como redução de esforço e aceleração prática, não como mágica.
 - Inclua limites de plausibilidade para manter a promessa segura e vendável.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
@@ -13,6 +13,7 @@ Regras obrigatórias:
 - A dor emocional deve mostrar o peso psicológico da situação.
 - A dor social deve mostrar impacto em imagem, autoridade, comparação ou segurança profissional.
 - O custo deve expressar perda de dinheiro, tempo, previsibilidade ou oportunidade.
+- A dor deve seguir o canon de psicologia aplicada a ofertas: explicitar dor pratica, dor emocional, esforco evitado, identidade ameacada e uma cena concreta da rotina em que a dor aparece.
 - A dor deve poder ser atacada por produto digital, diagnóstico, roteiro, template, plano, biblioteca ou ferramenta baseada em IA.
 - Não crie promessa final, preço ou oferta nesta etapa.
 - Não repita hipótese já gerada para o mesmo nicho. Quando `existingHypothesesSummary` trouxer histórico, escolha uma dor de entrada, persona, promessa implícita e mecanismo potencial claramente diferentes das hipóteses anteriores.
@@ -23,6 +24,7 @@ Critérios de qualidade:
 - Priorize uma dor que possa gerar venda, não curiosidade superficial.
 - Evite problemas amplos demais como “falta de marketing” sem traduzir a consequência concreta.
 - Se houver várias dores possíveis, escolha a mais urgente e mais fácil de transformar em anúncio e landing page.
+- Prefira dores que o consumidor reconheca rapidamente porque ja viveu, viu, sentiu ou tentou evitar.
 - Inclua sinais de evidência apenas quando eles estiverem apoiados pelo contexto recebido.
 
 Contexto do nicho e artefatos disponíveis:

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
@@ -9,6 +9,7 @@ Regras obrigatórias:
 - Use a dor, o resultado e o mecanismo concluídos como base principal; não invente uma nova dor, promessa ou mecanismo.
 - A prova deve reduzir ceticismo e mostrar por que o mecanismo é plausível para o nicho.
 - A prova precisa ser viável para produto digital apoiado por IA: diagnóstico, checklist, amostra, simulação, mini-plano, antes/depois demonstrável ou evidência operacional.
+- A prova deve ajudar o consumidor a visualizar o antes/depois ou o primeiro alivio concreto antes de assumir risco maior.
 - Não prometa cura, renda garantida, resultado absoluto, automação total ou dependência de acesso interno ao negócio do cliente.
 - Não crie preço, checkout, campanha de anúncios ou página de vendas nesta etapa.
 - Não use markdown dentro dos campos.
@@ -17,6 +18,7 @@ Regras obrigatórias:
 Critérios de qualidade:
 - A prova deve ser específica, fácil de produzir e conectada à rotina real do nicho.
 - Explique qual objeção a prova reduz e como ela será coletada ou demonstrada.
+- Prefira provas que mostrem reducao de esforco, clareza, ganho de controle ou melhoria perceptivel na rotina.
 - Preserve o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
 
 Contexto do nicho, dor concluída, resultado concluído e mecanismo concluído:

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-result.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-result.md
@@ -9,6 +9,7 @@ Regras obrigatórias:
 - Use a dor concluída como base principal; não invente uma dor nova.
 - O resultado precisa ser específico, concreto e compatível com produto digital apoiado por IA.
 - O resultado deve reduzir dor e esforço, aumentando facilidade, prazer, previsibilidade ou ganho percebido.
+- O resultado deve permitir que o consumidor imagine uma cena futura melhor, com menos carga mental, mais controle ou mais seguranca para agir.
 - Não prometa cura, garantia absoluta, enriquecimento garantido ou transformação irreal.
 - Não crie mecanismo, prova, preço ou oferta nesta etapa.
 - Não use markdown dentro dos campos.
@@ -18,6 +19,7 @@ Critérios de qualidade:
 - O resultado deve ser forte o suficiente para sustentar anúncio e primeira dobra de landing page.
 - Expresse a mudança em linguagem simples, como benefício prático percebido pelo nicho.
 - Mostre um ganho rápido possível sem vender milagre.
+- Conecte o resultado a uma identidade desejada plausivel: mais profissional, mais organizado, mais seguro, mais livre ou mais no controle, conforme o nicho.
 - Inclua limites de plausibilidade para impedir promessa exagerada.
 
 Contexto do nicho, dor concluída e artefatos disponíveis:

--- a/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/mechanism/user.md
+++ b/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/mechanism/user.md
@@ -12,6 +12,7 @@ Resuma com foco em:
 - mecanismo principal em linguagem comercial
 - o que fica visível antes da compra
 - razão principal para acreditar
+- como o mecanismo reduz esforco, carga mental ou tentativa manual do cliente
 
 Instruções extras do usuário:
 {{CUSTOM_INSTRUCTIONS}}

--- a/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/offer/user.md
+++ b/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/offer/user.md
@@ -13,6 +13,7 @@ Resuma com foco em:
 - ativo de prova associado
 - entregáveis mais fortes
 - CTA preferencial
+- reducao de esforco percebida, facilidade de aplicacao e valor psicologico da oferta
 
 Instruções extras do usuário:
 {{CUSTOM_INSTRUCTIONS}}

--- a/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/pain/user.md
+++ b/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/pain/user.md
@@ -12,6 +12,7 @@ Resuma com foco em:
 - problema central mais acionável
 - consequência comercial principal
 - urgência percebida para agir
+- dor emocional, esforco evitado e cena concreta da rotina quando aparecerem no material
 
 Instruções extras do usuário:
 {{CUSTOM_INSTRUCTIONS}}

--- a/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/proof/user.md
+++ b/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/proof/user.md
@@ -12,6 +12,7 @@ Resuma com foco em:
 - tipo de prova
 - ativo de prova mais convincente
 - mensagem central que reduz ceticismo
+- antes/depois, alivio percebido ou primeira evidencia concreta que facilite a decisao
 
 Instruções extras do usuário:
 {{CUSTOM_INSTRUCTIONS}}

--- a/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/result/user.md
+++ b/backend/ads-service/src/main/resources/prompts/hypothesis-framework/summary/result/user.md
@@ -12,6 +12,7 @@ Resuma com foco em:
 - transformação desejada
 - outcome de negócio
 - marcador objetivo de sucesso
+- futuro imaginavel e identidade desejada que o publico busca alcancar
 
 Instruções extras do usuário:
 {{CUSTOM_INSTRUCTIONS}}

--- a/docs/canonical/psicologia-aplicada-ofertas-canon.v1.md
+++ b/docs/canonical/psicologia-aplicada-ofertas-canon.v1.md
@@ -1,0 +1,127 @@
+# Psicologia aplicada a ofertas - canon v1
+
+Data de criacao: 2026-07-06
+
+## Objetivo
+
+Transformar os aprendizados dos artigos de `docs/neuron` em regra operacional para criacao de produtos, ofertas, anuncios, landings e revisoes comerciais do Marketing Hub.
+
+O principio central e que o consumidor nao decide apenas por argumento logico. Ele interpreta a oferta a partir de dor percebida, memoria autobiografica, emocao, identidade, contexto social, esforco esperado e simulacao mental do futuro.
+
+## Regra central
+
+Toda oferta deve deixar claro, de forma concreta e rapidamente imaginavel:
+
+- qual dor real sera afastada;
+- qual esforco sera reduzido;
+- qual facilidade ou prazer sera aproximado;
+- qual cena concreta da rotina muda depois da compra;
+- qual identidade desejada fica mais acessivel;
+- por que o mecanismo parece plausivel;
+- qual prova reduz risco antes da decisao.
+
+## Mapa psicologico da dor
+
+Toda hipotese comercial deve procurar estes sinais:
+
+- dor pratica: o problema operacional que atrapalha a rotina;
+- dor emocional: ansiedade, vergonha, medo, frustracao, cansaco ou inseguranca associados;
+- esforco evitado: tarefa, decisao, pesquisa, tentativa ou exposicao que a pessoa quer reduzir;
+- prazer buscado: alivio, clareza, controle, reconhecimento, previsibilidade ou ganho percebido;
+- identidade ameacada: como a dor faz a pessoa se sentir menos capaz, profissional, desejada, segura ou livre;
+- futuro desejado: a cena simples que a pessoa gostaria de viver depois de resolver o problema.
+
+## Matriz de experiencia concreta
+
+Produto e comunicacao devem usar linguagem que ajude o usuario a reconhecer uma experiencia real. Sempre que possivel, preferir cenas do dia a dia:
+
+- abrir WhatsApp e nao saber responder;
+- olhar agenda, conta, estoque, perfil, pedido ou mensagem e sentir atraso;
+- perder tempo tentando decidir o proximo passo;
+- comparar-se com concorrentes ou pessoas semelhantes;
+- evitar uma tarefa por parecer confusa, tecnica ou cansativa;
+- perceber uma oportunidade comercial passando.
+
+Evitar promessa abstrata quando uma cena concreta puder comunicar melhor.
+
+## Identidade e futuro
+
+A comunicacao deve ajudar a pessoa a se imaginar como alguem que saiu do estado atual para um estado mais desejavel:
+
+- de confusa para orientada;
+- de travada para em movimento;
+- de improvisada para profissional;
+- de invisivel para lembrada;
+- de sobrecarregada para no controle;
+- de insegura para confiante o suficiente para agir.
+
+Essa identidade deve ser apresentada com sobriedade. Nao vender fantasia, milagre ou status falso.
+
+## Comunicacao de baixo esforco
+
+Toda pagina, anuncio e artefato comercial deve reduzir carga cognitiva:
+
+- dizer para quem e;
+- mostrar a dor em linguagem reconhecivel;
+- explicar o resultado esperado;
+- mostrar o mecanismo de forma simples;
+- apresentar prova ou preview;
+- deixar claro o que a pessoa recebe;
+- indicar o proximo passo sem ambiguidade.
+
+Se a pessoa precisa pensar demais para entender a oferta, a comunicacao esta fraca.
+
+## Score psicologico de oferta
+
+Ao avaliar uma hipotese, considerar:
+
+- intensidade da dor;
+- frequencia da dor;
+- clareza do alivio;
+- facilidade percebida;
+- apelo de identidade;
+- forca da cena antes/depois;
+- urgencia emocional;
+- plausibilidade do mecanismo;
+- prova disponivel para reduzir risco.
+
+Ofertas com dor forte, alivio claro, baixo esforco percebido e futuro facil de imaginar devem receber prioridade.
+
+## Aplicacao nos pipelines
+
+### Hipotese
+
+As etapas de dor, resultado, mecanismo, prova e oferta devem preservar sinais psicologicos do publico. O eixo Dor -> Resultado -> Mecanismo -> Prova -> Oferta deve ser tratado como narrativa de transformacao percebida, nao apenas como estrutura tecnica.
+
+### Anuncio
+
+O anuncio deve ativar reconhecimento imediato. O gancho deve parecer uma situacao que a pessoa vive ou teme viver, e o clique deve prometer alivio concreto com baixo esforco.
+
+### Landing page
+
+A landing deve permitir que o visitante visualize rapidamente:
+
+- "isso fala comigo";
+- "esse problema me custa algo";
+- "o resultado parece desejavel";
+- "o caminho parece simples";
+- "a prova reduz meu risco";
+- "o proximo passo parece facil".
+
+### Quality review
+
+Uma landing nao deve ser aprovada apenas por parecer bonita. Ela precisa gerar reconhecimento psicologico, desejo de transformacao, percepcao de facilidade e confianca suficiente para avancar.
+
+## Limites
+
+- Nao manipular medo, vergonha ou inseguranca de forma abusiva.
+- Nao prometer cura, renda garantida, transformacao absoluta ou resultado individual inevitavel.
+- Nao usar urgencia falsa.
+- Nao criar identidade aspiracional desconectada da entrega real.
+- Nao esconder esforco necessario quando ele existir.
+
+## Criterio final
+
+Uma boa oferta do Marketing Hub deve fazer o consumidor pensar:
+
+"Essa dor e minha, esse caminho parece possivel, isso reduz meu esforco e eu consigo imaginar minha vida melhor depois de usar."

--- a/docs/neuron/ini.md
+++ b/docs/neuron/ini.md
@@ -1,1 +1,7 @@
+## Uso operacional no Marketing Hub
 
+Os artigos deste diretorio foram consolidados no canon:
+
+- `docs/canonical/psicologia-aplicada-ofertas-canon.v1.md`
+
+Esse canon deve orientar a criacao e revisao de produtos, ofertas, anuncios e landings, principalmente nos pontos de dor percebida, reducao de esforco, identidade, cenas concretas da rotina e simulacao do futuro desejado.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5625,3 +5625,9 @@
 - Causa-raiz: o `ads-service` ainda mantinha endpoints públicos do Lead Portal, criando ambiguidade entre atendimento ao cliente e gestão interna do Marketing Hub.
 - Correção aplicada: removidos do `ads-service` os controllers públicos `/api/flows`, `/api/public/lead-portal/image-packages` e `/api/public/lead-portal/purchases`; o tracking de funil no Marketing Hub passou a ser callback interno em `/api/internal/lead-portal/flows`; a borda pública de pacotes ficou no `lead-portal`; e o redirecionamento público de checkout ficou no `lead-portal-payments-service`.
 - Prevenção de recorrência: regra ArchUnit bloqueia controllers de cliente do Lead Portal no pacote `leadportal.web` do `ads-service`, e a documentação canônica foi atualizada para não apontar atendimento de lead/cliente no backend principal.
+
+## 2026-07-06 - Psicologia aplicada a ofertas
+
+- Criado o canon `docs/canonical/psicologia-aplicada-ofertas-canon.v1.md`.
+- Consolidado o uso dos artigos de `docs/neuron` como regra operacional para dor, resultado, mecanismo, prova, oferta, anuncio, landing e quality review.
+- Ajustados prompts do `ai-worker` e prompts de resumo do backend para preservar sinais de dor emocional, esforco evitado, identidade, cena concreta e futuro imaginavel.


### PR DESCRIPTION
## Resumo

- Cria o canon `psicologia-aplicada-ofertas-canon.v1.md` a partir dos artigos de `docs/neuron`.
- Incorpora os sinais psicologicos nos prompts de dor, resultado, mecanismo, prova, oferta, anuncio, landing e quality review.
- Atualiza prompts de resumo do backend para preservar dor emocional, esforco evitado, identidade, cena concreta e futuro imaginavel.
- Registra a mudanca em `docs/neuron/ini.md` e `docs/registros/experimentos.md`.

## Impacto

A geracao de produtos e comunicacoes passa a priorizar reconhecimento imediato da dor, reducao de esforco, plausibilidade do mecanismo, prova de valor e visualizacao do futuro desejado, alinhada ao principio comercial central do Marketing Hub.

## Validacao

- `git diff --check`
- Sem testes unitarios: alteracao restrita a documentacao e prompts, sem codigo Java/TypeScript executavel.