### PR TITLE
[codex] Improve rendered prompt readability

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -92,6 +92,15 @@
   overflow-x: auto;
 }
 
+#gera-sales-page-audit .accordion-body > .row > .col-12:first-child {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+#gera-sales-page-audit .accordion-body > .row > .col-12:first-child pre {
+  max-height: 34rem;
+}
+
 .markdown-content-viewer th,
 .markdown-content-viewer td {
   border: 1px solid var(--bs-border-color);

--- a/frontend/src/components/CollapsibleJsonViewer.tsx
+++ b/frontend/src/components/CollapsibleJsonViewer.tsx
@@ -13,6 +13,9 @@ type CollapsibleJsonViewerProps = {
   emptyMessage?: string;
   initiallyCollapsed?: boolean;
   parseAsJson?: boolean;
+  className?: string;
+  maxHeight?: string;
+  plainTextVariant?: "default" | "reading";
 };
 
 function parseJson(content?: string | null): JsonValue | null {
@@ -119,6 +122,9 @@ export default function CollapsibleJsonViewer({
   emptyMessage = "Sem conteúdo registrado.",
   initiallyCollapsed = false,
   parseAsJson = true,
+  className = "",
+  maxHeight = "28rem",
+  plainTextVariant = parseAsJson ? "default" : "reading",
 }: CollapsibleJsonViewerProps) {
   const parsed = useMemo(
     () => (parseAsJson ? parseJson(content) : null),
@@ -130,13 +136,18 @@ export default function CollapsibleJsonViewer({
   }
 
   if (!parsed) {
+    const isReadingVariant = plainTextVariant === "reading";
     return (
       <pre
-        className="bg-body-tertiary p-3 rounded small mb-0"
+        className={`bg-body-tertiary border rounded mb-0 ${isReadingVariant ? "p-4" : "p-3 small"} ${className}`}
         style={{
           whiteSpace: "pre-wrap",
           overflowWrap: "anywhere",
           wordBreak: "break-word",
+          maxHeight,
+          overflow: "auto",
+          fontSize: isReadingVariant ? "0.95rem" : undefined,
+          lineHeight: isReadingVariant ? 1.65 : undefined,
         }}
       >
         {decodeEscapedText(content)}
@@ -146,8 +157,8 @@ export default function CollapsibleJsonViewer({
 
   return (
     <div
-      className="bg-body-tertiary border rounded p-2"
-      style={{ maxHeight: "28rem", overflow: "auto" }}
+      className={`bg-body-tertiary border rounded p-2 ${className}`}
+      style={{ maxHeight, overflow: "auto" }}
     >
       <JsonNode value={parsed} initiallyCollapsed={initiallyCollapsed} />
     </div>


### PR DESCRIPTION
## O que mudou

- Melhorou o modo de leitura de textos brutos no `CollapsibleJsonViewer`, com borda, rolagem interna, fonte maior e espaçamento mais confortável.
- Fez o bloco `Prompt renderizado` da auditoria do GeraSalesPage ocupar a largura inteira da área, mantendo schema/request como apoio técnico abaixo.

## Por quê

A leitura do prompt renderizado estava difícil na tela porque o conteúdo longo ficava comprimido e com pouco espaçamento visual.

## Validação

- `npm run typecheck`
- `npm run build`

Observação: foi necessário instalar devDependencies com `npm ci --include=dev` porque o ambiente estava com `npm config omit=dev`.