### PR TITLE
[codex] fix sales video ai profile endpoint

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/salesvideo/SalesVideoBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/salesvideo/SalesVideoBackendClient.java
@@ -106,8 +106,9 @@ public class SalesVideoBackendClient {
         return postOpenAiJob(jobId, "/fail", request, SalesVideoJobDto.class);
     }
 
+    /** Busca o perfil pelo contrato interno para evitar dependência de tenant administrativo. */
     public SalesVideoProfileDto getProfile(Long profileId) {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/sales-videos/profiles/" + profileId);
+        String url = UrlUtils.joinPath(backendBaseUrl, internalPrefix, "/ai/sales-videos/profiles/" + profileId);
         return get(url, SalesVideoProfileDto.class);
     }
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/salesvideo/SalesVideoBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/salesvideo/SalesVideoBackendClientTest.java
@@ -1,0 +1,56 @@
+package com.marketinghub.worker.salesvideo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar os contratos HTTP do client de vídeo no ai-worker. */
+class SalesVideoBackendClientTest {
+
+    private MockWebServer server;
+
+    /** Inicializa o backend simulado usado para capturar as chamadas do client. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado após cada teste. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve buscar perfil pelo endpoint interno do ai-worker, sem usar rota administrativa com tenant. */
+    @Test
+    void getProfileShouldUseInternalAiEndpoint() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"id\":59,\"title\":\"Manicure em domicílio\"}"));
+        SalesVideoBackendClient client = newClient();
+
+        var profile = client.getProfile(59L);
+
+        var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/internal/ai/sales-videos/profiles/59");
+        assertThat(profile.getId()).isEqualTo(59L);
+        assertThat(profile.getTitle()).isEqualTo("Manicure em domicílio");
+    }
+
+    /** Cria o client de vídeo apontando para o backend simulado. */
+    private SalesVideoBackendClient newClient() {
+        return new SalesVideoBackendClient(
+                WebClient.builder(),
+                server.url("/").toString(),
+                "/api",
+                "/internal");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
@@ -170,6 +170,12 @@ public class SalesVideoController {
         return salesVideoService.getJob(jobId);
     }
 
+    /** Consulta perfil de vídeo para processamento interno do ai-worker. */
+    @GetMapping("/internal/ai/sales-videos/profiles/{profileId}")
+    public SalesVideoProfileDto getOpenAiProfile(@PathVariable Long profileId) {
+        return salesVideoService.getProfile(profileId);
+    }
+
     /** Faz claim de job OpenAI interno. */
     @PostMapping("/internal/ai/openai-jobs/{jobId}/claim")
     public SalesVideoJobDto claimOpenAiJob(@PathVariable Long jobId,

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/controller/SalesVideoAssetControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/controller/SalesVideoAssetControllerTest.java
@@ -5,6 +5,7 @@ import com.marketinghub.media.AssetStatus;
 import com.marketinghub.media.AssetType;
 import com.marketinghub.media.MediaProvider;
 import com.marketinghub.media.mapper.AssetMapperImpl;
+import com.marketinghub.salesvideo.dto.SalesVideoProfileDto;
 import com.marketinghub.salesvideo.service.SalesVideoService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,11 +17,14 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/** Responsabilidade: validar contratos internos de assets e perfis de vídeo. */
 @WebMvcTest(SalesVideoController.class)
 @Import(AssetMapperImpl.class)
 class SalesVideoAssetControllerTest {
@@ -31,6 +35,7 @@ class SalesVideoAssetControllerTest {
     @MockBean
     private SalesVideoService salesVideoService;
 
+    /** Deve aceitar upload interno e devolver o asset criado. */
     @Test
     void shouldUploadFileAndReturnAssetDto() throws Exception {
         Asset asset = Asset.builder()
@@ -54,5 +59,21 @@ class SalesVideoAssetControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(10L))
                 .andExpect(jsonPath("$.url").value("https://cdn.local/video.mp4"));
+    }
+
+    /** Deve expor perfil por endpoint interno sem exigir header de tenant. */
+    @Test
+    void shouldGetProfileFromInternalAiEndpointWithoutTenantHeader() throws Exception {
+        SalesVideoProfileDto profile = new SalesVideoProfileDto();
+        profile.setId(59L);
+        profile.setTitle("Manicure em domicílio");
+        when(salesVideoService.getProfile(59L)).thenReturn(profile);
+
+        mockMvc.perform(get("/internal/ai/sales-videos/profiles/59"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(59L))
+                .andExpect(jsonPath("$.title").value("Manicure em domicílio"));
+
+        verify(salesVideoService).getProfile(59L);
     }
 }

--- a/docs/swagger/avatar-sales-video-integration-swagger.yaml
+++ b/docs/swagger/avatar-sales-video-integration-swagger.yaml
@@ -16,6 +16,8 @@ servers:
 tags:
   - name: InternalVideoJobs
     description: Endpoints internos consumidos pelo módulo de vídeo para orquestrar jobs.
+  - name: InternalAiSalesVideo
+    description: Endpoints internos consumidos pelo ai-worker para geração de scripts de vídeo.
   - name: PublicVideoProfiles
     description: Endpoints de leitura de perfil usados pelo módulo de vídeo.
 
@@ -193,6 +195,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/SalesVideoJobDto'
 
+  /internal/ai/sales-videos/profiles/{profileId}:
+    get:
+      tags: [InternalAiSalesVideo]
+      summary: Carrega perfil de vídeo para geração de script pelo ai-worker
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Perfil encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoProfileDto'
+        '404':
+          description: Perfil não encontrado
 
   /api/sales-videos/rollout/status:
     get:


### PR DESCRIPTION
## O que mudou

- Cria endpoint interno `/internal/ai/sales-videos/profiles/{profileId}` para o ai-worker consultar perfis de vídeo sem depender do contrato administrativo com `X-Tenant-ID`.
- Ajusta o `SalesVideoBackendClient` do ai-worker para usar esse endpoint interno.
- Atualiza o Swagger de integração e adiciona testes de contrato no backend e no ai-worker.

## Por quê

A causa-raiz do bloqueio `TENANT_HEADER_REQUIRED` era o ai-worker buscar perfil de vídeo pela rota administrativa `/api/sales-videos/profiles/{id}`, que exige tenant ativo. Como o worker já consome jobs por contratos internos, a consulta do perfil também precisa seguir um contrato interno.

## Validação

- `backend/ads-service`: `mvn -Dtest=SalesVideoAssetControllerTest test`
- `ai-worker`: `mvn -Dtest=SalesVideoBackendClientTest test`