### PR TITLE
add weekly experiment planning cards

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
@@ -1,0 +1,15 @@
+package com.marketinghub.planning.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/** Responsabilidade: expor o consolidado semanal de experimentos do planejamento comercial. */
+public record CommercialPlanWeekDto(
+        Integer weekNumber,
+        LocalDate startDate,
+        LocalDate endDate,
+        Integer experimentsCreated,
+        BigDecimal totalCost,
+        BigDecimal totalRevenue,
+        List<CommercialPlanWeekExperimentDto> experiments) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.planning.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsabilidade: expor um experimento criado em uma semana do planejamento comercial. */
+public record CommercialPlanWeekExperimentDto(
+        Long id,
+        String name,
+        String productType,
+        String status,
+        Instant createdAt,
+        BigDecimal campaignCost,
+        BigDecimal aiCost,
+        BigDecimal videoCost,
+        BigDecimal totalCost,
+        BigDecimal revenue,
+        String result) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncService.java
@@ -102,6 +102,11 @@ public class CommercialPlanExecutionSyncService {
                 where measured_at >= ? and measured_at < ?
                 """, start, end));
         BigDecimal aiCost = money(currencyConversionService.usdToBrl(aiCostUsd).add(aiCostFromMetrics));
+        BigDecimal videoCost = money(queryDecimal("""
+                select coalesce(sum(cost), 0)
+                from experiment_video_asset
+                where created_at >= ? and created_at < ?
+                """, start, end));
         BigDecimal revenue = money(queryDecimal("""
                 select coalesce(sum(revenue_cents), 0) / 100.0
                 from experiment_financial_metric
@@ -120,7 +125,7 @@ public class CommercialPlanExecutionSyncService {
         return new ExecutionTotals(
                 campaignCost,
                 aiCost,
-                money(campaignCost.add(aiCost)),
+                money(campaignCost.add(aiCost).add(videoCost)),
                 revenue,
                 experimentsCreated,
                 experimentsPublished,

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -1,0 +1,180 @@
+package com.marketinghub.planning.service;
+
+import com.marketinghub.planning.CommercialPlan;
+import com.marketinghub.planning.dto.CommercialPlanWeekDto;
+import com.marketinghub.planning.dto.CommercialPlanWeekExperimentDto;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Responsabilidade: montar a leitura semanal de experimentos do planejamento comercial. */
+@Service
+public class CommercialPlanWeeklyExperimentService {
+    private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+
+    private final CommercialPlanService planService;
+    private final JdbcTemplate jdbcTemplate;
+
+    /** Inicializa o serviço com a fonte de plano e acesso SQL de leitura operacional. */
+    public CommercialPlanWeeklyExperimentService(CommercialPlanService planService, JdbcTemplate jdbcTemplate) {
+        this.planService = planService;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /** Lista as semanas do mês do plano com os experimentos criados em cada período. */
+    @Transactional(readOnly = true)
+    public List<CommercialPlanWeekDto> listWeeks(Long planId) {
+        CommercialPlan plan = planService.getPlan(planId);
+        LocalDate monthEnd = resolvePlanEnd(plan);
+        LocalDate monthStart = monthEnd.withDayOfMonth(1);
+        List<CommercialPlanWeekDto> weeks = new ArrayList<>();
+        LocalDate start = monthStart;
+        int weekNumber = 1;
+        while (!start.isAfter(monthEnd)) {
+            LocalDate end = start.plusDays(6).isAfter(monthEnd) ? monthEnd : start.plusDays(6);
+            List<CommercialPlanWeekExperimentDto> experiments = listExperiments(start, end.plusDays(1));
+            weeks.add(new CommercialPlanWeekDto(
+                    weekNumber,
+                    start,
+                    end,
+                    experiments.size(),
+                    sumCost(experiments),
+                    sumRevenue(experiments),
+                    experiments));
+            start = end.plusDays(1);
+            weekNumber++;
+        }
+        return weeks;
+    }
+
+    /** Resolve o mês de referência do plano a partir do prazo ou da criação. */
+    private LocalDate resolvePlanEnd(CommercialPlan plan) {
+        if (plan.getDeadline() != null) {
+            return plan.getDeadline();
+        }
+        Instant createdAt = plan.getCreatedAt() == null ? Instant.now() : plan.getCreatedAt();
+        LocalDate createdDate = createdAt.atZone(ZoneOffset.UTC).toLocalDate();
+        return createdDate.withDayOfMonth(createdDate.lengthOfMonth());
+    }
+
+    /** Busca os experimentos criados no intervalo e agrega custos rastreáveis por experimento. */
+    private List<CommercialPlanWeekExperimentDto> listExperiments(LocalDate startInclusive, LocalDate endExclusive) {
+        Timestamp start = Timestamp.from(startInclusive.atStartOfDay().toInstant(ZoneOffset.UTC));
+        Timestamp end = Timestamp.from(endExclusive.atStartOfDay().toInstant(ZoneOffset.UTC));
+        return jdbcTemplate.query("""
+                select
+                    e.id,
+                    e.name,
+                    coalesce(e.product_ai_subtype, e.experiment_type) as product_type,
+                    e.status,
+                    e.created_at,
+                    coalesce(campaign.cost, 0) as campaign_cost,
+                    coalesce(financial.ai_cost, 0) as ai_cost,
+                    coalesce(video.cost, 0) as video_cost,
+                    coalesce(financial.revenue, 0) as revenue
+                from experiment e
+                left join (
+                    select m.experiment_id, sum(coalesce(m.spend, 0)) as cost
+                    from experiment_campaign_metric m
+                    where (
+                        m.date_start is not null
+                        and m.date_start < ?
+                        and (m.date_stop is null or m.date_stop >= ?)
+                    )
+                    or (
+                        m.date_start is null
+                        and m.updated_at >= ?
+                        and m.updated_at < ?
+                    )
+                    group by m.experiment_id
+                ) campaign on campaign.experiment_id = e.id
+                left join (
+                    select b.external_experiment_id as experiment_id,
+                           sum(coalesce(f.ai_cost_cents, 0)) / 100.0 as ai_cost,
+                           sum(coalesce(f.revenue_cents, 0)) / 100.0 as revenue
+                    from experiment_budget b
+                    join experiment_financial_metric f on f.experiment_budget_id = b.id
+                    where f.measured_at >= ? and f.measured_at < ?
+                    group by b.external_experiment_id
+                ) financial on financial.experiment_id = e.id
+                left join (
+                    select experiment_id, sum(coalesce(cost, 0)) as cost
+                    from experiment_video_asset
+                    where created_at >= ? and created_at < ?
+                    group by experiment_id
+                ) video on video.experiment_id = e.id
+                where e.created_at >= ? and e.created_at < ?
+                order by e.created_at asc, e.id asc
+                """, this::mapExperiment, java.sql.Date.valueOf(endExclusive), java.sql.Date.valueOf(startInclusive),
+                start, end, start, end, start, end, start, end);
+    }
+
+    /** Converte a linha SQL no contrato de experimento semanal. */
+    private CommercialPlanWeekExperimentDto mapExperiment(ResultSet rs, int rowNum) throws SQLException {
+        BigDecimal campaignCost = money(rs.getBigDecimal("campaign_cost"));
+        BigDecimal aiCost = money(rs.getBigDecimal("ai_cost"));
+        BigDecimal videoCost = money(rs.getBigDecimal("video_cost"));
+        BigDecimal revenue = money(rs.getBigDecimal("revenue"));
+        BigDecimal totalCost = money(campaignCost.add(aiCost).add(videoCost));
+        return new CommercialPlanWeekExperimentDto(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("product_type"),
+                rs.getString("status"),
+                toInstant(rs.getTimestamp("created_at")),
+                campaignCost,
+                aiCost,
+                videoCost,
+                totalCost,
+                revenue,
+                resultLabel(revenue, totalCost));
+    }
+
+    /** Soma custo total dos experimentos da semana. */
+    private BigDecimal sumCost(List<CommercialPlanWeekExperimentDto> experiments) {
+        return money(experiments.stream()
+                .map(CommercialPlanWeekExperimentDto::totalCost)
+                .reduce(BigDecimal.ZERO, BigDecimal::add));
+    }
+
+    /** Soma receita dos experimentos da semana. */
+    private BigDecimal sumRevenue(List<CommercialPlanWeekExperimentDto> experiments) {
+        return money(experiments.stream()
+                .map(CommercialPlanWeekExperimentDto::revenue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add));
+    }
+
+    /** Classifica o resultado financeiro rastreável do experimento. */
+    private String resultLabel(BigDecimal revenue, BigDecimal totalCost) {
+        if (revenue.compareTo(BigDecimal.ZERO) > 0 && revenue.compareTo(totalCost) >= 0) {
+            return "Receita cobre custo";
+        }
+        if (revenue.compareTo(BigDecimal.ZERO) > 0) {
+            return "Receita parcial";
+        }
+        if (totalCost.compareTo(BigDecimal.ZERO) > 0) {
+            return "Sem receita rastreada";
+        }
+        return "Sem custo rastreado";
+    }
+
+    /** Normaliza valores monetários para reais. */
+    private BigDecimal money(BigDecimal value) {
+        return value == null ? ZERO : value.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /** Converte timestamp nulo ou preenchido para Instant. */
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/web/CommercialPlanController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/web/CommercialPlanController.java
@@ -4,12 +4,14 @@ import com.marketinghub.planning.CommercialPlanStatus;
 import com.marketinghub.planning.dto.CommercialPlanDto;
 import com.marketinghub.planning.dto.CommercialPlanMilestoneDto;
 import com.marketinghub.planning.dto.CommercialPlanSimulationDto;
+import com.marketinghub.planning.dto.CommercialPlanWeekDto;
 import com.marketinghub.planning.dto.CreateCommercialPlanRequest;
 import com.marketinghub.planning.dto.CreateCommercialPlanSimulationRequest;
 import com.marketinghub.planning.dto.UpdateCommercialPlanMilestoneRequest;
 import com.marketinghub.planning.dto.UpdateCommercialPlanRequest;
 import com.marketinghub.planning.mapper.CommercialPlanMapper;
 import com.marketinghub.planning.service.CommercialPlanService;
+import com.marketinghub.planning.service.CommercialPlanWeeklyExperimentService;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -26,10 +28,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/planning/commercial-plans")
 public class CommercialPlanController {
     private final CommercialPlanService service;
+    private final CommercialPlanWeeklyExperimentService weeklyExperimentService;
     private final CommercialPlanMapper mapper;
 
-    public CommercialPlanController(CommercialPlanService service, CommercialPlanMapper mapper) {
+    public CommercialPlanController(
+            CommercialPlanService service,
+            CommercialPlanWeeklyExperimentService weeklyExperimentService,
+            CommercialPlanMapper mapper) {
         this.service = service;
+        this.weeklyExperimentService = weeklyExperimentService;
         this.mapper = mapper;
     }
 
@@ -52,6 +59,12 @@ public class CommercialPlanController {
     @GetMapping("/{id}")
     public CommercialPlanDto get(@PathVariable Long id) {
         return mapper.toDto(service.getPlan(id), service.listMilestones(id), service.listSimulations(id));
+    }
+
+    /** Lista os experimentos criados em cada semana do mês do plano. */
+    @GetMapping("/{id}/weeks")
+    public List<CommercialPlanWeekDto> listWeeks(@PathVariable Long id) {
+        return weeklyExperimentService.listWeeks(id);
     }
 
     /** Atualiza um plano comercial existente. */

--- a/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncServiceTest.java
@@ -36,12 +36,14 @@ class CommercialPlanExecutionSyncServiceTest {
                 BigDecimal.valueOf(120),
                 BigDecimal.valueOf(2),
                 BigDecimal.valueOf(4),
+                BigDecimal.valueOf(6),
                 BigDecimal.valueOf(81),
                 3,
                 2,
                 BigDecimal.valueOf(120),
                 BigDecimal.valueOf(2),
                 BigDecimal.valueOf(4),
+                BigDecimal.valueOf(6),
                 BigDecimal.valueOf(81),
                 3,
                 2);
@@ -54,14 +56,14 @@ class CommercialPlanExecutionSyncServiceTest {
 
         assertThat(plan.getActualCampaignCost()).isEqualByComparingTo("120.00");
         assertThat(plan.getActualAiCost()).isEqualByComparingTo("14.00");
-        assertThat(plan.getActualTotalCost()).isEqualByComparingTo("134.00");
+        assertThat(plan.getActualTotalCost()).isEqualByComparingTo("140.00");
         assertThat(plan.getActualRevenue()).isEqualByComparingTo("81.00");
         assertThat(plan.getActualExperimentsCreated()).isEqualTo(3);
         assertThat(plan.getActualExperimentsPublished()).isEqualTo(2);
         assertThat(plan.getExecutionSyncedAt()).isNotNull();
         assertThat(milestone.getActualCampaignCost()).isEqualByComparingTo("120.00");
         assertThat(milestone.getActualAiCost()).isEqualByComparingTo("14.00");
-        assertThat(milestone.getActualTotalCost()).isEqualByComparingTo("134.00");
+        assertThat(milestone.getActualTotalCost()).isEqualByComparingTo("140.00");
         assertThat(milestone.getActualRevenue()).isEqualByComparingTo("81.00");
         assertThat(milestone.getActualExperimentsCreated()).isEqualTo(3);
         assertThat(milestone.getActualExperimentsPublished()).isEqualTo(2);

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -97,6 +97,30 @@ export interface CommercialPlan {
   updatedAt?: string | null;
 }
 
+export interface CommercialPlanWeekExperiment {
+  id: number;
+  name: string;
+  productType?: string | null;
+  status?: string | null;
+  createdAt?: string | null;
+  campaignCost?: number | null;
+  aiCost?: number | null;
+  videoCost?: number | null;
+  totalCost?: number | null;
+  revenue?: number | null;
+  result?: string | null;
+}
+
+export interface CommercialPlanWeek {
+  weekNumber: number;
+  startDate: string;
+  endDate: string;
+  experimentsCreated: number;
+  totalCost?: number | null;
+  totalRevenue?: number | null;
+  experiments: CommercialPlanWeekExperiment[];
+}
+
 export interface SaveCommercialPlanPayload {
   name: string;
   status?: CommercialPlanStatus;
@@ -129,6 +153,19 @@ export function useCommercialPlans() {
     queryFn: async () => {
       const { data } = await axios.get<CommercialPlan[]>(
         "/api/planning/commercial-plans",
+      );
+      return data;
+    },
+  });
+}
+
+export function useCommercialPlanWeeks(planId?: number | null) {
+  return useQuery({
+    queryKey: ["commercial-plan-weeks", planId],
+    enabled: !!planId,
+    queryFn: async () => {
+      const { data } = await axios.get<CommercialPlanWeek[]>(
+        `/api/planning/commercial-plans/${planId}/weeks`,
       );
       return data;
     },

--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -161,6 +161,72 @@
   color: #667085;
 }
 
+.commercial-planning-week-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.commercial-planning-week-card {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid #d9dee7;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-week-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.commercial-planning-week-card-header h3 {
+  margin: 0;
+  color: #101828;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.commercial-planning-week-card-header p {
+  margin: 0.2rem 0 0;
+  color: #667085;
+}
+
+.commercial-planning-week-totals {
+  display: grid;
+  justify-items: end;
+  gap: 0.1rem;
+  color: #667085;
+  text-align: right;
+}
+
+.commercial-planning-week-totals strong {
+  color: #101828;
+  font-size: 1.1rem;
+}
+
+.commercial-planning-week-table-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.commercial-planning-week-table {
+  min-width: 900px;
+}
+
+.commercial-planning-week-table th {
+  color: #667085;
+  font-size: 0.76rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-week-table td {
+  color: #344054;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 1199.98px) {
   .commercial-planning-month-heading,
   .commercial-planning-month-grid {
@@ -169,6 +235,17 @@
 
   .commercial-planning-month-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .commercial-planning-week-card-header {
+    flex-direction: column;
+  }
+
+  .commercial-planning-week-totals {
+    justify-items: start;
+    text-align: left;
   }
 }
 

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -43,6 +43,29 @@ const defaultPlans = [
 ];
 
 let mockPlans: unknown[] = defaultPlans;
+let mockWeeks: unknown[] = [
+  {
+    weekNumber: 1,
+    startDate: "2026-07-01",
+    endDate: "2026-07-07",
+    experimentsCreated: 1,
+    totalCost: 37,
+    totalRevenue: 27,
+    experiments: [
+      {
+        id: 39,
+        name: "Kit manutenção",
+        productType: "LOW_TICKET",
+        status: "ACTIVE",
+        createdAt: "2026-07-02T10:00:00Z",
+        totalCost: 37,
+        videoCost: 12,
+        revenue: 27,
+        result: "Receita parcial",
+      },
+    ],
+  },
+];
 
 vi.mock("../../api/planning/useCommercialPlans", async () => {
   const actual = await vi.importActual<
@@ -56,11 +79,39 @@ vi.mock("../../api/planning/useCommercialPlans", async () => {
       isLoading: false,
       isError: false,
     }),
+    useCommercialPlanWeeks: () => ({
+      data: mockWeeks,
+      isLoading: false,
+      isError: false,
+    }),
   };
 });
 
 afterEach(() => {
   mockPlans = defaultPlans;
+  mockWeeks = [
+    {
+      weekNumber: 1,
+      startDate: "2026-07-01",
+      endDate: "2026-07-07",
+      experimentsCreated: 1,
+      totalCost: 37,
+      totalRevenue: 27,
+      experiments: [
+        {
+          id: 39,
+          name: "Kit manutenção",
+          productType: "LOW_TICKET",
+          status: "ACTIVE",
+          createdAt: "2026-07-02T10:00:00Z",
+          totalCost: 37,
+          videoCost: 12,
+          revenue: 27,
+          result: "Receita parcial",
+        },
+      ],
+    },
+  ];
   cleanup();
 });
 
@@ -70,7 +121,7 @@ describe("CommercialPlanningPage", () => {
 
     expect(screen.getByText("Planejamento")).toBeTruthy();
     expect(screen.getByText("Plano do mês corrente")).toBeTruthy();
-    expect(screen.getByText("Custo total")).toBeTruthy();
+    expect(screen.getAllByText("Custo total").length).toBeGreaterThan(0);
     expect(screen.getByText("Receita mínima")).toBeTruthy();
     expect(screen.queryByText("Tipos de produto")).toBeNull();
     expect(screen.queryByText("Critério de decisão")).toBeNull();
@@ -78,6 +129,15 @@ describe("CommercialPlanningPage", () => {
     expect(screen.queryByText("Plano ativo")).toBeNull();
     expect(screen.queryByText("Planos de Primeira Venda")).toBeNull();
     expect(screen.queryByText("Novo Plano de Primeira Venda")).toBeNull();
+  });
+
+  it("renderiza experimentos criados por semana do mes", () => {
+    render(<CommercialPlanningPage />);
+
+    expect(screen.getByText("Semana 1")).toBeTruthy();
+    expect(screen.getByText("Kit manutenção")).toBeTruthy();
+    expect(screen.getByText("Vídeo")).toBeTruthy();
+    expect(screen.getByText("Receita parcial")).toBeTruthy();
   });
 
   it("usa valores seguros quando status vem fora do contrato", () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -2,8 +2,10 @@ import { useMemo } from "react";
 import PageTitle from "../../components/PageTitle";
 import {
   CommercialPlan,
+  CommercialPlanWeek,
   CommercialPlanStatus,
   SaveCommercialPlanPayload,
+  useCommercialPlanWeeks,
   useCommercialPlans,
 } from "../../api/planning/useCommercialPlans";
 import "./CommercialPlanningPage.css";
@@ -103,6 +105,11 @@ function formatExecutedNumber(value?: number | null) {
   return value == null ? "0" : String(value);
 }
 
+function formatDate(value?: string | null) {
+  if (!value) return "Não definido";
+  return new Date(value).toLocaleDateString("pt-BR", { timeZone: "UTC" });
+}
+
 function progressPercentage(target?: number | null, actual?: number | null) {
   if (!target || target <= 0) return 0;
   return Math.min(100, Math.round(((actual ?? 0) / target) * 100));
@@ -178,6 +185,71 @@ function MonthlyMetricCard({
   );
 }
 
+function WeeklyExperimentTable({ weeks }: { weeks: CommercialPlanWeek[] }) {
+  return (
+    <section className="commercial-planning-week-list">
+      {weeks.map((week) => (
+        <article className="commercial-planning-week-card" key={week.weekNumber}>
+          <div className="commercial-planning-week-card-header">
+            <div>
+              <h3>Semana {week.weekNumber}</h3>
+              <p>
+                {formatDate(week.startDate)} até {formatDate(week.endDate)}
+              </p>
+            </div>
+            <div className="commercial-planning-week-totals">
+              <span>{week.experimentsCreated} experimentos</span>
+              <strong>{formatExecutedCurrency(week.totalCost)}</strong>
+              <small>{formatExecutedCurrency(week.totalRevenue)} receita</small>
+            </div>
+          </div>
+
+          <div className="commercial-planning-week-table-wrap">
+            <table className="table table-sm align-middle mb-0 commercial-planning-week-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Nome</th>
+                  <th>Tipo</th>
+                  <th>Status</th>
+                  <th>Criado</th>
+                  <th>Custo total</th>
+                  <th>Vídeo</th>
+                  <th>Receita</th>
+                  <th>Resultado</th>
+                </tr>
+              </thead>
+              <tbody>
+                {week.experiments.length > 0 ? (
+                  week.experiments.map((experiment) => (
+                    <tr key={experiment.id}>
+                      <td>{experiment.id}</td>
+                      <td>{experiment.name}</td>
+                      <td>{experiment.productType ?? "Não definido"}</td>
+                      <td>{experiment.status ?? "Não definido"}</td>
+                      <td>{formatDate(experiment.createdAt)}</td>
+                      <td>{formatExecutedCurrency(experiment.totalCost)}</td>
+                      <td>{formatExecutedCurrency(experiment.videoCost)}</td>
+                      <td>{formatExecutedCurrency(experiment.revenue)}</td>
+                      <td>{experiment.result ?? "Sem resultado"}</td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={9} className="text-muted">
+                      Nenhum experimento criado nesta semana.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
 export default function CommercialPlanningPage() {
   const plansQuery = useCommercialPlans();
   const plans = asArray(plansQuery.data);
@@ -185,6 +257,10 @@ export default function CommercialPlanningPage() {
     () => plans[0] ?? fallbackMonthPlan(),
     [plans],
   );
+  const planWeeksQuery = useCommercialPlanWeeks(
+    currentMonthPlan.id > 0 ? currentMonthPlan.id : null,
+  );
+  const weeks = asArray(planWeeksQuery.data);
   const costProgress = progressPercentage(
     currentMonthPlan.maxBudget,
     currentMonthPlan.actualTotalCost,
@@ -279,6 +355,14 @@ export default function CommercialPlanningPage() {
           </div>
         </div>
       </section>
+
+      {planWeeksQuery.isError ? (
+        <div className="alert alert-danger mb-0" role="alert">
+          Não foi possível carregar os experimentos por semana.
+        </div>
+      ) : null}
+
+      {weeks.length > 0 ? <WeeklyExperimentTable weeks={weeks} /> : null}
     </div>
   );
 }


### PR DESCRIPTION
## O que mudou

- Adiciona endpoint `/api/planning/commercial-plans/{id}/weeks` para o backend entregar semanas do mês com experimentos criados no período.
- Exibe na tela de Planejamento um card por semana, com tabela de experimentos, custo total, custo de vídeo, receita e resultado.
- Inclui `experiment_video_asset.cost` no custo total executado do planejamento, fechando a lacuna em que vídeos produzidos não entravam no custo do experimento.

## Impacto

A tela passa a explicar melhor onde o mês está consumindo orçamento e quais experimentos estão gerando ou não receita, sem deixar o frontend recalcular regra financeira.

## Validação

- `mvn -Dtest=CommercialPlanExecutionSyncServiceTest,CommercialPlanServiceTest test`
- `npm run typecheck`
- `NODE_ENV=test npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx`
- `npm run build`

Observação: o push Git local falhou por permissão 403 do token do checkout; a branch foi criada e atualizada via conector GitHub.