### PR TITLE
[codex] Add experiment video assets

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
@@ -7,6 +7,7 @@ public enum ExperimentReadinessIssueType {
     CREATIVE,
     LEAD_PORTAL_FLOW,
     PRODUCT_AI_FUNNEL,
+    VIDEO_ASSET,
     TARGETING,
     GERA_LANDING,
     GERA_SALES_PAGE

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -14,6 +14,7 @@ import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
+import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,17 +62,20 @@ public class ExperimentReadinessService {
     );
 
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+    private final ExperimentVideoAssetService experimentVideoAssetService;
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
                                       GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
-                                      ExperimentCampaignDestinationPolicy campaignDestinationPolicy) {
+                                      ExperimentCampaignDestinationPolicy campaignDestinationPolicy,
+                                      ExperimentVideoAssetService experimentVideoAssetService) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
         this.campaignDestinationPolicy = campaignDestinationPolicy;
+        this.experimentVideoAssetService = experimentVideoAssetService;
     }
 
     /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
@@ -93,6 +97,7 @@ public class ExperimentReadinessService {
         boolean purchaseIntent = campaignDestinationPolicy.requiresSalesPageBeforePurchase(experiment);
         boolean hasCommercialContract = campaignDestinationPolicy.hasCompleteCommercialContract(experiment);
         boolean hasGeraSalesPagePipeline = campaignDestinationPolicy.hasCompletedGeraSalesPagePipeline(experimentId);
+        boolean hasRequiredVideoBlockingRelease = hasRequiredVideoBlockingRelease(experiment);
         Optional<GeraSalesPagePublicationAudit> salesPagePublication =
                 campaignDestinationPolicy.latestSalesPagePublication(experimentId);
 
@@ -121,6 +126,15 @@ public class ExperimentReadinessService {
                     "Sem funil de coleta para personalização",
                     "Produto IA com amostra personalizada precisa coletar dados do lead antes de prometer uma entrega exclusiva.",
                     "Crie o funil pelo comando de Produto IA antes de liberar campanha ou venda.",
+                    List.of()
+            ));
+        }
+        if (hasRequiredVideoBlockingRelease) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.VIDEO_ASSET,
+                    "Vídeo obrigatório ainda não aprovado",
+                    "Este experimento possui vídeo obrigatório para o funil, mas o ativo ainda não está pronto e aprovado.",
+                    "Finalize a geração, revise o vídeo e aprove o ativo antes de liberar tráfego.",
                     List.of()
             ));
         }
@@ -218,6 +232,9 @@ public class ExperimentReadinessService {
         if (isPersonalizedSampleProductAi(experiment) && !hasProductAiPersonalizationFunnel(experiment)) {
             missing.add("productAiPersonalizedSampleFunnel");
         }
+        if (hasRequiredVideoBlockingRelease(experiment)) {
+            missing.add("experimentVideoAsset");
+        }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("approvedTargetingPackage");
         }
