### PR TITLE
AI Hub: Verifiquei o erro do GitHub Actions.

**Causa**
O workflow `CI + CD – marketinghub backend` falhou no teste `FacebookAdsCampaignControllerTest`.

O problema veio da nova estrutura de A/B: no serviço real, **não existir teste A/B ativo não bloqueia…

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -51,6 +51,7 @@ import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -70,6 +71,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.any;
@@ -134,6 +136,12 @@ class FacebookAdsCampaignControllerTest {
     @MockBean
     ExperimentCampaignMetricService campaignMetricService;
 
+    @BeforeEach
+    // Mantem o comportamento real: sem teste A/B ativo, nao ha bloqueio de publicacao por A/B.
+    void configureDefaultSalesPageAbTestReadiness() {
+        lenient().when(salesPageAbTestService.hasReadyActiveTest(org.mockito.ArgumentMatchers.anyLong())).thenReturn(true);
+        lenient().when(salesPageAbTestService.findActiveForCampaign(org.mockito.ArgumentMatchers.anyLong())).thenReturn(Optional.empty());
+    }
 
     @Test
     // Verifica que o módulo Facebook expõe somente criativos aprovados para consumo do worker.


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: vamos evoluir os experimento 60, 61, 62 e 63

Modelo: Analisei os experimentos 60, 61, 62 e 63 no banco e cruzei com os aprendizados dos relatórios.

**Estado atual**
- Todos estão `PLANNED`.
- Ainda não há campanha Meta, criativo, landing, eventos, leads ou gasto.
- Portanto, ainda estamos no melhor momento para evoluir a estratégia antes de queimar verba.

**Evidência principal**
O histórico mostra que o sistema já teve bom clique e zero conversão: 575 visualizações de formulário e 0 envios em experimentos anteriores. Fonte: [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-9acf6d46-ec2d-4ad4-b19f-37e4711f6a17-aWxySi/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md).  
Então a evolução deve priorizar **oferta irresistível + baixa fricção + prova visual**, não só anúncio.

**3 caminhos possíveis**
1. **Rodar como estão**  
   Mais rápido, mas arriscado. Pode repetir o padrão de clique sem lead/venda.

2. **Transformar todos em captação de lead**  
   Bom para validar desejo, mas pode atrasar a primeira venda e manter dependência de formulário.

3. **Evoluir por papel no funil**  
   Melhor opção. Usar o experimento 60 para venda direta low-ticket e 61-63 para captar demanda/qualificar públicos com iscas fortes.

**Recomendação**

**Experimento 60 — Manicure / agenda**
Manter como principal candidato à primeira venda.  
Evolução recomendada:
- CTA: `Comprar o Kit Agenda Fechada por R$ 27`
- Hero: “Sua agenda parece cheia, mas ainda pode virar prejuízo?”
- Prova visual obrigatória: print/mockup do “Mapa Agenda Fechada 7D” com status: confirmado, aguardando, risco.
- Oferta: kit pronto, não diagnóstico longo.
- Funil: venda direta com amostra secundária, não formulário como etapa principal.

**Experimento 61 — Sofisticação acessível**
Bom topo de funil, mas promessa ainda ampla.  
Evoluir para uma dor mais concreta:
- Ângulo: “Você parece mais simples do que gostaria por detalhes fáceis de ajustar?”
- Isca: checklist visual “12 detalhes que elevam aparência sem gastar com luxo”.
- Produto futuro: guia/rotina de 30 dias por R$ 47.
- Métrica principal: lead qualificado, não venda imediata.

**Experimento 62 — Proteção emocional**
Tema forte, mas sensível. Precisa evitar promessa terapêutica.  
Evolução:
- Ângulo: clareza e limites, não “cura” nem diagnóstico psicológico.
- Isca: “21 sinais de manipulação emocional que muitas mulheres normalizam”.
- CTA melhor: `Identificar os sinais com segurança`
- Produto futuro: plano de clareza e próximos passos por R$ 67.
- Cuidado: linguagem ética, sem explorar medo excessivo.

**Experimento 63 — Autoridade e negociação**
Melhor potencial de ticket e compra futura.  
Evolução:
- Ângulo: perda financeira concreta por não saber negociar.
- Isca: “7 scripts para salário, preço, escopo e limites”.
- CTA: `Receber os scripts de negociação`
- Produto futuro: pacote de scripts + simulador de respostas por R$ 97.
- Criativo deve mostrar situação real: reunião, proposta, cliente pedindo desconto, chefe adiando aumento.

**Ordem que eu seguiria**
1. Evoluir e publicar primeiro o **60**, porque é o mais próximo de venda direta e já conversa com aprendizados de manicure anteriores.
2. Rodar **63** como teste de lead de alto valor.
3. Rodar **61** para volume e validação de desejo.
4. Rodar **62** com mais cuidado de compliance e promessa.

Não preparei PR nem alteração de arquivos. Minha recomendação é evoluir os ativos nessa ordem: **60 como venda**, **61/62/63 como validação de demanda com isca forte e produto low-ticket claro por trás**.

Usuário: vamos executaro o 60, 63, 61 

Modelo: Fechado. Eu executaria na ordem **60 → 63 → 61**, mas com um gate importante: **não liberar mídia ainda**, porque os três ainda estão `PLANNED` e sem ativos finais de campanha/landing/funil.

**Decisão**
1. **60 primeiro**: melhor chance de venda direta. Já tem dor, promessa, preço e CTA fortes. Precisa gerar página/oferta com prova visual antes do preço.
2. **63 segundo**: melhor potencial de ticket futuro. Rodar como lead qualificado com scripts de negociação.
3. **61 terceiro**: bom para volume, mas promessa mais ampla. Rodar com orçamento menor e medir desejo.

**Execução recomendada agora**
- **Exp. 60**: preparar venda do `Kit Agenda Fechada por R$ 27`; foco em prova visual, mensagens prontas e mapa preenchido.
- **Exp. 63**: campanha de lead para `7 scripts de negociação`; medir qualidade do lead e intenção de compra.
- **Exp. 61**: campanha de lead para checklist de elegância acessível; validar se a promessa gera lead barato ou só curiosidade.

**Gate obrigatório antes de publicar**
- Landing/formulário funcionando no mobile.
- Poucos campos: nome + WhatsApp/e-mail + pergunta qualificadora.
- Criativo e landing com a mesma promessa.
- Stop-loss claro: se tiver clique e 0 lead, parar rápido.
- Não repetir o erro anterior: **575 views de formulário e 0 envios**.

Minha recomendação operacional: **gerar e revisar os ativos desses três agora**, mas só liberar Facebook Ads depois que cada um tiver criativo, página/funil e teste real de envio validados.

Usuário: pode gerar e revisar os ativos dos 3

Modelo: Sim. Gerei e revisei os ativos estratégicos dos 3, sem alterar arquivos e sem preparar PR.

**Base usada**
- O histórico mostra gargalo pós-clique: 575 views de formulário e 0 envios, então o foco precisa ser prova visual, baixa fricção e CTA claro. Evidência: [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md:19).
- Para primeira venda, o plano recomenda produto low-ticket pronto, página curta, prova visual grande e sem briefing antes da compra. Fonte: [plano-evolucao-funil-primeira-venda.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/marketing/plano-evolucao-funil-primeira-venda.md:40).
- Para tráfego frio de compra, o anúncio não deve ir direto ao checkout; precisa passar por página de venda auditada. Fonte: [trafego-frio-compra-direta-canon.v1.md](/root/ai-hub/src/ai-hub-d4e154d7-8fe8-464f-a019-0a81726afd59-hfkpj6/repo/docs/canonical/trafego-frio-compra-direta-canon.v1.md:5).

**Alternativas avaliadas**
1. Rodar os 3 como leads: gera volume, mas não resolve a meta principal de primeira venda.
2. Rodar os 3 como venda direta: força receita, mas 61 e 63 ainda precisam validar desejo e público.
3. Funil por papel: 60 venda direta; 63 e 61 captação qualificada. Melhor equilíbrio entre venda agora e aprendizado.

Escolha: **60 como venda**, **63 como lead de alto valor**, **61 como lead de volume qualificado**.

**Exp. 60 — Kit Agenda Fechada 7D**
Status estratégico: melhor candidato para venda imediata.

Ativo recomendado:
- Headline: `Sua agenda parece cheia, mas ainda pode virar prejuízo esta semana?`
- Subheadline: `Veja quais horários estão em risco, confirme clientes sem parecer insistente e preencha buracos com mensagens prontas.`
- CTA principal: `Comprar o Kit Agenda Fechada por R$ 27`
- CTA secundário: `Ver amostra do mapa`
- Criativo 1: print/mockup do Mapa Agenda Fechada 7D com horários verde, amarelo e vermelho.
- Criativo 2: celular com WhatsApp mostrando mensagem de confirmação educada.
- Criativo 3: antes/depois da agenda: “cheia no papel” vs “confirmada de verdade”.
- Landing: primeira dobra com prova visual antes do preço; depois dor, mecanismo em 3 passos, entregáveis, exemplo de mensagem, preço, garantia simples e checkout.
- Métrica principal: compra.
- Diagnóstico intermediário: clique no checkout.

Revisão: forte. Só não deve publicar antes de existir página de venda auditada, checkout dentro da página e eventos mínimos de página/checkout.

**Exp. 63 — Scripts de Negociação**
Status estratégico: melhor potencial de ticket futuro.

Ativo recomendado:
- Headline: `Você não precisa pedir desculpa para negociar.`
- Subheadline: `Receba 7 scripts para pedir aumento, defender preço, limitar escopo e comunicar valor sem parecer agressiva.`
- CTA: `Receber os scripts`
- Criativo 1: mulher profissional olhando proposta com frase “escopo aumentou, preço não”.
- Criativo 2: tela com 3 scripts visíveis: aumento, cliente pedindo desconto, chefe adiando conversa.
- Criativo 3: comparação: “aceitar calada” vs “responder com firmeza”.
- Formulário: nome + e-mail/WhatsApp + pergunta qualificadora: `Qual conversa você mais evita hoje?`
- Produto futuro: pacote completo de scripts + simulador de respostas por R$ 97.
- Métrica principal: lead qualificado.
- Lead qualificado: marcou aumento, preço, cliente ou escopo como dor atual.

Revisão: bom para público com poder de compra maior. Precisa evitar tom genérico de “empoderamento” e focar em perda financeira concreta.

**Exp. 61 — Elegância/Sofisticação Acessível**
Status estratégico: bom para volume, mas mais sujeito a curiosidade barata.

Ativo recomendado:
- Headline: `12 detalhes que fazem você parecer mais sofisticada sem gastar com luxo.`
- Subheadline: `Um checklist visual para ajustar cabelo, pele, perfume, acessórios e presença com escolhas simples.`
- CTA: `Receber o checklist de elegância`
- Criativo 1: checklist visual com itens marcados: cabelo alinhado, perfume, unha, bolsa, postura.
- Criativo 2: “produto caro não salva detalhe errado”.
- Criativo 3: antes/depois sutil de aparência mais polida, sem ostentação.
- Formulário: nome + e-mail/WhatsApp + pergunta: `Qual detalhe mais te incomoda hoje?`
- Produto futuro: guia de rotina sofisticada acessível em 30 dias por R$ 47.
- Métrica principal: lead qualificado.
- Lead qualificado: escolhe cabelo, perfume, pele, roupa ou imagem profissional como dor.

Revisão: rodar com orçamento menor que 60 e 63. A promessa precisa ser concreta; “sofisticação” sozinha é ampla demais.

**Gate antes de mídia**
- Exp. 60: página de venda auditada + checkout + pixel/eventos.
- Exp. 63 e 61: formulário curto testado no mobile.
- Nenhum dos 3 deve sair com CTA desalinhado: anúncio, página e entrega precisam prometer exatamente a mesma coisa.

Minha recomendação final: executar primeiro **60**, porque mede venda; depois **63**, porque pode gerar público de maior valor; por último **61**, controlando orçamento para validar se há intenção real ou só curiosidade.

Usuário: exexuta os 3

Modelo: Executei a preparação operacional dos 3.

**Feito**
- Exp. **60, 63 e 61**: solicitei **3 criativos** para cada um.
- Exp. **60, 63 e 61**: solicitei **1 fluxo de Lead Portal** para cada um.
- Exp. **60**: solicitei **1 entregável**.
- Exp. **63**: iniciei GeraLanding wireframe. Job: `949cdb82-a090-4edb-a04b-8bd7707945d5`.
- Exp. **61**: iniciei GeraLanding wireframe. Job: `abf9cd70-2a90-4a87-bbea-b17007520f1a`.
- Criei runs operacionais:
  - Exp. 60: run `3`
  - Exp. 63: run `4`
  - Exp. 61: run `5`

**Bloqueios**
- Exp. **60** não foi liberado para mídia porque o backend bloqueou corretamente: falta **URL real de checkout** e página criada pelo **GeraSalesPage v1**.
- Exp. **63 e 61** tiveram `facebookReleaseRequestedAt` marcado, mas **não entraram na fila do Facebook Worker**. A fila `/api/facebook-campaigns/experiments-ready` retornou vazia porque ainda faltam criativos aprovados, público, Lead Portal concluído e GeraLanding completo.
- O preflight dos runs falhou por erro sistêmico de schema: coluna `gate_group` no banco está menor que o enum atual esperado pelo Java. Isso precisa de correção técnica antes de usar preflight como gate confiável.

**Estado agora**
- Os 3 estão em preparação.
- Nenhum anúncio foi publicado.
- Nenhum gasto foi iniciado.
- Próximo passo real: aguardar/rodar os workers de criativos e GeraLanding; para o 60, cadastrar a URL de checkout real antes de iniciar GeraSalesPage e liberar venda.

Usuário: eu gostaria de criar uma estrutura para fazer testes A/B nas páginas de venda. Colocar uma com video de uma pessoa explicando o produto e outra tradicional. Veja na Meta como fazer da melhor forma. Com melhor possibilidade sucesso.

Modelo: Sim, faz sentido. Para o Marketing Hub, eu criaria isso como **teste A/B de página de venda**, não como teste de anúncio.

**Decisão recomendada**
Usar duas páginas para o mesmo produto:

- **Página A — Tradicional:** promessa, prova visual, entregáveis, preço, garantia, FAQ e CTA.
- **Página B — Vídeo + tradicional curta:** mesma promessa e mesma oferta, mas com vídeo curto de uma pessoa explicando o produto antes da prova/CTA.

A variável testada deve ser **somente a presença do vídeo humano**. Não mudar preço, promessa, público, criativo, CTA ou checkout no mesmo teste.

**3 alternativas avaliadas**

1. **Dividir o tráfego dentro do próprio site**
   - Benefício: simples e preserva uma campanha só.
   - Risco: a Meta enxerga um destino misturado e otimiza sem saber qual página venceu.
   - Melhor para: teste técnico rápido.

2. **Criar dois anúncios idênticos, cada um com URL diferente**
   - Benefício: fácil de operar.
   - Risco: pode haver sobreposição de audiência e distribuição desigual pelo algoritmo.
   - Melhor para: orçamento pequeno e validação inicial.

3. **Usar A/B Test/Experiments da Meta com duas versões equivalentes**
   - Benefício: a Meta separa melhor os grupos e compara custo por resultado; é o caminho mais limpo para aprendizado.
   - Risco: exige volume mínimo e disciplina para não editar durante o teste.
   - Melhor para: decidir vencedor com mais confiança.

Escolha: **alternativa 3 para teste oficial**, com alternativa 2 como fallback se o worker/sistema ainda não suportar Experiments da Meta.

**Estrutura prática do teste**

Para o experimento 60, eu faria:

- Campanha: vendas/conversões.
- Público: igual nas duas versões.
- Criativos: iguais nas duas versões.
- Orçamento: dividido 50/50.
- Duração mínima: 4 a 7 dias, sem editar no meio.
- Página A: `/exp-60-agenda-fechada-tradicional`
- Página B: `/exp-60-agenda-fechada-video`
- Checkout: o mesmo nas duas.
- Evento principal inicial: `checkout_click`.
- Evento vencedor ideal: `purchase`, se houver volume suficiente.
- Eventos obrigatórios: `page_view`, `page_load_metric`, `section_view_time`, `video_play`, `video_50_percent`, `checkout_click`, `purchase`.

**Como deve ser a página com vídeo**

O vídeo não deve ser institucional. Deve ser direto, humano e vendedor:

- 30 a 60 segundos.
- Pessoa olhando para a câmera.
- Primeira frase com dor: “Se sua agenda parece cheia, mas as clientes desmarcam ou somem, você pode estar perdendo dinheiro sem perceber.”
- Mostrar o kit na tela: mapa, mensagens, checklist.
- Explicar o mecanismo em 3 passos.
- CTA: “Clique abaixo e compre o Kit Agenda Fechada por R$ 27.”

A página com vídeo ainda precisa ter prova visual abaixo. O vídeo não substitui a página; ele aumenta confiança.

**Critério de vitória**

Vencedor não é quem tem mais clique. Vencedor é quem melhora:

1. taxa de clique no checkout por visualização de página;
2. custo por clique no checkout;
3. compra por visualização de página;
4. custo por compra, quando houver volume.

Se a página com vídeo aumentar checkout click mas não compra, o vídeo convenceu, mas o checkout/oferta ainda está travando.

**Por que isso é aderente ao histórico**
O repositório mostra gargalo pós-clique: **575 visualizações de formulário e 0 envios** em campanhas anteriores. Então testar vídeo humano na página é uma boa hipótese porque ataca confiança, clareza e percepção de valor antes do checkout. Também respeita a regra interna de não mandar tráfego frio direto para checkout: primeiro página auditada, depois compra.

Fontes internas usadas:
- [analise-campanhas-resultados-fracos.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/relatorios/experimentos/analises/analise-campanhas-resultados-fracos.md)
- [trafego-frio-compra-direta-canon.v1.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/canonical/trafego-frio-compra-direta-canon.v1.md)
- [plano-evolucao-funil-primeira-venda.md](/root/ai-hub/src/ai-hub-01f8589f-55c3-4cec-88fa-022368de36fa-tdHpNP/repo/docs/marketing/plano-evolucao-funil-primeira-venda.md)

Referências Meta consultadas:
- Meta A/B Testing: https://www.facebook.com/business/help/290009911394576
- Meta Split Testing API: https://developers.facebook.com/documentation/ads-commerce/marketing-api/guides/split-testing
- Meta Pixel / eventos: https://developers.facebook.com/documentation/meta-pixel/reference
- Meta Conversions API: https://developers.facebook.com/documentation/ads-commerce/conversions-api

Não preparei PR nem alteração de arquivos. Minha recomendação é começar pelo **experimento 60**, porque é o melhor candidato de venda direta; depois replicar a estrutura nos experimentos 63 e 61 quando houver aprendizado.

Usuário: crie toda a estrutura no marketing hub para fazer esse teste A/B depois me avise que vou fazer o deploy e seguimos o trabalho.

Modelo: Pronto para deploy.

Criei a estrutura A/B no Marketing Hub para página de venda **tradicional vs página com vídeo humano**:

- Banco/Liquibase: novas tabelas `experiment_sales_page_ab_test` e `experiment_sales_page_ab_variant`.
- Backend: entidades, repositórios, serviço e controller.
- Endpoint para criar o teste padrão:
  `POST /api/experiments/{experimentId}/sales-page-ab-tests/meta-video-vs-traditional`
- Gate de campanha: se existir teste A/B em aberto, o experimento fica bloqueado para mídia até as duas variantes estarem prontas.
- Contrato Facebook: o endpoint de experimentos prontos agora pode expor o resumo do teste A/B para o worker.
- Documentação operacional: [teste-ab-pagina-venda-video-vs-tradicional.md](/root/ai-hub/src/ai-hub-8b8d3eeb-461c-47b0-a0fb-2d699fdf115b-zF7vnK/repo/docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md)

Validei com:

- `mvn -q -Dtest=ExperimentSalesPageAbTestServiceTest,ExperimentReadinessServiceTest,FacebookAdsCampaignMetricsAutoStopControllerTest test`
- `mvn -q -DskipTests compile` no `facebook-ads-worker`
- validação dos includes Liquibase: sem `changesets/...` sem `relativeToChangelogFile: true`

Não criei PR. Pode fazer o deploy; depois seguimos para criar o teste do experimento 60 e preparar as duas variantes reais.

Última mensagem do usuário:
deu erro no action do github. Verifique

**Resumo das alterações:**
Verifiquei o erro do GitHub Actions.

**Causa**
O workflow `CI + CD – marketinghub backend` falhou no teste `FacebookAdsCampaignControllerTest`.

O problema veio da nova estrutura de A/B: no serviço real, **não existir teste A/B ativo não bloqueia mídia**. Mas no teste com `@MockBean`, o mock retornava `false` por padrão e simulava incorretamente que faltava `salesPageAbTest`.

**Correção feita**
Ajustei o setup do teste em [FacebookAdsCampaignControllerTest.java](/root/ai-hub/src/ai-hub-e9f5f986-bcbf-4255-8acb-87750aa48400-to1a0E/repo/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java) para refletir o comportamento real:
- sem A/B ativo: não bloqueia;
- A/B ativo incompleto: continua podendo bloquear quando o teste simular isso.

**Validação**
Passei localmente:
- `mvn -q -Dtest=FacebookAdsCampaignControllerTest test`
- `mvn -B -q test`

Ambos passaram.

Não criei PR nem fiz push. O Actions atual no GitHub continua vermelho porque ele rodou antes dessa correção local. Próximo passo: publicar essa correção para disparar novo Actions.