### PR TITLE
[codex] Reconcile experiment costs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/cost/CostAttributionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/cost/CostAttributionService.java
@@ -8,10 +8,12 @@ import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Service;
 
 /**
- * Centralizes how generation and campaign costs cascade across experiment, hypothesis and niche.
+ * Centraliza como custos de geração e campanha sobem para experimento, hipótese e nicho.
  */
 @Service
 public class CostAttributionService {
@@ -20,6 +22,10 @@ public class CostAttributionService {
     private final MarketNicheRepository marketNicheRepository;
     private final CurrencyConversionService currencyConversionService;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /** Cria o serviço com repositórios de custo e conversão monetária. */
     public CostAttributionService(ExperimentRepository experimentRepository,
                                   HypothesisRepository hypothesisRepository,
                                   MarketNicheRepository marketNicheRepository,
@@ -30,64 +36,77 @@ public class CostAttributionService {
         this.currencyConversionService = currencyConversionService;
     }
 
+    /** Converte custo em dólar para real e propaga na hierarquia do experimento. */
     public void addUsdCostToExperimentHierarchy(Experiment experiment, BigDecimal costUsd) {
         BigDecimal delta = currencyConversionService.usdToBrl(costUsd);
         addCostToExperimentHierarchy(experiment, delta);
     }
 
+    /** Adiciona custo em real ao experimento e propaga para hipótese e nicho sem duplicar persistência. */
     public void addCostToExperimentHierarchy(Experiment experiment, BigDecimal costBrl) {
         BigDecimal delta = currencyConversionService.normalizeBrl(costBrl);
         if (!hasDelta(delta) || experiment == null) {
             return;
         }
         experiment.setTotalCost(add(experiment.getTotalCost(), delta));
-        if (experiment.getId() != null) {
+        if (experiment.getId() != null && !isManaged(experiment)) {
             experimentRepository.incrementTotalCost(experiment.getId(), delta);
         }
         addCostToHypothesisHierarchy(experiment.getHypothesisRef(), delta);
     }
 
+    /** Converte custo em dólar para real e propaga na hierarquia da hipótese. */
     public void addUsdCostToHypothesisHierarchy(Hypothesis hypothesis, BigDecimal costUsd) {
         BigDecimal delta = currencyConversionService.usdToBrl(costUsd);
         addCostToHypothesisHierarchy(hypothesis, delta);
     }
 
+    /** Adiciona custo em real à hipótese e ao nicho sem duplicar persistência. */
     public void addCostToHypothesisHierarchy(Hypothesis hypothesis, BigDecimal costBrl) {
         BigDecimal delta = currencyConversionService.normalizeBrl(costBrl);
         if (!hasDelta(delta) || hypothesis == null) {
             return;
         }
         hypothesis.setTotalCost(add(hypothesis.getTotalCost(), delta));
-        if (hypothesis.getId() != null) {
+        if (hypothesis.getId() != null && !isManaged(hypothesis)) {
             hypothesisRepository.incrementTotalCost(hypothesis.getId(), delta);
         }
         addCostToNiche(hypothesis.getMarketNiche(), delta);
     }
 
+    /** Converte custo em dólar para real e adiciona ao nicho. */
     public void addUsdCostToNiche(MarketNiche niche, BigDecimal costUsd) {
         BigDecimal delta = currencyConversionService.usdToBrl(costUsd);
         addCostToNiche(niche, delta);
     }
 
+    /** Adiciona custo em real ao nicho sem duplicar persistência. */
     public void addCostToNiche(MarketNiche niche, BigDecimal costBrl) {
         BigDecimal delta = currencyConversionService.normalizeBrl(costBrl);
         if (!hasDelta(delta) || niche == null) {
             return;
         }
         niche.setTotalCost(add(niche.getTotalCost(), delta));
-        if (niche.getId() != null) {
+        if (niche.getId() != null && !isManaged(niche)) {
             marketNicheRepository.incrementTotalCost(niche.getId(), delta);
         }
     }
 
+    /** Verifica se há variação financeira relevante para persistir. */
     private boolean hasDelta(BigDecimal delta) {
         return delta != null && delta.compareTo(BigDecimal.ZERO) != 0;
     }
 
+    /** Soma valores aceitando acumulado nulo. */
     private BigDecimal add(BigDecimal current, BigDecimal delta) {
         if (current == null) {
             return delta;
         }
         return current.add(delta);
+    }
+
+    /** Identifica entidades gerenciadas para evitar update SQL além do flush do JPA. */
+    private boolean isManaged(Object entity) {
+        return entityManager != null && entityManager.contains(entity);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -68,6 +68,9 @@ public class ExperimentDto {
     private BigDecimal unitPrice;
     private BigDecimal cost;
     private BigDecimal totalCost;
+    private BigDecimal auditableTotalCost;
+    private BigDecimal legacyTotalCost;
+    private BigDecimal unreconciledLegacyCost;
     private BigDecimal expense;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
@@ -9,10 +9,14 @@ import com.marketinghub.experiment.dto.ExperimentCampaignMetricDto;
 import com.marketinghub.experiment.dto.ExperimentDto;
 import com.marketinghub.experiment.dto.FacebookPageDto;
 import com.marketinghub.experiment.dto.InstagramAccountDto;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Mapper;
 
 /**
- * MapStruct mapper for Experiment.
+ * Mapeia experimentos para contratos usados pela interface.
  */
 @Mapper(componentModel = "spring", uses = FacebookInstantFormMapper.class)
 public interface ExperimentMapper {
@@ -37,14 +41,44 @@ public interface ExperimentMapper {
     @org.mapstruct.Mapping(target = "selectedSampleEmailCallToAction", source = "selectedSampleEmail.callToAction")
     @org.mapstruct.Mapping(target = "selectedSampleEmailModel", source = "selectedSampleEmail.model")
     @org.mapstruct.Mapping(target = "selectedSampleEmailUpdatedAt", source = "selectedSampleEmail.updatedAt")
+    @org.mapstruct.Mapping(target = "auditableTotalCost", ignore = true)
+    @org.mapstruct.Mapping(target = "legacyTotalCost", ignore = true)
+    @org.mapstruct.Mapping(target = "unreconciledLegacyCost", ignore = true)
     @org.mapstruct.Mapping(target = "campaignMetric", expression = "java(toCampaignMetricDto(experiment.getCampaignMetric()))")
     ExperimentDto toDto(Experiment experiment);
 
+    /** Completa campos financeiros reconciliados depois do mapeamento principal. */
+    @AfterMapping
+    default void fillCostReconciliation(Experiment experiment, @MappingTarget ExperimentDto dto) {
+        if (experiment == null || dto == null) {
+            return;
+        }
+        BigDecimal auditableTotal = money(experiment.getCost())
+                .add(money(experiment.getExpense()))
+                .add(money(experiment.getCampaignMetric() != null
+                        ? experiment.getCampaignMetric().getSpend()
+                        : null))
+                .setScale(2, RoundingMode.HALF_UP);
+        BigDecimal legacyTotal = money(experiment.getTotalCost()).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal unreconciled = legacyTotal.subtract(auditableTotal).setScale(2, RoundingMode.HALF_UP);
+        dto.setAuditableTotalCost(auditableTotal);
+        dto.setLegacyTotalCost(legacyTotal);
+        dto.setUnreconciledLegacyCost(unreconciled.compareTo(BigDecimal.ZERO) > 0 ? unreconciled : BigDecimal.ZERO);
+    }
+
+    /** Converte valor monetário opcional para zero quando ausente. */
+    default BigDecimal money(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+
+    /** Mapeia página do Facebook vinculada ao experimento. */
     @org.mapstruct.Mapping(target = "accountId", source = "account.id")
     FacebookPageDto toDto(FacebookPage page);
 
+    /** Mapeia conta do Instagram vinculada ao experimento. */
     InstagramAccountDto toDto(InstagramAccount account);
 
+    /** Mapeia métricas agregadas da campanha do experimento. */
     default ExperimentCampaignMetricDto toCampaignMetricDto(ExperimentCampaignMetric metric) {
         if (metric == null) {
             return null;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
@@ -18,6 +18,8 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -158,7 +160,9 @@ public class ExperimentCompleteMarkdownReportService {
                 "targetCvr", experiment.getTargetCvr(),
                 "mdePercent", experiment.getMdePercent(),
                 "unitPrice", experiment.getUnitPrice(),
-                "totalCost", experiment.getTotalCost(),
+                "auditableTotalCost", auditableTotalCost(experiment),
+                "legacyTotalCost", experiment.getTotalCost(),
+                "unreconciledLegacyCost", unreconciledLegacyCost(experiment),
                 "expense", experiment.getExpense()
         ));
     }
@@ -169,6 +173,42 @@ public class ExperimentCompleteMarkdownReportService {
     private void appendHypothesisFramework(StringBuilder markdown, Hypothesis hypothesis) {
         markdown.append("## 2. Framework da hipótese\n\n");
         appendCodeBlock(markdown, "json", prettyJson(hypothesis != null ? hypothesis.getFrameworkJson() : null));
+    }
+
+    /**
+     * Calcula o custo rastreável em BRL a partir de origem, mídia e despesa operacional.
+     */
+    private BigDecimal auditableTotalCost(Experiment experiment) {
+        if (experiment == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        BigDecimal paidMedia = experiment.getCampaignMetric() != null
+                ? money(experiment.getCampaignMetric().getSpend())
+                : BigDecimal.ZERO;
+        return money(experiment.getCost())
+                .add(money(experiment.getExpense()))
+                .add(paidMedia)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Calcula a diferença positiva entre o total legado e as fontes rastreáveis.
+     */
+    private BigDecimal unreconciledLegacyCost(Experiment experiment) {
+        if (experiment == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        BigDecimal difference = money(experiment.getTotalCost()).subtract(auditableTotalCost(experiment));
+        return difference.compareTo(BigDecimal.ZERO) > 0
+                ? difference.setScale(2, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Normaliza valor monetário ausente para zero.
+     */
+    private BigDecimal money(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/cost/CostAttributionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/cost/CostAttributionServiceTest.java
@@ -1,0 +1,95 @@
+package com.marketinghub.cost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.finance.CurrencyConversionService;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Garante que a atribuição de custos não duplica valores persistidos.
+ */
+@ExtendWith(MockitoExtension.class)
+class CostAttributionServiceTest {
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private HypothesisRepository hypothesisRepository;
+
+    @Mock
+    private MarketNicheRepository marketNicheRepository;
+
+    @Mock
+    private CurrencyConversionService currencyConversionService;
+
+    @Mock
+    private EntityManager entityManager;
+
+    private CostAttributionService service;
+
+    /** Prepara o serviço real com dependências controladas. */
+    @BeforeEach
+    void setUp() {
+        service = new CostAttributionService(
+                experimentRepository,
+                hypothesisRepository,
+                marketNicheRepository,
+                currencyConversionService);
+        ReflectionTestUtils.setField(service, "entityManager", entityManager);
+    }
+
+    /**
+     * Confirma que entidade gerenciada recebe apenas alteração em memória para o flush do JPA persistir.
+     */
+    @Test
+    void addCostToExperimentHierarchyDoesNotSqlIncrementManagedExperiment() {
+        Experiment experiment = Experiment.builder()
+                .id(59L)
+                .totalCost(new BigDecimal("10.00"))
+                .build();
+
+        when(currencyConversionService.normalizeBrl(new BigDecimal("1.25")))
+                .thenReturn(new BigDecimal("1.25"));
+        when(entityManager.contains(experiment)).thenReturn(true);
+
+        service.addCostToExperimentHierarchy(experiment, new BigDecimal("1.25"));
+
+        assertThat(experiment.getTotalCost()).isEqualByComparingTo("11.25");
+        verify(experimentRepository, never()).incrementTotalCost(59L, new BigDecimal("1.25"));
+    }
+
+    /**
+     * Confirma que entidade destacada ainda recebe incremento SQL para persistir o delta.
+     */
+    @Test
+    void addCostToExperimentHierarchySqlIncrementsDetachedExperiment() {
+        Experiment experiment = Experiment.builder()
+                .id(59L)
+                .totalCost(new BigDecimal("10.00"))
+                .build();
+
+        when(currencyConversionService.normalizeBrl(new BigDecimal("1.25")))
+                .thenReturn(new BigDecimal("1.25"));
+        when(entityManager.contains(experiment)).thenReturn(false);
+
+        service.addCostToExperimentHierarchy(experiment, new BigDecimal("1.25"));
+
+        assertThat(experiment.getTotalCost()).isEqualByComparingTo("11.25");
+        verify(experimentRepository).incrementTotalCost(59L, new BigDecimal("1.25"));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5661,3 +5661,10 @@
 - Correção aplicada: a publicação final do GeraSalesPage v1 passa a marcar automaticamente seções/blocos principais com `data-track-section`, injeta analytics mínimo quando faltar e salva/publica o HTML já rastreável.
 - Trava preventiva: a política de campanha/readiness agora bloqueia página de venda sem `data-track-section`, mesmo que contenha `page_view`, `page_load_metric`, `section_view_time` e `checkout_click`.
 - Tela: a página do experimento passa a exibir campanhas, conjuntos, anúncios e funis atribuídos por anúncio, permitindo visualizar também o Funil B quando o backend já tiver os dados.
+
+## 2026-07-07 — Reconciliação de custos do experimento
+
+- Problema: a tela de detalhe mostrava `total_cost` legado como custo total e misturava parcelas em BRL com custos técnicos em USD, fazendo diferenças antigas parecerem custo real.
+- Causa-raiz tratada: `CostAttributionService` podia alterar entidade gerenciada pelo JPA e também executar `incrementTotalCost` SQL na mesma operação, criando risco de dupla contagem; além disso, `experiment.total_cost` era usado como fonte principal sem reconciliação por origem.
+- Correção aplicada: o backend expõe custo rastreável em BRL por origem, mídia e despesa operacional, preserva `total_cost` como legado e calcula diferença não reconciliada; a tela destaca o total rastreável e separa custos técnicos em USD como auditoria.
+- Prevenção de recorrência: teste de atribuição impede incremento SQL quando a entidade já está gerenciada pelo JPA, e teste de resumo financeiro impede que diferença legada seja exibida como custo técnico real.

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -500,6 +500,31 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
 - **Regra preventiva**:
   - nenhuma etapa OpenAI deve persistir execução sem modelo efetivo, tokens e regra de preço identificável.
 
+## LOOP-EXPERIMENT-COST-RECONCILIATION — Total de custo sem origem auditável
+
+- **Severidade**: ALTO.
+- **Status**: fechado em 2026-07-07.
+- **Sintomas recorrentes**:
+  - `experiment.total_cost` maior que a soma de origem, mídia e despesa;
+  - custo técnico em USD aparecendo como se fechasse total em BRL;
+  - diferença legada sendo interpretada como custo real de IA;
+  - reprocessamento ou sincronização de mídia inflando custo acumulado.
+- **Causa-raiz sistêmica provável**:
+  - custo total tratado como acumulador persistido e fonte principal de verdade, sem razão idempotente por origem;
+  - atualização do custo combinando entidade JPA gerenciada com `increment` SQL direto.
+- **O que resolveu efetivamente no histórico**:
+  - usar custo rastreável em BRL como total principal da tela;
+  - manter `total_cost` como legado e mostrar diferença positiva como custo não reconciliado;
+  - separar auditoria técnica em USD de parcelas financeiras em BRL;
+  - impedir `incrementTotalCost` SQL quando a entidade já está gerenciada pelo JPA.
+- **Fechamento mínimo do loop**:
+  - toda tela ou relatório de experimento deve diferenciar custo rastreável, total legado e diferença não reconciliada;
+  - custos OpenAI/GeraLanding/GeraSalesPage em USD entram como auditoria técnica, não como parcela BRL sem conversão rastreável;
+  - sincronização de mídia deve aplicar apenas delta e ter teste de regressão;
+  - atribuição de custo não pode persistir o mesmo delta por dois caminhos na mesma transação.
+- **Regra preventiva**:
+  - nunca usar `experiment.total_cost` isolado como explicação financeira principal; sempre reconciliar por origem auditável ou marcar como legado não reconciliado.
+
 ---
 
 ## Checklist rápido antes de corrigir problema recorrente

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -115,6 +115,9 @@ export interface Experiment {
   unitPrice?: number | null;
   cost?: number | null;
   totalCost?: number | null;
+  auditableTotalCost?: number | null;
+  legacyTotalCost?: number | null;
+  unreconciledLegacyCost?: number | null;
   expense?: number | null;
   startDate: string | null;
   endDate: string | null;

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -45,6 +45,7 @@ import {
 import { useExperimentCompleteMarkdownReport } from "../../api/experiment/useExperimentCompleteMarkdownReport";
 import { useGeraSalesPagePublications } from "../../api/experiment/useGeraSalesPagePublications";
 import { useExperimentPipelineJobHistory } from "../../api/experiment/useExperimentPipelineJobHistory";
+import { buildExperimentCostSummary } from "./experimentCostSummary";
 
 function formatPipelineStageModel(stageModel?: GeraLandingStageModel) {
   const name = stageModel?.openAiModelName?.trim();
@@ -1769,11 +1770,6 @@ export default function ExperimentDetailPage() {
       : null);
   const salesPagePublications = geraSalesPagePublications.data ?? [];
   const latestSalesPagePublication = salesPagePublications[0];
-  const originCostBrl = data.cost ?? 0;
-  const paidMediaCostBrl = data.campaignMetric?.spend ?? 0;
-  const operationalExpenseBrl = data.expense ?? 0;
-  const totalExperimentCostBrl =
-    data.totalCost ?? originCostBrl + paidMediaCostBrl + operationalExpenseBrl;
   const contentPipelineCostUsd =
     experimentPipelineJobHistory.data?.content.reduce(
       (sum, job) => sum + (job.costUsd ?? 0),
@@ -1788,35 +1784,12 @@ export default function ExperimentDetailPage() {
       ),
     0,
   );
-  const experimentCostRows = [
-    {
-      label: "Custo de origem",
-      value: formatCurrencyValue(originCostBrl, "BRL"),
-    },
-    {
-      label: "Mídia paga",
-      value: formatCurrencyValue(paidMediaCostBrl, "BRL"),
-    },
-    {
-      label: "Despesa operacional",
-      value: formatCurrencyValue(operationalExpenseBrl, "BRL"),
-    },
-    {
-      label: "Pipeline de conteúdo",
-      value: formatCurrencyValue(contentPipelineCostUsd, "USD"),
-    },
-    {
-      label: "GeraLanding",
-      value: formatCurrencyValue(
-        totalCompletedGeraLandingAllStagesCostUsd,
-        "USD",
-      ),
-    },
-    {
-      label: "GeraSalesPage",
-      value: formatCurrencyValue(geraSalesPageCostUsd, "USD"),
-    },
-  ];
+  const experimentCostSummary = buildExperimentCostSummary({
+    experiment: data,
+    contentPipelineCostUsd,
+    geraLandingCostUsd: totalCompletedGeraLandingAllStagesCostUsd,
+    geraSalesPageCostUsd,
+  });
   const experimentPage = data.facebookPage;
   const instagramAccount = data.instagramAccount;
   const hasCreativesReady =
@@ -2791,19 +2764,22 @@ export default function ExperimentDetailPage() {
                     <div>
                       <h5 className="card-title mb-1">Custos do experimento</h5>
                       <p className="text-muted small mb-0">
-                        Total consolidado em BRL e custos técnicos auditáveis em
+                        Total rastreável em BRL separado da auditoria técnica em
                         USD.
                       </p>
                     </div>
                     <div className="text-end">
-                      <div className="text-muted small">Custo total</div>
+                      <div className="text-muted small">Custo rastreável</div>
                       <div className="fs-4 fw-semibold">
-                        {formatCurrencyValue(totalExperimentCostBrl, "BRL")}
+                        {formatCurrencyValue(
+                          experimentCostSummary.auditableTotalBrl,
+                          "BRL",
+                        )}
                       </div>
                     </div>
                   </div>
                   <div className="row g-3">
-                    {experimentCostRows.map((costRow) => (
+                    {experimentCostSummary.brlRows.map((costRow) => (
                       <div
                         key={costRow.label}
                         className="col-12 col-md-6 col-xl-4"
@@ -2812,11 +2788,56 @@ export default function ExperimentDetailPage() {
                           <div className="text-muted small">
                             {costRow.label}
                           </div>
-                          <div className="fw-semibold">{costRow.value}</div>
+                          <div className="fw-semibold">
+                            {formatCurrencyValue(
+                              costRow.value,
+                              costRow.currency,
+                            )}
+                          </div>
                         </div>
                       </div>
                     ))}
                   </div>
+                  <div className="row g-3 mt-1">
+                    {experimentCostSummary.technicalRows.map((costRow) => (
+                      <div
+                        key={costRow.label}
+                        className="col-12 col-md-6 col-xl-4"
+                      >
+                        <div className="border rounded-3 p-3 h-100">
+                          <div className="text-muted small">
+                            {costRow.label}
+                          </div>
+                          <div className="fw-semibold">
+                            {formatCurrencyValue(
+                              costRow.value,
+                              costRow.currency,
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {experimentCostSummary.unreconciledLegacyCostBrl > 0 ? (
+                    <div className="alert alert-warning mt-3 mb-0">
+                      <div className="fw-semibold">
+                        Custo legado não reconciliado:{" "}
+                        {formatCurrencyValue(
+                          experimentCostSummary.unreconciledLegacyCostBrl,
+                          "BRL",
+                        )}
+                      </div>
+                      <div className="small">
+                        Total legado registrado:{" "}
+                        {formatCurrencyValue(
+                          experimentCostSummary.legacyTotalBrl,
+                          "BRL",
+                        )}
+                        . Esta diferença não é exibida como custo técnico real
+                        porque não tem origem auditável nas parcelas atuais.
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               </div>
               <div className="card">

--- a/frontend/src/pages/experiment/experimentCostSummary.test.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildExperimentCostSummary } from "./experimentCostSummary";
+import type { Experiment } from "../../api/experiment/useExperiments";
+
+const baseExperiment = {
+  id: "59",
+  nicheId: 1,
+  hypothesisId: "hypothesis-59",
+  name: "Experimento 59",
+  hypothesis: "Hipótese",
+  startDate: null,
+  endDate: null,
+  creativeApproved: true,
+  status: "RUNNING",
+  platform: "FACEBOOK",
+  stage: "AD",
+  createdAt: "2026-07-07T00:00:00Z",
+  updatedAt: "2026-07-07T00:00:00Z",
+} satisfies Experiment;
+
+describe("buildExperimentCostSummary", () => {
+  it("prioritizes auditable BRL cost and isolates unreconciled legacy difference", () => {
+    const summary = buildExperimentCostSummary({
+      experiment: {
+        ...baseExperiment,
+        cost: 0,
+        expense: 0,
+        campaignMetric: { spend: 12.33 },
+        totalCost: 91.31,
+      },
+      contentPipelineCostUsd: 0.01,
+      geraLandingCostUsd: 0,
+      geraSalesPageCostUsd: 1.460795,
+    });
+
+    expect(summary.auditableTotalBrl).toBe(12.33);
+    expect(summary.legacyTotalBrl).toBe(91.31);
+    expect(summary.unreconciledLegacyCostBrl).toBe(78.98);
+    expect(summary.brlRows.map((row) => row.currency)).toEqual([
+      "BRL",
+      "BRL",
+      "BRL",
+    ]);
+    expect(summary.technicalRows.map((row) => row.currency)).toEqual([
+      "USD",
+      "USD",
+      "USD",
+    ]);
+  });
+
+  it("uses backend reconciliation fields when available", () => {
+    const summary = buildExperimentCostSummary({
+      experiment: {
+        ...baseExperiment,
+        cost: 99,
+        expense: 99,
+        campaignMetric: { spend: 99 },
+        auditableTotalCost: 19.56,
+        legacyTotalCost: 91.15,
+        unreconciledLegacyCost: 71.59,
+      },
+      contentPipelineCostUsd: 0,
+      geraLandingCostUsd: 0,
+      geraSalesPageCostUsd: 0,
+    });
+
+    expect(summary.auditableTotalBrl).toBe(19.56);
+    expect(summary.legacyTotalBrl).toBe(91.15);
+    expect(summary.unreconciledLegacyCostBrl).toBe(71.59);
+  });
+});

--- a/frontend/src/pages/experiment/experimentCostSummary.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.ts
@@ -1,0 +1,98 @@
+import type { Experiment } from "../../api/experiment/useExperiments";
+
+export interface ExperimentCostRow {
+  label: string;
+  value: number;
+  currency: "BRL" | "USD";
+}
+
+export interface ExperimentCostSummary {
+  auditableTotalBrl: number;
+  legacyTotalBrl: number;
+  unreconciledLegacyCostBrl: number;
+  brlRows: ExperimentCostRow[];
+  technicalRows: ExperimentCostRow[];
+}
+
+export interface ExperimentCostSummaryInput {
+  experiment: Experiment;
+  contentPipelineCostUsd: number;
+  geraLandingCostUsd: number;
+  geraSalesPageCostUsd: number;
+}
+
+const toNumber = (value: number | string | null | undefined) => {
+  if (value == null) return 0;
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const roundMoney = (value: number) => Math.round(value * 100) / 100;
+
+export function buildExperimentCostSummary({
+  experiment,
+  contentPipelineCostUsd,
+  geraLandingCostUsd,
+  geraSalesPageCostUsd,
+}: ExperimentCostSummaryInput): ExperimentCostSummary {
+  const originCostBrl = toNumber(experiment.cost);
+  const paidMediaCostBrl = toNumber(experiment.campaignMetric?.spend);
+  const operationalExpenseBrl = toNumber(experiment.expense);
+  const computedAuditableTotalBrl = roundMoney(
+    originCostBrl + paidMediaCostBrl + operationalExpenseBrl,
+  );
+  const auditableTotalBrl = roundMoney(
+    toNumber(experiment.auditableTotalCost) || computedAuditableTotalBrl,
+  );
+  const legacyTotalBrl = roundMoney(
+    toNumber(experiment.legacyTotalCost) || toNumber(experiment.totalCost),
+  );
+  const unreconciledLegacyCostBrl = roundMoney(
+    Math.max(
+      0,
+      toNumber(experiment.unreconciledLegacyCost) ||
+        legacyTotalBrl - auditableTotalBrl,
+    ),
+  );
+
+  return {
+    auditableTotalBrl,
+    legacyTotalBrl,
+    unreconciledLegacyCostBrl,
+    brlRows: [
+      {
+        label: "Custo de origem",
+        value: originCostBrl,
+        currency: "BRL",
+      },
+      {
+        label: "Mídia paga",
+        value: paidMediaCostBrl,
+        currency: "BRL",
+      },
+      {
+        label: "Despesa operacional",
+        value: operationalExpenseBrl,
+        currency: "BRL",
+      },
+    ],
+    technicalRows: [
+      {
+        label: "Pipeline de conteúdo",
+        value: contentPipelineCostUsd,
+        currency: "USD",
+      },
+      {
+        label: "GeraLanding",
+        value: geraLandingCostUsd,
+        currency: "USD",
+      },
+      {
+        label: "GeraSalesPage",
+        value: geraSalesPageCostUsd,
+        currency: "USD",
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Resumo

Corrige a leitura de custos do experimento para separar custo rastreável em BRL, total legado e diferença não reconciliada.

## Causa-raiz

O custo total legado podia ser inflado porque a atribuição alterava entidade gerenciada pelo JPA e também executava incremento SQL direto na mesma operação. Além disso, a tela tratava `experiment.total_cost` como fonte principal e misturava custos técnicos em USD com parcelas financeiras em BRL.

## O que mudou

- Backend expõe `auditableTotalCost`, `legacyTotalCost` e `unreconciledLegacyCost` no DTO do experimento.
- `CostAttributionService` deixa de executar `incrementTotalCost` quando a entidade já está gerenciada pelo JPA.
- Tela de detalhe mostra como principal o custo rastreável em BRL e separa auditoria técnica em USD.
- Relatório Markdown registra total rastreável, total legado e diferença não reconciliada.
- Documentação operacional registra o loop de reconciliação de custos.

## Validação

- `../mvnw -Dtest=CostAttributionServiceTest,ExperimentCampaignMetricServiceTest test`
- `npm test -- --run experimentCostSummary`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Observação: o teste Vitest passou, mas o runner emitiu aviso conhecido de timeout no fechamento do processo após concluir com sucesso.