### PR TITLE
[codex] Refaz dashboard mensal de planejamento

### DIFF
--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -2,6 +2,165 @@
   min-width: 0;
 }
 
+.commercial-planning-month-plan {
+  min-width: 0;
+  padding: 1.25rem;
+  border: 1px solid #d9dee7;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.08);
+}
+
+.commercial-planning-month-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.commercial-planning-month-eyebrow {
+  color: #5d6678;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-month-title {
+  color: #101828;
+  font-size: 2.25rem;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.commercial-planning-month-objective {
+  max-width: 900px;
+  color: #344054;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.commercial-planning-month-summary {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #f8fafc;
+}
+
+.commercial-planning-month-summary div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.commercial-planning-month-summary span,
+.commercial-planning-month-metric-label {
+  color: #667085;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-month-summary strong {
+  min-width: 0;
+  color: #101828;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-month-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.commercial-planning-month-metric {
+  display: grid;
+  min-width: 0;
+  min-height: 170px;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #fcfcfd;
+}
+
+.commercial-planning-month-metric-values {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.commercial-planning-month-metric-values strong {
+  color: #101828;
+  font-size: 1.35rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-month-metric-values span {
+  color: #667085;
+  font-size: 0.85rem;
+}
+
+.commercial-planning-month-metric-values.executed strong {
+  font-size: 1.05rem;
+}
+
+.commercial-planning-month-progress {
+  height: 0.5rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e4e7ec;
+}
+
+.commercial-planning-month-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #2563eb;
+}
+
+.commercial-planning-month-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.commercial-planning-month-panel {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-month-panel p {
+  color: #344054;
+}
+
+.commercial-planning-product-types {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.commercial-planning-product-types div {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.75rem;
+  border-left: 4px solid #2563eb;
+  background: #f8fafc;
+}
+
+.commercial-planning-product-types strong {
+  color: #101828;
+}
+
+.commercial-planning-product-types span,
+.commercial-planning-product-types small {
+  color: #667085;
+}
+
 .commercial-planning-workspace {
   display: grid;
   grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
@@ -38,7 +197,30 @@
 }
 
 @media (max-width: 1199.98px) {
+  .commercial-planning-month-heading,
+  .commercial-planning-month-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .commercial-planning-month-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .commercial-planning-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .commercial-planning-month-plan {
+    padding: 1rem;
+  }
+
+  .commercial-planning-month-title {
+    font-size: 1.75rem;
+  }
+
+  .commercial-planning-month-metrics {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -4,9 +4,12 @@ import {
   CalendarClock,
   CheckCircle2,
   Circle,
+  Gauge,
   PauseCircle,
   PlayCircle,
   Save,
+  TrendingUp,
+  WalletCards,
 } from "lucide-react";
 import PageTitle from "../../components/PageTitle";
 import { useExperiments } from "../../api/experiment/useExperiments";
@@ -208,6 +211,13 @@ function formatCurrency(value?: number | null) {
   });
 }
 
+function formatExecutedCurrency(value?: number | null) {
+  return (value ?? 0).toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
+}
+
 function formatNumber(value?: number | null) {
   return value == null ? "Não definido" : String(value);
 }
@@ -216,8 +226,50 @@ function formatExecutedNumber(value?: number | null) {
   return value == null ? "0" : String(value);
 }
 
+function progressPercentage(target?: number | null, actual?: number | null) {
+  if (!target || target <= 0) return 0;
+  return Math.min(100, Math.round(((actual ?? 0) / target) * 100));
+}
+
 function numberOrNull(value?: number | null) {
   return value == null ? null : Number(value);
+}
+
+function MonthlyMetricCard({
+  label,
+  target,
+  actual,
+  percentage,
+  tone = "primary",
+}: {
+  label: string;
+  target: string;
+  actual: string;
+  percentage: number;
+  tone?: "primary" | "success" | "warning" | "info";
+}) {
+  return (
+    <div className="commercial-planning-month-metric">
+      <div className="d-flex justify-content-between align-items-start gap-2">
+        <span className="commercial-planning-month-metric-label">{label}</span>
+        <span className={`badge text-bg-${tone}`}>{percentage}%</span>
+      </div>
+      <div className="commercial-planning-month-metric-values">
+        <strong>{target}</strong>
+        <span>Meta</span>
+      </div>
+      <div className="commercial-planning-month-metric-values executed">
+        <strong>{actual}</strong>
+        <span>Execução</span>
+      </div>
+      <div
+        className="commercial-planning-month-progress"
+        aria-hidden="true"
+      >
+        <span style={{ width: `${percentage}%` }} />
+      </div>
+    </div>
+  );
 }
 
 export default function CommercialPlanningPage() {
@@ -237,6 +289,43 @@ export default function CommercialPlanningPage() {
     () => plans.find((plan) => plan.id === selectedId) ?? plans[0],
     [plans, selectedId],
   );
+  const currentMonthPlan = useMemo<CommercialPlan>(
+    () =>
+      selectedPlan ?? {
+        id: 0,
+        name: julyPlanningForm.name,
+        planType: "FIRST_SALE",
+        status: julyPlanningForm.status ?? "DRAFT",
+        commercialObjective: julyPlanningForm.commercialObjective,
+        targetAudience: julyPlanningForm.targetAudience,
+        mainPain: julyPlanningForm.mainPain,
+        mainOffer: julyPlanningForm.mainOffer,
+        mainLeadMagnet: julyPlanningForm.mainLeadMagnet,
+        mainChannel: julyPlanningForm.mainChannel,
+        mainMetric: julyPlanningForm.mainMetric,
+        successCriteria: julyPlanningForm.successCriteria,
+        stopCriteria: julyPlanningForm.stopCriteria,
+        deadline: julyPlanningForm.deadline,
+        maxBudget: julyPlanningForm.maxBudget,
+        targetRevenue: julyPlanningForm.targetRevenue,
+        operationalRevenueTarget: julyPlanningForm.operationalRevenueTarget,
+        experimentsToCreate: julyPlanningForm.experimentsToCreate,
+        experimentsToPublish: julyPlanningForm.experimentsToPublish,
+        actualCampaignCost: null,
+        actualAiCost: null,
+        actualTotalCost: null,
+        actualRevenue: null,
+        actualExperimentsCreated: null,
+        actualExperimentsPublished: null,
+        daysRemaining: 25,
+        nextAction: julyPlanningForm.nextAction,
+        currentBlocker: julyPlanningForm.currentBlocker,
+        rootCause: julyPlanningForm.rootCause,
+        milestones: [],
+        simulations: [],
+      },
+    [selectedPlan],
+  );
   const [form, setForm] = useState<SaveCommercialPlanPayload>(emptyForm);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [simulationFeedback, setSimulationFeedback] = useState<{
@@ -252,6 +341,26 @@ export default function CommercialPlanningPage() {
       ? simulationFeedback.simulation
       : asArray(selectedPlan?.simulations)[0];
   const selectedMilestones = asArray(selectedPlan?.milestones);
+  const costProgress = progressPercentage(
+    currentMonthPlan.maxBudget,
+    currentMonthPlan.actualTotalCost,
+  );
+  const revenueProgress = progressPercentage(
+    currentMonthPlan.targetRevenue,
+    currentMonthPlan.actualRevenue,
+  );
+  const operationalRevenueProgress = progressPercentage(
+    currentMonthPlan.operationalRevenueTarget,
+    currentMonthPlan.actualRevenue,
+  );
+  const createdExperimentsProgress = progressPercentage(
+    currentMonthPlan.experimentsToCreate,
+    currentMonthPlan.actualExperimentsCreated,
+  );
+  const publishedExperimentsProgress = progressPercentage(
+    currentMonthPlan.experimentsToPublish,
+    currentMonthPlan.actualExperimentsPublished,
+  );
 
   function updateField<K extends keyof SaveCommercialPlanPayload>(
     field: K,
@@ -338,6 +447,166 @@ export default function CommercialPlanningPage() {
           Não foi possível carregar os planos comerciais.
         </div>
       ) : null}
+
+      <section className="commercial-planning-month-plan">
+        <div className="d-flex flex-column gap-4">
+          <div className="commercial-planning-month-heading">
+            <div>
+              <span
+                className={`badge ${planStatusClass(currentMonthPlan.status)} mb-3`}
+              >
+                {planStatusLabel(currentMonthPlan.status)}
+              </span>
+              <p className="commercial-planning-month-eyebrow mb-1">
+                Plano do mês corrente
+              </p>
+              <h2 className="commercial-planning-month-title mb-2">
+                Julho 2026
+              </h2>
+              <p className="commercial-planning-month-objective mb-0">
+                {currentMonthPlan.commercialObjective ||
+                  "Defina o objetivo comercial do mês."}
+              </p>
+            </div>
+            <div className="commercial-planning-month-summary">
+              <div>
+                <span>{selectedPlan ? "Plano ativo" : "Plano sugerido"}</span>
+                <strong>{currentMonthPlan.name}</strong>
+              </div>
+              <div>
+                <span>Prazo</span>
+                <strong>
+                  {currentMonthPlan.deadline
+                    ? new Date(currentMonthPlan.deadline).toLocaleDateString(
+                        "pt-BR",
+                      )
+                    : "Não definido"}
+                </strong>
+              </div>
+              <div>
+                <span>Dias restantes</span>
+                <strong>
+                  {currentMonthPlan.daysRemaining ?? "Não definido"}
+                </strong>
+              </div>
+            </div>
+          </div>
+
+          <div className="commercial-planning-month-metrics">
+            <MonthlyMetricCard
+              label="Custo total"
+              target={formatCurrency(currentMonthPlan.maxBudget)}
+              actual={formatExecutedCurrency(currentMonthPlan.actualTotalCost)}
+              percentage={costProgress}
+              tone="warning"
+            />
+            <MonthlyMetricCard
+              label="Receita mínima"
+              target={formatCurrency(currentMonthPlan.targetRevenue)}
+              actual={formatExecutedCurrency(currentMonthPlan.actualRevenue)}
+              percentage={revenueProgress}
+              tone="success"
+            />
+            <MonthlyMetricCard
+              label="Receita operacional"
+              target={formatCurrency(currentMonthPlan.operationalRevenueTarget)}
+              actual={formatExecutedCurrency(currentMonthPlan.actualRevenue)}
+              percentage={operationalRevenueProgress}
+              tone="info"
+            />
+            <MonthlyMetricCard
+              label="Experimentos criados"
+              target={formatNumber(currentMonthPlan.experimentsToCreate)}
+              actual={formatExecutedNumber(
+                currentMonthPlan.actualExperimentsCreated,
+              )}
+              percentage={createdExperimentsProgress}
+            />
+            <MonthlyMetricCard
+              label="Experimentos publicados"
+              target={formatNumber(currentMonthPlan.experimentsToPublish)}
+              actual={formatExecutedNumber(
+                currentMonthPlan.actualExperimentsPublished,
+              )}
+              percentage={publishedExperimentsProgress}
+            />
+          </div>
+
+          <div className="commercial-planning-month-grid">
+            <section className="commercial-planning-month-panel">
+              <div className="d-flex align-items-center gap-2 mb-3">
+                <WalletCards size={20} aria-hidden="true" />
+                <h3 className="h6 mb-0">Tipos de produto</h3>
+              </div>
+              <div className="commercial-planning-product-types">
+                <div>
+                  <strong>Low-ticket</strong>
+                  <span>Meta: produto comprável de R$ 19,90</span>
+                  <small>
+                    Execução:{" "}
+                    {currentMonthPlan.actualRevenue
+                      ? "venda registrada"
+                      : "aguardando primeira compra"}
+                  </small>
+                </div>
+                <div>
+                  <strong>Produto IA</strong>
+                  <span>Meta: material personalizado com custo controlado</span>
+                  <small>
+                    Execução:{" "}
+                    {formatExecutedCurrency(currentMonthPlan.actualAiCost)} em IA
+                  </small>
+                </div>
+                <div>
+                  <strong>Captura</strong>
+                  <span>Meta: recuperar interesse sem competir com checkout</span>
+                  <small>
+                    Execução:{" "}
+                    {formatExecutedNumber(
+                      currentMonthPlan.actualExperimentsPublished,
+                    )}{" "}
+                    experimento(s) publicado(s)
+                  </small>
+                </div>
+              </div>
+            </section>
+
+            <section className="commercial-planning-month-panel">
+              <div className="d-flex align-items-center gap-2 mb-3">
+                <Gauge size={20} aria-hidden="true" />
+                <h3 className="h6 mb-0">Critério de decisão</h3>
+              </div>
+              <p className="mb-2">
+                <strong>Métrica principal:</strong>{" "}
+                {currentMonthPlan.mainMetric || "Não definida"}
+              </p>
+              <p className="mb-2">
+                <strong>Sucesso:</strong>{" "}
+                {currentMonthPlan.successCriteria || "Não definido"}
+              </p>
+              <p className="mb-0">
+                <strong>Parada:</strong>{" "}
+                {currentMonthPlan.stopCriteria || "Não definido"}
+              </p>
+            </section>
+
+            <section className="commercial-planning-month-panel">
+              <div className="d-flex align-items-center gap-2 mb-3">
+                <TrendingUp size={20} aria-hidden="true" />
+                <h3 className="h6 mb-0">Execução imediata</h3>
+              </div>
+              <p className="mb-2">
+                {currentMonthPlan.nextAction || "Sem próxima ação definida."}
+              </p>
+              <p className="text-secondary mb-0">
+                Gargalo:{" "}
+                {currentMonthPlan.currentBlocker ||
+                  "nenhum bloqueio registrado."}
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
 
       <section className="commercial-planning-workspace">
         <aside className="commercial-planning-sidebar">


### PR DESCRIPTION
## O que mudou

- Coloca o plano de Julho 2026 como primeira área da tela de Planejamento, ocupando a largura principal.
- Adiciona leitura de meta vs execução para custo, receita mínima, receita operacional, experimentos criados e experimentos publicados.
- Inclui blocos de tipos de produto, critério de decisão e execução imediata.
- Quando ainda não há plano salvo, exibe uma prévia sugerida de Julho em vez de deixar a primeira dobra vazia.

## Impacto

A tela passa a responder primeiro à decisão comercial do mês: quanto gastar, quanto buscar de receita, quantos experimentos criar/publicar e quais tipos de produto testar.

## Validação

- `npm run typecheck`
- `NODE_ENV=test npm run test -- CommercialPlanningPage.test.tsx --run`
- `npm run build`
- Validação visual local em `http://127.0.0.1:5173/planning` com Chromium headless.