### PR TITLE
Corrige links e botoes de experimento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -26,11 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommercialPlanWeeklyExperimentService {
     private static final BigDecimal ZERO = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
     private static final List<String> JULY_FIRST_WEEK_DEFAULT_OBJECTIVES = List.of(
-            "Parar de vender material, guia ou mapa como produto principal.",
-            "Vender uma transformacao mais concreta: recupere X clientes perdidas, preencha Y horarios vagos, monte seu antes/depois personalizado ou receba sua previa visual em minutos.",
-            "Colocar prova visual forte antes do preco.",
-            "Usar preco de entrada mais impulsivo, tipo R$ 9,90 para previa paga em Produto IA.",
-            "Medir como sucesso primario checkout_click, nao compra, ate a pagina provar intencao minima.");
+            "Manter venda real como objetivo principal; checkout_click e lead servem apenas como diagnostico intermediario.",
+            "Garantir tracking confiavel antes de gastar: campanha sem metrica atualizada nao pode continuar rodando como aprendizado valido.",
+            "Colocar prova visual forte antes do preco para reduzir duvida e aumentar disposicao de pagamento.",
+            "Separar criterio por funil: venda direta mede compra, previa paga mede checkout iniciado e captura mede lead que avanca para checkout.",
+            "Aplicar trava de gasto: experimento sem resultado primario ou aprendizado acionavel deve ser parado ao atingir o limite operacional.");
 
     private final CommercialPlanService planService;
     private final JdbcTemplate jdbcTemplate;

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -313,6 +313,9 @@ export default function ExperimentDetailPage() {
   const { data: facebookCampaigns, isLoading: isLoadingFacebookCampaigns } =
     useExperimentFacebookCampaigns(expId);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
+  const [openAuditStageJobId, setOpenAuditStageJobId] = useState<
+    string | null
+  >(null);
   const [copiedCardKey, setCopiedCardKey] = useState<string | null>(null);
   const [copyingCardKey, setCopyingCardKey] = useState<string | null>(null);
   const [downloadingCardKey, setDownloadingCardKey] = useState<string | null>(
@@ -2450,12 +2453,19 @@ export default function ExperimentDetailPage() {
                         id={`audit-stage-${stage.idJob}`}
                       >
                         <button
-                          className={`accordion-button ${index === 0 ? "" : "collapsed"}`}
+                          className={`accordion-button ${
+                            openAuditStageJobId === stage.idJob ||
+                            (!openAuditStageJobId && index === 0)
+                              ? ""
+                              : "collapsed"
+                          }`}
                           type="button"
-                          data-bs-toggle="collapse"
-                          data-bs-target={`#audit-stage-body-${stage.idJob}`}
-                          aria-expanded={index === 0}
+                          aria-expanded={
+                            openAuditStageJobId === stage.idJob ||
+                            (!openAuditStageJobId && index === 0)
+                          }
                           aria-controls={`audit-stage-body-${stage.idJob}`}
+                          onClick={() => setOpenAuditStageJobId(stage.idJob)}
                         >
                           <span className="fw-semibold me-2">
                             {stage.stageCode}
@@ -2472,7 +2482,12 @@ export default function ExperimentDetailPage() {
                       </h2>
                       <div
                         id={`audit-stage-body-${stage.idJob}`}
-                        className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
+                        className={`accordion-collapse collapse ${
+                          openAuditStageJobId === stage.idJob ||
+                          (!openAuditStageJobId && index === 0)
+                            ? "show"
+                            : ""
+                        }`}
                         aria-labelledby={`audit-stage-${stage.idJob}`}
                       >
                         <div className="accordion-body">

--- a/frontend/src/pages/experiment/ExperimentRunPanel.tsx
+++ b/frontend/src/pages/experiment/ExperimentRunPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type {
   ExperimentRun,
   ExperimentRunGateGroup,
@@ -92,6 +93,7 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
   const runPreflight = useRunExperimentPreflight(experimentId);
   const preflight = preflightQuery.data;
   const gateGroups = groupGates(preflight?.gates ?? []);
+  const [openGateGroup, setOpenGateGroup] = useState<string | null>(null);
 
   const handleCreateRun = () => {
     if (!createRun.isPending) {
@@ -178,17 +180,18 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
                       <div className="accordion-item" key={group}>
                         <h2 className="accordion-header">
                           <button
-                            className={`accordion-button ${index === 0 ? "" : "collapsed"}`}
+                            className={`accordion-button ${openGateGroup === group || (!openGateGroup && index === 0) ? "" : "collapsed"}`}
                             type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target={`#experiment-run-preflight-${currentRun.id}-${group}`}
+                            aria-expanded={openGateGroup === group || (!openGateGroup && index === 0)}
+                            aria-controls={`experiment-run-preflight-${currentRun.id}-${group}`}
+                            onClick={() => setOpenGateGroup(group)}
                           >
                             {gateGroupLabels[group as ExperimentRunGateGroup] ?? group}
                           </button>
                         </h2>
                         <div
                           id={`experiment-run-preflight-${currentRun.id}-${group}`}
-                          className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
+                          className={`accordion-collapse collapse ${openGateGroup === group || (!openGateGroup && index === 0) ? "show" : ""}`}
                         >
                           <div className="accordion-body p-0">
                             <ul className="list-group list-group-flush">

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import CommercialPlanningPage from "./CommercialPlanningPage";
 
@@ -103,6 +104,14 @@ vi.mock("../../api/planning/useCommercialPlans", async () => {
   };
 });
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CommercialPlanningPage />
+    </MemoryRouter>,
+  );
+}
+
 afterEach(() => {
   mockPlans = defaultPlans;
   mockWeeks = [
@@ -142,7 +151,7 @@ afterEach(() => {
 
 describe("CommercialPlanningPage", () => {
   it("renderiza somente o planejamento superior", () => {
-    render(<CommercialPlanningPage />);
+    renderPage();
 
     expect(screen.getByText("Planejamento")).toBeTruthy();
     expect(screen.getByText("Plano do mês corrente")).toBeTruthy();
@@ -157,17 +166,20 @@ describe("CommercialPlanningPage", () => {
   });
 
   it("renderiza experimentos criados por semana do mes", () => {
-    render(<CommercialPlanningPage />);
+    renderPage();
 
     expect(screen.getByText("Semana 1")).toBeTruthy();
-    expect(screen.getByText("Kit manutenção")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Kit manutenção" })).toHaveAttribute(
+      "href",
+      "/experiments/39",
+    );
     expect(screen.getByText("Vídeo")).toBeTruthy();
     expect(screen.getByText("Receita parcial")).toBeTruthy();
   });
 
   it("renderiza objetivos semanais como texto e mostra campo apenas para novo objetivo", async () => {
     const user = userEvent.setup();
-    render(<CommercialPlanningPage />);
+    renderPage();
 
     expect(screen.getByText("Objetivos da semana")).toBeTruthy();
     expect(screen.getByText(/checkout_click/)).toBeTruthy();
@@ -181,7 +193,7 @@ describe("CommercialPlanningPage", () => {
   });
 
   it("usa valores seguros quando status vem fora do contrato", () => {
-    render(<CommercialPlanningPage />);
+    renderPage();
 
     expect(screen.getAllByText("Rascunho").length).toBeGreaterThan(0);
   });
@@ -189,7 +201,7 @@ describe("CommercialPlanningPage", () => {
   it("renderiza sugestao de julho quando a API ainda nao retorna planos", () => {
     mockPlans = [];
 
-    render(<CommercialPlanningPage />);
+    renderPage();
 
     expect(screen.getByText("Planejamento")).toBeTruthy();
     expect(screen.getByText("Julho 2026")).toBeTruthy();

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
   CommercialPlan,
@@ -353,7 +354,11 @@ function WeeklyExperimentTable({
                   week.experiments.map((experiment) => (
                     <tr key={experiment.id}>
                       <td>{experiment.id}</td>
-                      <td>{experiment.name}</td>
+                      <td>
+                        <Link to={`/experiments/${experiment.id}`}>
+                          {experiment.name}
+                        </Link>
+                      </td>
                       <td>{experiment.productType ?? "Não definido"}</td>
                       <td>{experiment.status ?? "Não definido"}</td>
                       <td>{formatDate(experiment.createdAt)}</td>


### PR DESCRIPTION
## O que mudou

- O nome dos experimentos na tela de planejamento agora abre o detalhe do experimento.
- Os accordions da tela de experimento deixam de depender do JavaScript do Bootstrap e passam a ser controlados por estado React.
- Os objetivos padrão da primeira semana de julho foram revisados para priorizar venda real, tracking confiável e trava de gasto sem aprendizado.

## Por que

A causa-raiz do botão que não funcionava era o uso de `data-bs-toggle`/`data-bs-target` sem o JavaScript do Bootstrap carregado no app. O ajuste remove essa dependência e evita recorrência no frontend.

Também foi reforçada a leitura operacional de marketing: experimentos sem métrica confiável não devem continuar consumindo verba como se gerassem aprendizado válido.

## Validação

- `rg -n "data-bs-toggle|data-bs-target" frontend/src -S`: sem ocorrências.
- `NODE_ENV=test npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx src/pages/experiment/ExperimentListPage.test.tsx src/pages/experiment/ExperimentFunnelTab.test.tsx`: 16 testes passaram.
- `NODE_ENV=test npm run typecheck`: passou.
- `npm run build`: passou.
- `../mvnw -DskipTests compile` em `backend/ads-service`: passou.