### PR TITLE
AI Hub: Pronto para deploy.

Criei a estrutura A/B no Marketing Hub para página de venda **tradicional vs página com vídeo humano**:

- Banco/Liquibase: novas tabelas `experiment_sales_page_ab_test` e `experiment_sales_page_ab_variant`.
- Backend: entidad…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
@@ -10,5 +10,6 @@ public enum ExperimentReadinessIssueType {
     VIDEO_ASSET,
     TARGETING,
     GERA_LANDING,
-    GERA_SALES_PAGE
+    GERA_SALES_PAGE,
+    SALES_PAGE_AB_TEST
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbTest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbTest.java
@@ -1,0 +1,91 @@
+package com.marketinghub.experiment.salespageab;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Responsabilidade: guardar o plano de teste A/B de pagina de venda de um experimento. */
+@Entity
+@Table(name = "experiment_sales_page_ab_test")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentSalesPageAbTest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    @ToString.Exclude
+    private Experiment experiment;
+
+    @Column(name = "name", nullable = false, length = 191)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private ExperimentSalesPageAbTestStatus status;
+
+    @Column(name = "hypothesis", nullable = false, length = 1024)
+    private String hypothesis;
+
+    @Column(name = "primary_metric", nullable = false, length = 191)
+    private String primaryMetric;
+
+    @Column(name = "secondary_metrics", length = 512)
+    private String secondaryMetrics;
+
+    @Column(name = "winner_rule", nullable = false, length = 1024)
+    private String winnerRule;
+
+    @Column(name = "minimum_runtime_days", nullable = false)
+    private Integer minimumRuntimeDays;
+
+    @Column(name = "minimum_sample_size", nullable = false)
+    private Integer minimumSampleSize;
+
+    @Column(name = "meta_split_test_recommended", nullable = false)
+    private boolean metaSplitTestRecommended;
+
+    @Column(name = "notes", columnDefinition = "LONGTEXT")
+    private String notes;
+
+    @OneToMany(mappedBy = "test", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    @ToString.Exclude
+    private List<ExperimentSalesPageAbVariant> variants = new ArrayList<>();
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbTestStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbTestStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.salespageab;
+
+/** Responsabilidade: representar o estado operacional de um teste A/B de página de venda. */
+public enum ExperimentSalesPageAbTestStatus {
+    DRAFT,
+    READY,
+    RUNNING,
+    PAUSED,
+    FINISHED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariant.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariant.java
@@ -1,0 +1,95 @@
+package com.marketinghub.experiment.salespageab;
+
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Responsabilidade: guardar uma variante mensuravel dentro de um teste A/B de pagina de venda. */
+@Entity
+@Table(name = "experiment_sales_page_ab_variant")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentSalesPageAbVariant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ab_test_id", nullable = false)
+    @ToString.Exclude
+    private ExperimentSalesPageAbTest test;
+
+    @Column(name = "variant_key", nullable = false, length = 16)
+    private String variantKey;
+
+    @Column(name = "name", nullable = false, length = 191)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "variant_type", nullable = false, length = 32)
+    private ExperimentSalesPageAbVariantType variantType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private ExperimentSalesPageAbVariantStatus status;
+
+    @Column(name = "traffic_weight", nullable = false, precision = 5, scale = 2)
+    private BigDecimal trafficWeight;
+
+    @Column(name = "sales_page_url", length = 1024)
+    private String salesPageUrl;
+
+    @Column(name = "checkout_url", length = 1024)
+    private String checkoutUrl;
+
+    @Column(name = "ad_destination_url", length = 1024)
+    private String adDestinationUrl;
+
+    @Column(name = "analytics_variant_param", nullable = false, length = 64)
+    private String analyticsVariantParam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publication_audit_id")
+    @ToString.Exclude
+    private GeraSalesPagePublicationAudit publicationAudit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_video_asset_id")
+    @ToString.Exclude
+    private ExperimentVideoAsset experimentVideoAsset;
+
+    @Column(name = "required_collectors_present", nullable = false)
+    private boolean requiredCollectorsPresent;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariantStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariantStatus.java
@@ -1,0 +1,9 @@
+package com.marketinghub.experiment.salespageab;
+
+/** Responsabilidade: representar a prontidão individual de uma variante do teste A/B. */
+public enum ExperimentSalesPageAbVariantStatus {
+    DRAFT,
+    READY,
+    WINNER,
+    LOSER
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariantType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/ExperimentSalesPageAbVariantType.java
@@ -1,0 +1,7 @@
+package com.marketinghub.experiment.salespageab;
+
+/** Responsabilidade: classificar o formato comercial testado em uma variante de página de venda. */
+public enum ExperimentSalesPageAbVariantType {
+    TRADITIONAL,
+    HUMAN_VIDEO
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbTestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbTestDto.java
@@ -1,0 +1,24 @@
+package com.marketinghub.experiment.salespageab.dto;
+
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTestStatus;
+import java.time.Instant;
+import java.util.List;
+
+/** Responsabilidade: expor o plano de teste A/B de pagina de venda para UI e workers. */
+public record ExperimentSalesPageAbTestDto(
+        Long id,
+        Long experimentId,
+        String name,
+        ExperimentSalesPageAbTestStatus status,
+        String hypothesis,
+        String primaryMetric,
+        String secondaryMetrics,
+        String winnerRule,
+        Integer minimumRuntimeDays,
+        Integer minimumSampleSize,
+        boolean metaSplitTestRecommended,
+        String notes,
+        List<ExperimentSalesPageAbVariantDto> variants,
+        Instant createdAt,
+        Instant updatedAt) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbVariantDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbVariantDto.java
@@ -1,0 +1,25 @@
+package com.marketinghub.experiment.salespageab.dto;
+
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantStatus;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantType;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsabilidade: expor uma variante de teste A/B para UI e workers. */
+public record ExperimentSalesPageAbVariantDto(
+        Long id,
+        String variantKey,
+        String name,
+        ExperimentSalesPageAbVariantType variantType,
+        ExperimentSalesPageAbVariantStatus status,
+        BigDecimal trafficWeight,
+        String salesPageUrl,
+        String checkoutUrl,
+        String adDestinationUrl,
+        String analyticsVariantParam,
+        Long publicationAuditId,
+        Long experimentVideoAssetId,
+        boolean requiredCollectorsPresent,
+        Instant createdAt,
+        Instant updatedAt) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/UpdateExperimentSalesPageAbVariantRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/UpdateExperimentSalesPageAbVariantRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.experiment.salespageab.dto;
+
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantStatus;
+import java.math.BigDecimal;
+
+/** Responsabilidade: receber alteracoes operacionais de uma variante A/B. */
+public record UpdateExperimentSalesPageAbVariantRequest(
+        ExperimentSalesPageAbVariantStatus status,
+        BigDecimal trafficWeight,
+        String salesPageUrl,
+        String checkoutUrl,
+        String adDestinationUrl,
+        String analyticsVariantParam,
+        Long publicationAuditId,
+        Long experimentVideoAssetId,
+        Boolean requiredCollectorsPresent) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
@@ -1,0 +1,268 @@
+package com.marketinghub.experiment.salespageab.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTest;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTestStatus;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariant;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantStatus;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantType;
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbTestDto;
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbVariantDto;
+import com.marketinghub.experiment.salespageab.dto.UpdateExperimentSalesPageAbVariantRequest;
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbTestRepository;
+import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbVariantRepository;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: criar e manter testes A/B de pagina de venda ligados ao experimento. */
+@Service
+public class ExperimentSalesPageAbTestService {
+    private static final BigDecimal HALF_TRAFFIC = new BigDecimal("50.00");
+    private static final List<ExperimentSalesPageAbTestStatus> ACTIVE_STATUSES = List.of(
+            ExperimentSalesPageAbTestStatus.DRAFT,
+            ExperimentSalesPageAbTestStatus.READY,
+            ExperimentSalesPageAbTestStatus.RUNNING);
+
+    private final ExperimentSalesPageAbTestRepository testRepository;
+    private final ExperimentSalesPageAbVariantRepository variantRepository;
+    private final ExperimentRepository experimentRepository;
+    private final GeraSalesPagePublicationAuditRepository publicationAuditRepository;
+    private final ExperimentVideoAssetRepository videoAssetRepository;
+
+    /** Inicializa o servico com as fontes canonicas de experimento, publicacao e video. */
+    public ExperimentSalesPageAbTestService(ExperimentSalesPageAbTestRepository testRepository,
+                                            ExperimentSalesPageAbVariantRepository variantRepository,
+                                            ExperimentRepository experimentRepository,
+                                            GeraSalesPagePublicationAuditRepository publicationAuditRepository,
+                                            ExperimentVideoAssetRepository videoAssetRepository) {
+        this.testRepository = testRepository;
+        this.variantRepository = variantRepository;
+        this.experimentRepository = experimentRepository;
+        this.publicationAuditRepository = publicationAuditRepository;
+        this.videoAssetRepository = videoAssetRepository;
+    }
+
+    /** Cria o plano padrao recomendado para Meta: pagina tradicional contra pagina com video humano. */
+    @Transactional
+    public ExperimentSalesPageAbTestDto createMetaVideoVsTraditional(Long experimentId) {
+        Experiment experiment = findExperiment(experimentId);
+        ExperimentSalesPageAbTest test = ExperimentSalesPageAbTest.builder()
+                .experiment(experiment)
+                .name("A/B Meta - pagina tradicional vs video humano")
+                .status(ExperimentSalesPageAbTestStatus.DRAFT)
+                .hypothesis("Video humano curto antes da prova visual aumenta confianca e clique no checkout sem alterar oferta, preco, publico ou criativo.")
+                .primaryMetric("checkout_click_rate")
+                .secondaryMetrics("purchase_rate,cost_per_checkout_click,cost_per_purchase,video_50_percent")
+                .winnerRule("Vencer a variante com melhor custo por checkout_click; confirmar por purchase quando houver volume suficiente.")
+                .minimumRuntimeDays(7)
+                .minimumSampleSize(100)
+                .metaSplitTestRecommended(true)
+                .notes("Manter oferta, preco, checkout, publico, criativos e orcamento equivalentes. Testar apenas a presenca do video humano.")
+                .build();
+        test.getVariants().add(buildVariant(test, "A", "Pagina tradicional", ExperimentSalesPageAbVariantType.TRADITIONAL));
+        test.getVariants().add(buildVariant(test, "B", "Pagina com video humano", ExperimentSalesPageAbVariantType.HUMAN_VIDEO));
+        return toDto(testRepository.save(test));
+    }
+
+    /** Lista os planos A/B cadastrados para um experimento. */
+    @Transactional(readOnly = true)
+    public List<ExperimentSalesPageAbTestDto> list(Long experimentId) {
+        findExperiment(experimentId);
+        return testRepository.findByExperimentIdOrderByCreatedAtDesc(experimentId).stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    /** Retorna o teste aberto mais recente para validar prontidao e informar workers de campanha. */
+    @Transactional(readOnly = true)
+    public Optional<ExperimentSalesPageAbTestDto> findActiveForCampaign(Long experimentId) {
+        return testRepository.findTopByExperimentIdAndStatusInOrderByUpdatedAtDesc(experimentId, ACTIVE_STATUSES)
+                .map(this::toDto);
+    }
+
+    /** Atualiza uma variante com URLs, vinculos de auditoria e status de prontidao. */
+    @Transactional
+    public ExperimentSalesPageAbTestDto updateVariant(
+            Long experimentId,
+            Long variantId,
+            UpdateExperimentSalesPageAbVariantRequest request) {
+        findExperiment(experimentId);
+        ExperimentSalesPageAbVariant variant = variantRepository.findByIdAndTestExperimentId(variantId, experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "ab test variant not found"));
+        applyVariantUpdate(variant, request, experimentId);
+        normalizeTestStatus(variant.getTest());
+        variantRepository.save(variant);
+        return toDto(variant.getTest());
+    }
+
+    /** Verifica se o teste A/B ativo possui duas variantes prontas e equivalentes para campanha. */
+    @Transactional(readOnly = true)
+    public boolean hasReadyActiveTest(Long experimentId) {
+        return findActiveForCampaign(experimentId)
+                .map(test -> test.variants().size() == 2
+                        && test.variants().stream().allMatch(this::isVariantReadyForTraffic))
+                .orElse(true);
+    }
+
+    /** Cria uma variante inicial com divisao de trafego 50/50. */
+    private ExperimentSalesPageAbVariant buildVariant(
+            ExperimentSalesPageAbTest test,
+            String key,
+            String name,
+            ExperimentSalesPageAbVariantType type) {
+        return ExperimentSalesPageAbVariant.builder()
+                .test(test)
+                .variantKey(key)
+                .name(name)
+                .variantType(type)
+                .status(ExperimentSalesPageAbVariantStatus.DRAFT)
+                .trafficWeight(HALF_TRAFFIC)
+                .analyticsVariantParam("ab=" + key.toLowerCase())
+                .requiredCollectorsPresent(false)
+                .build();
+    }
+
+    /** Aplica somente os campos enviados na variante. */
+    private void applyVariantUpdate(
+            ExperimentSalesPageAbVariant variant,
+            UpdateExperimentSalesPageAbVariantRequest request,
+            Long experimentId) {
+        if (request == null) {
+            return;
+        }
+        if (request.status() != null) {
+            variant.setStatus(request.status());
+        }
+        if (request.trafficWeight() != null) {
+            variant.setTrafficWeight(request.trafficWeight());
+        }
+        if (request.salesPageUrl() != null) {
+            variant.setSalesPageUrl(request.salesPageUrl());
+        }
+        if (request.checkoutUrl() != null) {
+            variant.setCheckoutUrl(request.checkoutUrl());
+        }
+        if (request.adDestinationUrl() != null) {
+            variant.setAdDestinationUrl(request.adDestinationUrl());
+        }
+        if (request.analyticsVariantParam() != null) {
+            variant.setAnalyticsVariantParam(request.analyticsVariantParam());
+        }
+        if (request.requiredCollectorsPresent() != null) {
+            variant.setRequiredCollectorsPresent(request.requiredCollectorsPresent());
+        }
+        if (request.publicationAuditId() != null) {
+            variant.setPublicationAudit(resolvePublicationAudit(request.publicationAuditId(), experimentId));
+        }
+        if (request.experimentVideoAssetId() != null) {
+            variant.setExperimentVideoAsset(resolveVideoAsset(request.experimentVideoAssetId(), experimentId));
+        }
+    }
+
+    /** Promove o teste para READY apenas quando as duas variantes estao prontas para trafego. */
+    private void normalizeTestStatus(ExperimentSalesPageAbTest test) {
+        boolean ready = test.getVariants() != null
+                && test.getVariants().size() == 2
+                && test.getVariants().stream().allMatch(variant -> isVariantReadyForTraffic(toVariantDto(variant)));
+        if (ready && test.getStatus() == ExperimentSalesPageAbTestStatus.DRAFT) {
+            test.setStatus(ExperimentSalesPageAbTestStatus.READY);
+        }
+    }
+
+    /** Busca o experimento alvo ou retorna erro HTTP claro. */
+    private Experiment findExperiment(Long experimentId) {
+        return experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "experiment not found"));
+    }
+
+    /** Busca a auditoria de publicacao e impede vinculo com outro experimento. */
+    private GeraSalesPagePublicationAudit resolvePublicationAudit(Long auditId, Long experimentId) {
+        GeraSalesPagePublicationAudit audit = publicationAuditRepository.findById(auditId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "publication audit not found"));
+        if (!experimentId.equals(audit.getExperimentId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "publication audit belongs to another experiment");
+        }
+        return audit;
+    }
+
+    /** Busca o video e impede vinculo com outro experimento. */
+    private ExperimentVideoAsset resolveVideoAsset(Long videoAssetId, Long experimentId) {
+        ExperimentVideoAsset asset = videoAssetRepository.findById(videoAssetId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "video asset not found"));
+        Long assetExperimentId = asset.getExperiment() != null ? asset.getExperiment().getId() : null;
+        if (!experimentId.equals(assetExperimentId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "video asset belongs to another experiment");
+        }
+        return asset;
+    }
+
+    /** Confirma se a variante pode receber trafego pago. */
+    private boolean isVariantReadyForTraffic(ExperimentSalesPageAbVariantDto variant) {
+        return variant.status() == ExperimentSalesPageAbVariantStatus.READY
+                && StringUtils.hasText(variant.salesPageUrl())
+                && StringUtils.hasText(variant.adDestinationUrl())
+                && variant.salesPageUrl().equals(variant.adDestinationUrl())
+                && StringUtils.hasText(variant.checkoutUrl())
+                && variant.requiredCollectorsPresent()
+                && variant.trafficWeight() != null
+                && variant.trafficWeight().signum() > 0;
+    }
+
+    /** Converte o teste para contrato de API com variantes ordenadas. */
+    private ExperimentSalesPageAbTestDto toDto(ExperimentSalesPageAbTest test) {
+        List<ExperimentSalesPageAbVariantDto> variants = test.getVariants() == null
+                ? List.of()
+                : test.getVariants().stream()
+                .sorted(Comparator.comparing(ExperimentSalesPageAbVariant::getVariantKey))
+                .map(this::toVariantDto)
+                .toList();
+        return new ExperimentSalesPageAbTestDto(
+                test.getId(),
+                test.getExperiment() != null ? test.getExperiment().getId() : null,
+                test.getName(),
+                test.getStatus(),
+                test.getHypothesis(),
+                test.getPrimaryMetric(),
+                test.getSecondaryMetrics(),
+                test.getWinnerRule(),
+                test.getMinimumRuntimeDays(),
+                test.getMinimumSampleSize(),
+                test.isMetaSplitTestRecommended(),
+                test.getNotes(),
+                variants,
+                test.getCreatedAt(),
+                test.getUpdatedAt());
+    }
+
+    /** Converte a variante para contrato de API. */
+    private ExperimentSalesPageAbVariantDto toVariantDto(ExperimentSalesPageAbVariant variant) {
+        return new ExperimentSalesPageAbVariantDto(
+                variant.getId(),
+                variant.getVariantKey(),
+                variant.getName(),
+                variant.getVariantType(),
+                variant.getStatus(),
+                variant.getTrafficWeight(),
+                variant.getSalesPageUrl(),
+                variant.getCheckoutUrl(),
+                variant.getAdDestinationUrl(),
+                variant.getAnalyticsVariantParam(),
+                variant.getPublicationAudit() != null ? variant.getPublicationAudit().getId() : null,
+                variant.getExperimentVideoAsset() != null ? variant.getExperimentVideoAsset().getId() : null,
+                variant.isRequiredCollectorsPresent(),
+                variant.getCreatedAt(),
+                variant.getUpdatedAt());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/web/ExperimentSalesPageAbTestController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/web/ExperimentSalesPageAbTestController.java
@@ -1,0 +1,45 @@
+package com.marketinghub.experiment.salespageab.web;
+
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbTestDto;
+import com.marketinghub.experiment.salespageab.dto.UpdateExperimentSalesPageAbVariantRequest;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor operacoes de teste A/B de pagina de venda por experimento. */
+@RestController
+@RequestMapping("/api/experiments/{experimentId}/sales-page-ab-tests")
+public class ExperimentSalesPageAbTestController {
+    private final ExperimentSalesPageAbTestService service;
+
+    /** Inicializa o controller com o servico de testes A/B de pagina de venda. */
+    public ExperimentSalesPageAbTestController(ExperimentSalesPageAbTestService service) {
+        this.service = service;
+    }
+
+    /** Lista os testes A/B cadastrados no experimento. */
+    @GetMapping
+    public List<ExperimentSalesPageAbTestDto> list(@PathVariable Long experimentId) {
+        return service.list(experimentId);
+    }
+
+    /** Cria o teste recomendado para Meta: tradicional contra video humano. */
+    @PostMapping("/meta-video-vs-traditional")
+    public ExperimentSalesPageAbTestDto createMetaVideoVsTraditional(@PathVariable Long experimentId) {
+        return service.createMetaVideoVsTraditional(experimentId);
+    }
+
+    /** Atualiza os dados operacionais de uma variante do teste A/B. */
+    @PatchMapping("/variants/{variantId}")
+    public ExperimentSalesPageAbTestDto updateVariant(@PathVariable Long experimentId,
+                                                      @PathVariable Long variantId,
+                                                      @RequestBody UpdateExperimentSalesPageAbVariantRequest request) {
+        return service.updateVariant(experimentId, variantId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -15,6 +15,7 @@ import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,19 +64,22 @@ public class ExperimentReadinessService {
 
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
     private final ExperimentVideoAssetService experimentVideoAssetService;
+    private final ExperimentSalesPageAbTestService salesPageAbTestService;
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
                                       GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
                                       ExperimentCampaignDestinationPolicy campaignDestinationPolicy,
-                                      ExperimentVideoAssetService experimentVideoAssetService) {
+                                      ExperimentVideoAssetService experimentVideoAssetService,
+                                      ExperimentSalesPageAbTestService salesPageAbTestService) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
         this.campaignDestinationPolicy = campaignDestinationPolicy;
         this.experimentVideoAssetService = experimentVideoAssetService;
+        this.salesPageAbTestService = salesPageAbTestService;
     }
 
     /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
@@ -98,6 +102,7 @@ public class ExperimentReadinessService {
         boolean hasCommercialContract = campaignDestinationPolicy.hasCompleteCommercialContract(experiment);
         boolean hasGeraSalesPagePipeline = campaignDestinationPolicy.hasCompletedGeraSalesPagePipeline(experimentId);
         boolean hasRequiredVideoBlockingRelease = hasRequiredVideoBlockingRelease(experiment);
+        boolean hasReadySalesPageAbTest = salesPageAbTestService.hasReadyActiveTest(experimentId);
         Optional<GeraSalesPagePublicationAudit> salesPagePublication =
                 campaignDestinationPolicy.latestSalesPagePublication(experimentId);
 
@@ -135,6 +140,15 @@ public class ExperimentReadinessService {
                     "Vídeo obrigatório ainda não aprovado",
                     "Este experimento possui vídeo obrigatório para o funil, mas o ativo ainda não está pronto e aprovado.",
                     "Finalize a geração, revise o vídeo e aprove o ativo antes de liberar tráfego.",
+                    List.of()
+            ));
+        }
+        if (!hasReadySalesPageAbTest) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.SALES_PAGE_AB_TEST,
+                    "Teste A/B de página incompleto",
+                    "Existe um teste A/B ativo para a página de venda, mas as duas variantes ainda não estão prontas para tráfego.",
+                    "Configure página, checkout, destino do anúncio, coletores e divisão de tráfego das duas variantes antes de liberar a campanha.",
                     List.of()
             ));
         }
