### PR TITLE
Add @Autowired to CommercialPlanWeeklyExperimentService constructor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,7 @@ public class CommercialPlanWeeklyExperimentService {
     private final Clock clock;
 
     /** Inicializa o serviço com a fonte de plano e acesso SQL de leitura operacional. */
+    @Autowired
     public CommercialPlanWeeklyExperimentService(
             CommercialPlanService planService,
             JdbcTemplate jdbcTemplate,


### PR DESCRIPTION
### Motivation
- Ensure Spring performs constructor injection for `CommercialPlanWeeklyExperimentService` by explicitly annotating the public constructor with `@Autowired`.

### Description
- Added `org.springframework.beans.factory.annotation.Autowired` import and annotated the public constructor of `CommercialPlanWeeklyExperimentService` with `@Autowired` so Spring can resolve dependencies.

### Testing
- Ran the existing unit test suite with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9be1efa483218047cee7f949f25c)