### PR TITLE
Add weekly planning objectives

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/CommercialPlanWeekObjective.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/CommercialPlanWeekObjective.java
@@ -1,0 +1,60 @@
+package com.marketinghub.planning;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+
+/** Responsabilidade: representar um objetivo avaliavel de uma semana do planejamento comercial. */
+@Entity
+@Table(name = "commercial_plan_week_objective")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommercialPlanWeekObjective {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private CommercialPlan plan;
+
+    @Column(name = "week_number", nullable = false)
+    private Integer weekNumber;
+
+    @Column(name = "sequence_order", nullable = false)
+    private Integer sequenceOrder;
+
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "objective_text", nullable = false, columnDefinition = "LONGTEXT")
+    private String objectiveText;
+
+    @Column(name = "score")
+    private Integer score;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
@@ -12,4 +12,5 @@ public record CommercialPlanWeekDto(
         Integer experimentsCreated,
         BigDecimal totalCost,
         BigDecimal totalRevenue,
+        List<CommercialPlanWeekObjectiveDto> objectives,
         List<CommercialPlanWeekExperimentDto> experiments) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekObjectiveDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekObjectiveDto.java
@@ -1,0 +1,4 @@
+package com.marketinghub.planning.dto;
+
+/** Responsabilidade: expor um objetivo semanal editavel do planejamento comercial. */
+public record CommercialPlanWeekObjectiveDto(Long id, Integer sequenceOrder, String objectiveText, Integer score) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/UpdateCommercialPlanWeekObjectivesRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/UpdateCommercialPlanWeekObjectivesRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.planning.dto;
+
+import java.util.List;
+
+/** Responsabilidade: receber a lista editada de objetivos semanais do planejamento comercial. */
+public record UpdateCommercialPlanWeekObjectivesRequest(List<Item> objectives) {
+    /** Responsabilidade: representar um objetivo semanal enviado pela tela. */
+    public record Item(Long id, Integer sequenceOrder, String objectiveText, Integer score) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -1,8 +1,12 @@
 package com.marketinghub.planning.service;
 
 import com.marketinghub.planning.CommercialPlan;
+import com.marketinghub.planning.CommercialPlanWeekObjective;
 import com.marketinghub.planning.dto.CommercialPlanWeekDto;
 import com.marketinghub.planning.dto.CommercialPlanWeekExperimentDto;
+import com.marketinghub.planning.dto.CommercialPlanWeekObjectiveDto;
+import com.marketinghub.planning.dto.UpdateCommercialPlanWeekObjectivesRequest;
+import com.marketinghub.repository.jpa.planning.CommercialPlanWeekObjectiveRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.ResultSet;
@@ -21,14 +25,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CommercialPlanWeeklyExperimentService {
     private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    private static final List<String> JULY_FIRST_WEEK_DEFAULT_OBJECTIVES = List.of(
+            "Parar de vender material, guia ou mapa como produto principal.",
+            "Vender uma transformacao mais concreta: recupere X clientes perdidas, preencha Y horarios vagos, monte seu antes/depois personalizado ou receba sua previa visual em minutos.",
+            "Colocar prova visual forte antes do preco.",
+            "Usar preco de entrada mais impulsivo, tipo R$ 9,90 para previa paga em Produto IA.",
+            "Medir como sucesso primario checkout_click, nao compra, ate a pagina provar intencao minima.");
 
     private final CommercialPlanService planService;
     private final JdbcTemplate jdbcTemplate;
+    private final CommercialPlanWeekObjectiveRepository objectiveRepository;
 
     /** Inicializa o serviço com a fonte de plano e acesso SQL de leitura operacional. */
-    public CommercialPlanWeeklyExperimentService(CommercialPlanService planService, JdbcTemplate jdbcTemplate) {
+    public CommercialPlanWeeklyExperimentService(
+            CommercialPlanService planService,
+            JdbcTemplate jdbcTemplate,
+            CommercialPlanWeekObjectiveRepository objectiveRepository) {
         this.planService = planService;
         this.jdbcTemplate = jdbcTemplate;
+        this.objectiveRepository = objectiveRepository;
     }
 
     /** Lista as semanas do mês do plano com os experimentos criados em cada período. */
@@ -50,11 +65,42 @@ public class CommercialPlanWeeklyExperimentService {
                     experiments.size(),
                     sumCost(experiments),
                     sumRevenue(experiments),
+                    listObjectives(plan, weekNumber),
                     experiments));
             start = end.plusDays(1);
             weekNumber++;
         }
         return weeks;
+    }
+
+    /** Atualiza os objetivos avaliaveis de uma semana do plano. */
+    @Transactional
+    public List<CommercialPlanWeekObjectiveDto> updateObjectives(
+            Long planId,
+            Integer weekNumber,
+            UpdateCommercialPlanWeekObjectivesRequest request) {
+        CommercialPlan plan = planService.getPlan(planId);
+        objectiveRepository.deleteByPlanIdAndWeekNumber(planId, weekNumber);
+        List<CommercialPlanWeekObjective> objectives = new ArrayList<>();
+        List<UpdateCommercialPlanWeekObjectivesRequest.Item> items =
+                request == null || request.objectives() == null ? List.of() : request.objectives();
+        int nextOrder = 1;
+        for (UpdateCommercialPlanWeekObjectivesRequest.Item item : items) {
+            if (item.objectiveText() == null || item.objectiveText().isBlank()) {
+                continue;
+            }
+            objectives.add(CommercialPlanWeekObjective.builder()
+                    .plan(plan)
+                    .weekNumber(weekNumber)
+                    .sequenceOrder(nextOrder)
+                    .objectiveText(item.objectiveText().trim())
+                    .score(normalizeScore(item.score()))
+                    .build());
+            nextOrder++;
+        }
+        return objectiveRepository.saveAll(objectives).stream()
+                .map(this::toObjectiveDto)
+                .toList();
     }
 
     /** Resolve o mês de referência do plano a partir do prazo ou da criação. */