@@ -234,6 +248,9 @@ public class ExperimentReadinessService {
         }
         if (hasRequiredVideoBlockingRelease(experiment)) {
             missing.add("experimentVideoAsset");
+        }
+        if (!salesPageAbTestService.hasReadyActiveTest(experiment.getId())) {
+            missing.add("salesPageAbTest");
         }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("approvedTargetingPackage");

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -16,6 +16,9 @@ import com.marketinghub.experiment.ExperimentCampaignMetric;
 import com.marketinghub.experiment.funnel.ExperimentFunnelAutoStopService;
 import com.marketinghub.experiment.service.ExperimentCampaignMetricService;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbTestDto;
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbVariantDto;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
 import com.marketinghub.journey.model.JourneyStep;
 import com.marketinghub.journey.model.JourneyStimulusType;
 import com.marketinghub.leadportal.LeadPortalFlow;
@@ -106,6 +109,7 @@ public class FacebookAdsCampaignController {
     private final FacebookCampaignRecommendationService recommendationService;
     private final FacebookCampaignPublicationJobStepService publicationJobStepService;
     private final CampaignStrategyService campaignStrategyService;
+    private final ExperimentSalesPageAbTestService salesPageAbTestService;
 
     /**
      * Cria o controller com os repositórios e serviços usados pelos contratos de campanhas Facebook.
@@ -126,7 +130,8 @@ public class FacebookAdsCampaignController {
                                          LeadPortalMetricsService leadPortalMetricsService,
                                          FacebookCampaignRecommendationService recommendationService,
                                          FacebookCampaignPublicationJobStepService publicationJobStepService,
-                                         CampaignStrategyService campaignStrategyService) {
+                                         CampaignStrategyService campaignStrategyService,
+                                         ExperimentSalesPageAbTestService salesPageAbTestService) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
         this.accountRepository = accountRepository;
@@ -144,6 +149,7 @@ public class FacebookAdsCampaignController {
         this.recommendationService = recommendationService;
         this.publicationJobStepService = publicationJobStepService;
         this.campaignStrategyService = campaignStrategyService;
+        this.salesPageAbTestService = salesPageAbTestService;
     }
 
     @GetMapping("/experiments-ready")
@@ -761,7 +767,47 @@ public class FacebookAdsCampaignController {
                 buildPublicationJobId(experiment),
                 toLeadPortalFunnelSummary(leadPortalMetrics),
                 toMetricSummary(experiment.getCampaignMetric()),
-                toCampaignStrategySummary(campaignStrategyService.findLatestByExperimentId(experiment.getId())));
+                toCampaignStrategySummary(campaignStrategyService.findLatestByExperimentId(experiment.getId())),
+                toSalesPageAbTestSummary(salesPageAbTestService.findActiveForCampaign(experiment.getId()).orElse(null)));
+    }
+
+    // Converte o teste A/B de pagina de venda para resumo consumido pelo worker Meta.
+    private SalesPageAbTestSummary toSalesPageAbTestSummary(ExperimentSalesPageAbTestDto test) {
+        if (test == null) {
+            return null;
+        }
+        List<SalesPageAbVariantSummary> variants = test.variants() == null
+                ? List.of()
+                : test.variants().stream()
+                .map(this::toSalesPageAbVariantSummary)
+                .toList();
+        return new SalesPageAbTestSummary(
+                test.id(),
+                test.name(),
+                test.status() != null ? test.status().name() : null,
+                test.primaryMetric(),
+                test.winnerRule(),
+                test.minimumRuntimeDays(),
+                test.minimumSampleSize(),
+                test.metaSplitTestRecommended(),
+                variants);
+    }
+
+    // Converte uma variante A/B para resumo consumido pelo worker Meta.
+    private SalesPageAbVariantSummary toSalesPageAbVariantSummary(ExperimentSalesPageAbVariantDto variant) {
+        return new SalesPageAbVariantSummary(
+                variant.id(),
+                variant.variantKey(),
+                variant.name(),
+                variant.variantType() != null ? variant.variantType().name() : null,
+                variant.status() != null ? variant.status().name() : null,
+                variant.trafficWeight(),
+                variant.salesPageUrl(),
+                variant.checkoutUrl(),
+                variant.adDestinationUrl(),
+                variant.analyticsVariantParam(),
+                variant.experimentVideoAssetId(),
+                variant.requiredCollectorsPresent());
     }
 
     // Converte a estrategia de campanha para resumo consumido pela tela.
@@ -952,7 +998,8 @@ public class FacebookAdsCampaignController {
             String publicationJobId,
             LeadPortalFunnelSummary leadPortalFunnel,
             CampaignMetricSummary metrics,
-            CampaignStrategySummary campaignStrategy) {}
+            CampaignStrategySummary campaignStrategy,
+            SalesPageAbTestSummary salesPageAbTest) {}
 
     public record LeadPortalFlowSummary(Long id, String name, String slug, String publicUrl) {}
 
@@ -992,6 +1039,31 @@ public class FacebookAdsCampaignController {
             Long minimumLinkClicks,
             Long minimumImpressions,
             boolean enabled) {}
+
+    public record SalesPageAbTestSummary(
+            Long id,
+            String name,
+            String status,
+            String primaryMetric,
+            String winnerRule,
+            Integer minimumRuntimeDays,
+            Integer minimumSampleSize,
+            boolean metaSplitTestRecommended,
+            List<SalesPageAbVariantSummary> variants) {}
+
+    public record SalesPageAbVariantSummary(
+            Long id,
+            String variantKey,
+            String name,
+            String variantType,
+            String status,
+            BigDecimal trafficWeight,
+            String salesPageUrl,
+            String checkoutUrl,
+            String adDestinationUrl,
+            String analyticsVariantParam,
+            Long experimentVideoAssetId,
+            boolean requiredCollectorsPresent) {}
 
     public record CampaignMetricsSyncTarget(String campaignId, Long experimentId, Instant lastSyncedAt) {}
 

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespageab/ExperimentSalesPageAbTestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespageab/ExperimentSalesPageAbTestRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.repository.jpa.experiment.salespageab;
+
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTest;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTestStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: acessar planos de teste A/B de pagina de venda persistidos. */
+public interface ExperimentSalesPageAbTestRepository extends JpaRepository<ExperimentSalesPageAbTest, Long> {
+    /** Lista os testes A/B de um experimento em ordem recente. */
+    List<ExperimentSalesPageAbTest> findByExperimentIdOrderByCreatedAtDesc(Long experimentId);
+
+    /** Busca o teste A/B ativo ou pronto mais recente de um experimento. */
+    Optional<ExperimentSalesPageAbTest> findTopByExperimentIdAndStatusInOrderByUpdatedAtDesc(
+            Long experimentId,
+            List<ExperimentSalesPageAbTestStatus> statuses);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespageab/ExperimentSalesPageAbVariantRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespageab/ExperimentSalesPageAbVariantRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.experiment.salespageab;
+
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: acessar variantes de teste A/B de pagina de venda persistidas. */
+public interface ExperimentSalesPageAbVariantRepository extends JpaRepository<ExperimentSalesPageAbVariant, Long> {
+    /** Lista as variantes de um teste A/B. */
+    List<ExperimentSalesPageAbVariant> findByTestIdOrderByVariantKeyAsc(Long testId);
+
+    /** Busca uma variante garantindo que pertence ao experimento informado. */
+    Optional<ExperimentSalesPageAbVariant> findByIdAndTestExperimentId(Long id, Long experimentId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-09-sales-page-ab-test.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-09-sales-page-ab-test.yaml
@@ -1,0 +1,84 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-09-01-create-sales-page-ab-test
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_sales_page_ab_test
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_sales_page_ab_test (
+                  id BIGINT NOT NULL AUTO_INCREMENT,
+                  experiment_id BIGINT NOT NULL,
+                  name VARCHAR(191) NOT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  hypothesis VARCHAR(1024) NOT NULL,
+                  primary_metric VARCHAR(191) NOT NULL,
+                  secondary_metrics VARCHAR(512) NULL,
+                  winner_rule VARCHAR(1024) NOT NULL,
+                  minimum_runtime_days INT NOT NULL,
+                  minimum_sample_size INT NOT NULL,
+                  meta_split_test_recommended BIT(1) NOT NULL DEFAULT b'1',
+                  notes LONGTEXT NULL,
+                  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id),
+                  CONSTRAINT fk_sales_page_ab_test_experiment
+                      FOREIGN KEY (experiment_id) REFERENCES experiment (id)
+              );
+              CREATE INDEX idx_sales_page_ab_test_experiment_status
+                  ON experiment_sales_page_ab_test (experiment_id, status, updated_at);
+
+  - changeSet:
+      id: 2026-07-09-02-create-sales-page-ab-variant
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_sales_page_ab_variant
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_sales_page_ab_variant (
+                  id BIGINT NOT NULL AUTO_INCREMENT,
+                  ab_test_id BIGINT NOT NULL,
+                  variant_key VARCHAR(16) NOT NULL,
+                  name VARCHAR(191) NOT NULL,
+                  variant_type VARCHAR(32) NOT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  traffic_weight DECIMAL(5, 2) NOT NULL,
+                  sales_page_url VARCHAR(1024) NULL,
+                  checkout_url VARCHAR(1024) NULL,
+                  ad_destination_url VARCHAR(1024) NULL,
+                  analytics_variant_param VARCHAR(64) NOT NULL,
+                  publication_audit_id BIGINT NULL,
+                  experiment_video_asset_id BIGINT NULL,
+                  required_collectors_present BIT(1) NOT NULL DEFAULT b'0',
+                  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id),
+                  CONSTRAINT fk_sales_page_ab_variant_test
+                      FOREIGN KEY (ab_test_id) REFERENCES experiment_sales_page_ab_test (id),
+                  CONSTRAINT fk_sales_page_ab_variant_publication_audit
+                      FOREIGN KEY (publication_audit_id) REFERENCES gera_sales_page_publication_audit (id),
+                  CONSTRAINT fk_sales_page_ab_variant_video_asset
+                      FOREIGN KEY (experiment_video_asset_id) REFERENCES experiment_video_asset (id),
+                  CONSTRAINT uk_sales_page_ab_variant_key
+                      UNIQUE (ab_test_id, variant_key)
+              );
+              CREATE INDEX idx_sales_page_ab_variant_test_status
+                  ON experiment_sales_page_ab_variant (ab_test_id, status);
+              CREATE INDEX idx_sales_page_ab_variant_type
+                  ON experiment_sales_page_ab_variant (variant_type);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1278,3 +1278,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-07-09-facebook-campaign-final-metrics-sync.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-07-09-sales-page-ab-test.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
@@ -1,0 +1,146 @@
+package com.marketinghub.experiment.salespageab.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTest;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbTestStatus;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariant;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantStatus;
+import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantType;
+import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbTestDto;
+import com.marketinghub.experiment.salespageab.dto.UpdateExperimentSalesPageAbVariantRequest;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbTestRepository;
+import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbVariantRepository;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
+import com.marketinghub.repository.jpa.gerasalespage.v1.GeraSalesPagePublicationAuditRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/** Valida a estrutura operacional de teste A/B de pagina de venda. */
+@ExtendWith(MockitoExtension.class)
+class ExperimentSalesPageAbTestServiceTest {
+    @Mock
+    private ExperimentSalesPageAbTestRepository testRepository;
+    @Mock
+    private ExperimentSalesPageAbVariantRepository variantRepository;
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private GeraSalesPagePublicationAuditRepository publicationAuditRepository;
+    @Mock
+    private ExperimentVideoAssetRepository videoAssetRepository;
+
+    private ExperimentSalesPageAbTestService service;
+
+    /** Inicializa o servico com repositorios simulados para testes unitarios. */
+    @BeforeEach
+    void setUp() {
+        service = new ExperimentSalesPageAbTestService(
+                testRepository,
+                variantRepository,
+                experimentRepository,
+                publicationAuditRepository,
+                videoAssetRepository);
+    }
+
+    /** Garante que o plano padrao nasce com duas variantes equivalentes e metrica de checkout. */
+    @Test
+    void shouldCreateMetaVideoVsTraditionalTest() {
+        Experiment experiment = Experiment.builder().id(60L).name("Agenda Fechada").build();
+        given(experimentRepository.findById(60L)).willReturn(Optional.of(experiment));
+        given(testRepository.save(any(ExperimentSalesPageAbTest.class))).willAnswer(invocation -> {
+            ExperimentSalesPageAbTest saved = invocation.getArgument(0);
+            saved.setId(11L);
+            saved.getVariants().get(0).setId(21L);
+            saved.getVariants().get(1).setId(22L);
+            return saved;
+        });
+
+        ExperimentSalesPageAbTestDto dto = service.createMetaVideoVsTraditional(60L);
+
+        assertThat(dto.id()).isEqualTo(11L);
+        assertThat(dto.experimentId()).isEqualTo(60L);
+        assertThat(dto.status()).isEqualTo(ExperimentSalesPageAbTestStatus.DRAFT);
+        assertThat(dto.primaryMetric()).isEqualTo("checkout_click_rate");
+        assertThat(dto.metaSplitTestRecommended()).isTrue();
+        assertThat(dto.variants()).hasSize(2);
+        assertThat(dto.variants()).extracting("variantType")
+                .containsExactly(
+                        ExperimentSalesPageAbVariantType.TRADITIONAL,
+                        ExperimentSalesPageAbVariantType.HUMAN_VIDEO);
+        assertThat(dto.variants()).extracting("trafficWeight")
+                .containsExactly(new BigDecimal("50.00"), new BigDecimal("50.00"));
+    }
+
+    /** Garante que uma variante pronta precisa de pagina, checkout, destino e coletores. */
+    @Test
+    void shouldPromoteTestToReadyWhenBothVariantsAreReady() {
+        Experiment experiment = Experiment.builder().id(60L).build();
+        ExperimentSalesPageAbTest test = ExperimentSalesPageAbTest.builder()
+                .id(11L)
+                .experiment(experiment)
+                .name("A/B")
+                .status(ExperimentSalesPageAbTestStatus.DRAFT)
+                .hypothesis("Video aumenta confianca")
+                .primaryMetric("checkout_click_rate")
+                .winnerRule("menor custo por checkout")
+                .minimumRuntimeDays(7)
+                .minimumSampleSize(100)
+                .metaSplitTestRecommended(true)
+                .build();
+        ExperimentSalesPageAbVariant variantA = readyVariant(test, 21L, "A", ExperimentSalesPageAbVariantType.TRADITIONAL);
+        ExperimentSalesPageAbVariant variantB = readyVariant(test, 22L, "B", ExperimentSalesPageAbVariantType.HUMAN_VIDEO);
+        test.getVariants().add(variantA);
+        test.getVariants().add(variantB);
+        given(experimentRepository.findById(60L)).willReturn(Optional.of(experiment));
+        given(variantRepository.findByIdAndTestExperimentId(22L, 60L)).willReturn(Optional.of(variantB));
+        given(variantRepository.save(variantB)).willReturn(variantB);
+
+        ExperimentSalesPageAbTestDto dto = service.updateVariant(
+                60L,
+                22L,
+                new UpdateExperimentSalesPageAbVariantRequest(
+                        ExperimentSalesPageAbVariantStatus.READY,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        true));
+
+        assertThat(dto.status()).isEqualTo(ExperimentSalesPageAbTestStatus.READY);
+    }
+
+    /** Cria uma variante pronta para uso em testes do servico. */
+    private ExperimentSalesPageAbVariant readyVariant(
+            ExperimentSalesPageAbTest test,
+            Long id,
+            String key,
+            ExperimentSalesPageAbVariantType type) {
+        return ExperimentSalesPageAbVariant.builder()
+                .id(id)
+                .test(test)
+                .variantKey(key)
+                .name("Variante " + key)
+                .variantType(type)
+                .status(ExperimentSalesPageAbVariantStatus.READY)
+                .trafficWeight(new BigDecimal("50.00"))
+                .salesPageUrl("https://example.com/sales-" + key.toLowerCase())
+                .checkoutUrl("https://checkout.example.com/" + key.toLowerCase())
+                .adDestinationUrl("https://example.com/sales-" + key.toLowerCase())
+                .analyticsVariantParam("ab=" + key.toLowerCase())
+                .requiredCollectorsPresent(true)
+                .build();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
@@ -40,6 +41,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +61,8 @@ class ExperimentReadinessServiceTest {
     private GeraSalesPagePublicationAuditRepository geraSalesPagePublicationAuditRepository;
     @Mock
     private ExperimentVideoAssetService experimentVideoAssetService;
+    @Mock
+    private ExperimentSalesPageAbTestService salesPageAbTestService;
 
     private ExperimentReadinessService service;
 
@@ -73,7 +77,9 @@ class ExperimentReadinessServiceTest {
                 targetingSelectionRepository,
                 geraLandingStageExecutionRepository,
                 campaignDestinationPolicy,
-                experimentVideoAssetService);
+                experimentVideoAssetService,
+                salesPageAbTestService);
+        lenient().when(salesPageAbTestService.hasReadyActiveTest(org.mockito.ArgumentMatchers.anyLong())).thenReturn(true);
     }
 
     @Test
@@ -154,6 +160,21 @@ class ExperimentReadinessServiceTest {
 
         assertThat(service.computeMissingConfiguration(experiment))
                 .containsExactly("experimentVideoAsset");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    /** Garante que teste A/B ativo incompleto bloqueia a liberacao para campanha. */
+    @Test
+    void shouldBlockCampaignWhenActiveSalesPageAbTestIsIncomplete() {
+        Experiment experiment = buildExperiment(44L, 54L);
+        experiment.setFollowUpActionUrl("https://example.com/landing/44");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(44L, CreativeStatus.READY)).thenReturn(true);
+        when(salesPageAbTestService.hasReadyActiveTest(44L)).thenReturn(false);
+        mockPublishableSelection(44L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("salesPageAbTest");
         assertThat(service.isReadyForCampaign(experiment)).isFalse();
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -23,6 +23,7 @@ import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
 import com.marketinghub.facebookads.FacebookAdsAd;
 import com.marketinghub.facebookads.FacebookAdsAdCreative;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdCreativeRepository;
@@ -123,6 +124,8 @@ class FacebookAdsCampaignControllerTest {
     FacebookCampaignPublicationJobStepService publicationJobStepService;
     @MockBean
     CampaignStrategyService campaignStrategyService;
+    @MockBean
+    ExperimentSalesPageAbTestService salesPageAbTestService;
 
     @MockBean
     LeadPortalMetricsService leadPortalMetricsService;

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
@@ -18,6 +18,7 @@ import com.marketinghub.experiment.funnel.dto.FunnelThresholdCheckDto;
 import com.marketinghub.experiment.service.ExperimentCampaignMetricService;
 import com.marketinghub.experiment.service.ExperimentReadinessService;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
 import com.marketinghub.facebookads.FacebookAdStatus;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookCampaignStopReason;
@@ -100,6 +101,8 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
     private ExperimentCampaignMetricRepository campaignMetricRepository;
     @Mock
     private CampaignStrategyService campaignStrategyService;
+    @Mock
+    private ExperimentSalesPageAbTestService salesPageAbTestService;
 
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
@@ -130,7 +133,8 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
                 leadPortalMetricsService,
                 recommendationService,
                 org.mockito.Mockito.mock(FacebookCampaignPublicationJobStepService.class),
-                campaignStrategyService
+                campaignStrategyService,
+                salesPageAbTestService
         );
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }

--- a/docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md
+++ b/docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md
@@ -1,0 +1,63 @@
+# Teste A/B de pagina de venda: video humano vs tradicional
+
+## Objetivo comercial
+
+Validar se uma pagina de venda com video curto de uma pessoa explicando o produto aumenta confianca, clique no checkout e compra em relacao a uma pagina tradicional, sem alterar oferta, preco, publico, criativo ou checkout.
+
+## Estrutura criada no Marketing Hub
+
+- Entidade `experiment_sales_page_ab_test`: plano do teste, hipotese, metrica principal, regra de vencedor, duracao minima e recomendacao de Split Test Meta.
+- Entidade `experiment_sales_page_ab_variant`: variantes A e B com tipo, peso de trafego, URL da pagina, URL de checkout, URL de destino do anuncio, parametro de analytics e vinculo opcional com video.
+- Endpoint de criacao: `POST /api/experiments/{experimentId}/sales-page-ab-tests/meta-video-vs-traditional`.
+- Endpoint de listagem: `GET /api/experiments/{experimentId}/sales-page-ab-tests`.
+- Endpoint de atualizacao de variante: `PATCH /api/experiments/{experimentId}/sales-page-ab-tests/variants/{variantId}`.
+- Gate de campanha: se existir teste A/B ativo ou pronto, o experimento so entra na fila de Facebook quando as duas variantes estiverem prontas.
+
+## Variantes padrao
+
+### Variante A: pagina tradicional
+
+- Promessa, dor, prova visual, entregaveis, preco, garantia, FAQ e CTA.
+- Sem video humano no topo.
+- Peso inicial: 50%.
+
+### Variante B: pagina com video humano
+
+- Mesma promessa, mesma oferta, mesmo preco, mesmo checkout e mesma prova visual.
+- Video humano curto antes da prova/CTA.
+- Peso inicial: 50%.
+
+## Regras para nao contaminar o teste
+
+- Nao mudar preco entre variantes.
+- Nao mudar publico.
+- Nao mudar criativo.
+- Nao mudar CTA principal.
+- Nao mudar checkout.
+- Nao editar a campanha no meio do teste.
+- Rodar por pelo menos 7 dias ou ate ter amostra minima suficiente.
+
+## Eventos minimos
+
+- `page_view`
+- `page_load_metric`
+- `section_view_time`
+- `video_play`
+- `video_50_percent`
+- `checkout_click`
+- `purchase`
+
+## Criterio de decisao
+
+Metrica principal inicial: `checkout_click_rate`.
+
+O vencedor deve ser a variante com melhor custo por clique no checkout. Quando houver volume suficiente de compras, confirmar por taxa de compra e custo por compra.
+
+## Uso recomendado no experimento 60
+
+Comecar pelo experimento 60 porque ele e o candidato mais proximo de venda direta. A pagina B deve usar video de 30 a 60 segundos com:
+
+- dor nos primeiros segundos;
+- demonstracao do kit;
+- mecanismo em 3 passos;
+- CTA direto para comprar o Kit Agenda Fechada por R$ 27.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1154,7 +1154,8 @@ public class FacebookCampaignService {
         boolean nextStepInstantForm,
         String followUpActionUrl,
         String publicationJobId,
-        LeadPortalFlow leadPortalFlow
+        LeadPortalFlow leadPortalFlow,
+        SalesPageAbTest salesPageAbTest
     ) {
         public FacebookPage associatedPage() {
             return facebookPage;
@@ -1172,6 +1173,31 @@ public class FacebookCampaignService {
             String shareLink
         ) {}
         public record LeadPortalFlow(Long id, String name, String slug, String publicUrl) {}
+        public record SalesPageAbTest(
+            Long id,
+            String name,
+            String status,
+            String primaryMetric,
+            String winnerRule,
+            Integer minimumRuntimeDays,
+            Integer minimumSampleSize,
+            boolean metaSplitTestRecommended,
+            List<SalesPageAbVariant> variants
+        ) {}
+        public record SalesPageAbVariant(
+            Long id,
+            String variantKey,
+            String name,
+            String variantType,
+            String status,
+            BigDecimal trafficWeight,
+            String salesPageUrl,
+            String checkoutUrl,
+            String adDestinationUrl,
+            String analyticsVariantParam,
+            Long experimentVideoAssetId,
+            boolean requiredCollectorsPresent
+        ) {}
     }
 
     public record CreateCampaignRequest(


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: vamos evoluir os experimento 60, 61, 62 e 63

Modelo: Analisei os experimentos 60, 61, 62 e 63 no banco e cruzei com os aprendizados dos relatórios.

**Estado atual**
- Todos estão `PLANNED`.
- Ainda não há campanha Meta, criativo, landing, eventos, leads ou gasto.
- Portanto, ainda estamos no melhor momento para evoluir a estratégia antes de queimar verba.

**Evidência principal**
O histórico mostra que o sistema já teve bom clique e zero conversão: 575 visualizações de formulário e 0 envios em experimentos anteriores. Fonte: [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-9acf6d46-ec2d-4ad4-b19f-37e4711f6a17-aWxySi/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md).  
Então a evolução deve priorizar **oferta irresistível + baixa fricção + prova visual**, não só anúncio.

**3 caminhos possíveis**
1. **Rodar como estão**  
   Mais rápido, mas arriscado. Pode repetir o padrão de clique sem lead/venda.

2. **Transformar todos em captação de lead**  
   Bom para validar desejo, mas pode atrasar a primeira venda e manter dependência de formulário.

3. **Evoluir por papel no funil**  
   Melhor opção. Usar o experimento 60 para venda direta low-ticket e 61-63 para captar demanda/qualificar públicos com iscas fortes.

**Recomendação**

**Experimento 60 — Manicure / agenda**
Manter como principal candidato à primeira venda.  
Evolução recomendada:
- CTA: `Comprar o Kit Agenda Fechada por R$ 27`
- Hero: “Sua agenda parece cheia, mas ainda pode virar prejuízo?”
- Prova visual obrigatória: print/mockup do “Mapa Agenda Fechada 7D” com status: confirmado, aguardando, risco.
- Oferta: kit pronto, não diagnóstico longo.
- Funil: venda direta com amostra secundária, não formulário como etapa principal.

**Experimento 61 — Sofisticação acessível**
Bom topo de funil, mas promessa ainda ampla.  
Evoluir para uma dor mais concreta:
- Ângulo: “Você parece mais simples do que gostaria por detalhes fáceis de ajustar?”
- Isca: checklist visual “12 detalhes que elevam aparência sem gastar com luxo”.
- Produto futuro: guia/rotina de 30 dias por R$ 47.
- Métrica principal: lead qualificado, não venda imediata.

**Experimento 62 — Proteção emocional**
Tema forte, mas sensível. Precisa evitar promessa terapêutica.  
Evolução:
- Ângulo: clareza e limites, não “cura” nem diagnóstico psicológico.
- Isca: “21 sinais de manipulação emocional que muitas mulheres normalizam”.
- CTA melhor: `Identificar os sinais com segurança`
- Produto futuro: plano de clareza e próximos passos por R$ 67.
- Cuidado: linguagem ética, sem explorar medo excessivo.

**Experimento 63 — Autoridade e negociação**
Melhor potencial de ticket e compra futura.  
Evolução:
- Ângulo: perda financeira concreta por não saber negociar.
- Isca: “7 scripts para salário, preço, escopo e limites”.
- CTA: `Receber os scripts de negociação`
- Produto futuro: pacote de scripts + simulador de respostas por R$ 97.
- Criativo deve mostrar situação real: reunião, proposta, cliente pedindo desconto, chefe adiando aumento.

**Ordem que eu seguiria**
1. Evoluir e publicar primeiro o **60**, porque é o mais próximo de venda direta e já conversa com aprendizados de manicure anteriores.
2. Rodar **63** como teste de lead de alto valor.
3. Rodar **61** para volume e validação de desejo.
4. Rodar **62** com mais cuidado de compliance e promessa.

Não preparei PR nem alteração de arquivos. Minha recomendação é evoluir os ativos nessa ordem: **60 como venda**, **61/62/63 como validação de demanda com isca forte e produto low-ticket claro por trás**.

Usuário: vamos executaro o 60, 63, 61 

Modelo: Fechado. Eu executaria na ordem **60 → 63 → 61**, mas com um gate importante: **não liberar mídia ainda**, porque os três ainda estão `PLANNED` e sem ativos finais de campanha/landing/funil.

**Decisão**
1. **60 primeiro**: melhor chance de venda direta. Já tem dor, promessa, preço e CTA fortes. Precisa gerar página/oferta com prova visual antes do preço.
2. **63 segundo**: melhor potencial de ticket futuro. Rodar como lead qualificado com scripts de negociação.
3. **61 terceiro**: bom para volume, mas promessa mais ampla. Rodar com orçamento menor e medir desejo.

**Execução recomendada agora**
- **Exp. 60**: preparar venda do `Kit Agenda Fechada por R$ 27`; foco em prova visual, mensagens prontas e mapa preenchido.
- **Exp. 63**: campanha de lead para `7 scripts de negociação`; medir qualidade do lead e intenção de compra.
- **Exp. 61**: campanha de lead para checklist de elegância acessível; validar se a promessa gera lead barato ou só curiosidade.

**Gate obrigatório antes de publicar**
- Landing/formulário funcionando no mobile.
- Poucos campos: nome + WhatsApp/e-mail + pergunta qualificadora.
- Criativo e landing com a mesma promessa.
- Stop-loss claro: se tiver clique e 0 lead, parar rápido.
- Não repetir o erro anterior: **575 views de formulário e 0 envios**.

Minha recomendação operacional: **gerar e revisar os ativos desses três agora**, mas só liberar Facebook Ads depois que cada um tiver criativo, página/funil e teste real de envio validados.

Usuário: pode gerar e revisar os ativos dos 3

Modelo: Sim. Gerei e revisei os ativos estratégicos dos 3, sem alterar arquivos e sem preparar PR.

**Base usada**
- O histórico mostra gargalo pós-clique: 575 views de formulário e 0 envios, então o foco precisa ser prova visual, baixa fricção e CTA claro. Evidência: [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md:19).
- Para primeira venda, o plano recomenda produto low-ticket pronto, página curta, prova visual grande e sem briefing antes da compra. Fonte: [plano-evolucao-funil-primeira-venda.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/marketing/plano-evolucao-funil-primeira-venda.md:40).
- Para tráfego frio de compra, o anúncio não deve ir direto ao checkout; precisa passar por página de venda auditada. Fonte: [trafego-frio-compra-direta-canon.v1.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/canonical/trafego-frio-compra-direta-canon.v1.md:5).

**Alternativas avaliadas**
1. Rodar os 3 como leads: gera volume, mas não resolve a meta principal de primeira venda.
2. Rodar os 3 como venda direta: força receita, mas 61 e 63 ainda precisam validar desejo e público.
3. Funil por papel: 60 venda direta; 63 e 61 captação qualificada. Melhor equilíbrio entre venda agora e aprendizado.

Escolha: **60 como venda**, **63 como lead de alto valor**, **61 como lead de volume qualificado**.

**Exp. 60 — Kit Agenda Fechada 7D**
Status estratégico: melhor candidato para venda imediata.

Ativo recomendado:
- Headline: `Sua agenda parece cheia, mas ainda pode virar prejuízo esta semana?`
- Subheadline: `Veja quais horários estão em risco, confirme clientes sem parecer insistente e preencha buracos com mensagens prontas.`
- CTA principal: `Comprar o Kit Agenda Fechada por R$ 27`
- CTA secundário: `Ver amostra do mapa`
- Criativo 1: print/mockup do Mapa Agenda Fechada 7D com horários verde, amarelo e vermelho.
- Criativo 2: celular com WhatsApp mostrando mensagem de confirmação educada.
- Criativo 3: antes/depois da agenda: “cheia no papel” vs “confirmada de verdade”.
- Landing: primeira dobra com prova visual antes do preço; depois dor, mecanismo em 3 passos, entregáveis, exemplo de mensagem, preço, garantia simples e checkout.
- Métrica principal: compra.
- Diagnóstico intermediário: clique no checkout.

Revisão: forte. Só não deve publicar antes de existir página de venda auditada, checkout dentro da página e eventos mínimos de página/checkout.

**Exp. 63 — Scripts de Negociação**
Status estratégico: melhor potencial de ticket futuro.

Ativo recomendado:
- Headline: `Você não precisa pedir desculpa para negociar.`
- Subheadline: `Receba 7 scripts para pedir aumento, defender preço, limitar escopo e comunicar valor sem parecer agressiva.`
- CTA: `Receber os scripts`
- Criativo 1: mulher profissional olhando proposta com frase “escopo aumentou, preço não”.
- Criativo 2: tela com 3 scripts visíveis: aumento, cliente pedindo desconto, chefe adiando conversa.
- Criativo 3: comparação: “aceitar calada” vs “responder com firmeza”.
- Formulário: nome + e-mail/WhatsApp + pergunta qualificadora: `Qual conversa você mais evita hoje?`
- Produto futuro: pacote completo de scripts + simulador de respostas por R$ 97.
- Métrica principal: lead qualificado.
- Lead qualificado: marcou aumento, preço, cliente ou escopo como dor atual.

Revisão: bom para público com poder de compra maior. Precisa evitar tom genérico de “empoderamento” e focar em perda financeira concreta.

**Exp. 61 — Elegância/Sofisticação Acessível**
Status estratégico: bom para volume, mas mais sujeito a curiosidade barata.

Ativo recomendado:
- Headline: `12 detalhes que fazem você parecer mais sofisticada sem gastar com luxo.`
- Subheadline: `Um checklist visual para ajustar cabelo, pele, perfume, acessórios e presença com escolhas simples.`
- CTA: `Receber o checklist de elegância`
- Criativo 1: checklist visual com itens marcados: cabelo alinhado, perfume, unha, bolsa, postura.
- Criativo 2: “produto caro não salva detalhe errado”.
- Criativo 3: antes/depois sutil de aparência mais polida, sem ostentação.
- Formulário: nome + e-mail/WhatsApp + pergunta: `Qual detalhe mais te incomoda hoje?`
- Produto futuro: guia de rotina sofisticada acessível em 30 dias por R$ 47.
- Métrica principal: lead qualificado.
- Lead qualificado: escolhe cabelo, perfume, pele, roupa ou imagem profissional como dor.

Revisão: rodar com orçamento menor que 60 e 63. A promessa precisa ser concreta; “sofisticação” sozinha é ampla demais.

**Gate antes de mídia**
- Exp. 60: página de venda auditada + checkout + pixel/eventos.
- Exp. 63 e 61: formulário curto testado no mobile.
- Nenhum dos 3 deve sair com CTA desalinhado: anúncio, página e entrega precisam prometer exatamente a mesma coisa.

Minha recomendação final: executar primeiro **60**, porque mede venda; depois **63**, porque pode gerar público de maior valor; por último **61**, controlando orçamento para validar se há intenção real ou só curiosidade.

Usuário: exexuta os 3

Modelo: Executei a preparação operacional dos 3.

**Feito**
- Exp. **60, 63 e 61**: solicitei **3 criativos** para cada um.
- Exp. **60, 63 e 61**: solicitei **1 fluxo de Lead Portal** para cada um.
- Exp. **60**: solicitei **1 entregável**.
- Exp. **63**: iniciei GeraLanding wireframe. Job: `949cdb82-a090-4edb-a04b-8bd7707945d5`.
- Exp. **61**: iniciei GeraLanding wireframe. Job: `abf9cd70-2a90-4a87-bbea-b17007520f1a`.
- Criei runs operacionais:
  - Exp. 60: run `3`
  - Exp. 63: run `4`
  - Exp. 61: run `5`

**Bloqueios**
- Exp. **60** não foi liberado para mídia porque o backend bloqueou corretamente: falta **URL real de checkout** e página criada pelo **GeraSalesPage v1**.
- Exp. **63 e 61** tiveram `facebookReleaseRequestedAt` marcado, mas **não entraram na fila do Facebook Worker**. A fila `/api/facebook-campaigns/experiments-ready` retornou vazia porque ainda faltam criativos aprovados, público, Lead Portal concluído e GeraLanding completo.
- O preflight dos runs falhou por erro sistêmico de schema: coluna `gate_group` no banco está menor que o enum atual esperado pelo Java. Isso precisa de correção técnica antes de usar preflight como gate confiável.

**Estado agora**
- Os 3 estão em preparação.
- Nenhum anúncio foi publicado.
- Nenhum gasto foi iniciado.
- Próximo passo real: aguardar/rodar os workers de criativos e GeraLanding; para o 60, cadastrar a URL de checkout real antes de iniciar GeraSalesPage e liberar venda.

Usuário: eu gostaria de criar uma estrutura para fazer testes A/B nas páginas de venda. Colocar uma com video de uma pessoa explicando o produto e outra tradicional. Veja na Meta como fazer da melhor forma. Com melhor possibilidade sucesso.

Modelo: Sim, faz sentido. Para o Marketing Hub, eu criaria isso como **teste A/B de página de venda**, não como teste de anúncio.

**Decisão recomendada**
Usar duas páginas para o mesmo produto:

- **Página A — Tradicional:** promessa, prova visual, entregáveis, preço, garantia, FAQ e CTA.
- **Página B — Vídeo + tradicional curta:** mesma promessa e mesma oferta, mas com vídeo curto de uma pessoa explicando o produto antes da prova/CTA.

A variável testada deve ser **somente a presença do vídeo humano**. Não mudar preço, promessa, público, criativo, CTA ou checkout no mesmo teste.

**3 alternativas avaliadas**

1. **Dividir o tráfego dentro do próprio site**
   - Benefício: simples e preserva uma campanha só.
   - Risco: a Meta enxerga um destino misturado e otimiza sem saber qual página venceu.
   - Melhor para: teste técnico rápido.

2. **Criar dois anúncios idênticos, cada um com URL diferente**
   - Benefício: fácil de operar.
   - Risco: pode haver sobreposição de audiência e distribuição desigual pelo algoritmo.
   - Melhor para: orçamento pequeno e validação inicial.

3. **Usar A/B Test/Experiments da Meta com duas versões equivalentes**
   - Benefício: a Meta separa melhor os grupos e compara custo por resultado; é o caminho mais limpo para aprendizado.
   - Risco: exige volume mínimo e disciplina para não editar durante o teste.
   - Melhor para: decidir vencedor com mais confiança.

Escolha: **alternativa 3 para teste oficial**, com alternativa 2 como fallback se o worker/sistema ainda não suportar Experiments da Meta.

**Estrutura prática do teste**

Para o experimento 60, eu faria:

- Campanha: vendas/conversões.
- Público: igual nas duas versões.
- Criativos: iguais nas duas versões.
- Orçamento: dividido 50/50.
- Duração mínima: 4 a 7 dias, sem editar no meio.
- Página A: `/exp-60-agenda-fechada-tradicional`
- Página B: `/exp-60-agenda-fechada-video`
- Checkout: o mesmo nas duas.
- Evento principal inicial: `checkout_click`.
- Evento vencedor ideal: `purchase`, se houver volume suficiente.
- Eventos obrigatórios: `page_view`, `page_load_metric`, `section_view_time`, `video_play`, `video_50_percent`, `checkout_click`, `purchase`.

**Como deve ser a página com vídeo**

O vídeo não deve ser institucional. Deve ser direto, humano e vendedor:

- 30 a 60 segundos.
- Pessoa olhando para a câmera.
- Primeira frase com dor: “Se sua agenda parece cheia, mas as clientes desmarcam ou somem, você pode estar perdendo dinheiro sem perceber.”
- Mostrar o kit na tela: mapa, mensagens, checklist.
- Explicar o mecanismo em 3 passos.
- CTA: “Clique abaixo e compre o Kit Agenda Fechada por R$ 27.”

A página com vídeo ainda precisa ter prova visual abaixo. O vídeo não substitui a página; ele aumenta confiança.

**Critério de vitória**

Vencedor não é quem tem mais clique. Vencedor é quem melhora:

1. taxa de clique no checkout por visualização de página;
2. custo por clique no checkout;
3. compra por visualização de página;
4. custo por compra, quando houver volume.

Se a página com vídeo aumentar checkout click mas não compra, o vídeo convenceu, mas o checkout/oferta ainda está travando.

**Por que isso é aderente ao histórico**
O repositório mostra gargalo pós-clique: **575 visualizações de formulário e 0 envios** em campanhas anteriores. Então testar vídeo humano na página é uma boa hipótese porque ataca confiança, clareza e percepção de valor antes do checkout. Também respeita a regra interna de não mandar tráfego frio direto para checkout: primeiro página auditada, depois compra.

Fontes internas usadas:
- [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md)
- [trafego-frio-compra-direta-canon.v1.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/canonical/trafego-frio-compra-direta-canon.v1.md)
- [plano-evolucao-funil-primeira-venda.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/marketing/plano-evolucao-funil-primeira-venda.md)

Referências Meta consultadas:
- Meta A/B Testing: https://www.facebook.com/business/help/290009911394576
- Meta Split Testing API: https://developers.facebook.com/documentation/ads-commerce/marketing-api/guides/split-testing
- Meta Pixel / eventos: https://developers.facebook.com/documentation/meta-pixel/reference
- Meta Conversions API: https://developers.facebook.com/documentation/ads-commerce/conversions-api

Não preparei PR nem alteração de arquivos. Minha recomendação é começar pelo **experimento 60**, porque é o melhor candidato de venda direta; depois replicar a estrutura nos experimentos 63 e 61 quando houver aprendizado.

Última mensagem do usuário:
crie toda a estrutura no marketing hub para fazer esse teste A/B depois me avise que vou fazer o deploy e seguimos o trabalho.

**Resumo das alterações:**
Pronto para deploy.

Criei a estrutura A/B no Marketing Hub para página de venda **tradicional vs página com vídeo humano**:

- Banco/Liquibase: novas tabelas `experiment_sales_page_ab_test` e `experiment_sales_page_ab_variant`.
- Backend: entidades, repositórios, serviço e controller.
- Endpoint para criar o teste padrão:
  `POST /api/experiments/{experimentId}/sales-page-ab-tests/meta-video-vs-traditional`
- Gate de campanha: se existir teste A/B em aberto, o experimento fica bloqueado para mídia até as duas variantes estarem prontas.
- Contrato Facebook: o endpoint de experimentos prontos agora pode expor o resumo do teste A/B para o worker.
- Documentação operacional: [teste-ab-pagina-venda-video-vs-tradicional.md](/root/ai-hub/src/ai-hub-8b8d3eeb-461c-47b0-a0fb-2d699fdf115b-zF7vnK/repo/docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md)

Validei com:

- `mvn -q -Dtest=ExperimentSalesPageAbTestServiceTest,ExperimentReadinessServiceTest,FacebookAdsCampaignMetricsAutoStopControllerTest test`
- `mvn -q -DskipTests compile` no `facebook-ads-worker`
- validação dos includes Liquibase: sem `changesets/...` sem `relativeToChangelogFile: true`

Não criei PR. Pode fazer o deploy; depois seguimos para criar o teste do experimento 60 e preparar as duas variantes reais.