### PR TITLE
Ajusta objetivos do planejamento comercial

### DIFF
--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -214,7 +214,7 @@
 .commercial-planning-week-objectives {
   display: grid;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  margin-top: 1rem;
   padding: 0.875rem;
   border: 1px solid #e4e7ec;
   border-radius: 0.5rem;
@@ -242,7 +242,7 @@
 
 .commercial-planning-week-objective {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) 5.5rem auto;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
   gap: 0.5rem;
   align-items: start;
 }
@@ -259,8 +259,17 @@
   font-weight: 800;
 }
 
-.commercial-planning-week-score {
-  min-width: 0;
+.commercial-planning-week-objective-text {
+  color: #344054;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-week-objective-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: start;
 }
 
 .commercial-planning-week-objectives-actions {

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import CommercialPlanningPage from "./CommercialPlanningPage";
 
@@ -164,13 +165,19 @@ describe("CommercialPlanningPage", () => {
     expect(screen.getByText("Receita parcial")).toBeTruthy();
   });
 
-  it("renderiza objetivos semanais editaveis", () => {
+  it("renderiza objetivos semanais como texto e mostra campo apenas para novo objetivo", async () => {
+    const user = userEvent.setup();
     render(<CommercialPlanningPage />);
 
     expect(screen.getByText("Objetivos da semana")).toBeTruthy();
-    expect(screen.getByDisplayValue(/checkout_click/)).toBeTruthy();
-    expect(screen.getByLabelText("Nota do objetivo 1 da semana 1")).toBeTruthy();
-    expect(screen.getByText("Salvar objetivos")).toBeTruthy();
+    expect(screen.getByText(/checkout_click/)).toBeTruthy();
+    expect(screen.queryByDisplayValue(/checkout_click/)).toBeNull();
+    expect(screen.queryByLabelText("Novo objetivo da semana 1")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Inserir novo" }));
+
+    expect(screen.getByLabelText("Novo objetivo da semana 1")).toBeTruthy();
+    expect(screen.getByText("Salvar novo")).toBeTruthy();
   });
 
   it("usa valores seguros quando status vem fora do contrato", () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -198,60 +198,32 @@ function WeeklyObjectiveEditor({
   const [objectives, setObjectives] = useState<CommercialPlanWeekObjective[]>(
     () => normalizeObjectives(week.objectives),
   );
+  const [isAddingObjective, setIsAddingObjective] = useState(false);
+  const [newObjectiveText, setNewObjectiveText] = useState("");
 
   useEffect(() => {
     setObjectives(normalizeObjectives(week.objectives));
+    setIsAddingObjective(false);
+    setNewObjectiveText("");
   }, [week.objectives]);
 
-  function updateObjective(
-    index: number,
-    field: "objectiveText" | "score",
-    value: string,
-  ) {
-    setObjectives((current) =>
-      current.map((objective, objectiveIndex) => {
-        if (objectiveIndex !== index) return objective;
-        if (field === "score") {
-          return {
-            ...objective,
-            score: value === "" ? null : Number(value),
-          };
-        }
-        return { ...objective, objectiveText: value };
-      }),
-    );
-  }
-
-  function addObjective() {
-    setObjectives((current) => [
-      ...current,
+  function saveNewObjective() {
+    const objectiveText = newObjectiveText.trim();
+    if (!objectiveText) return;
+    const nextObjectives = [
+      ...objectives,
       {
         id: null,
-        sequenceOrder: current.length + 1,
-        objectiveText: "",
+        sequenceOrder: objectives.length + 1,
+        objectiveText,
         score: null,
       },
-    ]);
-  }
-
-  function removeObjective(index: number) {
-    setObjectives((current) =>
-      current
-        .filter((_, objectiveIndex) => objectiveIndex !== index)
-        .map((objective, objectiveIndex) => ({
-          ...objective,
-          sequenceOrder: objectiveIndex + 1,
-        })),
-    );
-  }
-
-  function saveObjectives() {
+    ];
     updateObjectives.mutate({
       weekNumber: week.weekNumber,
-      objectives: objectives.map((objective, index) => ({
+      objectives: nextObjectives.map((objective, index) => ({
         ...objective,
         sequenceOrder: index + 1,
-        objectiveText: objective.objectiveText.trim(),
       })),
     });
   }
@@ -263,9 +235,9 @@ function WeeklyObjectiveEditor({
         <button
           className="btn btn-sm btn-outline-primary"
           type="button"
-          onClick={addObjective}
+          onClick={() => setIsAddingObjective((current) => !current)}
         >
-          Adicionar tópico
+          Inserir novo
         </button>
       </div>
 
@@ -278,52 +250,45 @@ function WeeklyObjectiveEditor({
             <span className="commercial-planning-week-objective-bullet">
               {index + 1}
             </span>
-            <textarea
-              aria-label={`Objetivo ${index + 1} da semana ${week.weekNumber}`}
-              className="form-control form-control-sm"
-              rows={2}
-              value={objective.objectiveText}
-              onChange={(event) =>
-                updateObjective(index, "objectiveText", event.target.value)
-              }
-            />
-            <input
-              aria-label={`Nota do objetivo ${index + 1} da semana ${week.weekNumber}`}
-              className="form-control form-control-sm commercial-planning-week-score"
-              type="number"
-              min={0}
-              max={10}
-              placeholder="Nota"
-              value={objective.score ?? ""}
-              onChange={(event) =>
-                updateObjective(index, "score", event.target.value)
-              }
-            />
-            <button
-              className="btn btn-sm btn-outline-secondary"
-              type="button"
-              onClick={() => removeObjective(index)}
-            >
-              Remover
-            </button>
+            <p className="commercial-planning-week-objective-text mb-0">
+              {objective.objectiveText || "Objetivo sem descrição."}
+            </p>
+            {objective.score != null ? (
+              <span className="badge text-bg-light border">
+                Nota {objective.score}
+              </span>
+            ) : null}
           </div>
         ))}
       </div>
 
+      {isAddingObjective ? (
+        <div className="commercial-planning-week-objective-form">
+          <textarea
+            aria-label={`Novo objetivo da semana ${week.weekNumber}`}
+            className="form-control form-control-sm"
+            rows={2}
+            value={newObjectiveText}
+            onChange={(event) => setNewObjectiveText(event.target.value)}
+            placeholder="Descreva o novo objetivo da semana"
+          />
+          <button
+            className="btn btn-sm btn-primary"
+            type="button"
+            disabled={updateObjectives.isPending || !newObjectiveText.trim()}
+            onClick={saveNewObjective}
+          >
+            {updateObjectives.isPending ? "Salvando..." : "Salvar novo"}
+          </button>
+        </div>
+      ) : null}
+
       <div className="commercial-planning-week-objectives-actions">
-        <button
-          className="btn btn-sm btn-primary"
-          type="button"
-          disabled={updateObjectives.isPending}
-          onClick={saveObjectives}
-        >
-          {updateObjectives.isPending ? "Salvando..." : "Salvar objetivos"}
-        </button>
         {updateObjectives.isError ? (
           <span className="text-danger">Não foi possível salvar.</span>
         ) : null}
         {updateObjectives.isSuccess ? (
-          <span className="text-success">Objetivos salvos.</span>
+          <span className="text-success">Objetivo inserido.</span>
         ) : null}
       </div>
     </div>
@@ -340,14 +305,7 @@ function normalizeObjectives(
       score: objective.score ?? null,
     }));
   }
-  return [
-    {
-      id: null,
-      sequenceOrder: 1,
-      objectiveText: "",
-      score: null,
-    },
-  ];
+  return [];
 }
 
 function WeeklyExperimentTable({
@@ -374,8 +332,6 @@ function WeeklyExperimentTable({
               <small>{formatExecutedCurrency(week.totalRevenue)} receita</small>
             </div>
           </div>
-
-          <WeeklyObjectiveEditor planId={planId} week={week} />
 
           <div className="commercial-planning-week-table-wrap">
             <table className="table table-sm align-middle mb-0 commercial-planning-week-table">
@@ -417,6 +373,8 @@ function WeeklyExperimentTable({
               </tbody>
             </table>
           </div>
+
+          <WeeklyObjectiveEditor planId={planId} week={week} />
         </article>
       ))}
     </section>


### PR DESCRIPTION
## O que mudou

- Move o quadro de objetivos semanais para baixo da tabela de experimentos.
- Troca a edição inline de todos os objetivos por exibição em texto simples.
- Mantém apenas o fluxo de inserir novo objetivo com caixa de texto.
- Atualiza o teste da tela para travar esse comportamento.

## Por que

A tela estava colocando todos os objetivos como campos editáveis, criando excesso de input e ruído operacional. A mudança deixa a leitura dos objetivos mais clara e concentra a ação do usuário no que importa: inserir um novo objetivo quando necessário.

## Validação

- `NODE_ENV=development npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx src/pages/openaiModel/OpenAiModelListPage.test.tsx`
- `../mvnw -Dtest=OpenAiModelPricingSyncServiceTest,OpenAiPricingPageClientTest test`

Observação: o push direto via remoto local falhou por permissão 403, então a branch e os commits remotos foram publicados pelo conector GitHub.