### PR TITLE
AI Hub: Foi erro no backend, não no frontend.

Causa: o GitHub Action falhou no `ArquiteturaTest`. A classe `HypothesisPainStageService` passou a usar `HypothesisPipelineContentGuard`, mas a regra ArchUnit ainda não permitia esse serviço compartilhado den…

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -88,6 +88,8 @@ class ArquiteturaTest {
             HYPOTHESIS_PAIN_STAGE_EXECUTION_REPOSITORY_CLASS,
             MARKET_NICHE_REPOSITORY_CLASS,
             AI_PROMPT_SCHEMA_TEMPLATE_REPOSITORY_CLASS);
+    private static final List<String> ALLOWED_HYPOTHESIS_STAGE_SHARED_SERVICE_CLASSES =
+            List.of("com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard");
     private static final Pattern BACKEND_CONTROLLER_NAME_PATTERN = Pattern.compile("^Backend([A-Za-z0-9]+)Controller$");
     private static final Pattern BACKEND_SERVICE_NAME_PATTERN = Pattern.compile("^Backend([A-Za-z0-9]+)Service$");
     private static final Pattern EPM_CONTROLLER_PACKAGE_PATTERN = Pattern.compile("^com\\.marketinghub\\.epm\\.controller$");
@@ -2970,6 +2972,7 @@ class ArquiteturaTest {
                             || targetName.equals(HYPOTHESIS_CLASS)
                             || targetName.equals(MARKET_NICHE_CLASS)
                             || isAiPromptSchemaTemplateClass(targetName)
+                            || isAllowedHypothesisStageSharedServiceClass(targetName)
                             || isAllowedHypothesisStageServiceRepository(targetName)) {
                         return;
                     }
@@ -2982,12 +2985,21 @@ class ArquiteturaTest {
                             + HYPOTHESIS_CLASS + ", "
                             + MARKET_NICHE_CLASS + ", "
                             + AI_PROMPT_SCHEMA_TEMPLATE_CLASS
+                            + ", serviços compartilhados explicitamente liberados: "
+                            + ALLOWED_HYPOTHESIS_STAGE_SHARED_SERVICE_CLASSES
                             + " e somente repositories canônicos explicitamente liberados: "
                             + ALLOWED_HYPOTHESIS_STAGE_SERVICE_REPOSITORIES;
                     events.add(SimpleConditionEvent.violated(item, message));
                 });
             }
         };
+    }
+
+    /**
+     * Verifica se a dependência alvo é um serviço compartilhado liberado para services do Hypothesis.
+     */
+    private static boolean isAllowedHypothesisStageSharedServiceClass(String targetName) {
+        return ALLOWED_HYPOTHESIS_STAGE_SHARED_SERVICE_CLASSES.contains(targetName);
     }
 
     /**


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
Veja la o github action deu erro. O que foi ? Consegue ajustar ?

**Resumo das alterações:**
Foi erro no backend, não no frontend.

Causa: o GitHub Action falhou no `ArquiteturaTest`. A classe `HypothesisPainStageService` passou a usar `HypothesisPipelineContentGuard`, mas a regra ArchUnit ainda não permitia esse serviço compartilhado dentro das etapas de hipótese.

Ajustei a regra em:

[ArquiteturaTest.java](/root/ai-hub/src/ai-hub-d24701ff-39a7-44e1-879c-e199213869e6-8LbwA9/repo/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java)

Correção feita: liberei explicitamente apenas `HypothesisPipelineContentGuard` como serviço compartilhado permitido para o pipeline de hipótese, sem abrir a regra para qualquer dependência genérica.

Validação local:

`mvn -B test` no `backend/ads-service`

Resultado: `1059` testes, `0` falhas, `1` skipped, `BUILD SUCCESS`.

Não criei PR nem fiz push, conforme combinado.