### PR TITLE
Sincroniza catálogo OpenAI na rotina diária

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricingScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricingScheduler.java
@@ -1,5 +1,6 @@
 package com.marketinghub.openai;
 
+import com.marketinghub.modelos.openai.catalogo.v1.service.OpenAiModelCatalogV1Service;
 import com.marketinghub.openai.service.OpenAiModelPricingSyncService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,17 +12,21 @@ import org.springframework.stereotype.Component;
 public class OpenAiModelPricingScheduler {
     private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingScheduler.class);
 
+    private final OpenAiModelCatalogV1Service catalogService;
     private final OpenAiModelPricingSyncService syncService;
 
-    /** Inicializa o agendador com o serviço transacional de sincronização de preços. */
-    public OpenAiModelPricingScheduler(OpenAiModelPricingSyncService syncService) {
+    /** Inicializa o agendador com os serviços de sincronização do catálogo técnico e dos preços. */
+    public OpenAiModelPricingScheduler(
+            OpenAiModelCatalogV1Service catalogService, OpenAiModelPricingSyncService syncService) {
+        this.catalogService = catalogService;
         this.syncService = syncService;
     }
 
-    /** Executa diariamente às 04:00 no fuso de São Paulo para manter os preços dos modelos atualizados. */
+    /** Executa diariamente às 04:00 no fuso de São Paulo para manter modelos e preços atualizados. */
     @Scheduled(cron = "0 0 4 * * *", zone = "America/Sao_Paulo")
     public void syncDailyPricing() {
         try {
+            catalogService.fetchAndPersistCatalog();
             int updated = syncService.syncOfficialPricing();
             log.info("Rotina diária de preços OpenAI concluída; operation=openai-pricing-daily-sync modelsUpdated={}", updated);
         } catch (RuntimeException ex) {

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSchedulerTest.java
@@ -1,0 +1,28 @@
+package com.marketinghub.openai;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.modelos.openai.catalogo.v1.service.OpenAiModelCatalogV1Service;
+import com.marketinghub.openai.service.OpenAiModelPricingSyncService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+/** Responsabilidade: validar a rotina diária que mantém modelos e preços OpenAI sincronizados. */
+class OpenAiModelPricingSchedulerTest {
+
+    /** Garante que a rotina diária atualize o catálogo técnico antes dos preços financeiros. */
+    @Test
+    void shouldSyncOfficialCatalogBeforePricing() {
+        OpenAiModelCatalogV1Service catalogService = mock(OpenAiModelCatalogV1Service.class);
+        OpenAiModelPricingSyncService syncService = mock(OpenAiModelPricingSyncService.class);
+        when(syncService.syncOfficialPricing()).thenReturn(3);
+
+        new OpenAiModelPricingScheduler(catalogService, syncService).syncDailyPricing();
+
+        InOrder order = inOrder(catalogService, syncService);
+        order.verify(catalogService).fetchAndPersistCatalog();
+        order.verify(syncService).syncOfficialPricing();
+    }
+}


### PR DESCRIPTION
## O que mudou

- A rotina diária de modelos OpenAI agora sincroniza primeiro o catálogo técnico oficial `/models` e depois atualiza os preços financeiros.
- Foi adicionado teste unitário garantindo essa ordem de execução.

## Por que

A tela de modelos já ordena os itens por preço decrescente, mas a rotina diária estava focada nos preços. A causa-raiz provável para mudanças de modelos/capacidades ficarem defasadas era a ausência da atualização diária do catálogo técnico oficial.

## Impacto

- Novos modelos e mudanças de disponibilidade/capacidade passam a ser capturados no ciclo diário.
- A tabela administrativa continua usando o mesmo endpoint e preserva o cálculo financeiro atual.

## Validação

- `../mvnw -Dtest=OpenAiModelPricingSchedulerTest,OpenAiModelPricingSyncServiceTest test`
- `npm test -- --run src/pages/openaiModel/OpenAiModelListPage.test.tsx`
- `git diff --check`

Observação: o Vitest concluiu com testes verdes, mas emitiu aviso de processo pendente após o sucesso (`close timed out after 10000ms`), sem falha de teste.