### PR TITLE
[codex] Corrige endpoint de analytics do Lead Portal

### DIFF
--- a/lead-portal/frontend/src/utils/customTemplateHtml.ts
+++ b/lead-portal/frontend/src/utils/customTemplateHtml.ts
@@ -1,5 +1,7 @@
 const HTML_HINT = /<\s*!doctype|<\s*html|<\s*body|<\s*(?:main|section|div|header|footer)/i;
 const FENCED_JSON = /```(?:json)?\s*([\s\S]*?)```/i;
+const LEGACY_MARKETING_HUB_ANALYTICS_PATH = /\/mh-api\/public\/lead-portal\/flows\//g;
+const LEAD_PORTAL_ANALYTICS_PATH = "/api/flows/";
 
 export interface CustomTemplateFormFieldSpec {
   name: string;
@@ -49,7 +51,7 @@ export function normalizeCustomTemplatePayload(raw?: string | null): CustomTempl
     return undefined;
   }
   if (looksLikeHtml(trimmed)) {
-    return { html: trimmed };
+    return { html: normalizeLegacyAnalyticsEndpoints(trimmed) };
   }
   return extractFromJson(trimmed);
 }
@@ -69,7 +71,7 @@ function findPayloadInValue(value: unknown): CustomTemplatePayload | undefined {
       return undefined;
     }
     if (looksLikeHtml(trimmed)) {
-      return { html: trimmed };
+      return { html: normalizeLegacyAnalyticsEndpoints(trimmed) };
     }
     if (looksLikeJsonCandidate(trimmed)) {
       return extractFromJson(trimmed);
@@ -104,6 +106,10 @@ function findPayloadInValue(value: unknown): CustomTemplatePayload | undefined {
     }
   }
   return undefined;
+}
+
+function normalizeLegacyAnalyticsEndpoints(html: string): string {
+  return html.replace(LEGACY_MARKETING_HUB_ANALYTICS_PATH, LEAD_PORTAL_ANALYTICS_PATH);
 }
 
 function normalizeFormSpec(raw: unknown): CustomTemplateFormSpec | undefined {


### PR DESCRIPTION
## O que mudou

- Normaliza HTML customizado do Lead Portal para trocar o endpoint legado `/mh-api/public/lead-portal/flows/` pela rota pública atual `/api/flows/` antes de renderizar/executar scripts.

## Causa-raiz

Os últimos experimentos low-ticket tinham acessos registrados via `render-complete`, mas os eventos `landing-page-analytics` permaneciam zerados. A investigação em banco mostrou que os experimentos 56, 57 e 58 tinham renderizações, mas nenhum analytics. O HTML publicado pelo GeraSalesPage enviava `page-analytics` para `/mh-api/public/lead-portal/flows/...`, rota que retorna 405 no domínio atual; a rota funcional é `/api/flows/...`.

## Impacto

Páginas antigas ou novas que cheguem com o script de vendas legado passam a alimentar o funil/analytics pelo contrato canônico do Lead Portal, reduzindo risco de tráfego real aparecer como zero na tela do experimento.

## Validação

- `npm run build` em `lead-portal/frontend`
- `npm run lint` em `lead-portal/frontend`

## Observação operacional

Também registrei localmente o aprendizado em `docs/registros/experimentos.md`, mas o push nativo para o repositório retornou 403 e o conector exige atualização por conteúdo completo; esse arquivo tem aproximadamente 610 KB. Por isso, este PR contém a correção funcional. O commit local com o registro ficou em `6dd4e98` no workspace.