@@ -312,6 +329,13 @@ public class ExperimentReadinessService {
                 .map(question -> question.getDataKey() == null ? "" : question.getDataKey().toLowerCase(Locale.ROOT))
                 .collect(java.util.stream.Collectors.toSet());
         return keys.containsAll(PRODUCT_AI_PERSONALIZED_SAMPLE_REQUIRED_KEYS);
+    }
+
+    /** Verifica se algum vídeo obrigatório do experimento ainda impede liberação comercial. */
+    private boolean hasRequiredVideoBlockingRelease(Experiment experiment) {
+        return experiment != null
+                && experiment.getId() != null
+                && experimentVideoAssetService.hasRequiredVideoBlockingRelease(experiment.getId());
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoAsset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoAsset.java
@@ -1,0 +1,129 @@
+package com.marketinghub.experiment.video;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.media.Asset;
+import com.marketinghub.salesvideo.LandingVideoSlot;
+import com.marketinghub.salesvideo.SalesVideoJob;
+import com.marketinghub.salesvideo.SalesVideoProfile;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Representa um vídeo vinculado a um experimento como artefato mensurável de funil.
+ */
+@Entity
+@Table(name = "experiment_video_asset")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentVideoAsset {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    @ToString.Exclude
+    private Experiment experiment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "slot", nullable = false, length = 32)
+    private ExperimentVideoSlot slot;
+
+    @Column(name = "objective", nullable = false, length = 512)
+    private String objective;
+
+    @Column(name = "primary_metric", nullable = false, length = 191)
+    private String primaryMetric;
+
+    @Column(name = "script", columnDefinition = "LONGTEXT")
+    private String script;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "provider", nullable = false, length = 64)
+    private String provider;
+
+    @Column(name = "model", nullable = false, length = 128)
+    private String model;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private ExperimentVideoStatus status;
+
+    @Column(name = "asset_url", length = 1024)
+    private String assetUrl;
+
+    @Column(name = "thumbnail_url", length = 1024)
+    private String thumbnailUrl;
+
+    @Column(name = "duration_seconds")
+    private Integer durationSeconds;
+
+    @Column(name = "aspect_ratio", length = 16)
+    private String aspectRatio;
+
+    @Column(name = "request_json", columnDefinition = "LONGTEXT")
+    private String requestJson;
+
+    @Column(name = "response_json", columnDefinition = "LONGTEXT")
+    private String responseJson;
+
+    @Column(name = "cost", precision = 12, scale = 4)
+    private BigDecimal cost;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_status", nullable = false, length = 32)
+    private ExperimentVideoReviewStatus reviewStatus;
+
+    @Column(name = "required_for_release", nullable = false)
+    private boolean requiredForRelease;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_video_profile_id")
+    @ToString.Exclude
+    private SalesVideoProfile salesVideoProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_video_job_id")
+    @ToString.Exclude
+    private SalesVideoJob salesVideoJob;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "asset_id")
+    @ToString.Exclude
+    private Asset asset;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "landing_video_slot_id")
+    @ToString.Exclude
+    private LandingVideoSlot landingVideoSlot;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoReviewStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoReviewStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.video;
+
+/**
+ * Estados de revisão humana do vídeo antes de entrar no funil do experimento.
+ */
+public enum ExperimentVideoReviewStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoSlot.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoSlot.java
@@ -1,0 +1,11 @@
+package com.marketinghub.experiment.video;
+
+/**
+ * Pontos do funil em que o vídeo pode atuar como ativo comercial.
+ */
+public enum ExperimentVideoSlot {
+    AD,
+    LANDING_HERO,
+    FORM_EXPLAINER,
+    PRE_CHECKOUT
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.experiment.video;
+
+/**
+ * Estados operacionais do ativo de vídeo do experimento.
+ */
+public enum ExperimentVideoStatus {
+    PLANNED,
+    GENERATING,
+    READY,
+    FAILED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/CreateExperimentVideoAssetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/CreateExperimentVideoAssetRequest.java
@@ -1,0 +1,35 @@
+package com.marketinghub.experiment.video.dto;
+
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoSlot;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * Dados para registrar um vídeo planejado ou gerado dentro de um experimento.
+ */
+public record CreateExperimentVideoAssetRequest(
+        @NotNull ExperimentVideoSlot slot,
+        @NotBlank String objective,
+        @NotBlank String primaryMetric,
+        String script,
+        String prompt,
+        @NotBlank String provider,
+        @NotBlank String model,
+        ExperimentVideoStatus status,
+        String assetUrl,
+        String thumbnailUrl,
+        Integer durationSeconds,
+        String aspectRatio,
+        String requestJson,
+        String responseJson,
+        BigDecimal cost,
+        ExperimentVideoReviewStatus reviewStatus,
+        boolean requiredForRelease,
+        Long salesVideoProfileId,
+        Long salesVideoJobId,
+        Long assetId,
+        Long landingVideoSlotId
+) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/ExperimentVideoAssetDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/ExperimentVideoAssetDto.java
@@ -1,0 +1,38 @@
+package com.marketinghub.experiment.video.dto;
+
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoSlot;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Representação de leitura do vídeo vinculado ao experimento.
+ */
+public record ExperimentVideoAssetDto(
+        Long id,
+        Long experimentId,
+        ExperimentVideoSlot slot,
+        String objective,
+        String primaryMetric,
+        String script,
+        String prompt,
+        String provider,
+        String model,
+        ExperimentVideoStatus status,
+        String assetUrl,
+        String thumbnailUrl,
+        Integer durationSeconds,
+        String aspectRatio,
+        String requestJson,
+        String responseJson,
+        BigDecimal cost,
+        ExperimentVideoReviewStatus reviewStatus,
+        boolean requiredForRelease,
+        Long salesVideoProfileId,
+        Long salesVideoJobId,
+        Long assetId,
+        Long landingVideoSlotId,
+        Instant createdAt,
+        Instant updatedAt
+) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/UpdateExperimentVideoAssetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/UpdateExperimentVideoAssetRequest.java
@@ -1,0 +1,33 @@
+package com.marketinghub.experiment.video.dto;
+
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoSlot;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import java.math.BigDecimal;
+
+/**
+ * Dados opcionais para atualizar estado, revisão e vínculos do vídeo do experimento.
+ */
+public record UpdateExperimentVideoAssetRequest(
+        ExperimentVideoSlot slot,
+        String objective,
+        String primaryMetric,
+        String script,
+        String prompt,
+        String provider,
+        String model,
+        ExperimentVideoStatus status,
+        String assetUrl,
+        String thumbnailUrl,
+        Integer durationSeconds,
+        String aspectRatio,
+        String requestJson,
+        String responseJson,
+        BigDecimal cost,
+        ExperimentVideoReviewStatus reviewStatus,
+        Boolean requiredForRelease,
+        Long salesVideoProfileId,
+        Long salesVideoJobId,
+        Long assetId,
+        Long landingVideoSlotId
+) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -1,0 +1,267 @@
+package com.marketinghub.experiment.video.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.LandingPage;
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
+import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
+import com.marketinghub.media.Asset;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
+import com.marketinghub.repository.jpa.media.AssetRepository;
+import com.marketinghub.repository.jpa.salesvideo.LandingVideoSlotRepository;
+import com.marketinghub.repository.jpa.salesvideo.SalesVideoJobRepository;
+import com.marketinghub.repository.jpa.salesvideo.SalesVideoProfileRepository;
+import com.marketinghub.salesvideo.LandingVideoSlot;
+import com.marketinghub.salesvideo.SalesVideoJob;
+import com.marketinghub.salesvideo.SalesVideoProfile;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Gerencia vídeos como ativos comerciais rastreáveis dentro de um experimento.
+ */
+@Service
+public class ExperimentVideoAssetService {
+    private final ExperimentVideoAssetRepository repository;
+    private final ExperimentRepository experimentRepository;
+    private final SalesVideoProfileRepository profileRepository;
+    private final SalesVideoJobRepository jobRepository;
+    private final AssetRepository assetRepository;
+    private final LandingVideoSlotRepository landingVideoSlotRepository;
+
+    /** Inicializa o serviço com os repositórios dos vínculos de experimento e vídeo. */
+    public ExperimentVideoAssetService(ExperimentVideoAssetRepository repository,
+                                       ExperimentRepository experimentRepository,
+                                       SalesVideoProfileRepository profileRepository,
+                                       SalesVideoJobRepository jobRepository,
+                                       AssetRepository assetRepository,
+                                       LandingVideoSlotRepository landingVideoSlotRepository) {
+        this.repository = repository;
+        this.experimentRepository = experimentRepository;
+        this.profileRepository = profileRepository;
+        this.jobRepository = jobRepository;
+        this.assetRepository = assetRepository;
+        this.landingVideoSlotRepository = landingVideoSlotRepository;
+    }
+
+    /** Lista todos os vídeos registrados para um experimento. */
+    @Transactional(readOnly = true)
+    public List<ExperimentVideoAssetDto> list(Long experimentId) {
+        ensureExperiment(experimentId);
+        return repository.findByExperimentIdOrderByCreatedAtDesc(experimentId).stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    /** Cria um vídeo de experimento com seus vínculos opcionais validados. */
+    @Transactional
+    public ExperimentVideoAssetDto create(Long experimentId, CreateExperimentVideoAssetRequest request) {
+        Experiment experiment = ensureExperiment(experimentId);
+        ExperimentVideoAsset videoAsset = ExperimentVideoAsset.builder()
+                .experiment(experiment)
+                .slot(request.slot())
+                .objective(request.objective())
+                .primaryMetric(request.primaryMetric())
+                .script(request.script())
+                .prompt(request.prompt())
+                .provider(request.provider())
+                .model(request.model())
+                .status(request.status() == null ? ExperimentVideoStatus.PLANNED : request.status())
+                .assetUrl(request.assetUrl())
+                .thumbnailUrl(request.thumbnailUrl())
+                .durationSeconds(request.durationSeconds())
+                .aspectRatio(request.aspectRatio())
+                .requestJson(request.requestJson())
+                .responseJson(request.responseJson())
+                .cost(request.cost())
+                .reviewStatus(request.reviewStatus() == null ? ExperimentVideoReviewStatus.PENDING : request.reviewStatus())
+                .requiredForRelease(request.requiredForRelease())
+                .salesVideoProfile(resolveProfile(request.salesVideoProfileId()))
+                .salesVideoJob(resolveJob(request.salesVideoJobId()))
+                .asset(resolveAsset(request.assetId()))
+                .landingVideoSlot(resolveLandingVideoSlot(experimentId, request.landingVideoSlotId()))
+                .build();
+        return toDto(repository.save(videoAsset));
+    }
+
+    /** Atualiza um vídeo de experimento sem perder os campos não enviados. */
+    @Transactional
+    public ExperimentVideoAssetDto update(Long experimentId, Long videoAssetId, UpdateExperimentVideoAssetRequest request) {
+        ensureExperiment(experimentId);
+        ExperimentVideoAsset videoAsset = repository.findById(videoAssetId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "video asset not found"));
+        if (videoAsset.getExperiment() == null || !experimentId.equals(videoAsset.getExperiment().getId())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "video asset not found for experiment");
+        }
+        applyUpdate(videoAsset, request, experimentId);
+        return toDto(repository.save(videoAsset));
+    }
+
+    /** Verifica se existe vídeo obrigatório ainda sem status READY e revisão APPROVED. */
+    @Transactional(readOnly = true)
+    public boolean hasRequiredVideoBlockingRelease(Long experimentId) {
+        if (experimentId == null) {
+            return false;
+        }
+        return repository.existsRequiredReleaseBlocker(
+                experimentId,
+                ExperimentVideoStatus.READY,
+                ExperimentVideoReviewStatus.APPROVED);
+    }
+
+    /** Aplica os campos opcionais enviados na atualização do ativo de vídeo. */
+    private void applyUpdate(ExperimentVideoAsset videoAsset, UpdateExperimentVideoAssetRequest request, Long experimentId) {
+        if (request.slot() != null) {
+            videoAsset.setSlot(request.slot());
+        }
+        if (request.objective() != null) {
+            videoAsset.setObjective(request.objective());
+        }
+        if (request.primaryMetric() != null) {
+            videoAsset.setPrimaryMetric(request.primaryMetric());
+        }
+        if (request.script() != null) {
+            videoAsset.setScript(request.script());
+        }
+        if (request.prompt() != null) {
+            videoAsset.setPrompt(request.prompt());
+        }
+        if (request.provider() != null) {
+            videoAsset.setProvider(request.provider());
+        }
+        if (request.model() != null) {
+            videoAsset.setModel(request.model());
+        }
+        if (request.status() != null) {
+            videoAsset.setStatus(request.status());
+        }
+        if (request.assetUrl() != null) {
+            videoAsset.setAssetUrl(request.assetUrl());
+        }
+        if (request.thumbnailUrl() != null) {
+            videoAsset.setThumbnailUrl(request.thumbnailUrl());
+        }
+        if (request.durationSeconds() != null) {
+            videoAsset.setDurationSeconds(request.durationSeconds());
+        }
+        if (request.aspectRatio() != null) {
+            videoAsset.setAspectRatio(request.aspectRatio());
+        }
+        if (request.requestJson() != null) {
+            videoAsset.setRequestJson(request.requestJson());
+        }
+        if (request.responseJson() != null) {
+            videoAsset.setResponseJson(request.responseJson());
+        }
+        if (request.cost() != null) {
+            videoAsset.setCost(request.cost());
+        }
+        if (request.reviewStatus() != null) {
+            videoAsset.setReviewStatus(request.reviewStatus());
+        }
+        if (request.requiredForRelease() != null) {
+            videoAsset.setRequiredForRelease(request.requiredForRelease());
+        }
+        if (request.salesVideoProfileId() != null) {
+            videoAsset.setSalesVideoProfile(resolveProfile(request.salesVideoProfileId()));
+        }
+        if (request.salesVideoJobId() != null) {
+            videoAsset.setSalesVideoJob(resolveJob(request.salesVideoJobId()));
+        }
+        if (request.assetId() != null) {
+            videoAsset.setAsset(resolveAsset(request.assetId()));
+        }
+        if (request.landingVideoSlotId() != null) {
+            videoAsset.setLandingVideoSlot(resolveLandingVideoSlot(experimentId, request.landingVideoSlotId()));
+        }
+    }
+
+    /** Busca o experimento alvo ou falha com resposta HTTP clara. */
+    private Experiment ensureExperiment(Long experimentId) {
+        return experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "experiment not found"));
+    }
+
+    /** Busca o perfil de vídeo quando informado. */
+    private SalesVideoProfile resolveProfile(Long profileId) {
+        if (profileId == null) {
+            return null;
+        }
+        return profileRepository.findById(profileId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "sales video profile not found"));
+    }
+
+    /** Busca o job de vídeo quando informado. */
+    private SalesVideoJob resolveJob(Long jobId) {
+        if (jobId == null) {
+            return null;
+        }
+        return jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "sales video job not found"));
+    }
+
+    /** Busca o asset final quando informado. */
+    private Asset resolveAsset(Long assetId) {
+        if (assetId == null) {
+            return null;
+        }
+        return assetRepository.findById(assetId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "asset not found"));
+    }
+
+    /** Busca o slot de landing e impede vínculo com outro experimento. */
+    private LandingVideoSlot resolveLandingVideoSlot(Long experimentId, Long slotId) {
+        if (slotId == null) {
+            return null;
+        }
+        LandingVideoSlot slot = landingVideoSlotRepository.findById(slotId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "landing video slot not found"));
+        LandingPage landingPage = slot.getLandingPage();
+        Long slotExperimentId = landingPage != null && landingPage.getExperiment() != null
+                ? landingPage.getExperiment().getId()
+                : null;
+        if (!experimentId.equals(slotExperimentId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "landing video slot belongs to another experiment");
+        }
+        return slot;
+    }
+
+    /** Converte a entidade para o contrato de leitura da API. */
+    private ExperimentVideoAssetDto toDto(ExperimentVideoAsset videoAsset) {
+        return new ExperimentVideoAssetDto(
+                videoAsset.getId(),
+                videoAsset.getExperiment() != null ? videoAsset.getExperiment().getId() : null,
+                videoAsset.getSlot(),
+                videoAsset.getObjective(),
+                videoAsset.getPrimaryMetric(),
+                videoAsset.getScript(),
+                videoAsset.getPrompt(),
+                videoAsset.getProvider(),
+                videoAsset.getModel(),
+                videoAsset.getStatus(),
+                videoAsset.getAssetUrl(),
+                videoAsset.getThumbnailUrl(),
+                videoAsset.getDurationSeconds(),
+                videoAsset.getAspectRatio(),
+                videoAsset.getRequestJson(),
+                videoAsset.getResponseJson(),
+                videoAsset.getCost(),
+                videoAsset.getReviewStatus(),
+                videoAsset.isRequiredForRelease(),
+                videoAsset.getSalesVideoProfile() != null ? videoAsset.getSalesVideoProfile().getId() : null,
+                videoAsset.getSalesVideoJob() != null ? videoAsset.getSalesVideoJob().getId() : null,
+                videoAsset.getAsset() != null ? videoAsset.getAsset().getId() : null,
+                videoAsset.getLandingVideoSlot() != null ? videoAsset.getLandingVideoSlot().getId() : null,
+                videoAsset.getCreatedAt(),
+                videoAsset.getUpdatedAt());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/web/ExperimentVideoAssetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/web/ExperimentVideoAssetController.java
@@ -1,0 +1,50 @@
+package com.marketinghub.experiment.video.web;
+
+import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
+import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
+import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Expõe vídeos de experimento para planejamento, revisão e liberação do funil.
+ */
+@RestController
+@RequestMapping("/api/experiments/{experimentId}/video-assets")
+public class ExperimentVideoAssetController {
+    private final ExperimentVideoAssetService service;
+
+    /** Inicializa o controller com o serviço de vídeos de experimento. */
+    public ExperimentVideoAssetController(ExperimentVideoAssetService service) {
+        this.service = service;
+    }
+
+    /** Lista os vídeos vinculados a um experimento. */
+    @GetMapping
+    public List<ExperimentVideoAssetDto> list(@PathVariable Long experimentId) {
+        return service.list(experimentId);
+    }
+
+    /** Cria um novo vídeo comercial para o experimento. */
+    @PostMapping
+    public ExperimentVideoAssetDto create(@PathVariable Long experimentId,
+                                          @Valid @RequestBody CreateExperimentVideoAssetRequest request) {
+        return service.create(experimentId, request);
+    }
+
+    /** Atualiza status, revisão e vínculos de um vídeo comercial do experimento. */
+    @PatchMapping("/{videoAssetId}")
+    public ExperimentVideoAssetDto update(@PathVariable Long experimentId,
+                                          @PathVariable Long videoAssetId,
+                                          @RequestBody UpdateExperimentVideoAssetRequest request) {
+        return service.update(experimentId, videoAssetId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
@@ -1,0 +1,31 @@
+package com.marketinghub.repository.jpa.experiment.video;
+
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Repositório dos vídeos comerciais vinculados a experimentos.
+ */
+public interface ExperimentVideoAssetRepository extends JpaRepository<ExperimentVideoAsset, Long> {
+    /** Lista os vídeos de um experimento com os vínculos necessários para resposta da API. */
+    @EntityGraph(attributePaths = {"experiment", "salesVideoProfile", "salesVideoJob", "asset", "landingVideoSlot"})
+    List<ExperimentVideoAsset> findByExperimentIdOrderByCreatedAtDesc(Long experimentId);
+
+    /** Verifica se existem vídeos obrigatórios que ainda bloqueiam a publicação. */
+    @Query("""
+            select case when count(v) > 0 then true else false end
+            from ExperimentVideoAsset v
+            where v.experiment.id = :experimentId
+              and v.requiredForRelease = true
+              and (v.status <> :readyStatus or v.reviewStatus <> :approvedStatus)
+            """)
+    boolean existsRequiredReleaseBlocker(@Param("experimentId") Long experimentId,
+                                         @Param("readyStatus") ExperimentVideoStatus readyStatus,
+                                         @Param("approvedStatus") ExperimentVideoReviewStatus approvedStatus);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-06-experiment-video-asset.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-06-experiment-video-asset.yaml
@@ -1,0 +1,57 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-06-01-create-experiment-video-asset
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_video_asset
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_video_asset (
+                  id BIGINT NOT NULL AUTO_INCREMENT,
+                  experiment_id BIGINT NOT NULL,
+                  slot VARCHAR(32) NOT NULL,
+                  objective VARCHAR(512) NOT NULL,
+                  primary_metric VARCHAR(191) NOT NULL,
+                  script LONGTEXT NULL,
+                  prompt LONGTEXT NULL,
+                  provider VARCHAR(64) NOT NULL,
+                  model VARCHAR(128) NOT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  asset_url VARCHAR(1024) NULL,
+                  thumbnail_url VARCHAR(1024) NULL,
+                  duration_seconds INT NULL,
+                  aspect_ratio VARCHAR(16) NULL,
+                  request_json LONGTEXT NULL,
+                  response_json LONGTEXT NULL,
+                  cost DECIMAL(12, 4) NULL,
+                  review_status VARCHAR(32) NOT NULL,
+                  required_for_release BIT(1) NOT NULL DEFAULT b'0',
+                  sales_video_profile_id BIGINT NULL,
+                  sales_video_job_id BIGINT NULL,
+                  asset_id BIGINT NULL,
+                  landing_video_slot_id BIGINT NULL,
+                  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id),
+                  CONSTRAINT fk_experiment_video_asset_experiment
+                      FOREIGN KEY (experiment_id) REFERENCES experiment (id),
+                  CONSTRAINT fk_experiment_video_asset_profile
+                      FOREIGN KEY (sales_video_profile_id) REFERENCES sales_video_profile (id),
+                  CONSTRAINT fk_experiment_video_asset_job
+                      FOREIGN KEY (sales_video_job_id) REFERENCES sales_video_job (id),
+                  CONSTRAINT fk_experiment_video_asset_asset
+                      FOREIGN KEY (asset_id) REFERENCES asset (id),
+                  CONSTRAINT fk_experiment_video_asset_landing_slot
+                      FOREIGN KEY (landing_video_slot_id) REFERENCES landing_video_slot (id)
+              );
+              CREATE INDEX idx_experiment_video_asset_experiment ON experiment_video_asset (experiment_id);
+              CREATE INDEX idx_experiment_video_asset_release ON experiment_video_asset (experiment_id, required_for_release, status, review_status);
+              CREATE INDEX idx_experiment_video_asset_slot ON experiment_video_asset (experiment_id, slot);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-06-experiment-video-asset.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-06-campaign-strategy.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
@@ -56,6 +57,8 @@ class ExperimentReadinessServiceTest {
     private GeraSalesPageStageExecutionRepository geraSalesPageStageExecutionRepository;
     @Mock
     private GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
+    @Mock
+    private ExperimentVideoAssetService experimentVideoAssetService;
 
     private ExperimentReadinessService service;
 
@@ -69,7 +72,8 @@ class ExperimentReadinessServiceTest {
                 creativeRepository,
                 targetingSelectionRepository,
                 geraLandingStageExecutionRepository,
-                campaignDestinationPolicy);
+                campaignDestinationPolicy,
+                experimentVideoAssetService);
     }
 
     @Test
@@ -136,6 +140,21 @@ class ExperimentReadinessServiceTest {
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
+    }
+
+    /** Garante que vídeo obrigatório sem aprovação bloqueia a campanha. */
+    @Test
+    void shouldBlockCampaignWhenRequiredVideoIsNotReadyAndApproved() {
+        Experiment experiment = buildExperiment(39L, 49L);
+        experiment.setFollowUpActionUrl("https://example.com/landing/39");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(39L, CreativeStatus.READY)).thenReturn(true);
+        when(experimentVideoAssetService.hasRequiredVideoBlockingRelease(39L)).thenReturn(true);
+        mockPublishableSelection(39L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("experimentVideoAsset");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
     }
 
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -1,0 +1,213 @@
+package com.marketinghub.experiment.video.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.LandingPage;
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoSlot;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
+import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
+import com.marketinghub.repository.jpa.media.AssetRepository;
+import com.marketinghub.repository.jpa.salesvideo.LandingVideoSlotRepository;
+import com.marketinghub.repository.jpa.salesvideo.SalesVideoJobRepository;
+import com.marketinghub.repository.jpa.salesvideo.SalesVideoProfileRepository;
+import com.marketinghub.salesvideo.LandingVideoSlot;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Valida o registro de vídeos como ativos comerciais vinculados ao experimento.
+ */
+@ExtendWith(MockitoExtension.class)
+class ExperimentVideoAssetServiceTest {
+    @Mock
+    private ExperimentVideoAssetRepository repository;
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private SalesVideoProfileRepository profileRepository;
+    @Mock
+    private SalesVideoJobRepository jobRepository;
+    @Mock
+    private AssetRepository assetRepository;
+    @Mock
+    private LandingVideoSlotRepository landingVideoSlotRepository;
+
+    private ExperimentVideoAssetService service;
+
+    /** Inicializa o serviço com repositórios simulados para testes unitários. */
+    @BeforeEach
+    void setUp() {
+        service = new ExperimentVideoAssetService(
+                repository,
+                experimentRepository,
+                profileRepository,
+                jobRepository,
+                assetRepository,
+                landingVideoSlotRepository);
+    }
+
+    /** Garante que um vídeo novo recebe estados padrão quando criado para o experimento. */
+    @Test
+    void shouldCreatePlannedVideoAssetForExperiment() {
+        Experiment experiment = Experiment.builder().id(39L).build();
+        given(experimentRepository.findById(39L)).willReturn(Optional.of(experiment));
+        given(repository.save(any(ExperimentVideoAsset.class))).willAnswer(invocation -> {
+            ExperimentVideoAsset saved = invocation.getArgument(0);
+            saved.setId(7L);
+            return saved;
+        });
+        CreateExperimentVideoAssetRequest request = new CreateExperimentVideoAssetRequest(
+                ExperimentVideoSlot.LANDING_HERO,
+                "Aumentar envio do formulario",
+                "form_submit_rate",
+                "Agenda cheia no WhatsApp ainda pode estar vulneravel.",
+                "Gerar video vertical curto",
+                "VEO",
+                "veo-3.1-generate-preview",
+                null,
+                null,
+                null,
+                15,
+                "9:16",
+                null,
+                null,
+                null,
+                null,
+                true,
+                null,
+                null,
+                null,
+                null);
+
+        ExperimentVideoAssetDto dto = service.create(39L, request);
+
+        assertThat(dto.id()).isEqualTo(7L);
+        assertThat(dto.status()).isEqualTo(ExperimentVideoStatus.PLANNED);
+        assertThat(dto.reviewStatus()).isEqualTo(ExperimentVideoReviewStatus.PENDING);
+        assertThat(dto.requiredForRelease()).isTrue();
+    }
+
+    /** Garante que a landing de outro experimento não pode contaminar o aprendizado do funil atual. */
+    @Test
+    void shouldRejectLandingVideoSlotFromAnotherExperiment() {
+        Experiment experiment = Experiment.builder().id(39L).build();
+        Experiment anotherExperiment = Experiment.builder().id(40L).build();
+        LandingPage landingPage = LandingPage.builder().id(3L).experiment(anotherExperiment).build();
+        LandingVideoSlot slot = LandingVideoSlot.builder().id(12L).landingPage(landingPage).build();
+        given(experimentRepository.findById(39L)).willReturn(Optional.of(experiment));
+        given(landingVideoSlotRepository.findById(12L)).willReturn(Optional.of(slot));
+        CreateExperimentVideoAssetRequest request = new CreateExperimentVideoAssetRequest(
+                ExperimentVideoSlot.LANDING_HERO,
+                "Aumentar envio",
+                "form_submit_rate",
+                null,
+                null,
+                "VEO",
+                "veo-3.1-generate-preview",
+                ExperimentVideoStatus.READY,
+                "https://cdn.test/video.mp4",
+                null,
+                15,
+                "9:16",
+                null,
+                null,
+                null,
+                ExperimentVideoReviewStatus.APPROVED,
+                true,
+                null,
+                null,
+                null,
+                12L);
+
+        assertThrows(ResponseStatusException.class, () -> service.create(39L, request));
+    }
+
+    /** Garante que status operacional e revisão humana podem liberar o vídeo obrigatório. */
+    @Test
+    void shouldUpdateReviewStatusAndReadyState() {
+        Experiment experiment = Experiment.builder().id(39L).build();
+        ExperimentVideoAsset videoAsset = ExperimentVideoAsset.builder()
+                .id(5L)
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.LANDING_HERO)
+                .objective("Aumentar envio")
+                .primaryMetric("form_submit_rate")
+                .provider("VEO")
+                .model("veo-3.1-generate-preview")
+                .status(ExperimentVideoStatus.GENERATING)
+                .reviewStatus(ExperimentVideoReviewStatus.PENDING)
+                .requiredForRelease(true)
+                .build();
+        given(experimentRepository.findById(39L)).willReturn(Optional.of(experiment));
+        given(repository.findById(5L)).willReturn(Optional.of(videoAsset));
+        given(repository.save(videoAsset)).willReturn(videoAsset);
+
+        ExperimentVideoAssetDto dto = service.update(39L, 5L, new UpdateExperimentVideoAssetRequest(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                ExperimentVideoStatus.READY,
+                "https://cdn.test/video.mp4",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                ExperimentVideoReviewStatus.APPROVED,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        assertThat(dto.status()).isEqualTo(ExperimentVideoStatus.READY);
+        assertThat(dto.reviewStatus()).isEqualTo(ExperimentVideoReviewStatus.APPROVED);
+        assertThat(dto.assetUrl()).isEqualTo("https://cdn.test/video.mp4");
+    }
+
+    /** Garante que a listagem retorna os vídeos registrados para o experimento. */
+    @Test
+    void shouldListVideoAssetsForExperiment() {
+        Experiment experiment = Experiment.builder().id(39L).build();
+        ExperimentVideoAsset videoAsset = ExperimentVideoAsset.builder()
+                .id(5L)
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.FORM_EXPLAINER)
+                .objective("Reduzir duvida")
+                .primaryMetric("form_submit_rate")
+                .provider("VEO")
+                .model("veo-3.1-generate-preview")
+                .status(ExperimentVideoStatus.READY)
+                .reviewStatus(ExperimentVideoReviewStatus.APPROVED)
+                .requiredForRelease(true)
+                .build();
+        given(experimentRepository.findById(39L)).willReturn(Optional.of(experiment));
+        given(repository.findByExperimentIdOrderByCreatedAtDesc(39L)).willReturn(List.of(videoAsset));
+
+        List<ExperimentVideoAssetDto> result = service.list(39L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).slot()).isEqualTo(ExperimentVideoSlot.FORM_EXPLAINER);
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-06 — Experimentos: camada Experiment Video Asset
+
+- decisão aplicada: vídeo passa a ser registrado como artefato mensurável do experimento, com slot no funil, objetivo comercial e métrica principal.
+- objetivo de negócio: permitir novos experimentos com vídeo na landing ou formulário sem tratar vídeo como módulo solto, preservando aprendizado por hipótese e por ponto do funil.
+- foi feito: criado contrato backend `/api/experiments/{experimentId}/video-assets` para listar, criar e atualizar vídeos do experimento.
+- foi feito: vídeo obrigatório bloqueia liberação de campanha enquanto não estiver `READY` e `APPROVED`.
+- prevenção de recorrência: o backend valida que `landing_video_slot` pertence ao mesmo experimento antes de vincular, evitando contaminação de aprendizado entre funis.
+
 ## 2026-07-02 — Definição canônica de tipos de produto e rastreio de prompt/schema por experimento
 
 - decisão registrada: produto low-ticket passa a significar pacote de infoprodutos de baixo custo produzido majoritariamente por IA; Produto IA passa a significar infoproduto/ferramenta com integração OpenAI por trás, entregue ao usuário como solução simples e prática, sem exigir entendimento de IA.

--- a/docs/swagger/experiment-video-assets-swagger.yaml
+++ b/docs/swagger/experiment-video-assets-swagger.yaml
@@ -1,0 +1,128 @@
+openapi: 3.0.3
+info:
+  title: Experiment Video Assets API
+  version: "1.0"
+  description: Contratos para registrar vídeos como ativos mensuráveis de experimentos.
+paths:
+  /api/experiments/{experimentId}/video-assets:
+    get:
+      summary: Lista vídeos de um experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Vídeos encontrados
+    post:
+      summary: Cria vídeo comercial para um experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateExperimentVideoAssetRequest"
+      responses:
+        "200":
+          description: Vídeo criado
+  /api/experiments/{experimentId}/video-assets/{videoAssetId}:
+    patch:
+      summary: Atualiza vídeo comercial de um experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: videoAssetId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateExperimentVideoAssetRequest"
+      responses:
+        "200":
+          description: Vídeo atualizado
+components:
+  schemas:
+    CreateExperimentVideoAssetRequest:
+      type: object
+      required:
+        - slot
+        - objective
+        - primaryMetric
+        - provider
+        - model
+      properties:
+        slot:
+          type: string
+          enum: [AD, LANDING_HERO, FORM_EXPLAINER, PRE_CHECKOUT]
+        objective:
+          type: string
+        primaryMetric:
+          type: string
+        script:
+          type: string
+        prompt:
+          type: string
+        provider:
+          type: string
+          example: VEO
+        model:
+          type: string
+          example: veo-3.1-generate-preview
+        status:
+          type: string
+          enum: [PLANNED, GENERATING, READY, FAILED]
+        assetUrl:
+          type: string
+        thumbnailUrl:
+          type: string
+        durationSeconds:
+          type: integer
+        aspectRatio:
+          type: string
+          example: "9:16"
+        requestJson:
+          type: string
+        responseJson:
+          type: string
+        cost:
+          type: number
+        reviewStatus:
+          type: string
+          enum: [PENDING, APPROVED, REJECTED]
+        requiredForRelease:
+          type: boolean
+        salesVideoProfileId:
+          type: integer
+          format: int64
+        salesVideoJobId:
+          type: integer
+          format: int64
+        assetId:
+          type: integer
+          format: int64
+        landingVideoSlotId:
+          type: integer
+          format: int64
+    UpdateExperimentVideoAssetRequest:
+      allOf:
+        - $ref: "#/components/schemas/CreateExperimentVideoAssetRequest"


### PR DESCRIPTION
## O que mudou

- Cria a camada `Experiment Video Asset` para registrar videos como artefatos mensuraveis de experimentos.
- Adiciona endpoints para listar, criar e atualizar videos em `/api/experiments/{experimentId}/video-assets`.
- Adiciona tabela `experiment_video_asset` via Liquibase com vinculos opcionais para `sales_video_profile`, `sales_video_job`, `asset` e `landing_video_slot`.
- Bloqueia readiness de campanha quando existir video obrigatorio sem `READY` + `APPROVED`.
- Documenta o contrato em Swagger e registra a decisao em `docs/registros/experimentos.md`.

## Por que

O video precisa nascer ligado a uma hipotese comercial e a um ponto especifico do funil, como `LANDING_HERO` ou `FORM_EXPLAINER`, para medir impacto em conversao e evitar virar apenas um gerador de videos solto.

## Validacao

- `../../backend/mvnw -Dtest=ExperimentVideoAssetServiceTest,ExperimentReadinessServiceTest test` passou com 13 testes.
- `../../backend/mvnw -Dtest=com.marketinghub.experiment.ExperimentControllerTest test` passou com 2 testes e validou subida do contexto Spring.
- Changelog master validado sem include relativo faltando `relativeToChangelogFile: true`.
- Changelog novo revisado sem `TIMESTAMP NOT NULL` e sem `UPDATE/DELETE` com risco MySQL 5.7 1093.

## Limitacao

- `../../backend/mvnw spotless:check -DskipTests` nao roda neste modulo porque o plugin Spotless nao esta configurado.