### PR TITLE
Melhora visão comercial de planejamento e detalhes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekDto.java
@@ -12,5 +12,7 @@ public record CommercialPlanWeekDto(
         Integer experimentsCreated,
         BigDecimal totalCost,
         BigDecimal totalRevenue,
+        Boolean objectivesEditable,
+        String objectiveEditWindowMessage,
         List<CommercialPlanWeekObjectiveDto> objectives,
         List<CommercialPlanWeekExperimentDto> experiments) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
@@ -7,6 +7,10 @@ import java.time.Instant;
 public record CommercialPlanWeekExperimentDto(
         Long id,
         String name,
+        Long nicheId,
+        String nicheName,
+        String hypothesisId,
+        String hypothesisTitle,
         String productType,
         String status,
         Instant createdAt,
@@ -15,4 +19,8 @@ public record CommercialPlanWeekExperimentDto(
         BigDecimal videoCost,
         BigDecimal totalCost,
         BigDecimal revenue,
+        Long clicks,
+        Long leads,
+        Integer checkoutClicks,
+        Integer purchases,
         String result) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -12,14 +12,17 @@ import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Responsabilidade: montar a leitura semanal de experimentos do planejamento comercial. */
 @Service
@@ -35,15 +38,26 @@ public class CommercialPlanWeeklyExperimentService {
     private final CommercialPlanService planService;
     private final JdbcTemplate jdbcTemplate;
     private final CommercialPlanWeekObjectiveRepository objectiveRepository;
+    private final Clock clock;
 
     /** Inicializa o serviço com a fonte de plano e acesso SQL de leitura operacional. */
     public CommercialPlanWeeklyExperimentService(
             CommercialPlanService planService,
             JdbcTemplate jdbcTemplate,
             CommercialPlanWeekObjectiveRepository objectiveRepository) {
+        this(planService, jdbcTemplate, objectiveRepository, Clock.systemUTC());
+    }
+
+    /** Inicializa o serviço permitindo controlar o relogio em testes de janela semanal. */
+    CommercialPlanWeeklyExperimentService(
+            CommercialPlanService planService,
+            JdbcTemplate jdbcTemplate,
+            CommercialPlanWeekObjectiveRepository objectiveRepository,
+            Clock clock) {
         this.planService = planService;
         this.jdbcTemplate = jdbcTemplate;
         this.objectiveRepository = objectiveRepository;
+        this.clock = clock;
     }
 
     /** Lista as semanas do mês do plano com os experimentos criados em cada período. */
@@ -58,6 +72,7 @@ public class CommercialPlanWeeklyExperimentService {
         while (!start.isAfter(monthEnd)) {
             LocalDate end = start.plusDays(6).isAfter(monthEnd) ? monthEnd : start.plusDays(6);
             List<CommercialPlanWeekExperimentDto> experiments = listExperiments(start, end.plusDays(1));
+            boolean objectivesEditable = isObjectiveEditWindowOpen(end);
             weeks.add(new CommercialPlanWeekDto(
                     weekNumber,
                     start,
@@ -65,6 +80,8 @@ public class CommercialPlanWeeklyExperimentService {
                     experiments.size(),
                     sumCost(experiments),
                     sumRevenue(experiments),
+                    objectivesEditable,
+                    objectiveEditWindowMessage(end, objectivesEditable),
                     listObjectives(plan, weekNumber),
                     experiments));
             start = end.plusDays(1);
@@ -80,6 +97,10 @@ public class CommercialPlanWeeklyExperimentService {
             Integer weekNumber,
             UpdateCommercialPlanWeekObjectivesRequest request) {
         CommercialPlan plan = planService.getPlan(planId);
+        WeekPeriod period = resolveWeekPeriod(plan, weekNumber);
+        if (!isObjectiveEditWindowOpen(period.endDate())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, objectiveEditWindowMessage(period.endDate(), false));
+        }
         objectiveRepository.deleteByPlanIdAndWeekNumber(planId, weekNumber);
         List<CommercialPlanWeekObjective> objectives = new ArrayList<>();
         List<UpdateCommercialPlanWeekObjectivesRequest.Item> items =
@@ -101,6 +122,43 @@ public class CommercialPlanWeeklyExperimentService {
         return objectiveRepository.saveAll(objectives).stream()
                 .map(this::toObjectiveDto)
                 .toList();
+    }
+
+    /** Resolve a semana solicitada dentro do mes de referencia do plano. */
+    private WeekPeriod resolveWeekPeriod(CommercialPlan plan, Integer weekNumber) {
+        if (weekNumber == null || weekNumber < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Semana do planejamento invalida.");
+        }
+        LocalDate monthEnd = resolvePlanEnd(plan);
+        LocalDate start = monthEnd.withDayOfMonth(1);
+        int currentWeek = 1;
+        while (!start.isAfter(monthEnd)) {
+            LocalDate end = start.plusDays(6).isAfter(monthEnd) ? monthEnd : start.plusDays(6);
+            if (currentWeek == weekNumber) {
+                return new WeekPeriod(start, end);
+            }
+            start = end.plusDays(1);
+            currentWeek++;
+        }
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Semana do planejamento fora do mes do plano.");
+    }
+
+    /** Verifica se a edicao de objetivos esta dentro de dois dias antes ou depois do fim da semana. */
+    private boolean isObjectiveEditWindowOpen(LocalDate weekEndDate) {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate windowStart = weekEndDate.minusDays(2);
+        LocalDate windowEnd = weekEndDate.plusDays(2);
+        return !today.isBefore(windowStart) && !today.isAfter(windowEnd);
+    }
+
+    /** Monta a mensagem de disponibilidade da janela de objetivos semanais. */
+    private String objectiveEditWindowMessage(LocalDate weekEndDate, boolean editable) {
+        LocalDate windowStart = weekEndDate.minusDays(2);
+        LocalDate windowEnd = weekEndDate.plusDays(2);
+        if (editable) {
+            return "Objetivos liberados ate " + windowEnd + ".";
+        }
+        return "Objetivos disponiveis de " + windowStart + " ate " + windowEnd + ".";
     }
 
     /** Resolve o mês de referência do plano a partir do prazo ou da criação. */
@@ -301,4 +359,7 @@ public class CommercialPlanWeeklyExperimentService {
     private Instant toInstant(Timestamp timestamp) {
         return timestamp == null ? null : timestamp.toInstant();
     }
+
+    /** Representa o periodo de uma semana dentro do planejamento comercial. */
+    private record WeekPeriod(LocalDate startDate, LocalDate endDate) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -167,16 +167,36 @@ public class CommercialPlanWeeklyExperimentService {
                 select
                     e.id,
                     e.name,
+                    e.niche_id,
+                    mn.name as niche_name,
+                    lower(concat(
+                        substr(hex(h.id), 1, 8), '-',
+                        substr(hex(h.id), 9, 4), '-',
+                        substr(hex(h.id), 13, 4), '-',
+                        substr(hex(h.id), 17, 4), '-',
+                        substr(hex(h.id), 21, 12)
+                    )) as hypothesis_id,
+                    h.title as hypothesis_title,
                     coalesce(e.product_ai_subtype, e.experiment_type) as product_type,
                     e.status,
                     e.created_at,
                     coalesce(campaign.cost, 0) as campaign_cost,
                     coalesce(financial.ai_cost, 0) as ai_cost,
                     coalesce(video.cost, 0) as video_cost,
-                    coalesce(financial.revenue, 0) as revenue
+                    coalesce(financial.revenue, 0) as revenue,
+                    coalesce(nullif(financial.clicks, 0), campaign.clicks, 0) as clicks,
+                    coalesce(nullif(financial.leads, 0), campaign.leads, 0) as leads,
+                    coalesce(financial.checkout_clicks, 0) as checkout_clicks,
+                    coalesce(financial.purchases, 0) as purchases
                 from experiment e
+                left join market_niche mn on mn.id = e.niche_id
+                left join hypothesis h on h.id = e.hypothesis_id
                 left join (
-                    select m.experiment_id, sum(coalesce(m.spend, 0)) as cost
+                    select
+                        m.experiment_id,
+                        sum(coalesce(m.spend, 0)) as cost,
+                        sum(coalesce(m.clicks, 0)) as clicks,
+                        sum(coalesce(m.leads, 0)) as leads
                     from experiment_campaign_metric m
                     where (
                         m.date_start is not null
@@ -193,7 +213,11 @@ public class CommercialPlanWeeklyExperimentService {
                 left join (
                     select b.external_experiment_id as experiment_id,
                            sum(coalesce(f.ai_cost_cents, 0)) / 100.0 as ai_cost,
-                           sum(coalesce(f.revenue_cents, 0)) / 100.0 as revenue
+                           sum(coalesce(f.revenue_cents, 0)) / 100.0 as revenue,
+                           sum(coalesce(f.clicks, 0)) as clicks,
+                           sum(coalesce(f.leads, 0)) as leads,
+                           sum(coalesce(f.checkout_clicks, 0)) as checkout_clicks,
+                           sum(coalesce(f.purchases, 0)) as purchases
                     from experiment_budget b
                     join experiment_financial_metric f on f.experiment_budget_id = b.id
                     where f.measured_at >= ? and f.measured_at < ?
@@ -221,6 +245,10 @@ public class CommercialPlanWeeklyExperimentService {
         return new CommercialPlanWeekExperimentDto(
                 rs.getLong("id"),
                 rs.getString("name"),
+                rs.getLong("niche_id"),
+                rs.getString("niche_name"),
+                rs.getString("hypothesis_id"),
+                rs.getString("hypothesis_title"),
                 rs.getString("product_type"),
                 rs.getString("status"),
                 toInstant(rs.getTimestamp("created_at")),
@@ -229,6 +257,10 @@ public class CommercialPlanWeeklyExperimentService {
                 videoCost,
                 totalCost,
                 revenue,
+                rs.getLong("clicks"),
+                rs.getLong("leads"),
+                rs.getInt("checkout_clicks"),
+                rs.getInt("purchases"),
                 resultLabel(revenue, totalCost));
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
@@ -1,0 +1,102 @@
+package com.marketinghub.planning.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.planning.CommercialPlan;
+import com.marketinghub.planning.dto.CommercialPlanWeekDto;
+import com.marketinghub.planning.dto.CommercialPlanWeekExperimentDto;
+import com.marketinghub.planning.dto.UpdateCommercialPlanWeekObjectivesRequest;
+import com.marketinghub.repository.jpa.planning.CommercialPlanWeekObjectiveRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: validar a leitura semanal e a janela de edicao dos objetivos comerciais. */
+@ExtendWith(MockitoExtension.class)
+class CommercialPlanWeeklyExperimentServiceTest {
+    @Mock
+    private CommercialPlanService planService;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private CommercialPlanWeekObjectiveRepository objectiveRepository;
+
+    private CommercialPlan plan;
+
+    /** Prepara um plano de julho sem experimentos para isolar a regra de janela semanal. */
+    @BeforeEach
+    void setUp() {
+        plan = CommercialPlan.builder()
+                .id(1L)
+                .name("Julho")
+                .deadline(LocalDate.of(2026, 7, 31))
+                .build();
+        when(planService.getPlan(1L)).thenReturn(plan);
+    }
+
+    /** Deve liberar edicao de objetivos dois dias antes ate dois dias depois do fim da semana. */
+    @Test
+    void listWeeksMarksObjectivesEditableOnlyInsideWindow() {
+        CommercialPlanWeeklyExperimentService service = serviceAt(LocalDate.of(2026, 7, 8));
+        when(objectiveRepository.findByPlanIdAndWeekNumberOrderBySequenceOrderAsc(any(), any()))
+                .thenReturn(List.of());
+        when(jdbcTemplate.query(
+                        anyString(),
+                        any(RowMapper.class),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()))
+                .thenReturn(List.<CommercialPlanWeekExperimentDto>of());
+
+        List<CommercialPlanWeekDto> weeks = service.listWeeks(1L);
+
+        assertThat(weeks).hasSize(5);
+        assertThat(weeks.get(0).objectivesEditable()).isTrue();
+        assertThat(weeks.get(1).objectivesEditable()).isFalse();
+        assertThat(weeks.get(0).objectiveEditWindowMessage()).contains("2026-07-09");
+    }
+
+    /** Deve impedir gravacao de objetivos quando a semana esta fora da janela comercial. */
+    @Test
+    void updateObjectivesRejectsWeekOutsideEditWindow() {
+        CommercialPlanWeeklyExperimentService service = serviceAt(LocalDate.of(2026, 7, 8));
+
+        assertThatThrownBy(() -> service.updateObjectives(
+                        1L,
+                        2,
+                        new UpdateCommercialPlanWeekObjectivesRequest(List.of())))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Objetivos disponiveis");
+        verify(objectiveRepository, never()).deleteByPlanIdAndWeekNumber(1L, 2);
+    }
+
+    /** Cria o servico com data fixa para testar a regra de disponibilidade. */
+    private CommercialPlanWeeklyExperimentService serviceAt(LocalDate date) {
+        Clock clock = Clock.fixed(date.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
+        return new CommercialPlanWeeklyExperimentService(planService, jdbcTemplate, objectiveRepository, clock);
+    }
+}

--- a/frontend/src/api/hypothesis/types.test.ts
+++ b/frontend/src/api/hypothesis/types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFramework } from "./types";
+
+describe("normalizeFramework", () => {
+  it("extrai campos legíveis quando o framework vem com JSON serializado", () => {
+    const painPayload = JSON.stringify({
+      surface: "Agenda cheia que some quando a cliente falta.",
+      root: "Falta uma regra simples de confirmação.",
+      emotional: "A profissional fica ansiosa.",
+      social: "Parece desorganizada para a cliente.",
+      cost: "Perde horário e deslocamento.",
+      summary: "Dor prioritária da agenda instável.",
+      evidenceSignals: ["Taxa de agendamento reduz faltas."],
+    });
+    const resultPayload = JSON.stringify({
+      desiredOutcome: "Agenda mais previsível.",
+      measurableChange: "Mais horários confirmados antes do deslocamento.",
+      beforeAfterContrast: "Antes improvisa; depois confirma com clareza.",
+      businessValue: "Protege tempo vendido.",
+      summary: "Resultado desejável da agenda firme.",
+    });
+
+    const framework = normalizeFramework({
+      version: "v1",
+      pain: {
+        surface: painPayload,
+        root: painPayload,
+        summary: painPayload,
+      },
+      result: {
+        desiredResult: resultPayload,
+        summary: resultPayload,
+      },
+      mechanism: {},
+      proof: {},
+      offer: {},
+      checklist: {},
+    });
+
+    expect(framework.pain.surface).toBe(
+      "Agenda cheia que some quando a cliente falta.",
+    );
+    expect(framework.pain.root).toBe("Falta uma regra simples de confirmação.");
+    expect(framework.pain.evidenceSignals).toEqual([
+      "Taxa de agendamento reduz faltas.",
+    ]);
+    expect(framework.result.desiredResult).toBe("Agenda mais previsível.");
+    expect(framework.result.successSignal).toBe(
+      "Mais horários confirmados antes do deslocamento.",
+    );
+  });
+});

--- a/frontend/src/api/hypothesis/types.ts
+++ b/frontend/src/api/hypothesis/types.ts
@@ -12,6 +12,7 @@ export interface HypothesisFrameworkPain {
   social?: string;
   cost?: string;
   summary?: string;
+  evidenceSignals?: string[];
 }
 
 export interface HypothesisFrameworkResult {
@@ -20,6 +21,7 @@ export interface HypothesisFrameworkResult {
   businessOutcome?: string;
   successSignal?: string;
   summary?: string;
+  evidenceSignals?: string[];
 }
 
 export interface HypothesisFrameworkMechanism {
@@ -28,6 +30,7 @@ export interface HypothesisFrameworkMechanism {
   visible?: string;
   believability?: string;
   summary?: string;
+  evidenceSignals?: string[];
 }
 
 export interface HypothesisFrameworkProof {
@@ -36,6 +39,7 @@ export interface HypothesisFrameworkProof {
   message?: string;
   deliveryStage?: string;
   summary?: string;
+  evidenceSignals?: string[];
 }
 
 export interface HypothesisFrameworkOffer {
@@ -48,6 +52,7 @@ export interface HypothesisFrameworkOffer {
   priceAmount?: number;
   offerType?: string;
   summary?: string;
+  evidenceSignals?: string[];
 }
 
 export interface HypothesisFrameworkChecklist {
@@ -88,21 +93,167 @@ export const EMPTY_FRAMEWORK: HypothesisFramework = {
   },
 };
 
-export function normalizeFramework(
-  framework?: HypothesisFramework | null,
-): HypothesisFramework {
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObject(value: unknown): UnknownRecord | undefined {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return undefined;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeSectionRecord(section: unknown): UnknownRecord {
+  const direct = parseJsonObject(section) ?? (isRecord(section) ? section : {});
+  const embedded = Object.values(direct)
+    .map(parseJsonObject)
+    .find((value) => value && Object.keys(value).length > 1);
+
+  return { ...direct, ...(embedded ?? {}) };
+}
+
+function stringFrom(record: UnknownRecord, ...keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      const parsed = parseJsonObject(value);
+      if (!parsed) return value;
+    }
+    if (typeof value === "number") return String(value);
+    if (Array.isArray(value)) return value.filter(Boolean).join("\n");
+  }
+  return undefined;
+}
+
+function numberFrom(record: UnknownRecord, ...keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number") return value;
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value.replace(",", "."));
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function stringArrayFrom(record: UnknownRecord, ...keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value
+        .filter((item): item is string => typeof item === "string")
+        .filter((item) => item.trim());
+    }
+  }
+  return undefined;
+}
+
+function normalizePainSection(section: unknown): HypothesisFrameworkPain {
+  const record = normalizeSectionRecord(section);
   return {
-    version: framework?.version ?? EMPTY_FRAMEWORK.version,
-    pain: { ...EMPTY_FRAMEWORK.pain, ...framework?.pain },
-    result: { ...EMPTY_FRAMEWORK.result, ...framework?.result },
-    mechanism: { ...EMPTY_FRAMEWORK.mechanism, ...framework?.mechanism },
-    proof: { ...EMPTY_FRAMEWORK.proof, ...framework?.proof },
+    surface: stringFrom(record, "surface"),
+    root: stringFrom(record, "root"),
+    emotional: stringFrom(record, "emotional"),
+    social: stringFrom(record, "social"),
+    cost: stringFrom(record, "cost"),
+    summary: stringFrom(record, "summary"),
+    evidenceSignals: stringArrayFrom(record, "evidenceSignals"),
+  };
+}
+
+function normalizeResultSection(section: unknown): HypothesisFrameworkResult {
+  const record = normalizeSectionRecord(section);
+  return {
+    desiredResult: stringFrom(record, "desiredResult", "desiredOutcome"),
+    desiredIdentity: stringFrom(
+      record,
+      "desiredIdentity",
+      "beforeAfterContrast",
+    ),
+    businessOutcome: stringFrom(record, "businessOutcome", "businessValue"),
+    successSignal: stringFrom(record, "successSignal", "measurableChange"),
+    summary: stringFrom(record, "summary"),
+    evidenceSignals: stringArrayFrom(record, "evidenceSignals"),
+  };
+}
+
+function normalizeMechanismSection(
+  section: unknown,
+): HypothesisFrameworkMechanism {
+  const record = normalizeSectionRecord(section);
+  return {
+    core: stringFrom(record, "core", "coreMechanism"),
+    unique: stringFrom(record, "unique", "mechanismName"),
+    visible: stringFrom(record, "visible", "howItWorks", "steps"),
+    believability: stringFrom(record, "believability", "whyBelievable"),
+    summary: stringFrom(record, "summary"),
+    evidenceSignals: stringArrayFrom(record, "evidenceSignals"),
+  };
+}
+
+function normalizeProofSection(section: unknown): HypothesisFrameworkProof {
+  const record = normalizeSectionRecord(section);
+  return {
+    type: stringFrom(record, "type", "proofType"),
+    asset: stringFrom(record, "asset", "proofAsset"),
+    message: stringFrom(record, "message", "proofMessage"),
+    deliveryStage: stringFrom(record, "deliveryStage", "collectionMethod"),
+    summary: stringFrom(record, "summary"),
+    evidenceSignals: stringArrayFrom(record, "evidenceSignals"),
+  };
+}
+
+function normalizeOfferSection(section: unknown): HypothesisFrameworkOffer {
+  const record = normalizeSectionRecord(section);
+  return {
+    name: stringFrom(record, "name", "offerName"),
+    corePromise: stringFrom(record, "corePromise", "coreOffer"),
+    deliverables: stringFrom(record, "deliverables", "steps"),
+    riskReversal: stringFrom(record, "riskReversal", "objectionReduced"),
+    priceLogic: stringFrom(record, "priceLogic", "whyBelievable"),
+    cta: stringFrom(record, "cta"),
+    priceAmount: numberFrom(record, "priceAmount"),
+    offerType: stringFrom(record, "offerType"),
+    summary: stringFrom(record, "summary"),
+    evidenceSignals: stringArrayFrom(record, "evidenceSignals"),
+  };
+}
+
+export function normalizeFramework(framework?: unknown): HypothesisFramework {
+  const source: UnknownRecord = isRecord(framework) ? framework : {};
+  return {
+    version:
+      typeof source.version === "string"
+        ? source.version
+        : EMPTY_FRAMEWORK.version,
+    pain: { ...EMPTY_FRAMEWORK.pain, ...normalizePainSection(source.pain) },
+    result: {
+      ...EMPTY_FRAMEWORK.result,
+      ...normalizeResultSection(source.result),
+    },
+    mechanism: {
+      ...EMPTY_FRAMEWORK.mechanism,
+      ...normalizeMechanismSection(source.mechanism),
+    },
+    proof: { ...EMPTY_FRAMEWORK.proof, ...normalizeProofSection(source.proof) },
     offer: {
       ...EMPTY_FRAMEWORK.offer,
-      ...framework?.offer,
-      priceAmount: framework?.offer?.priceAmount ?? undefined,
-      offerType: framework?.offer?.offerType ?? undefined,
+      ...normalizeOfferSection(source.offer),
     },
-    checklist: { ...EMPTY_FRAMEWORK.checklist, ...framework?.checklist },
+    checklist: {
+      ...EMPTY_FRAMEWORK.checklist,
+      ...(isRecord(source.checklist) ? source.checklist : {}),
+    },
   };
 }

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -133,6 +133,8 @@ export interface CommercialPlanWeek {
   experimentsCreated: number;
   totalCost?: number | null;
   totalRevenue?: number | null;
+  objectivesEditable?: boolean | null;
+  objectiveEditWindowMessage?: string | null;
   objectives: CommercialPlanWeekObjective[];
   experiments: CommercialPlanWeekExperiment[];
 }

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -100,6 +100,10 @@ export interface CommercialPlan {
 export interface CommercialPlanWeekExperiment {
   id: number;
   name: string;
+  nicheId?: number | null;
+  nicheName?: string | null;
+  hypothesisId?: string | null;
+  hypothesisTitle?: string | null;
   productType?: string | null;
   status?: string | null;
   createdAt?: string | null;
@@ -108,6 +112,10 @@ export interface CommercialPlanWeekExperiment {
   videoCost?: number | null;
   totalCost?: number | null;
   revenue?: number | null;
+  clicks?: number | null;
+  leads?: number | null;
+  checkoutClicks?: number | null;
+  purchases?: number | null;
   result?: string | null;
 }
 

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1990,13 +1990,6 @@ export default function ExperimentDetailPage() {
       value: experimentTypeLabel,
     },
     {
-      label: "Mecanismo de Produto IA",
-      value: data.productAiSubtype
-        ? (productAiSubtypeLabel[data.productAiSubtype] ??
-          data.productAiSubtype)
-        : "-",
-    },
-    {
       label: "Nicho",
       value: <Link to={`/niches/${data.nicheId}`}>{niche?.name}</Link>,
     },
@@ -2011,14 +2004,6 @@ export default function ExperimentDetailPage() {
     {
       label: "Etapa priorizada",
       value: getExperimentStageLabel(data.stage as ExperimentStage),
-    },
-    {
-      label: "Variável principal",
-      value: data.primaryVariable || "—",
-    },
-    {
-      label: "Métrica principal",
-      value: data.primaryMetric || "—",
     },
     {
       label: "Dor única",
@@ -2042,67 +2027,25 @@ export default function ExperimentDetailPage() {
       label: "Objetivo da campanha",
       value: campaignObjectiveLabel,
     },
+    { label: "Custo rastreável", value: formatCurrency(data.cost) },
     {
-      label: "Página do Facebook",
-      value: experimentPage
-        ? `${experimentPage.name} (${experimentPage.pageId})`
-        : "—",
+      label: "Criativos aprovados",
+      value: `${readinessCreativeCount}/3`,
     },
     {
-      label: "Conta do Instagram",
-      value: instagramAccount
-        ? `${instagramAccount.name} (${instagramAccount.handle})`
-        : "—",
-    },
-    { label: "Preset de Métricas", value: preset?.name || "—" },
-    {
-      label: "Sample size",
-      value: data.sampleSize ?? preset?.sampleSize ?? "—",
-    },
-    { label: "Criativos a gerar", value: data.creativesToGenerate ?? "—" },
-    { label: "E-mails a gerar", value: data.emailsToGenerate ?? "—" },
-    {
-      label: "E-mails de amostra a gerar",
-      value: data.sampleEmailsToGenerate ?? "—",
+      label: "Público para publicação",
+      value: hasPublisherTargeting ? "Salvo" : "Pendente",
     },
     {
-      label: "Fluxo de portal do lead",
-      value: data.leadPortalFlowName ? (
-        <div className="d-flex flex-column">
-          <span>{data.leadPortalFlowName}</span>
-          {data.leadPortalFlowSlug ? (
-            <span className="text-muted small">
-              Slug: {data.leadPortalFlowSlug}
-            </span>
-          ) : null}
-        </div>
+      label: "Página de venda",
+      value: data.followUpActionUrl ? (
+        <a href={data.followUpActionUrl} target="_blank" rel="noreferrer">
+          Abrir página
+        </a>
       ) : (
-        "—"
+        "Pendente"
       ),
     },
-    {
-      label: "Modelo de imagem",
-      value: data.imageModelName
-        ? `${data.imageModelName}${data.imageModelQualityName ? " · " + data.imageModelQualityName : ""}`
-        : "—",
-    },
-    {
-      label: "MDE (p.p.)",
-      value: data.mdePercent ?? preset?.defaultMdePp ?? "—",
-    },
-    {
-      label: "Stop-loss factor",
-      value: preset?.stopLossFactor ? `${preset.stopLossFactor}×` : "—",
-    },
-    {
-      label: "CPL-meta",
-      value: formatCurrency(data.kpiTarget ?? data.kpiTargetCpl),
-    },
-    { label: "Custo", value: formatCurrency(data.cost) },
-    { label: "Despesa", value: formatCurrency(data.expense) },
-    { label: "Stop-loss CPL", value: formatCurrency(stopLossCpl) },
-    { label: "Baseline CVR", value: formatPercent(data.baselineCvr) },
-    { label: "Target CVR", value: formatPercent(data.targetCvr) },
     { label: "Plataforma", value: data.platform },
     { label: "Início", value: data.startDate },
     { label: "Término", value: data.endDate },
@@ -2128,25 +2071,6 @@ export default function ExperimentDetailPage() {
               Editar
             </Link>
           )}
-          {alterationLocked ? (
-            <span
-              className="btn btn-outline-primary disabled me-2"
-              aria-disabled="true"
-              title="Playbook bloqueado após a liberação/publicação do experimento."
-            >
-              Playbook de Ad Sets
-            </span>
-          ) : (
-            <Link to="adset-workflow" className="btn btn-outline-primary me-2">
-              Playbook de Ad Sets
-            </Link>
-          )}
-          <Link to="facebook-api-logs" className="btn btn-outline-info me-2">
-            Chamadas Meta
-          </Link>
-          <Link to="pipeline-jobs" className="btn btn-outline-dark me-2">
-            Jobs do pipeline
-          </Link>
           {canDownloadCompleteReport ? (
             <button
               type="button"
@@ -2168,25 +2092,6 @@ export default function ExperimentDetailPage() {
               )}
             </button>
           ) : null}
-          <button
-            type="button"
-            className="btn btn-outline-danger me-2"
-            onClick={openResetModal}
-            disabled={resetCampaigns.isPending || alterationLocked}
-          >
-            {resetCampaigns.isPending ? (
-              <>
-                <span
-                  className="spinner-border spinner-border-sm me-2"
-                  role="status"
-                  aria-hidden="true"
-                />
-                Resetando...
-              </>
-            ) : (
-              "Resetar pendências"
-            )}
-          </button>
           <span className="badge bg-secondary">{data.status}</span>
         </div>
       </div>
@@ -2301,7 +2206,7 @@ export default function ExperimentDetailPage() {
           ) : null}
         </div>
       ) : null}
-      {isLowTicketProduct ? (
+      {false ? (
         <div className="card border-0 shadow-sm rounded-3 mt-3">
           <div className="card-body">
             <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
@@ -2370,7 +2275,7 @@ export default function ExperimentDetailPage() {
           </div>
         </div>
       ) : null}
-      {isLowTicketProduct ? (
+      {false ? (
         <div className="card border-0 shadow-sm rounded-3 mt-3">
           <div className="card-body">
             <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
@@ -2415,7 +2320,7 @@ export default function ExperimentDetailPage() {
                       <div className="text-muted small">Página de venda</div>
                       {latestSalesPagePublication.salesPageUrl ? (
                         <a
-                          href={latestSalesPagePublication.salesPageUrl}
+                          href={latestSalesPagePublication.salesPageUrl ?? undefined}
                           target="_blank"
                           rel="noreferrer"
                           className="small text-break"
@@ -2432,7 +2337,7 @@ export default function ExperimentDetailPage() {
                       <div className="text-muted small">Checkout usado</div>
                       {latestSalesPagePublication.checkoutUrl ? (
                         <a
-                          href={latestSalesPagePublication.checkoutUrl}
+                          href={latestSalesPagePublication.checkoutUrl ?? undefined}
                           target="_blank"
                           rel="noreferrer"
                           className="small text-break"
@@ -2599,6 +2504,7 @@ export default function ExperimentDetailPage() {
           </div>
         </div>
       </div>
+      {false ? (
       <div className="card border-0 shadow-sm rounded-3 mt-3">
         <div className="card-body">
           <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap mb-3">
@@ -2619,7 +2525,7 @@ export default function ExperimentDetailPage() {
             <div className="text-muted small">Carregando campanhas...</div>
           ) : facebookCampaigns?.length ? (
             <div className="d-flex flex-column gap-3">
-              {facebookCampaigns.map((campaign) => (
+              {(facebookCampaigns ?? []).map((campaign) => (
                 <div key={campaign.id} className="border rounded-3 p-3">
                   <div className="d-flex justify-content-between gap-3 flex-wrap">
                     <div>
@@ -2736,6 +2642,7 @@ export default function ExperimentDetailPage() {
           )}
         </div>
       </div>
+      ) : null}
       <div ref={tabsSectionRef}>
         <Tabs.Root value={tab} onValueChange={setTab} className="mt-3">
           <Tabs.List className="nav nav-tabs">
@@ -2744,9 +2651,6 @@ export default function ExperimentDetailPage() {
             </Tabs.Trigger>
             <Tabs.Trigger value="funnel" className="nav-link">
               Funil de vendas
-            </Tabs.Trigger>
-            <Tabs.Trigger value="execucao" className="nav-link">
-              Execução
             </Tabs.Trigger>
             <Tabs.Trigger value="analytics" className="nav-link">
               Analytics
@@ -2757,14 +2661,8 @@ export default function ExperimentDetailPage() {
             <Tabs.Trigger value="landing" className="nav-link">
               Landing
             </Tabs.Trigger>
-            <Tabs.Trigger value="gera-landing" className="nav-link">
-              Gera landing
-            </Tabs.Trigger>
             <Tabs.Trigger value="content-structure" className="nav-link">
               Estrutura de conteúdo
-            </Tabs.Trigger>
-            <Tabs.Trigger value="conteudo" className="nav-link">
-              Conteúdo
             </Tabs.Trigger>
             <Tabs.Trigger value="publico" className="nav-link">
               Público

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.css
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.css
@@ -1,0 +1,220 @@
+.hypothesis-detail {
+  color: #182230;
+}
+
+.hypothesis-detail__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 24rem);
+  gap: 1rem;
+  align-items: stretch;
+  border: 1px solid #d7dde8;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.hypothesis-detail__hero span,
+.hypothesis-detail__eyebrow {
+  display: block;
+  color: #536176;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.hypothesis-detail__hero h1 {
+  margin: 0.2rem 0 0.5rem;
+  font-size: clamp(1.35rem, 2vw, 2rem);
+  line-height: 1.15;
+}
+
+.hypothesis-detail__hero p {
+  max-width: 76rem;
+  margin: 0;
+  color: #344054;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.hypothesis-detail__meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+.hypothesis-detail__meta div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #dde3ed;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.75rem 0.9rem;
+}
+
+.hypothesis-detail__meta strong {
+  color: #101828;
+  font-size: 0.95rem;
+}
+
+.hypothesis-detail__meta span {
+  color: #667085;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.hypothesis-detail__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.hypothesis-detail__section {
+  border: 1px solid #d7dde8;
+  border-radius: 8px;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.hypothesis-detail__section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 4px solid #2563eb;
+  background: #f8fafc;
+  padding: 1rem;
+}
+
+.hypothesis-detail__section--pain .hypothesis-detail__section-header {
+  border-top-color: #dc2626;
+}
+
+.hypothesis-detail__section--result .hypothesis-detail__section-header {
+  border-top-color: #16a34a;
+}
+
+.hypothesis-detail__section--mechanism .hypothesis-detail__section-header {
+  border-top-color: #2563eb;
+}
+
+.hypothesis-detail__section--proof .hypothesis-detail__section-header {
+  border-top-color: #7c3aed;
+}
+
+.hypothesis-detail__section--offer .hypothesis-detail__section-header {
+  border-top-color: #ca8a04;
+}
+
+.hypothesis-detail__section-header h2 {
+  margin: 0.35rem 0 0;
+  color: #101828;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.hypothesis-detail__collapses {
+  display: flex;
+  flex-direction: column;
+}
+
+.hypothesis-detail__collapse {
+  border-top: 1px solid #e4e7ec;
+}
+
+.hypothesis-detail__collapse summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding: 0.75rem 1rem;
+  color: #101828;
+  cursor: pointer;
+  font-weight: 700;
+  list-style: none;
+}
+
+.hypothesis-detail__collapse summary::-webkit-details-marker {
+  display: none;
+}
+
+.hypothesis-detail__collapse summary::before {
+  content: "+";
+  display: inline-grid;
+  flex: 0 0 1.25rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  color: #475467;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.hypothesis-detail__collapse[open] summary::before {
+  content: "-";
+}
+
+.hypothesis-detail__collapse summary > span:first-child {
+  flex: 1;
+}
+
+.hypothesis-detail__collapse-action {
+  color: #667085;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.hypothesis-detail__collapse-body {
+  padding: 0 1rem 1rem 3rem;
+  color: #344054;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.hypothesis-detail__collapse-body p {
+  margin: 0 0 0.75rem;
+}
+
+.hypothesis-detail__collapse-body p:last-child,
+.hypothesis-detail__list {
+  margin-bottom: 0;
+}
+
+.hypothesis-detail__list {
+  padding-left: 1.1rem;
+}
+
+.hypothesis-detail__list li + li {
+  margin-top: 0.45rem;
+}
+
+@media (max-width: 1199.98px) {
+  .hypothesis-detail__hero,
+  .hypothesis-detail__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hypothesis-detail__meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .hypothesis-detail__hero {
+    padding: 1rem;
+  }
+
+  .hypothesis-detail__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .hypothesis-detail__collapse-body {
+    padding-left: 1rem;
+  }
+}

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
@@ -7,6 +6,84 @@ import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { normalizeFramework } from "../../api/hypothesis/types";
+import "./HypothesisDetailPage.css";
+
+type SectionRow = {
+  label: string;
+  value?: string | number | string[] | null;
+  defaultOpen?: boolean;
+};
+
+type DetailSection = {
+  title: string;
+  summary?: string;
+  tone: "pain" | "result" | "mechanism" | "proof" | "offer";
+  rows: SectionRow[];
+};
+
+function hasReadableValue(value?: string | number | string[] | null) {
+  if (Array.isArray(value)) return value.some((item) => item.trim());
+  if (typeof value === "number") return true;
+  return Boolean(value?.trim());
+}
+
+function renderReadableValue(value?: string | number | string[] | null) {
+  if (!hasReadableValue(value)) {
+    return <span className="text-muted">Sem informação registrada.</span>;
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <ul className="hypothesis-detail__list">
+        {value
+          .filter((item) => item.trim())
+          .map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+      </ul>
+    );
+  }
+
+  return String(value)
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => <p key={line}>{line}</p>);
+}
+
+function HypothesisSectionCard({ section }: { section: DetailSection }) {
+  const filledRows = section.rows.filter((row) => hasReadableValue(row.value));
+  const rows = filledRows.length > 0 ? filledRows : section.rows;
+
+  return (
+    <article
+      className={`hypothesis-detail__section hypothesis-detail__section--${section.tone}`}
+    >
+      <div className="hypothesis-detail__section-header">
+        <div>
+          <span className="hypothesis-detail__eyebrow">{section.title}</span>
+          <h2>{section.summary?.trim() || "Resumo ainda não gerado"}</h2>
+        </div>
+      </div>
+      <div className="hypothesis-detail__collapses">
+        {rows.map((row, index) => (
+          <details
+            key={row.label}
+            className="hypothesis-detail__collapse"
+            open={row.defaultOpen ?? index < 2}
+          >
+            <summary>
+              <span>{row.label}</span>
+              <span className="hypothesis-detail__collapse-action">Ver</span>
+            </summary>
+            <div className="hypothesis-detail__collapse-body">
+              {renderReadableValue(row.value)}
+            </div>
+          </details>
+        ))}
+      </div>
+    </article>
+  );
+}
 
 export default function HypothesisDetailPage() {
   const { nicheId, hypothesisId } = useParams();
@@ -26,83 +103,131 @@ export default function HypothesisDetailPage() {
   if (!data) return <p>Não encontrado</p>;
 
   const framework = normalizeFramework(data.framework);
-  const sections = [
+  const sections: DetailSection[] = [
     {
       title: "Dor",
       summary: framework.pain.summary,
+      tone: "pain",
       rows: [
-        { label: "Dor superficial", value: framework.pain.surface },
-        { label: "Dor raiz", value: framework.pain.root },
+        {
+          label: "Dor superficial",
+          value: framework.pain.surface,
+          defaultOpen: true,
+        },
+        { label: "Dor raiz", value: framework.pain.root, defaultOpen: true },
         { label: "Dor emocional", value: framework.pain.emotional },
         { label: "Dor social", value: framework.pain.social },
         { label: "Custo da inação", value: framework.pain.cost },
+        { label: "Evidências", value: framework.pain.evidenceSignals },
       ],
     },
     {
       title: "Resultado",
       summary: framework.result.summary,
+      tone: "result",
       rows: [
         {
           label: "Resultado desejado",
           value: framework.result.desiredResult,
+          defaultOpen: true,
         },
         {
-          label: "Identidade desejada",
+          label: "Antes e depois",
           value: framework.result.desiredIdentity,
+          defaultOpen: true,
         },
         {
           label: "Resultado de negócio",
           value: framework.result.businessOutcome,
         },
         { label: "Sinal de sucesso", value: framework.result.successSignal },
+        { label: "Evidências", value: framework.result.evidenceSignals },
       ],
     },
     {
       title: "Mecanismo",
       summary: framework.mechanism.summary,
+      tone: "mechanism",
       rows: [
-        { label: "Mecanismo central", value: framework.mechanism.core },
-        { label: "Mecanismo único", value: framework.mechanism.unique },
-        { label: "Evidência visível", value: framework.mechanism.visible },
+        {
+          label: "Mecanismo central",
+          value: framework.mechanism.core,
+          defaultOpen: true,
+        },
+        {
+          label: "Nome / diferencial",
+          value: framework.mechanism.unique,
+          defaultOpen: true,
+        },
+        { label: "Como funciona", value: framework.mechanism.visible },
         {
           label: "Fator de credibilidade",
           value: framework.mechanism.believability,
         },
+        { label: "Evidências", value: framework.mechanism.evidenceSignals },
       ],
     },
     {
       title: "Prova",
       summary: framework.proof.summary,
+      tone: "proof",
       rows: [
-        { label: "Tipo de prova", value: framework.proof.type },
-        { label: "Ativo de prova", value: framework.proof.asset },
+        {
+          label: "Tipo de prova",
+          value: framework.proof.type,
+          defaultOpen: true,
+        },
+        {
+          label: "Ativo de prova",
+          value: framework.proof.asset,
+          defaultOpen: true,
+        },
         { label: "Mensagem", value: framework.proof.message },
-        { label: "Estágio de entrega", value: framework.proof.deliveryStage },
+        {
+          label: "Como coletar / entregar",
+          value: framework.proof.deliveryStage,
+        },
+        { label: "Evidências", value: framework.proof.evidenceSignals },
       ],
     },
     {
       title: "Oferta",
       summary: framework.offer.summary,
+      tone: "offer",
       rows: [
-        { label: "Nome da oferta", value: framework.offer.name },
-        { label: "Promessa central", value: framework.offer.corePromise },
+        {
+          label: "Nome da oferta",
+          value: framework.offer.name,
+          defaultOpen: true,
+        },
+        {
+          label: "Promessa central",
+          value: framework.offer.corePromise,
+          defaultOpen: true,
+        },
         { label: "Entregáveis", value: framework.offer.deliverables },
         { label: "Reversão de risco", value: framework.offer.riskReversal },
         { label: "Lógica de preço", value: framework.offer.priceLogic },
         { label: "Preço", value: framework.offer.priceAmount },
         { label: "Tipo da oferta", value: framework.offer.offerType },
         { label: "Call to action", value: framework.offer.cta },
+        { label: "Evidências", value: framework.offer.evidenceSignals },
       ],
     },
   ];
 
   const buildFrameworkSectionMarkdown = (
     title: string,
-    fields: Array<{ label: string; value?: string | number | null }>,
+    fields: SectionRow[],
     summary?: string,
   ) => {
     const fieldsMd = fields
-      .map(({ label, value }) => `- **${label}:** ${value ?? ""}`)
+      .map(({ label, value }) => {
+        const displayValue = Array.isArray(value)
+          ? value.filter((item) => item.trim()).join("; ")
+          : value;
+        return `- **${label}:** ${displayValue ?? ""}`;
+      })
       .join("\n");
 
     return (
@@ -134,7 +259,7 @@ export default function HypothesisDetailPage() {
     URL.revokeObjectURL(url);
   };
   return (
-    <div>
+    <div className="hypothesis-detail">
       <div className="d-flex justify-content-between align-items-center mb-4">
         <PageTitle icon={hypothesisIcon}>{data.title}</PageTitle>
         <div className="d-flex gap-2">
@@ -154,36 +279,47 @@ export default function HypothesisDetailPage() {
         </div>
       </div>
 
-      <section className="row row-cols-1 row-cols-xl-2 g-3">
-        {sections.map((section) => (
-          <div className="col" key={section.title}>
-            <article className="card h-100">
-              <div className="card-header">
-                <h2 className="h5 mb-0">{section.title}</h2>
-              </div>
-              <div className="card-body">
-                {section.summary ? (
-                  <p className="fw-semibold">{section.summary}</p>
-                ) : null}
-                <dl className="row mb-0">
-                  {section.rows.map((row, idx) => (
-                    <Fragment key={row.label}>
-                      <dt
-                        className={`col-sm-4 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
-                      >
-                        {row.label}
-                      </dt>
-                      <dd
-                        className={`col-sm-8 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
-                      >
-                        {row.value ?? "—"}
-                      </dd>
-                    </Fragment>
-                  ))}
-                </dl>
-              </div>
-            </article>
+      <section
+        className="hypothesis-detail__hero"
+        aria-label="Resumo da hipótese"
+      >
+        <div>
+          <span>Hipótese comercial</span>
+          <h1>{framework.offer.name || data.title}</h1>
+          <p>
+            {framework.offer.corePromise ||
+              framework.result.desiredResult ||
+              framework.pain.summary ||
+              "Framework comercial ainda em construção."}
+          </p>
+        </div>
+        <div className="hypothesis-detail__meta">
+          <div>
+            <strong>{data.status || "—"}</strong>
+            <span>Status</span>
           </div>
+          <div>
+            <strong>
+              {typeof data.costUsd === "number"
+                ? `$ ${data.costUsd.toFixed(2)}`
+                : "—"}
+            </strong>
+            <span>Custo IA</span>
+          </div>
+          <div>
+            <strong>
+              {framework.offer.priceAmount
+                ? `R$ ${framework.offer.priceAmount.toFixed(2)}`
+                : "—"}
+            </strong>
+            <span>Preço sugerido</span>
+          </div>
+        </div>
+      </section>
+
+      <section className="hypothesis-detail__grid">
+        {sections.map((section) => (
+          <HypothesisSectionCard section={section} key={section.title} />
         ))}
       </section>
 

--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -206,9 +206,177 @@
   font-size: 1.1rem;
 }
 
-.commercial-planning-week-table-wrap {
+.commercial-planning-hierarchy {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.commercial-planning-niche-node,
+.commercial-planning-hypothesis-node {
   min-width: 0;
-  overflow-x: auto;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-niche-node {
+  padding: 0.875rem;
+  background: #f8fafc;
+}
+
+.commercial-planning-hypothesis-node {
+  padding: 0.75rem;
+}
+
+.commercial-planning-node-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.commercial-planning-node-header h4,
+.commercial-planning-node-header h5 {
+  margin: 0.15rem 0 0;
+  color: #101828;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-node-header h4 {
+  font-size: 1rem;
+}
+
+.commercial-planning-node-header h5 {
+  font-size: 0.95rem;
+}
+
+.commercial-planning-node-kicker {
+  color: #667085;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-hierarchy-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  color: #344054;
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.commercial-planning-hierarchy-summary span {
+  padding: 0.25rem 0.45rem;
+  border: 1px solid #d9dee7;
+  border-radius: 999px;
+  background: #ffffff;
+  white-space: nowrap;
+}
+
+.commercial-planning-hypothesis-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.commercial-planning-experiment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.commercial-planning-experiment-card {
+  display: grid;
+  min-width: 0;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #d9dee7;
+  border-radius: 0.5rem;
+  background: #fcfcfd;
+}
+
+.commercial-planning-experiment-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.commercial-planning-experiment-card-header div {
+  display: grid;
+  min-width: 0;
+  gap: 0.2rem;
+}
+
+.commercial-planning-experiment-card-header span:first-child {
+  color: #667085;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.commercial-planning-experiment-card-header a {
+  color: #101828;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.commercial-planning-experiment-card-header a:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.commercial-planning-experiment-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.commercial-planning-experiment-metrics div {
+  min-width: 0;
+  padding: 0.55rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-experiment-metrics span {
+  display: block;
+  color: #667085;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-experiment-metrics strong {
+  display: block;
+  margin-top: 0.15rem;
+  color: #101828;
+  font-size: 0.9rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-experiment-result,
+.commercial-planning-empty-week {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #344054;
+  font-size: 0.9rem;
+}
+
+.commercial-planning-empty-week {
+  color: #667085;
 }
 
 .commercial-planning-week-objectives {
@@ -279,22 +447,6 @@
   align-items: center;
 }
 
-.commercial-planning-week-table {
-  min-width: 900px;
-}
-
-.commercial-planning-week-table th {
-  color: #667085;
-  font-size: 0.76rem;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.commercial-planning-week-table td {
-  color: #344054;
-  overflow-wrap: anywhere;
-}
-
 @media (max-width: 1199.98px) {
   .commercial-planning-month-heading,
   .commercial-planning-month-grid {
@@ -324,6 +476,16 @@
     justify-items: start;
     text-align: left;
   }
+
+  .commercial-planning-node-header,
+  .commercial-planning-experiment-card-header {
+    flex-direction: column;
+  }
+
+  .commercial-planning-hierarchy-summary {
+    justify-content: flex-start;
+    text-align: left;
+  }
 }
 
 @media (max-width: 575.98px) {
@@ -336,6 +498,11 @@
   }
 
   .commercial-planning-month-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .commercial-planning-experiment-grid,
+  .commercial-planning-experiment-metrics {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -53,6 +53,8 @@ let mockWeeks: unknown[] = [
     experimentsCreated: 1,
     totalCost: 37,
     totalRevenue: 27,
+    objectivesEditable: true,
+    objectiveEditWindowMessage: "Objetivos liberados ate 2026-07-09.",
     objectives: [
       {
         id: null,
@@ -130,6 +132,8 @@ afterEach(() => {
       experimentsCreated: 1,
       totalCost: 37,
       totalRevenue: 27,
+      objectivesEditable: true,
+      objectiveEditWindowMessage: "Objetivos liberados ate 2026-07-09.",
       objectives: [
         {
           id: null,
@@ -212,6 +216,23 @@ describe("CommercialPlanningPage", () => {
 
     expect(screen.getByLabelText("Novo objetivo da semana 1")).toBeTruthy();
     expect(screen.getByText("Salvar novo")).toBeTruthy();
+  });
+
+  it("oculta insercao de objetivo quando a semana esta fora da janela permitida", () => {
+    mockWeeks = [
+      {
+        ...(mockWeeks[0] as Record<string, unknown>),
+        objectivesEditable: false,
+        objectiveEditWindowMessage:
+          "Objetivos disponiveis de 2026-07-12 ate 2026-07-16.",
+      },
+    ];
+
+    renderPage();
+
+    expect(screen.getByText("Objetivos da semana")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Inserir novo" })).toBeNull();
+    expect(screen.queryByLabelText("Novo objetivo da semana 1")).toBeNull();
   });
 
   it("usa valores seguros quando status vem fora do contrato", () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -66,12 +66,20 @@ let mockWeeks: unknown[] = [
       {
         id: 39,
         name: "Kit manutenção",
+        nicheId: 21,
+        nicheName: "Manicure profissional",
+        hypothesisId: "11111111-1111-1111-1111-111111111111",
+        hypothesisTitle: "Kit de manutenção guiada para manicures",
         productType: "LOW_TICKET",
         status: "ACTIVE",
         createdAt: "2026-07-02T10:00:00Z",
         totalCost: 37,
         videoCost: 12,
         revenue: 27,
+        clicks: 44,
+        leads: 6,
+        checkoutClicks: 2,
+        purchases: 1,
         result: "Receita parcial",
       },
     ],
@@ -135,12 +143,20 @@ afterEach(() => {
         {
           id: 39,
           name: "Kit manutenção",
+          nicheId: 21,
+          nicheName: "Manicure profissional",
+          hypothesisId: "11111111-1111-1111-1111-111111111111",
+          hypothesisTitle: "Kit de manutenção guiada para manicures",
           productType: "LOW_TICKET",
           status: "ACTIVE",
           createdAt: "2026-07-02T10:00:00Z",
           totalCost: 37,
           videoCost: 12,
           revenue: 27,
+          clicks: 44,
+          leads: 6,
+          checkoutClicks: 2,
+          purchases: 1,
           result: "Receita parcial",
         },
       ],
@@ -169,11 +185,17 @@ describe("CommercialPlanningPage", () => {
     renderPage();
 
     expect(screen.getByText("Semana 1")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Kit manutenção" })).toHaveAttribute(
-      "href",
-      "/experiments/39",
-    );
-    expect(screen.getByText("Vídeo")).toBeTruthy();
+    expect(screen.getByText("Nicho")).toBeTruthy();
+    expect(screen.getByText("Manicure profissional")).toBeTruthy();
+    expect(screen.getByText("Hipótese")).toBeTruthy();
+    expect(
+      screen.getByText("Kit de manutenção guiada para manicures"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Kit manutenção" }),
+    ).toHaveAttribute("href", "/experiments/39");
+    expect(screen.getByText("Checkout")).toBeTruthy();
+    expect(screen.getByText("Compras")).toBeTruthy();
     expect(screen.getByText("Receita parcial")).toBeTruthy();
   });
 

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -206,6 +206,7 @@ function WeeklyObjectiveEditor({
   );
   const [isAddingObjective, setIsAddingObjective] = useState(false);
   const [newObjectiveText, setNewObjectiveText] = useState("");
+  const objectivesEditable = week.objectivesEditable === true;
 
   useEffect(() => {
     setObjectives(normalizeObjectives(week.objectives));
@@ -238,13 +239,15 @@ function WeeklyObjectiveEditor({
     <div className="commercial-planning-week-objectives">
       <div className="commercial-planning-week-objectives-header">
         <h4>Objetivos da semana</h4>
-        <button
-          className="btn btn-sm btn-outline-primary"
-          type="button"
-          onClick={() => setIsAddingObjective((current) => !current)}
-        >
-          Inserir novo
-        </button>
+        {objectivesEditable ? (
+          <button
+            className="btn btn-sm btn-outline-primary"
+            type="button"
+            onClick={() => setIsAddingObjective((current) => !current)}
+          >
+            Inserir novo
+          </button>
+        ) : null}
       </div>
 
       <div className="commercial-planning-week-objective-list">
@@ -268,7 +271,7 @@ function WeeklyObjectiveEditor({
         ))}
       </div>
 
-      {isAddingObjective ? (
+      {isAddingObjective && objectivesEditable ? (
         <div className="commercial-planning-week-objective-form">
           <textarea
             aria-label={`Novo objetivo da semana ${week.weekNumber}`}

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -108,6 +108,11 @@ function formatExecutedNumber(value?: number | null) {
   return value == null ? "0" : String(value);
 }
 
+function formatRoas(revenue?: number | null, cost?: number | null) {
+  if (!cost || cost <= 0) return "Não definido";
+  return `${((revenue ?? 0) / cost).toFixed(2)}x`;
+}
+
 function formatDate(value?: string | null) {
   if (!value) return "Não definido";
   return new Date(value).toLocaleDateString("pt-BR", { timeZone: "UTC" });
@@ -309,6 +314,116 @@ function normalizeObjectives(
   return [];
 }
 
+interface ExperimentHierarchyMetricSummary {
+  experiments: number;
+  totalCost: number;
+  revenue: number;
+  clicks: number;
+  leads: number;
+  checkoutClicks: number;
+  purchases: number;
+}
+
+interface ExperimentHierarchyHypothesis {
+  key: string;
+  id?: string | null;
+  title: string;
+  summary: ExperimentHierarchyMetricSummary;
+  experiments: CommercialPlanWeek["experiments"];
+}
+
+interface ExperimentHierarchyNiche {
+  key: string;
+  id?: number | null;
+  name: string;
+  summary: ExperimentHierarchyMetricSummary;
+  hypotheses: ExperimentHierarchyHypothesis[];
+}
+
+function emptySummary(): ExperimentHierarchyMetricSummary {
+  return {
+    experiments: 0,
+    totalCost: 0,
+    revenue: 0,
+    clicks: 0,
+    leads: 0,
+    checkoutClicks: 0,
+    purchases: 0,
+  };
+}
+
+function addExperimentToSummary(
+  summary: ExperimentHierarchyMetricSummary,
+  experiment: CommercialPlanWeek["experiments"][number],
+) {
+  summary.experiments += 1;
+  summary.totalCost += experiment.totalCost ?? 0;
+  summary.revenue += experiment.revenue ?? 0;
+  summary.clicks += experiment.clicks ?? 0;
+  summary.leads += experiment.leads ?? 0;
+  summary.checkoutClicks += experiment.checkoutClicks ?? 0;
+  summary.purchases += experiment.purchases ?? 0;
+}
+
+function buildExperimentHierarchy(
+  experiments: CommercialPlanWeek["experiments"],
+): ExperimentHierarchyNiche[] {
+  const niches = new Map<string, ExperimentHierarchyNiche>();
+
+  experiments.forEach((experiment) => {
+    const nicheKey =
+      experiment.nicheId != null ? String(experiment.nicheId) : "sem-nicho";
+    const hypothesisKey =
+      experiment.hypothesisId ?? `sem-hipotese-${experiment.id}`;
+    let niche = niches.get(nicheKey);
+    if (!niche) {
+      niche = {
+        key: nicheKey,
+        id: experiment.nicheId,
+        name: experiment.nicheName ?? "Nicho não informado",
+        summary: emptySummary(),
+        hypotheses: [],
+      };
+      niches.set(nicheKey, niche);
+    }
+
+    let hypothesis = niche.hypotheses.find(
+      (item) => item.key === hypothesisKey,
+    );
+    if (!hypothesis) {
+      hypothesis = {
+        key: hypothesisKey,
+        id: experiment.hypothesisId,
+        title: experiment.hypothesisTitle ?? "Hipótese não informada",
+        summary: emptySummary(),
+        experiments: [],
+      };
+      niche.hypotheses.push(hypothesis);
+    }
+
+    addExperimentToSummary(niche.summary, experiment);
+    addExperimentToSummary(hypothesis.summary, experiment);
+    hypothesis.experiments.push(experiment);
+  });
+
+  return Array.from(niches.values());
+}
+
+function HierarchySummary({
+  summary,
+}: {
+  summary: ExperimentHierarchyMetricSummary;
+}) {
+  return (
+    <div className="commercial-planning-hierarchy-summary">
+      <span>{summary.experiments} exp.</span>
+      <span>{formatExecutedCurrency(summary.totalCost)} custo</span>
+      <span>{formatExecutedCurrency(summary.revenue)} receita</span>
+      <span>{summary.purchases} compras</span>
+    </div>
+  );
+}
+
 function WeeklyExperimentTable({
   planId,
   weeks,
@@ -319,7 +434,10 @@ function WeeklyExperimentTable({
   return (
     <section className="commercial-planning-week-list">
       {weeks.map((week) => (
-        <article className="commercial-planning-week-card" key={week.weekNumber}>
+        <article
+          className="commercial-planning-week-card"
+          key={week.weekNumber}
+        >
           <div className="commercial-planning-week-card-header">
             <div>
               <h3>Semana {week.weekNumber}</h3>
@@ -334,50 +452,132 @@ function WeeklyExperimentTable({
             </div>
           </div>
 
-          <div className="commercial-planning-week-table-wrap">
-            <table className="table table-sm align-middle mb-0 commercial-planning-week-table">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Nome</th>
-                  <th>Tipo</th>
-                  <th>Status</th>
-                  <th>Criado</th>
-                  <th>Custo total</th>
-                  <th>Vídeo</th>
-                  <th>Receita</th>
-                  <th>Resultado</th>
-                </tr>
-              </thead>
-              <tbody>
-                {week.experiments.length > 0 ? (
-                  week.experiments.map((experiment) => (
-                    <tr key={experiment.id}>
-                      <td>{experiment.id}</td>
-                      <td>
-                        <Link to={`/experiments/${experiment.id}`}>
-                          {experiment.name}
-                        </Link>
-                      </td>
-                      <td>{experiment.productType ?? "Não definido"}</td>
-                      <td>{experiment.status ?? "Não definido"}</td>
-                      <td>{formatDate(experiment.createdAt)}</td>
-                      <td>{formatExecutedCurrency(experiment.totalCost)}</td>
-                      <td>{formatExecutedCurrency(experiment.videoCost)}</td>
-                      <td>{formatExecutedCurrency(experiment.revenue)}</td>
-                      <td>{experiment.result ?? "Sem resultado"}</td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr>
-                    <td colSpan={9} className="text-muted">
-                      Nenhum experimento criado nesta semana.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+          {week.experiments.length > 0 ? (
+            <div className="commercial-planning-hierarchy">
+              {buildExperimentHierarchy(week.experiments).map((niche) => (
+                <section
+                  className="commercial-planning-niche-node"
+                  key={niche.key}
+                >
+                  <div className="commercial-planning-node-header">
+                    <div>
+                      <span className="commercial-planning-node-kicker">
+                        Nicho
+                      </span>
+                      <h4>{niche.name}</h4>
+                    </div>
+                    <HierarchySummary summary={niche.summary} />
+                  </div>
+
+                  <div className="commercial-planning-hypothesis-list">
+                    {niche.hypotheses.map((hypothesis) => (
+                      <section
+                        className="commercial-planning-hypothesis-node"
+                        key={hypothesis.key}
+                      >
+                        <div className="commercial-planning-node-header">
+                          <div>
+                            <span className="commercial-planning-node-kicker">
+                              Hipótese
+                            </span>
+                            <h5>{hypothesis.title}</h5>
+                          </div>
+                          <HierarchySummary summary={hypothesis.summary} />
+                        </div>
+
+                        <div className="commercial-planning-experiment-grid">
+                          {hypothesis.experiments.map((experiment) => (
+                            <article
+                              className="commercial-planning-experiment-card"
+                              key={experiment.id}
+                            >
+                              <div className="commercial-planning-experiment-card-header">
+                                <div>
+                                  <span>Experimento #{experiment.id}</span>
+                                  <Link to={`/experiments/${experiment.id}`}>
+                                    {experiment.name}
+                                  </Link>
+                                </div>
+                                <span className="badge text-bg-light border">
+                                  {experiment.status ?? "Não definido"}
+                                </span>
+                              </div>
+
+                              <div className="commercial-planning-experiment-metrics">
+                                <div>
+                                  <span>Receita</span>
+                                  <strong>
+                                    {formatExecutedCurrency(experiment.revenue)}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Compras</span>
+                                  <strong>
+                                    {formatExecutedNumber(experiment.purchases)}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Checkout</span>
+                                  <strong>
+                                    {formatExecutedNumber(
+                                      experiment.checkoutClicks,
+                                    )}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Leads</span>
+                                  <strong>
+                                    {formatExecutedNumber(experiment.leads)}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Cliques</span>
+                                  <strong>
+                                    {formatExecutedNumber(experiment.clicks)}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Custo</span>
+                                  <strong>
+                                    {formatExecutedCurrency(
+                                      experiment.totalCost,
+                                    )}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>ROAS</span>
+                                  <strong>
+                                    {formatRoas(
+                                      experiment.revenue,
+                                      experiment.totalCost,
+                                    )}
+                                  </strong>
+                                </div>
+                                <div>
+                                  <span>Criado</span>
+                                  <strong>
+                                    {formatDate(experiment.createdAt)}
+                                  </strong>
+                                </div>
+                              </div>
+
+                              <div className="commercial-planning-experiment-result">
+                                {experiment.result ?? "Sem resultado"}
+                              </div>
+                            </article>
+                          ))}
+                        </div>
+                      </section>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          ) : (
+            <div className="commercial-planning-empty-week">
+              Nenhum experimento criado nesta semana.
+            </div>
+          )}
 
           <WeeklyObjectiveEditor planId={planId} week={week} />
         </article>


### PR DESCRIPTION
## Resumo

Este PR reúne as alterações solicitadas nas últimas interações para melhorar a leitura comercial do Marketing Hub:

- transforma o quadro semanal em hierarquia `Nicho > Hipótese > Experimento`, mostrando a origem estratégica e as métricas principais do experimento;
- melhora a tela de detalhe da hipótese, removendo JSON bruto e usando blocos comerciais com collapses;
- limita o botão de objetivos da próxima semana à janela de 2 dias antes até 2 dias depois do fim da semana, com regra validada também no backend;
- limpa a página de detalhe do experimento, removendo blocos técnicos, obsoletos ou redundantes da visão principal.

## Impacto para o usuário

A navegação passa a focar melhor a decisão comercial: qual nicho está gerando sinal, qual hipótese originou o teste, qual experimento tem gargalo de funil e quando faz sentido registrar objetivos da próxima semana.

## Validação

- `mvn -q -Dtest=CommercialPlanWeeklyExperimentServiceTest test` em `backend/ads-service`
- `npm run typecheck` em `frontend`
- `NODE_ENV=test npm test -- CommercialPlanningPage.test.tsx src/api/hypothesis/types.test.ts --run` em `frontend`

Observação: o ambiente estava com `NODE_ENV=production`; por isso foi necessário instalar dependências frontend com `npm ci --include=dev` para executar as validações locais.