### PR TITLE
AI Hub: Implementei o fluxo manual sem alterar dados direto no banco e sem acionar IA.

O que entrou:

- Novo endpoint backend: `POST /api/manual-experiments`
- Nova tela: `/experiments/manual/new`
- Menu em **Experimentos > Experimento manual**
- Criação…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -41,6 +41,12 @@ public class Experiment {
     @Column(nullable = false)
     private String name;
 
+    /** Origem operacional usada para criar o experimento. */
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "creation_source", length = 32, nullable = false)
+    private ExperimentCreationSource creationSource = ExperimentCreationSource.SYSTEM_FLOW;
+
     @Column(length = 255)
     private String hypothesis;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentCreationSource.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentCreationSource.java
@@ -1,0 +1,9 @@
+package com.marketinghub.experiment;
+
+/**
+ * Identifica a origem de criação do experimento comercial para auditoria operacional.
+ */
+public enum ExperimentCreationSource {
+    SYSTEM_FLOW,
+    MANUAL_FLOW
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentCreationSource;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.productai.ProductAiSubtype;
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ public class CreateExperimentRequest {
     private Long marketNicheId;
     private java.util.UUID hypothesisId;
     private String name;
+    private ExperimentCreationSource creationSource;
     private String hypothesis;
     private String singlePain;
     private String freeReward;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -6,6 +6,7 @@ import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentCreationSource;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.CreativeGenerationStatus;
@@ -24,6 +25,7 @@ public class ExperimentDto {
     private Long nicheId;
     private java.util.UUID hypothesisId;
     private String name;
+    private ExperimentCreationSource creationSource;
     private String hypothesis;
     private String singlePain;
     private String freeReward;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationController.java
@@ -1,0 +1,33 @@
+package com.marketinghub.experiment.manual;
+
+import com.marketinghub.experiment.dto.ExperimentDto;
+import com.marketinghub.experiment.mapper.ExperimentMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Expõe a porta de entrada manual para criação de experimentos sem execução de IA.
+ */
+@RestController
+@RequestMapping("/api/manual-experiments")
+public class ManualExperimentCreationController {
+    private final ManualExperimentCreationService service;
+    private final ExperimentMapper mapper;
+
+    /** Inicializa o controller com o serviço manual e o mapper de experimentos. */
+    public ManualExperimentCreationController(ManualExperimentCreationService service, ExperimentMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    /** Cria um experimento oficial marcado como originado pelo fluxo manual. */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ExperimentDto create(@RequestBody ManualExperimentCreationRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationRequest.java
@@ -1,0 +1,39 @@
+package com.marketinghub.experiment.manual;
+
+import java.math.BigDecimal;
+import lombok.Data;
+
+/**
+ * Transporta os campos do wizard manual para criar nicho, hipótese e experimento sem acionar IA.
+ */
+@Data
+public class ManualExperimentCreationRequest {
+    private String nicheName;
+    private String nicheAudience;
+    private String nicheDescription;
+    private String marketReference;
+    private String pains;
+    private String desires;
+    private String likelyChannels;
+    private String hypothesisStatement;
+    private String persona;
+    private String problem;
+    private String promise;
+    private String mechanism;
+    private String proof;
+    private String successSignal;
+    private String offerName;
+    private String leadMagnet;
+    private String productName;
+    private String primaryCta;
+    private BigDecimal testPrice;
+    private String promiseLimit;
+    private String validationType;
+    private String experimentChannel;
+    private BigDecimal dailyBudget;
+    private BigDecimal kpiTargetCpl;
+    private Integer sampleSize;
+    private String creativeAngles;
+    private String successCriteria;
+    private String discardCriteria;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/manual/ManualExperimentCreationService.java
@@ -1,0 +1,262 @@
+package com.marketinghub.experiment.manual;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignObjective;
+import com.marketinghub.experiment.ExperimentCreationSource;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStage;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.HypothesisStatus;
+import com.marketinghub.hypothesis.OfferType;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Cria a cadeia oficial Nicho -> Hipótese -> Experimento a partir do fluxo manual do operador.
+ */
+@Service
+public class ManualExperimentCreationService {
+    private static final BigDecimal DEFAULT_KPI_TARGET_CPL = new BigDecimal("10.00");
+    private static final BigDecimal DEFAULT_DAILY_BUDGET = new BigDecimal("50.00");
+    private static final int DEFAULT_SAMPLE_SIZE = 100;
+
+    private final MarketNicheRepository nicheRepository;
+    private final HypothesisRepository hypothesisRepository;
+    private final ExperimentRepository experimentRepository;
+    private final JourneyTemplateRepository journeyTemplateRepository;
+
+    /** Inicializa o serviço com os repositórios oficiais do fluxo comercial. */
+    public ManualExperimentCreationService(
+            MarketNicheRepository nicheRepository,
+            HypothesisRepository hypothesisRepository,
+            ExperimentRepository experimentRepository,
+            JourneyTemplateRepository journeyTemplateRepository) {
+        this.nicheRepository = nicheRepository;
+        this.hypothesisRepository = hypothesisRepository;
+        this.experimentRepository = experimentRepository;
+        this.journeyTemplateRepository = journeyTemplateRepository;
+    }
+
+    /** Cria nicho, hipótese e experimento em uma única transação identificada como fluxo manual. */
+    @Transactional
+    public Experiment create(ManualExperimentCreationRequest request) {
+        validate(request);
+        MarketNiche niche = nicheRepository.save(buildNiche(request));
+        Hypothesis hypothesis = hypothesisRepository.save(buildHypothesis(request, niche));
+        Experiment experiment = buildExperiment(request, niche, hypothesis);
+        return experimentRepository.save(experiment);
+    }
+
+    /** Valida os campos mínimos para o experimento manual ser comercialmente acionável. */
+    private void validate(ManualExperimentCreationRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request required");
+        }
+        requireText(request.getNicheName(), "nicheName required");
+        requireText(request.getPersona(), "persona required");
+        requireText(request.getProblem(), "problem required");
+        requireText(request.getPromise(), "promise required");
+        requireText(request.getMechanism(), "mechanism required");
+        requireText(request.getLeadMagnet(), "leadMagnet required");
+        requireText(request.getPrimaryCta(), "primaryCta required");
+        if (request.getDailyBudget() != null && request.getDailyBudget().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dailyBudget must be greater than zero");
+        }
+        if (request.getKpiTargetCpl() != null && request.getKpiTargetCpl().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl must be greater than zero");
+        }
+        if (request.getSampleSize() != null && request.getSampleSize() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be at least 1");
+        }
+    }
+
+    /** Exige texto útil para campos críticos do wizard. */
+    private void requireText(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+        }
+    }
+
+    /** Monta o nicho oficial com os sinais de mercado informados manualmente. */
+    private MarketNiche buildNiche(ManualExperimentCreationRequest request) {
+        return MarketNiche.builder()
+                .name(request.getNicheName().trim())
+                .description(joinLines(
+                        request.getNicheDescription(),
+                        labeled("Referencia de mercado", request.getMarketReference()),
+                        labeled("Publico", request.getNicheAudience())))
+                .baseSegmentation(request.getNicheAudience())
+                .demandVolume(labeled("Dores observadas", request.getPains()))
+                .promises(labeled("Desejos observados", request.getDesires()))
+                .offers(labeled("Oferta inicial", request.getOfferName()))
+                .extraTips(joinLines(
+                        labeled("Canais provaveis", request.getLikelyChannels()),
+                        labeled("Origem", "Fluxo manual de experimento")))
+                .totalCost(BigDecimal.ZERO)
+                .build();
+    }
+
+    /** Monta a hipótese oficial a partir da aposta comercial inserida pelo operador. */
+    private Hypothesis buildHypothesis(ManualExperimentCreationRequest request, MarketNiche niche) {
+        return Hypothesis.builder()
+                .marketNiche(niche)
+                .title(buildHypothesisTitle(niche))
+                .promise(request.getPromise())
+                .problem(request.getProblem())
+                .persona(request.getPersona())
+                .mechanism(request.getMechanism())
+                .uniqueMechanism(request.getMechanism())
+                .entrega(request.getLeadMagnet())
+                .successRule(joinLines(
+                        request.getSuccessSignal(),
+                        labeled("Criterio de sucesso", request.getSuccessCriteria())))
+                .offerType(resolveOfferType(request.getValidationType()))
+                .price(request.getTestPrice())
+                .kpiTargetCpl(resolveKpiTargetCpl(request))
+                .status(HypothesisStatus.TESTING)
+                .build();
+    }
+
+    /** Monta o experimento oficial planejado e marcado como criado pelo fluxo manual. */
+    private Experiment buildExperiment(
+            ManualExperimentCreationRequest request,
+            MarketNiche niche,
+            Hypothesis hypothesis) {
+        String experimentName = buildExperimentName(niche, hypothesis);
+        return Experiment.builder()
+                .niche(niche)
+                .name(experimentName)
+                .creationSource(ExperimentCreationSource.MANUAL_FLOW)
+                .hypothesisRef(hypothesis)
+                .hypothesis(resolveNarrative(request))
+                .singlePain(request.getProblem())
+                .freeReward(request.getLeadMagnet())
+                .funnelPromise(request.getPromise())
+                .primaryCta(request.getPrimaryCta())
+                .experimentType(ExperimentType.NICHE_TEST)
+                .campaignObjective(ExperimentCampaignObjective.LEADS)
+                .kpiTargetCpl(resolveKpiTargetCpl(request))
+                .sampleSize(request.getSampleSize() != null ? request.getSampleSize() : DEFAULT_SAMPLE_SIZE)
+                .dailyBudget(request.getDailyBudget() != null ? request.getDailyBudget() : DEFAULT_DAILY_BUDGET)
+                .unitPrice(request.getTestPrice())
+                .status(ExperimentStatus.PLANNED)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .stage(ExperimentStage.AD)
+                .primaryVariable("Promessa manual")
+                .primaryMetric("Lead qualificado")
+                .creativeTextPrompt(request.getCreativeAngles())
+                .journeyTemplate(resolveJourneyTemplate())
+                .build();
+    }
+
+    /** Resolve o KPI de CPL informado ou aplica um padrão conservador para teste manual. */
+    private BigDecimal resolveKpiTargetCpl(ManualExperimentCreationRequest request) {
+        return request.getKpiTargetCpl() != null ? request.getKpiTargetCpl() : DEFAULT_KPI_TARGET_CPL;
+    }
+
+    /** Define o tipo de oferta da hipótese de acordo com o objetivo declarado no teste. */
+    private OfferType resolveOfferType(String validationType) {
+        if (validationType != null && validationType.toUpperCase(Locale.ROOT).contains("VENDA")) {
+            return OfferType.TRIPWIRE;
+        }
+        return OfferType.LEAD;
+    }
+
+    /** Busca um template de jornada existente ou cria um template mínimo para testes manuais. */
+    private JourneyTemplate resolveJourneyTemplate() {
+        return journeyTemplateRepository.findAll(PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElseGet(() -> journeyTemplateRepository.save(JourneyTemplate.builder()
+                        .name("Jornada manual de experimento")
+                        .description("Template padrao para experimentos criados pelo fluxo manual.")
+                        .objective("Capturar interesse e validar promessa comercial.")
+                        .preferredChannel("EMAIL")
+                        .phases(List.of(
+                                JourneyPhase.ATTENTION,
+                                JourneyPhase.INTEREST,
+                                JourneyPhase.DESIRE,
+                                JourneyPhase.ACTION))
+                        .build()));
+    }
+
+    /** Monta o título técnico da hipótese preservando o padrão de sigla e sequência do nicho. */
+    private String buildHypothesisTitle(MarketNiche niche) {
+        long nextNumber = hypothesisRepository.countByMarketNicheId(niche.getId()) + 1;
+        return "%s-H%03d".formatted(nicheAcronym(niche), nextNumber);
+    }
+
+    /** Monta o nome técnico do experimento a partir da hipótese oficial. */
+    private String buildExperimentName(MarketNiche niche, Hypothesis hypothesis) {
+        String baseName = "%s-E%03d".formatted(hypothesis.getTitle(), experimentRepository.countByHypothesisRef(hypothesis) + 1);
+        if (!experimentRepository.existsByNicheAndName(niche, baseName)) {
+            return baseName;
+        }
+        return "%s-%d".formatted(baseName, System.currentTimeMillis());
+    }
+
+    /** Gera uma sigla estável a partir do nome do nicho. */
+    private String nicheAcronym(MarketNiche niche) {
+        String normalized = Normalizer.normalize(niche.getName(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toUpperCase(Locale.ROOT);
+        StringBuilder acronym = new StringBuilder();
+        for (String word : normalized.split("[^A-Z0-9]+")) {
+            if (!word.isBlank()) {
+                acronym.append(word.charAt(0));
+            }
+            if (acronym.length() == 4) {
+                break;
+            }
+        }
+        while (acronym.length() < 3) {
+            acronym.append('X');
+        }
+        return acronym.toString();
+    }
+
+    /** Resolve a narrativa principal exibida no experimento. */
+    private String resolveNarrative(ManualExperimentCreationRequest request) {
+        if (StringUtils.hasText(request.getHypothesisStatement())) {
+            return request.getHypothesisStatement();
+        }
+        return "%s quer %s por meio de %s".formatted(
+                request.getPersona().trim(),
+                request.getPromise().trim(),
+                request.getMechanism().trim());
+    }
+
+    /** Prefixa um valor opcional com rótulo legível. */
+    private String labeled(String label, String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return label + ": " + value.trim();
+    }
+
+    /** Junta blocos textuais opcionais em linhas sem valores vazios. */
+    private String joinLines(String... values) {
+        return java.util.Arrays.stream(values)
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .reduce((left, right) -> left + "\n" + right)
+                .orElse(null);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -370,6 +370,9 @@ public class ExperimentService {
         Experiment exp = Experiment.builder()
                 .niche(niche)
                 .name(automaticName)
+                .creationSource(request.getCreationSource() != null
+                        ? request.getCreationSource()
+                        : ExperimentCreationSource.SYSTEM_FLOW)
                 .hypothesis(request.getHypothesis())
                 .singlePain(normalizeExperimentPromiseField(request.getSinglePain()))
                 .freeReward(normalizeExperimentPromiseField(request.getFreeReward()))
@@ -501,6 +504,7 @@ public class ExperimentService {
         Experiment copy = Experiment.builder()
                 .niche(original.getNiche())
                 .name(original.getName() + " copy")
+                .creationSource(original.getCreationSource())
                 .hypothesis(original.getHypothesis())
                 .singlePain(original.getSinglePain())
                 .freeReward(original.getFreeReward())

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-09-experiment-creation-source.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-09-experiment-creation-source.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-09-experiment-creation-source
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment
+        - not:
+            - columnExists:
+                tableName: experiment
+                columnName: creation_source
+      changes:
+        - addColumn:
+            tableName: experiment
+            columns:
+              - column:
+                  name: creation_source
+                  type: varchar(32)
+                  defaultValue: SYSTEM_FLOW
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: experiment
+            columnName: creation_source

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-09-experiment-creation-source.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-07-commercial-plan-week-objectives.yaml
       relativeToChangelogFile: true
   - include:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import MicroserviceExceptionListPage from "./pages/microservice/MicroserviceExce
 import PipelineCrudPage from "./pages/pipeline/PipelineCrudPage";
 import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
+import ManualExperimentWizardPage from "./pages/experiment/ManualExperimentWizardPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
 import EditExperimentPage from "./pages/experiment/EditExperimentPage";
 import InstantFormDetailPage from "./pages/experiment/InstantFormDetailPage";
@@ -242,6 +243,10 @@ export default function App() {
               <Route path="/experiments" element={<ExperimentListPage />} />
               <Route path="/planning" element={<CommercialPlanningPage />} />
               <Route path="/experiments/new" element={<NewExperimentPage />} />
+              <Route
+                path="/experiments/manual/new"
+                element={<ManualExperimentWizardPage />}
+              />
               <Route path="/experiments/:id" element={<AppLayout />}>
                 <Route index element={<ExperimentDetailPage />} />
                 <Route path="edit" element={<EditExperimentPage />} />

--- a/frontend/src/api/experiment/useCreateManualExperiment.ts
+++ b/frontend/src/api/experiment/useCreateManualExperiment.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+import type { Experiment } from "./useExperiments";
+
+export interface CreateManualExperiment {
+  nicheName: string;
+  nicheAudience?: string;
+  nicheDescription?: string;
+  marketReference?: string;
+  pains?: string;
+  desires?: string;
+  likelyChannels?: string;
+  hypothesisStatement?: string;
+  persona: string;
+  problem: string;
+  promise: string;
+  mechanism: string;
+  proof?: string;
+  successSignal?: string;
+  offerName?: string;
+  leadMagnet: string;
+  productName?: string;
+  primaryCta: string;
+  testPrice?: number;
+  promiseLimit?: string;
+  validationType?: string;
+  experimentChannel?: string;
+  dailyBudget?: number;
+  kpiTargetCpl?: number;
+  sampleSize?: number;
+  creativeAngles?: string;
+  successCriteria?: string;
+  discardCriteria?: string;
+}
+
+export function useCreateManualExperiment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateManualExperiment) => {
+      const { data } = await axios.post<Experiment>(
+        "/api/manual-experiments",
+        payload,
+      );
+      return data;
+    },
+    onSuccess: (experiment) => {
+      queryClient.invalidateQueries({ queryKey: ["experiments"] });
+      queryClient.invalidateQueries({ queryKey: ["niches"] });
+      queryClient.invalidateQueries({ queryKey: ["niche-summary"] });
+      queryClient.invalidateQueries({ queryKey: ["hypotheses"] });
+      toast.success(`Experimento manual criado: ${experiment.name}`);
+    },
+    onError: () => {
+      toast.error("Não foi possível criar o experimento manual.");
+    },
+  });
+}

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -17,6 +17,7 @@ export interface InstagramAccountSummary {
 
 export type ExperimentStage = "AD" | "LANDING" | "SAMPLE" | "SALES";
 export type ExperimentType = "NICHE_TEST" | "LOW_TICKET_PRODUCT";
+export type ExperimentCreationSource = "SYSTEM_FLOW" | "MANUAL_FLOW";
 export type ProductAiSubtype =
   | "AI_VISUAL_PREVIEW"
   | "AI_PERSONALIZED_SAMPLE"
@@ -68,6 +69,7 @@ export interface Experiment {
   nicheId: number;
   hypothesisId: string;
   name: string;
+  creationSource?: ExperimentCreationSource | null;
   hypothesis: string;
   singlePain?: string | null;
   freeReward?: string | null;

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -100,6 +100,11 @@ const NAV_SECTIONS: NavSection[] = [
         icon: experimentIcon,
         children: [
           {
+            to: "/experiments/manual/new",
+            label: "Experimento manual",
+            icon: PlusCircle,
+          },
+          {
             to: "/facebook-campaigns",
             label: "Experimentos para campanha",
             icon: Flag,

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2065,6 +2065,9 @@ export default function ExperimentDetailPage() {
       <div className="d-flex justify-content-between align-items-start">
         <div>
           <PageTitle icon={experimentIcon}>{data.name}</PageTitle>
+          {data.creationSource === "MANUAL_FLOW" ? (
+            <span className="badge text-bg-warning mb-2">Fluxo manual</span>
+          ) : null}
           <p className="text-muted mb-0">{data.hypothesis}</p>
         </div>
         <div className="d-flex align-items-center">

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -206,6 +206,9 @@ export default function ExperimentListPage() {
         <Link className="btn btn-primary" to="/experiments/new">
           Novo Teste
         </Link>
+        <Link className="btn btn-outline-primary" to="/experiments/manual/new">
+          Novo experimento manual
+        </Link>
         {latestPromiseOptionsDraft.data && (
           <Link className="btn btn-outline-primary" to="/experiments/new">
             Continuar teste em criação
@@ -283,7 +286,16 @@ export default function ExperimentListPage() {
               return (
                 <tr key={e.id}>
                   <td className="text-nowrap">{e.id}</td>
-                  <td>{e.name}</td>
+                  <td>
+                    <div className="d-flex flex-column gap-1">
+                      <span>{e.name}</span>
+                      {e.creationSource === "MANUAL_FLOW" ? (
+                        <span className="badge text-bg-warning align-self-start">
+                          Fluxo manual
+                        </span>
+                      ) : null}
+                    </div>
+                  </td>
                   <td className="text-nowrap">{formatDate(e.createdAt)}</td>
                   <td>
                     {nicheNameById.get(e.nicheId) || `Nicho #${e.nicheId}`}

--- a/frontend/src/pages/experiment/ManualExperimentWizardPage.tsx
+++ b/frontend/src/pages/experiment/ManualExperimentWizardPage.tsx
@@ -1,0 +1,401 @@
+import { FormEvent, ReactNode, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ClipboardList, FlaskConical, Layers, Megaphone } from "lucide-react";
+import PageTitle from "../../components/PageTitle";
+import experimentIcon from "../../assets/icons/experiment-icon.svg";
+import {
+  CreateManualExperiment,
+  useCreateManualExperiment,
+} from "../../api/experiment/useCreateManualExperiment";
+
+type FormState = Record<keyof CreateManualExperiment, string>;
+
+const INITIAL_STATE: FormState = {
+  nicheName: "",
+  nicheAudience: "",
+  nicheDescription: "",
+  marketReference: "",
+  pains: "",
+  desires: "",
+  likelyChannels: "Meta Ads",
+  hypothesisStatement: "",
+  persona: "",
+  problem: "",
+  promise: "",
+  mechanism: "",
+  proof: "",
+  successSignal: "",
+  offerName: "",
+  leadMagnet: "",
+  productName: "",
+  primaryCta: "",
+  testPrice: "47",
+  promiseLimit: "",
+  validationType: "Lista de prioridade",
+  experimentChannel: "Meta Ads",
+  dailyBudget: "50",
+  kpiTargetCpl: "10",
+  sampleSize: "100",
+  creativeAngles: "",
+  successCriteria:
+    "CTR acima de 1,5%; conversao em lead acima de 20%; clique em compra acima de 5%",
+  discardCriteria:
+    "Baixo clique no criativo, baixa conversao da landing ou ausencia de sinal de intencao de compra",
+};
+
+export default function ManualExperimentWizardPage() {
+  const navigate = useNavigate();
+  const createManualExperiment = useCreateManualExperiment();
+  const [form, setForm] = useState<FormState>(INITIAL_STATE);
+  const requiredFieldsComplete = useMemo(
+    () =>
+      Boolean(
+        form.nicheName &&
+          form.persona &&
+          form.problem &&
+          form.promise &&
+          form.mechanism &&
+          form.leadMagnet &&
+          form.primaryCta,
+      ),
+    [form],
+  );
+
+  function updateField(name: keyof CreateManualExperiment, value: string) {
+    setForm((current) => ({ ...current, [name]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const experiment = await createManualExperiment.mutateAsync(toPayload(form));
+    navigate(`/experiments/${experiment.id}`);
+  }
+
+  return (
+    <div>
+      <PageTitle icon={experimentIcon}>Experimento Manual</PageTitle>
+      <div className="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+        <div>
+          <span className="badge text-bg-warning mb-2">Fluxo manual</span>
+          <p className="text-muted mb-0">
+            Cria a cadeia oficial Nicho, Hipótese, Contrato Comercial e
+            Experimento sem acionar as IAs.
+          </p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/experiments">
+          Voltar
+        </Link>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <WizardSection
+          icon={<Layers size={20} />}
+          title="Nicho"
+          subtitle="Público e oportunidade de mercado"
+        >
+          <div className="row g-3">
+            <TextField
+              label="Nome do nicho"
+              name="nicheName"
+              value={form.nicheName}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Público"
+              name="nicheAudience"
+              value={form.nicheAudience}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Referência de mercado"
+              name="marketReference"
+              value={form.marketReference}
+              onChange={updateField}
+              placeholder="Ex.: Marie Claire, editorias de beleza, saúde e carreira"
+            />
+            <TextAreaField
+              label="Dores observadas"
+              name="pains"
+              value={form.pains}
+              onChange={updateField}
+            />
+          </div>
+        </WizardSection>
+
+        <WizardSection
+          icon={<FlaskConical size={20} />}
+          title="Hipótese"
+          subtitle="Aposta comercial a validar"
+        >
+          <div className="row g-3">
+            <TextField
+              label="Persona"
+              name="persona"
+              value={form.persona}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Dor principal"
+              name="problem"
+              value={form.problem}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Promessa"
+              name="promise"
+              value={form.promise}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Mecanismo"
+              name="mechanism"
+              value={form.mechanism}
+              onChange={updateField}
+              required
+            />
+            <TextAreaField
+              label="Hipótese em uma frase"
+              name="hypothesisStatement"
+              value={form.hypothesisStatement}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Prova ou evidência"
+              name="proof"
+              value={form.proof}
+              onChange={updateField}
+            />
+          </div>
+        </WizardSection>
+
+        <WizardSection
+          icon={<ClipboardList size={20} />}
+          title="Contrato Comercial"
+          subtitle="Oferta mínima testável"
+        >
+          <div className="row g-3">
+            <TextField
+              label="Nome da oferta"
+              name="offerName"
+              value={form.offerName}
+              onChange={updateField}
+            />
+            <TextField
+              label="Isca ou recompensa"
+              name="leadMagnet"
+              value={form.leadMagnet}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Produto em validação"
+              name="productName"
+              value={form.productName}
+              onChange={updateField}
+            />
+            <TextField
+              label="CTA principal"
+              name="primaryCta"
+              value={form.primaryCta}
+              onChange={updateField}
+              required
+            />
+            <TextField
+              label="Preço de teste"
+              name="testPrice"
+              type="number"
+              value={form.testPrice}
+              onChange={updateField}
+            />
+            <TextField
+              label="Tipo de validação"
+              name="validationType"
+              value={form.validationType}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Limite da promessa"
+              name="promiseLimit"
+              value={form.promiseLimit}
+              onChange={updateField}
+            />
+          </div>
+        </WizardSection>
+
+        <WizardSection
+          icon={<Megaphone size={20} />}
+          title="Experimento"
+          subtitle="Canal, criativos e critérios de decisão"
+        >
+          <div className="row g-3">
+            <TextField
+              label="Canal"
+              name="experimentChannel"
+              value={form.experimentChannel}
+              onChange={updateField}
+            />
+            <TextField
+              label="Orçamento diário"
+              name="dailyBudget"
+              type="number"
+              value={form.dailyBudget}
+              onChange={updateField}
+            />
+            <TextField
+              label="CPL alvo"
+              name="kpiTargetCpl"
+              type="number"
+              value={form.kpiTargetCpl}
+              onChange={updateField}
+            />
+            <TextField
+              label="Amostra"
+              name="sampleSize"
+              type="number"
+              value={form.sampleSize}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Ângulos de criativo"
+              name="creativeAngles"
+              value={form.creativeAngles}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Critério de aprovação"
+              name="successCriteria"
+              value={form.successCriteria}
+              onChange={updateField}
+            />
+            <TextAreaField
+              label="Critério de descarte"
+              name="discardCriteria"
+              value={form.discardCriteria}
+              onChange={updateField}
+            />
+          </div>
+        </WizardSection>
+
+        <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 border-top pt-3">
+          <span className="text-muted small">
+            O experimento será salvo como <strong>MANUAL_FLOW</strong> e
+            planejado para captação de leads.
+          </span>
+          <button
+            className="btn btn-primary"
+            type="submit"
+            disabled={!requiredFieldsComplete || createManualExperiment.isPending}
+          >
+            {createManualExperiment.isPending
+              ? "Criando..."
+              : "Criar experimento manual"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function WizardSection({
+  icon,
+  title,
+  subtitle,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="py-3 border-top">
+      <div className="d-flex align-items-center gap-2 mb-3">
+        <span className="text-primary d-inline-flex">{icon}</span>
+        <div>
+          <h2 className="h5 mb-0">{title}</h2>
+          <p className="small text-muted mb-0">{subtitle}</p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function TextField({
+  label,
+  name,
+  value,
+  onChange,
+  type = "text",
+  required,
+}: {
+  label: string;
+  name: keyof CreateManualExperiment;
+  value: string;
+  onChange: (name: keyof CreateManualExperiment, value: string) => void;
+  type?: string;
+  required?: boolean;
+}) {
+  return (
+    <div className="col-12 col-md-6">
+      <label className="form-label">
+        {label}
+        {required ? <span className="text-danger"> *</span> : null}
+      </label>
+      <input
+        className="form-control"
+        type={type}
+        value={value}
+        onChange={(event) => onChange(name, event.target.value)}
+        required={required}
+      />
+    </div>
+  );
+}
+
+function TextAreaField({
+  label,
+  name,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  name: keyof CreateManualExperiment;
+  value: string;
+  onChange: (name: keyof CreateManualExperiment, value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="col-12">
+      <label className="form-label">{label}</label>
+      <textarea
+        className="form-control"
+        rows={3}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(name, event.target.value)}
+      />
+    </div>
+  );
+}
+
+function toPayload(form: FormState): CreateManualExperiment {
+  return {
+    ...form,
+    testPrice: toOptionalNumber(form.testPrice),
+    dailyBudget: toOptionalNumber(form.dailyBudget),
+    kpiTargetCpl: toOptionalNumber(form.kpiTargetCpl),
+    sampleSize: toOptionalNumber(form.sampleSize),
+  };
+}
+
+function toOptionalNumber(value: string) {
+  if (!value.trim()) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: Da uma olhada nas materias desse site feminino : https://revistamarieclaire.globo.com/
Leia detalhadamente as principais materias e me liste 5 produtos que podem ter alta possibilidade de sucesso para esse publico.

Modelo: Analisei a home e editorias principais da Marie Claire Brasil em 9 de julho de 2026. O padrão editorial está muito claro: mulher ambiciosa, urbana, informada, preocupada com beleza/status, saúde feminina negligenciada, segurança emocional, carreira, maternidade e identidade.

**3 caminhos possíveis**
1. **Beleza/status acessível**: maior apelo imediato, fácil vender por desejo.
2. **Saúde feminina negligenciada**: dor forte e recorrente, exige cuidado jurídico/médico.
3. **Carreira + poder feminino**: ticket mais alto, público com maior poder de compra.

Minha escolha: combinar **beleza/status + saúde feminina + poder pessoal**, porque une desejo, dor e transformação prática.

**5 produtos com alta chance de sucesso**

1. **Manual da Mulher Sofisticada: beleza, perfume e presença sem gastar como rica**
Produto digital com curadoria de perfumes, cabelo, pele, maquiagem e imagem pessoal por faixa de orçamento.  
Por que venderia: a Marie Claire destaca temas como “perfumes com cheiro de rica”, cabelo de salão, corretivo intacto, unhas elegantes e produtos essenciais de pele. Existe desejo claro de parecer sofisticada sem depender de luxo inacessível.  
Oferta: curso + guias de compra + checklist de rotina + comunidade.  
Ângulo: “Pareça mais elegante em 30 dias sem trocar todo o guarda-roupa.”

2. **Corpo de Mulher Não é Frescura**
Programa educativo sobre dor feminina, endometriose, menopausa, cólicas, DIU, exames, sinais de alerta e como se preparar para consultas médicas.  
Por que venderia: várias matérias tratam da dor das mulheres não ser ouvida, endometriose, fogachos, menopausa, DIU e saúde ginecológica. A dor é real, recorrente e mal atendida.  
Oferta: aulas com especialistas, diário de sintomas, roteiro de perguntas para consulta, mapas de exames.  
Cuidado: não vender como diagnóstico ou tratamento, mas como educação e preparação para atendimento médico.

3. **Mulher Blindada: proteção emocional, relacionamentos e abuso psicológico**
Produto para mulheres identificarem manipulação, abuso psicológico, dependência emocional, limites e plano de saída seguro.  
Por que venderia: a home trouxe violência de gênero, abuso psicológico na gravidez, assédio, “passport bros”, masculinidade frágil e relacionamentos difíceis. É uma dor intensa e urgente.  
Oferta: curso + workbook + checklists de sinais + plano de segurança + rede de apoio.  
Ângulo: “Aprenda a reconhecer o que te diminui antes que vire prisão emocional.”

4. **Executiva Imparável: negociação, dinheiro e autoridade para mulheres**
Mentoria/curso para mulheres em carreira, negócios e liderança: negociação, posicionamento, networking, comunicação executiva e construção de autoridade.  
Por que venderia: matérias sobre CEO jovem em gestora de investimentos, mulheres no jornalismo esportivo, executivas, liderança e maternidade sem renúncia mostram público aspiracional e com ticket maior.  
Oferta: programa de 8 semanas + scripts de negociação + simulações + plano de carreira.  
Ângulo: “Se posicionar, negociar e liderar sem pedir licença.”

5. **Maternidade Sem Apagar a Mulher**
Produto para gestantes e mães recentes sobre saúde emocional, identidade, carreira, rede de apoio, relacionamento, autocuidado e retorno ao trabalho.  
Por que venderia: a Marie Claire cobre abuso psicológico na gravidez, mães exaustas, prematuridade/luto, maternidade e carreira. É um público com dor emocional profunda e alta busca por acolhimento prático.  
Oferta: trilha digital + planner + encontros em grupo + módulos para casal/família.  
Ângulo: “Você pode ser mãe sem desaparecer de si mesma.”

**Melhor aposta inicial**
Eu começaria pelo produto **Manual da Mulher Sofisticada**, porque tem menor barreira de compra, apelo visual forte, potencial para afiliados/upsell e conversa diretamente com beleza, perfume, cabelo, pele e elegância, temas muito presentes na Marie Claire.

Depois faria upsell para **Executiva Imparável** ou **Corpo de Mulher Não é Frescura**, dependendo do comportamento das compradoras.

Fontes analisadas: home da [Marie Claire Brasil](https://revistamarieclaire.globo.com/), editorias de [Beleza](https://revistamarieclaire.globo.com/beleza/), [Saúde](https://revistamarieclaire.globo.com/saude/), [Carreira](https://revistamarieclaire.globo.com/carreira/) e [Comportamento](https://revistamarieclaire.globo.com/comportamento/).

Usuário: Como poderiamos testar esses produtos atraves de experimentos no Mkt Hub ?

Modelo: Podemos testar no Mkt Hub como **experimentos de oferta**, não como produto completo. A ideia é validar primeiro: **dor + promessa + público + preço + canal**, antes de produzir o curso inteiro.

**3 formas boas de testar**

1. **Landing + anúncio + pré-lista**
Mais barato e rápido. Criamos uma página de promessa, capturamos e-mail/WhatsApp e medimos interesse.  
Risco: mede intenção, não compra real.

2. **Venda fake-door com checkout/espera**
A pessoa clica para comprar, vê preço e depois entra em lista de prioridade ou pré-venda.  
Melhor para medir disposição de compra.  
Risco: precisa cuidado na comunicação para não frustrar.

3. **Pré-venda real com entrega futura**
Vendemos um piloto com vagas limitadas e data de entrega.  
É o teste mais forte porque valida dinheiro.  
Risco: exige entregar caso venda.

Minha recomendação: começar com **fake-door ético + lista de prioridade**, e evoluir para **pré-venda real** nos 1 ou 2 produtos vencedores.

**Como testar no Mkt Hub**

Para cada produto, criaríamos um experimento com:

- **Hipótese**: “Mulheres interessadas em sofisticação acessível comprariam um guia prático por R$ 47-R$ 97.”
- **Avatar**: mulher urbana, 25-45, interessada em beleza, carreira, autocuidado e status acessível.
- **Promessa principal**: transformação clara e desejável.
- **Landing page**: uma página curta com dor, promessa, bullets, prova conceitual, bônus e CTA.
- **Criativos**: 3 a 5 ângulos por produto.
- **Canal inicial**: Meta Ads, porque conversa bem com beleza, saúde feminina, carreira e maternidade.
- **Métrica de decisão**: CTR, custo por lead, taxa de clique no botão de compra, intenção de compra e comentários qualitativos.

**Experimentos por produto**

1. **Manual da Mulher Sofisticada**
Teste com criativos de antes/depois de imagem pessoal, perfumes “cheiro de rica”, cabelo elegante e rotina de beleza simples.  
Oferta teste: “Guia de Elegância Acessível em 30 dias”.  
Métrica principal: clique em compra e custo por lead.

2. **Corpo de Mulher Não é Frescura**
Teste com dor ignorada, consulta médica mal aproveitada, sintomas e preparo para ginecologista.  
Oferta teste: “Kit Consulta Feminina: sintomas, perguntas e exames para não ser ignorada”.  
Métrica principal: lead qualificado e salvamento/compartilhamento do anúncio.

3. **Mulher Blindada**
Teste com abuso psicológico, dependência emocional, manipulação e limites.  
Oferta teste: “Checklist dos Sinais de Manipulação + Plano de Clareza Emocional”.  
Métrica principal: taxa de conversão da landing e respostas emocionais.

4. **Executiva Imparável**
Teste com negociação salarial, autoridade, comunicação e carreira.  
Oferta teste: “Scripts de Negociação e Posicionamento para Mulheres”.  
Métrica principal: intenção de compra em ticket maior.

5. **Maternidade Sem Apagar a Mulher**
Teste com exaustão, identidade, culpa, carreira e relacionamento pós-filhos.  
Oferta teste: “Plano de 21 dias para voltar a se priorizar sem culpa”.  
Métrica principal: custo por lead e engajamento nos comentários.

**Critério de vitória**

Eu usaria um funil simples:

- CTR do anúncio acima de **1,5%**
- Landing convertendo lead acima de **20%**
- Clique no botão de compra acima de **5%**
- Custo por lead dentro de uma faixa aceitável
- Comentários demonstrando dor real, não só curiosidade

Se um produto bater esses sinais, passamos para pré-venda real.

**Melhor ordem de teste**

Eu testaria primeiro:

1. **Manual da Mulher Sofisticada**: maior apelo visual, menor barreira de compra.
2. **Mulher Blindada**: dor forte e alta identificação.
3. **Executiva Imparável**: potencial de ticket maior.

Depois testaria saúde feminina e maternidade com mais cuidado jurídico/comunicacional.

**Próximo passo prático no Mkt Hub**

Criar 5 experimentos, um por produto, cada um com:

- 1 hipótese comercial
- 1 landing
- 3 ângulos de criativo
- 1 oferta de entrada
- 1 métrica de aprovação
- 1 decisão automática: descartar, ajustar ou avançar para pré-venda

Assim o Mkt Hub não “acha” qual produto é bom. Ele mede qual promessa faz a mulher parar, clicar, desejar e demonstrar intenção real de compra.

Usuário: sim mas o Marketing Hub tem uma estrutura de criação de experimento um pouco rigida. Nicho > Hipotese > Contrato Comercial > Experimento.
Como podemos adaptar nesse fluxo ? Sem passar pelas IAs etc.

Modelo: Sim. Nesse fluxo rígido, eu adaptaria assim: **não testar “produto” direto**. Testar uma **hipótese comercial empacotada** dentro da cadeia:

**Nicho → Hipótese → Contrato Comercial → Experimento**

A estrutura ficaria assim:

**1. Nicho**
Define o público e o contexto de consumo.

Exemplo:
- `Mulheres urbanas interessadas em beleza, autocuidado e sofisticação acessível`
- `Mulheres em relacionamento com dor emocional e necessidade de proteção`
- `Mulheres profissionais buscando autoridade, negociação e crescimento`

Aqui não colocamos ainda “curso” ou “produto”. O nicho é o mercado.

**2. Hipótese**
Transforma a oportunidade em uma aposta validável.

Exemplo para o produto de sofisticação:

> Mulheres de 25-45 anos que consomem conteúdo de beleza e estilo desejam parecer mais elegantes e sofisticadas sem gastar com marcas de luxo.

A hipótese precisa conter:
- dor principal;
- desejo;
- promessa;
- mecanismo plausível;
- público;
- sinal de compra esperado.

**3. Contrato Comercial**
Aqui entra a adaptação mais importante.

O contrato comercial deve virar o “produto mínimo testável”, com:

- **dor única**: “não sei parecer elegante sem gastar muito”
- **isca principal**: “Checklist dos 12 detalhes que deixam uma mulher com aparência sofisticada”
- **produto low-ticket**: “Manual da Mulher Sofisticada”
- **promessa principal**: “parecer mais elegante em 30 dias usando escolhas simples de beleza, perfume, cabelo e imagem”
- **CTA principal**: “Receber o checklist”
- **preço de teste**: R$ 47 ou R$ 67
- **prova conceitual**: antes/depois, exemplos de combinações, lista de produtos acessíveis
- **limite da promessa**: não promete riqueza, luxo real nem transformação estética médica

Ou seja: o contrato comercial é o lugar certo para traduzir a ideia em oferta.

**4. Experimento**
O experimento mede o comportamento real.

Sem IA, ele pode ser montado manualmente com:

- 1 landing simples;
- 1 formulário;
- 2 ou 3 anúncios manuais;
- 1 isca entregue manualmente ou por e-mail simples;
- eventos acompanhados no funil.

Pelo modelo do Hub, o funil importante é:

- visualização do anúncio;
- clique/acesso;
- visualização do formulário;
- envio do formulário;
- abertura da entrega/amostra;
- acesso ao checkout;
- compra.

**3 formas de organizar os 5 produtos**

1. **Um único nicho e cinco hipóteses**
Exemplo: nicho “mulheres Marie Claire”.  
Vantagem: rápido.  
Risco: fica amplo demais e mistura dores diferentes.

2. **Cinco nichos separados**
Um para beleza, saúde, relacionamento, carreira e maternidade.  
Vantagem: mais limpo e organizado.  
Risco: mais lento e pesado operacionalmente.

3. **Três nichos prioritários com hipóteses internas**
Minha recomendação. Equilibra velocidade e clareza.

Eu faria assim:

**Nicho 1: Sofisticação, beleza e imagem pessoal**
- Hipótese A: Manual da Mulher Sofisticada
- Hipótese B: kit de perfumes, cabelo e maquiagem acessível

**Nicho 2: Proteção emocional e relacionamentos**
- Hipótese A: Mulher Blindada
- Hipótese B: checklist de manipulação e limites

**Nicho 3: Mulher profissional, carreira e autonomia**
- Hipótese A: Executiva Imparável
- Hipótese B: negociação, autoridade e dinheiro

Depois deixaria saúde feminina e maternidade para uma segunda rodada, porque exigem mais cuidado de promessa, compliance e linguagem.

**Como eu testaria primeiro**

Eu criaria primeiro estes 3 fluxos:

1. **Nicho:** Sofisticação acessível  
   **Hipótese:** mulheres querem parecer elegantes sem gastar como ricas  
   **Contrato:** checklist gratuito + Manual da Mulher Sofisticada R$ 47  
   **Experimento:** campanha Leads com CTA “Receber checklist”

2. **Nicho:** Proteção emocional feminina  
   **Hipótese:** mulheres em dúvida sobre relacionamento abusivo querem clareza rápida  
   **Contrato:** checklist de sinais + Mulher Blindada R$ 67  
   **Experimento:** campanha Leads com CTA “Ver os sinais”

3. **Nicho:** Carreira feminina  
   **Hipótese:** mulheres profissionais querem negociar melhor e se posicionar com autoridade  
   **Contrato:** scripts de negociação + Executiva Imparável R$ 97  
   **Experimento:** campanha Leads com CTA “Receber scripts”

**Critério de decisão dentro do Hub**

Para cada experimento:

- se não tem clique: problema de criativo/ângulo;
- se tem clique mas não tem formulário: problema de landing/promessa;
- se tem formulário mas não tem checkout: problema de oferta/prova;
- se tem checkout mas não compra: problema de preço, confiança ou urgência.

Minha recomendação prática: começar com **3 nichos, 1 hipótese por nicho, 1 contrato comercial por hipótese e 1 experimento por contrato**. Isso respeita a rigidez do Marketing Hub e ainda permite comparar qual dor tem mais potencial comercial sem depender das IAs.

Usuário: Mas como fariamos isso pelo sistema sem alterar direto em banco de dados ? Precisamos criar um novo fluxo e um novo conjunto de telas para entrada. O que acha ?

Modelo: Sim, acho correto criar **um fluxo novo de entrada**, mas eu evitaria criar um “sistema paralelo”. O melhor é criar uma camada de **criação manual assistida** em cima da estrutura atual:

**Nicho → Hipótese → Contrato Comercial/Oferta → Experimento**

Sem alterar direto no banco e sem acionar IA.

**O que os documentos do repositório indicam**

O Marketing Hub já separa bem:

- **Hipótese**: dor, resultado, mecanismo, prova e oferta.
- **Oferta**: empacotamento comercial em validação.
- **Experimento**: campanha, criativos, landing e métricas.
- **Funil**: impressão, clique, formulário, checkout, compra etc.

Então a direção certa não é “inserir dados manualmente no banco”, mas criar telas que usem os endpoints do backend para montar esse encadeamento com rastreabilidade.

**3 alternativas**

1. **Usar as telas atuais manualmente**
Mais rápido, quase sem desenvolvimento.  
Problema: o fluxo fica espalhado e pouco adequado para testar ideias vindas de análise de mercado, como Marie Claire.

2. **Criar um novo módulo completo de “Experimentos Manuais”**
Mais limpo visualmente.  
Problema: risco alto de duplicar regra de nicho, hipótese, oferta e experimento.

3. **Criar um wizard manual dentro do fluxo atual**
Minha recomendação.  
Seria uma tela guiada que cria os registros oficiais no backend, respeitando a estrutura rígida atual, mas com uma experiência muito mais simples.

**Como eu faria**

Criaria uma entrada nova no sistema:

**Novo experimento manual**

Etapa 1: **Nicho**
- nome do nicho;
- público;
- dores principais;
- desejos;
- canais prováveis;
- referências de mercado, por exemplo “Marie Claire”.

Etapa 2: **Hipótese**
- dor;
- promessa;
- resultado esperado;
- mecanismo;
- prova;
- objeções;
- sinal de compra esperado.

Etapa 3: **Contrato Comercial**
Aqui entra a oferta testável:
- nome do produto;
- promessa principal;
- preço de teste;
- isca;
- bônus;
- CTA;
- garantia/mitigação de risco;
- limite da promessa;
- tipo de validação: lead, fake-door, pré-venda.

Etapa 4: **Experimento**
- canal inicial;
- orçamento;
- criativos manuais;
- copy dos anúncios;
- landing/formulário;
- métrica de aprovação;
- critério de descarte;
- critério para avançar para pré-venda.

**Ponto importante**

Eu não criaria uma tela para “produto” neste momento. Criaria uma tela para **oferta em validação**.

Produto é depois. Primeiro o sistema precisa provar que existe desejo, clique, lead, intenção de compra ou compra real.

**Para os produtos da Marie Claire, ficaria assim**

Exemplo:

- **Nicho:** mulheres urbanas interessadas em beleza, autocuidado e sofisticação acessível.
- **Hipótese:** mulheres querem parecer mais elegantes sem gastar com luxo.
- **Contrato Comercial:** Manual da Mulher Sofisticada, R$ 47, checklist gratuito como isca.
- **Experimento:** Meta Ads + landing + formulário + botão de intenção de compra.

Outro:

- **Nicho:** mulheres em relacionamento com insegurança emocional.
- **Hipótese:** mulheres querem identificar manipulação e recuperar clareza.
- **Contrato Comercial:** Mulher Blindada, R$ 67, checklist de sinais como isca.
- **Experimento:** campanha de leads + landing de diagnóstico + CTA para lista de prioridade.

**Minha recomendação objetiva**

Sim: criar um novo conjunto de telas, mas como **wizard de criação manual de experimento**, não como um módulo separado que grave fora do fluxo atual.

O objetivo da tela seria reduzir fricção para o operador transformar uma oportunidade de mercado em experimento real, mantendo tudo dentro da cadeia oficial:

**Nicho criado → Hipótese criada → Oferta/Contrato criado → Experimento criado → Funil medido**

Isso preserva rastreabilidade, evita mexer direto no banco e deixa o Marketing Hub mais útil para testar oportunidades comerciais rapidamente.

Última mensagem do usuário:
Ok concordo com vc e temos que identificar claramente que é um experimento gerado pelo fluxo manual.
Pode implementar.

**Resumo das alterações:**
Implementei o fluxo manual sem alterar dados direto no banco e sem acionar IA.

O que entrou:

- Novo endpoint backend: `POST /api/manual-experiments`
- Nova tela: `/experiments/manual/new`
- Menu em **Experimentos > Experimento manual**
- Criação encadeada oficial:
  **Nicho → Hipótese → Contrato Comercial → Experimento**
- Experimentos criados por esse fluxo agora ficam marcados com:
  `creation_source = MANUAL_FLOW`
- Listagem e detalhe do experimento exibem o selo **“Fluxo manual”**
- Liquibase adiciona a coluna `creation_source` em `experiment`, com default `SYSTEM_FLOW`, preservando os experimentos antigos

Também deixei o fluxo coerente com a regra de negócio: ele cria uma **oferta em validação**, não um produto definitivo. Assim conseguimos testar manualmente ideias como Marie Claire dentro da estrutura rígida atual do Marketing Hub.

Validações executadas:

- Backend `mvn -DskipTests compile`: passou
- Backend `mvn test`: passou, `1059` testes, `0` falhas
- Frontend `npm run build`: passou
- Frontend `npm run typecheck`: passou
- `git diff --check`: passou
- Validei o changelog mestre: nenhum include relativo sem `relativeToChangelogFile: true`

Limitações/observações:

- `mvn spotless:check` não está disponível neste módulo, o Maven retornou “No plugin found for prefix 'spotless'”.
- O `npm install --include=dev` reportou vulnerabilidades já existentes no ecossistema de dependências, mas não apliquei `audit fix` porque isso mudaria escopo.

Não criei PR.