@@ -65,6 +111,52 @@ public class CommercialPlanWeeklyExperimentService {
         Instant createdAt = plan.getCreatedAt() == null ? Instant.now() : plan.getCreatedAt();
         LocalDate createdDate = createdAt.atZone(ZoneOffset.UTC).toLocalDate();
         return createdDate.withDayOfMonth(createdDate.lengthOfMonth());
+    }
+
+    /** Lista objetivos persistidos ou a sugestao inicial da primeira semana de julho. */
+    private List<CommercialPlanWeekObjectiveDto> listObjectives(CommercialPlan plan, Integer weekNumber) {
+        List<CommercialPlanWeekObjectiveDto> objectives = objectiveRepository
+                .findByPlanIdAndWeekNumberOrderBySequenceOrderAsc(plan.getId(), weekNumber)
+                .stream()
+                .map(this::toObjectiveDto)
+                .toList();
+        if (!objectives.isEmpty() || !isJulyFirstWeek(plan, weekNumber)) {
+            return objectives;
+        }
+        List<CommercialPlanWeekObjectiveDto> defaults = new ArrayList<>();
+        for (int index = 0; index < JULY_FIRST_WEEK_DEFAULT_OBJECTIVES.size(); index++) {
+            defaults.add(new CommercialPlanWeekObjectiveDto(
+                    null,
+                    index + 1,
+                    JULY_FIRST_WEEK_DEFAULT_OBJECTIVES.get(index),
+                    null));
+        }
+        return defaults;
+    }
+
+    /** Verifica se a semana deve receber a sugestao inicial de objetivos de julho. */
+    private boolean isJulyFirstWeek(CommercialPlan plan, Integer weekNumber) {
+        return Integer.valueOf(1).equals(weekNumber)
+                && plan.getDeadline() != null
+                && plan.getDeadline().getYear() == 2026
+                && plan.getDeadline().getMonthValue() == 7;
+    }
+
+    /** Converte um objetivo semanal para o contrato da tela. */
+    private CommercialPlanWeekObjectiveDto toObjectiveDto(CommercialPlanWeekObjective objective) {
+        return new CommercialPlanWeekObjectiveDto(
+                objective.getId(),
+                objective.getSequenceOrder(),
+                objective.getObjectiveText(),
+                objective.getScore());
+    }
+
+    /** Mantem a nota dentro da escala simples de avaliacao semanal. */
+    private Integer normalizeScore(Integer score) {
+        if (score == null) {
+            return null;
+        }
+        return Math.max(0, Math.min(10, score));
     }
 
     /** Busca os experimentos criados no intervalo e agrega custos rastreáveis por experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/web/CommercialPlanController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/web/CommercialPlanController.java
@@ -5,10 +5,12 @@ import com.marketinghub.planning.dto.CommercialPlanDto;
 import com.marketinghub.planning.dto.CommercialPlanMilestoneDto;
 import com.marketinghub.planning.dto.CommercialPlanSimulationDto;
 import com.marketinghub.planning.dto.CommercialPlanWeekDto;
+import com.marketinghub.planning.dto.CommercialPlanWeekObjectiveDto;
 import com.marketinghub.planning.dto.CreateCommercialPlanRequest;
 import com.marketinghub.planning.dto.CreateCommercialPlanSimulationRequest;
 import com.marketinghub.planning.dto.UpdateCommercialPlanMilestoneRequest;
 import com.marketinghub.planning.dto.UpdateCommercialPlanRequest;
+import com.marketinghub.planning.dto.UpdateCommercialPlanWeekObjectivesRequest;
 import com.marketinghub.planning.mapper.CommercialPlanMapper;
 import com.marketinghub.planning.service.CommercialPlanService;
 import com.marketinghub.planning.service.CommercialPlanWeeklyExperimentService;
@@ -65,6 +67,15 @@ public class CommercialPlanController {
     @GetMapping("/{id}/weeks")
     public List<CommercialPlanWeekDto> listWeeks(@PathVariable Long id) {
         return weeklyExperimentService.listWeeks(id);
+    }
+
+    /** Atualiza os objetivos avaliaveis de uma semana do plano. */
+    @PutMapping("/{id}/weeks/{weekNumber}/objectives")
+    public List<CommercialPlanWeekObjectiveDto> updateWeekObjectives(
+            @PathVariable Long id,
+            @PathVariable Integer weekNumber,
+            @RequestBody UpdateCommercialPlanWeekObjectivesRequest request) {
+        return weeklyExperimentService.updateObjectives(id, weekNumber, request);
     }
 
     /** Atualiza um plano comercial existente. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/planning/CommercialPlanWeekObjectiveRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/planning/CommercialPlanWeekObjectiveRepository.java
@@ -1,0 +1,14 @@
+package com.marketinghub.repository.jpa.planning;
+
+import com.marketinghub.planning.CommercialPlanWeekObjective;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: persistir objetivos semanais do planejamento comercial. */
+public interface CommercialPlanWeekObjectiveRepository extends JpaRepository<CommercialPlanWeekObjective, Long> {
+    /** Lista objetivos de uma semana do plano na ordem de exibicao. */
+    List<CommercialPlanWeekObjective> findByPlanIdAndWeekNumberOrderBySequenceOrderAsc(Long planId, Integer weekNumber);
+
+    /** Remove objetivos de uma semana para substituir pela versao editada. */
+    void deleteByPlanIdAndWeekNumber(Long planId, Integer weekNumber);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-07-commercial-plan-week-objectives.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-07-commercial-plan-week-objectives.yaml
@@ -1,0 +1,67 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-07-01-commercial-plan-week-objectives
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            - tableExists:
+                tableName: commercial_plan_week_objective
+      changes:
+        - createTable:
+            tableName: commercial_plan_week_objective
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: plan_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: week_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sequence_order
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: objective_text
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: score
+                  type: INT
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+        - addForeignKeyConstraint:
+            baseTableName: commercial_plan_week_objective
+            baseColumnNames: plan_id
+            constraintName: fk_commercial_plan_week_objective_plan
+            referencedTableName: commercial_plan
+            referencedColumnNames: id
+        - createIndex:
+            tableName: commercial_plan_week_objective
+            indexName: idx_commercial_plan_week_objective_plan_week
+            columns:
+              - column:
+                  name: plan_id
+              - column:
+                  name: week_number
+              - column:
+                  name: sequence_order

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-07-commercial-plan-week-objectives.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-06-experiment-video-asset.yaml
       relativeToChangelogFile: true
   - include:

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -111,6 +111,13 @@ export interface CommercialPlanWeekExperiment {
   result?: string | null;
 }
 
+export interface CommercialPlanWeekObjective {
+  id?: number | null;
+  sequenceOrder: number;
+  objectiveText: string;
+  score?: number | null;
+}
+
 export interface CommercialPlanWeek {
   weekNumber: number;
   startDate: string;
@@ -118,6 +125,7 @@ export interface CommercialPlanWeek {
   experimentsCreated: number;
   totalCost?: number | null;
   totalRevenue?: number | null;
+  objectives: CommercialPlanWeekObjective[];
   experiments: CommercialPlanWeekExperiment[];
 }
 
@@ -169,6 +177,32 @@ export function useCommercialPlanWeeks(planId?: number | null) {
       );
       return data;
     },
+  });
+}
+
+export function useUpdateCommercialPlanWeekObjectives(planId?: number | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      weekNumber,
+      objectives,
+    }: {
+      weekNumber: number;
+      objectives: CommercialPlanWeekObjective[];
+    }) => {
+      if (!planId) {
+        throw new Error("Plano comercial não informado.");
+      }
+      const { data } = await axios.put<CommercialPlanWeekObjective[]>(
+        `/api/planning/commercial-plans/${planId}/weeks/${weekNumber}/objectives`,
+        { objectives },
+      );
+      return data;
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["commercial-plan-weeks", planId],
+      }),
   });
 }
 

--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -211,6 +211,65 @@
   overflow-x: auto;
 }
 
+.commercial-planning-week-objectives {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 0.875rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #f8fafc;
+}
+
+.commercial-planning-week-objectives-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.commercial-planning-week-objectives-header h4 {
+  margin: 0;
+  color: #101828;
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.commercial-planning-week-objective-list {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.commercial-planning-week-objective {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) 5.5rem auto;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.commercial-planning-week-objective-bullet {
+  display: inline-grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.commercial-planning-week-score {
+  min-width: 0;
+}
+
+.commercial-planning-week-objectives-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
 .commercial-planning-week-table {
   min-width: 900px;
 }
@@ -241,6 +300,15 @@
 @media (max-width: 767.98px) {
   .commercial-planning-week-card-header {
     flex-direction: column;
+  }
+
+  .commercial-planning-week-objectives-header,
+  .commercial-planning-week-objective {
+    grid-template-columns: 1fr;
+  }
+
+  .commercial-planning-week-objectives-header {
+    display: grid;
   }
 
   .commercial-planning-week-totals {

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -51,6 +51,15 @@ let mockWeeks: unknown[] = [
     experimentsCreated: 1,
     totalCost: 37,
     totalRevenue: 27,
+    objectives: [
+      {
+        id: null,
+        sequenceOrder: 1,
+        objectiveText:
+          "Medir como sucesso primário checkout_click, não compra, até a página provar intenção mínima.",
+        score: null,
+      },
+    ],
     experiments: [
       {
         id: 39,
@@ -84,6 +93,12 @@ vi.mock("../../api/planning/useCommercialPlans", async () => {
       isLoading: false,
       isError: false,
     }),
+    useUpdateCommercialPlanWeekObjectives: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+    }),
   };
 });
 
@@ -97,6 +112,15 @@ afterEach(() => {
       experimentsCreated: 1,
       totalCost: 37,
       totalRevenue: 27,
+      objectives: [
+        {
+          id: null,
+          sequenceOrder: 1,
+          objectiveText:
+            "Medir como sucesso primário checkout_click, não compra, até a página provar intenção mínima.",
+          score: null,
+        },
+      ],
       experiments: [
         {
           id: 39,
@@ -138,6 +162,15 @@ describe("CommercialPlanningPage", () => {
     expect(screen.getByText("Kit manutenção")).toBeTruthy();
     expect(screen.getByText("Vídeo")).toBeTruthy();
     expect(screen.getByText("Receita parcial")).toBeTruthy();
+  });
+
+  it("renderiza objetivos semanais editaveis", () => {
+    render(<CommercialPlanningPage />);
+
+    expect(screen.getByText("Objetivos da semana")).toBeTruthy();
+    expect(screen.getByDisplayValue(/checkout_click/)).toBeTruthy();
+    expect(screen.getByLabelText("Nota do objetivo 1 da semana 1")).toBeTruthy();
+    expect(screen.getByText("Salvar objetivos")).toBeTruthy();
   });
 
   it("usa valores seguros quando status vem fora do contrato", () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PageTitle from "../../components/PageTitle";
 import {
   CommercialPlan,
   CommercialPlanWeek,
+  CommercialPlanWeekObjective,
   CommercialPlanStatus,
   SaveCommercialPlanPayload,
   useCommercialPlanWeeks,
   useCommercialPlans,
+  useUpdateCommercialPlanWeekObjectives,
 } from "../../api/planning/useCommercialPlans";
 import "./CommercialPlanningPage.css";
 
@@ -185,7 +187,176 @@ function MonthlyMetricCard({
   );
 }
 
-function WeeklyExperimentTable({ weeks }: { weeks: CommercialPlanWeek[] }) {
+function WeeklyObjectiveEditor({
+  planId,
+  week,
+}: {
+  planId: number;
+  week: CommercialPlanWeek;
+}) {
+  const updateObjectives = useUpdateCommercialPlanWeekObjectives(planId);
+  const [objectives, setObjectives] = useState<CommercialPlanWeekObjective[]>(
+    () => normalizeObjectives(week.objectives),
+  );
+
+  useEffect(() => {
+    setObjectives(normalizeObjectives(week.objectives));
+  }, [week.objectives]);
+
+  function updateObjective(
+    index: number,
+    field: "objectiveText" | "score",
+    value: string,
+  ) {
+    setObjectives((current) =>
+      current.map((objective, objectiveIndex) => {
+        if (objectiveIndex !== index) return objective;
+        if (field === "score") {
+          return {
+            ...objective,
+            score: value === "" ? null : Number(value),
+          };
+        }
+        return { ...objective, objectiveText: value };
+      }),
+    );
+  }
+
+  function addObjective() {
+    setObjectives((current) => [
+      ...current,
+      {
+        id: null,
+        sequenceOrder: current.length + 1,
+        objectiveText: "",
+        score: null,
+      },
+    ]);
+  }
+
+  function removeObjective(index: number) {
+    setObjectives((current) =>
+      current
+        .filter((_, objectiveIndex) => objectiveIndex !== index)
+        .map((objective, objectiveIndex) => ({
+          ...objective,
+          sequenceOrder: objectiveIndex + 1,
+        })),
+    );
+  }
+
+  function saveObjectives() {
+    updateObjectives.mutate({
+      weekNumber: week.weekNumber,
+      objectives: objectives.map((objective, index) => ({
+        ...objective,
+        sequenceOrder: index + 1,
+        objectiveText: objective.objectiveText.trim(),
+      })),
+    });
+  }
+
+  return (
+    <div className="commercial-planning-week-objectives">
+      <div className="commercial-planning-week-objectives-header">
+        <h4>Objetivos da semana</h4>
+        <button
+          className="btn btn-sm btn-outline-primary"
+          type="button"
+          onClick={addObjective}
+        >
+          Adicionar tópico
+        </button>
+      </div>
+
+      <div className="commercial-planning-week-objective-list">
+        {objectives.map((objective, index) => (
+          <div
+            className="commercial-planning-week-objective"
+            key={`${objective.id ?? "new"}-${index}`}
+          >
+            <span className="commercial-planning-week-objective-bullet">
+              {index + 1}
+            </span>
+            <textarea
+              aria-label={`Objetivo ${index + 1} da semana ${week.weekNumber}`}
+              className="form-control form-control-sm"
+              rows={2}
+              value={objective.objectiveText}
+              onChange={(event) =>
+                updateObjective(index, "objectiveText", event.target.value)
+              }
+            />
+            <input
+              aria-label={`Nota do objetivo ${index + 1} da semana ${week.weekNumber}`}
+              className="form-control form-control-sm commercial-planning-week-score"
+              type="number"
+              min={0}
+              max={10}
+              placeholder="Nota"
+              value={objective.score ?? ""}
+              onChange={(event) =>
+                updateObjective(index, "score", event.target.value)
+              }
+            />
+            <button
+              className="btn btn-sm btn-outline-secondary"
+              type="button"
+              onClick={() => removeObjective(index)}
+            >
+              Remover
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="commercial-planning-week-objectives-actions">
+        <button
+          className="btn btn-sm btn-primary"
+          type="button"
+          disabled={updateObjectives.isPending}
+          onClick={saveObjectives}
+        >
+          {updateObjectives.isPending ? "Salvando..." : "Salvar objetivos"}
+        </button>
+        {updateObjectives.isError ? (
+          <span className="text-danger">Não foi possível salvar.</span>
+        ) : null}
+        {updateObjectives.isSuccess ? (
+          <span className="text-success">Objetivos salvos.</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function normalizeObjectives(
+  objectives?: CommercialPlanWeekObjective[] | null,
+): CommercialPlanWeekObjective[] {
+  if (Array.isArray(objectives) && objectives.length > 0) {
+    return objectives.map((objective, index) => ({
+      ...objective,
+      sequenceOrder: objective.sequenceOrder ?? index + 1,
+      score: objective.score ?? null,
+    }));
+  }
+  return [
+    {
+      id: null,
+      sequenceOrder: 1,
+      objectiveText: "",
+      score: null,
+    },
+  ];
+}
+
+function WeeklyExperimentTable({
+  planId,
+  weeks,
+}: {
+  planId: number;
+  weeks: CommercialPlanWeek[];
+}) {
   return (
     <section className="commercial-planning-week-list">
       {weeks.map((week) => (
@@ -203,6 +374,8 @@ function WeeklyExperimentTable({ weeks }: { weeks: CommercialPlanWeek[] }) {
               <small>{formatExecutedCurrency(week.totalRevenue)} receita</small>
             </div>
           </div>
+
+          <WeeklyObjectiveEditor planId={planId} week={week} />
 
           <div className="commercial-planning-week-table-wrap">
             <table className="table table-sm align-middle mb-0 commercial-planning-week-table">
@@ -362,7 +535,9 @@ export default function CommercialPlanningPage() {
         </div>
       ) : null}
 
-      {weeks.length > 0 ? <WeeklyExperimentTable weeks={weeks} /> : null}
+      {weeks.length > 0 ? (
+        <WeeklyExperimentTable planId={currentMonthPlan.id} weeks={weeks} />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## O que mudou

- Adiciona objetivos semanais editaveis na pagina de planejamento comercial.
- Exibe a sugestao da primeira semana de julho como topicos avaliaveis, incluindo foco em transformacao concreta, prova visual, preco de entrada e checkout_click como metrica primaria.
- Persiste objetivos e notas por semana em nova tabela `commercial_plan_week_objective`.
- Adiciona endpoint para salvar objetivos da semana e invalida a query semanal no frontend apos salvar.

## Por que

A tela precisava transformar o aprendizado de funil em plano operacional semanal, visivel e editavel, para depois avaliar cada topico por nota. A causa-raiz da confusao era que os dados semanais so mostravam experimentos e metricas, sem um campo persistido para orientar a decisao comercial da semana.

## Validacao

- `npm run typecheck`
- `NODE_ENV=test npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx`
- `npm run build`
- `mvn -q -Dtest=CommercialPlanServiceTest test`

Observacao: o `npm test` sem `NODE_ENV=test` usa build de producao do React neste ambiente e falha com `act(...) is not supported in production builds of React`; com `NODE_ENV=test`, os testes passam.