### PR TITLE
AI Hub: Implementei a tela para alterar os prompts operacionais pela própria aplicação, sem PR.

**Feito**
- Nova tela: `/ai-prompt-schema-templates`
- Menu: **IA e Conteúdo → Prompts operacionais**
- Lista por pipeline/etapa, já abrindo com `gera-sales-p…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/aiprompt/controller/AiPromptSchemaTemplateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/aiprompt/controller/AiPromptSchemaTemplateController.java
@@ -1,0 +1,54 @@
+package com.marketinghub.aiprompt.controller;
+
+import com.marketinghub.aiprompt.service.AiPromptSchemaTemplateService;
+import com.marketinghub.aiprompt.service.alterar.UpdateAiPromptSchemaTemplateRequest;
+import com.marketinghub.aiprompt.service.listar.AiPromptSchemaTemplateResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor administração dos prompts e schemas operacionais dos pipelines de IA. */
+@RestController
+@RequestMapping("/api/ai-prompt-schema-templates")
+public class AiPromptSchemaTemplateController {
+    private final AiPromptSchemaTemplateService service;
+
+    /** Inicializa o controller com o service de templates operacionais. */
+    public AiPromptSchemaTemplateController(AiPromptSchemaTemplateService service) {
+        this.service = service;
+    }
+
+    /** Lista templates com filtros opcionais por pipeline e etapa. */
+    @GetMapping
+    public List<AiPromptSchemaTemplateResponse> list(
+            @RequestParam(value = "pipelineCode", required = false) String pipelineCode,
+            @RequestParam(value = "stageCode", required = false) String stageCode) {
+        return service.list(pipelineCode, stageCode);
+    }
+
+    /** Busca um template operacional pelo identificador técnico. */
+    @GetMapping("/{templateKey}")
+    public AiPromptSchemaTemplateResponse get(@PathVariable String templateKey) {
+        return service.get(templateKey);
+    }
+
+    /** Atualiza prompt, schema, modelo e estado ativo do template. */
+    @PutMapping("/{templateKey}")
+    public AiPromptSchemaTemplateResponse update(
+            @PathVariable String templateKey,
+            @RequestBody UpdateAiPromptSchemaTemplateRequest request) {
+        return service.update(templateKey, request);
+    }
+
+    /** Ativa o template como versão canônica da etapa. */
+    @PostMapping("/{templateKey}/activate")
+    public AiPromptSchemaTemplateResponse activate(@PathVariable String templateKey) {
+        return service.activate(templateKey);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/AiPromptSchemaTemplateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/AiPromptSchemaTemplateService.java
@@ -1,0 +1,156 @@
+package com.marketinghub.aiprompt.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
+import com.marketinghub.aiprompt.service.alterar.UpdateAiPromptSchemaTemplateRequest;
+import com.marketinghub.aiprompt.service.listar.AiPromptSchemaTemplateResponse;
+import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: gerenciar templates operacionais de prompt/schema usados pelos pipelines de IA. */
+@Service
+public class AiPromptSchemaTemplateService {
+    private final AiPromptSchemaTemplateRepository repository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o service com persistência e validador JSON. */
+    public AiPromptSchemaTemplateService(AiPromptSchemaTemplateRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Lista templates com filtros opcionais por pipeline e etapa. */
+    @Transactional(readOnly = true)
+    public List<AiPromptSchemaTemplateResponse> list(String pipelineCode, String stageCode) {
+        if (StringUtils.hasText(pipelineCode) && StringUtils.hasText(stageCode)) {
+            return repository.findByPipelineCodeAndStageCodeOrderByVersionDesc(
+                            normalize(pipelineCode), normalize(stageCode))
+                    .stream()
+                    .map(this::toResponse)
+                    .toList();
+        }
+        if (StringUtils.hasText(pipelineCode)) {
+            return repository.findByPipelineCodeOrderByStageCodeAscVersionDesc(normalize(pipelineCode))
+                    .stream()
+                    .map(this::toResponse)
+                    .toList();
+        }
+        return repository.findAll().stream()
+                .sorted((left, right) -> compareTemplates(left, right))
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /** Busca um template pelo identificador técnico. */
+    @Transactional(readOnly = true)
+    public AiPromptSchemaTemplateResponse get(String templateKey) {
+        return toResponse(load(templateKey));
+    }
+
+    /** Atualiza prompt, schema e metadados de execução de um template existente. */
+    @Transactional
+    public AiPromptSchemaTemplateResponse update(String templateKey, UpdateAiPromptSchemaTemplateRequest request) {
+        AiPromptSchemaTemplate template = load(templateKey);
+        validate(request);
+        template.setVersion(request.version().trim());
+        template.setOpenAiModel(request.openAiModel().trim());
+        template.setSchemaName(request.schemaName().trim());
+        template.setPromptMarkdownContent(request.promptMarkdownContent());
+        template.setSchemaJson(request.schemaJson());
+        template.setActive(Boolean.TRUE.equals(request.active()));
+        template.setUpdatedAt(Instant.now());
+        AiPromptSchemaTemplate saved = repository.save(template);
+        if (saved.isActive()) {
+            repository.deactivateOthersForStage(
+                    saved.getPipelineCode(), saved.getStageCode(), saved.getTemplateKey(), Instant.now());
+        }
+        return toResponse(saved);
+    }
+
+    /** Ativa um template para a etapa e desativa os demais da mesma etapa. */
+    @Transactional
+    public AiPromptSchemaTemplateResponse activate(String templateKey) {
+        AiPromptSchemaTemplate template = load(templateKey);
+        template.setActive(true);
+        template.setUpdatedAt(Instant.now());
+        AiPromptSchemaTemplate saved = repository.save(template);
+        repository.deactivateOthersForStage(
+                saved.getPipelineCode(), saved.getStageCode(), saved.getTemplateKey(), Instant.now());
+        return toResponse(saved);
+    }
+
+    /** Carrega um template ou falha quando o identificador não existe. */
+    private AiPromptSchemaTemplate load(String templateKey) {
+        return repository.findById(templateKey)
+                .orElseThrow(() -> new EntityNotFoundException("AI prompt schema template not found: " + templateKey));
+    }
+
+    /** Valida campos obrigatórios e o JSON schema antes de persistir. */
+    private void validate(UpdateAiPromptSchemaTemplateRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request is required");
+        }
+        if (!StringUtils.hasText(request.version())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "version is required");
+        }
+        if (!StringUtils.hasText(request.openAiModel())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "openAiModel is required");
+        }
+        if (!StringUtils.hasText(request.schemaName())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "schemaName is required");
+        }
+        if (!StringUtils.hasText(request.promptMarkdownContent())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promptMarkdownContent is required");
+        }
+        if (!StringUtils.hasText(request.schemaJson())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "schemaJson is required");
+        }
+        try {
+            objectMapper.readTree(request.schemaJson());
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "schemaJson must be valid JSON", ex);
+        }
+    }
+
+    /** Converte entidade persistida para contrato da API. */
+    private AiPromptSchemaTemplateResponse toResponse(AiPromptSchemaTemplate template) {
+        return new AiPromptSchemaTemplateResponse(
+                template.getTemplateKey(),
+                template.getPipelineCode(),
+                template.getStageCode(),
+                template.getVersion(),
+                template.getOpenAiModel(),
+                template.getSchemaName(),
+                template.getPromptMarkdownContent(),
+                template.getSchemaJson(),
+                template.isActive(),
+                template.getCreatedAt(),
+                template.getUpdatedAt());
+    }
+
+    /** Ordena templates por pipeline, etapa e versão para listagem administrativa estável. */
+    private int compareTemplates(AiPromptSchemaTemplate left, AiPromptSchemaTemplate right) {
+        int pipeline = left.getPipelineCode().compareToIgnoreCase(right.getPipelineCode());
+        if (pipeline != 0) {
+            return pipeline;
+        }
+        int stage = left.getStageCode().compareToIgnoreCase(right.getStageCode());
+        if (stage != 0) {
+            return stage;
+        }
+        return right.getVersion().compareToIgnoreCase(left.getVersion());
+    }
+
+    /** Normaliza filtros preservando o padrão técnico dos códigos. */
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/alterar/UpdateAiPromptSchemaTemplateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/alterar/UpdateAiPromptSchemaTemplateRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.aiprompt.service.alterar;
+
+/** Responsabilidade: receber alterações administrativas de prompt/schema operacional de IA. */
+public record UpdateAiPromptSchemaTemplateRequest(
+        String version,
+        String openAiModel,
+        String schemaName,
+        String promptMarkdownContent,
+        String schemaJson,
+        Boolean active) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/listar/AiPromptSchemaTemplateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/aiprompt/service/listar/AiPromptSchemaTemplateResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.aiprompt.service.listar;
+
+import java.time.Instant;
+
+/** Responsabilidade: representar um template operacional de IA na API administrativa. */
+public record AiPromptSchemaTemplateResponse(
+        String templateKey,
+        String pipelineCode,
+        String stageCode,
+        String version,
+        String openAiModel,
+        String schemaName,
+        String promptMarkdownContent,
+        String schemaJson,
+        boolean active,
+        Instant createdAt,
+        Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/aiprompt/AiPromptSchemaTemplateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/aiprompt/AiPromptSchemaTemplateRepository.java
@@ -1,8 +1,13 @@
 package com.marketinghub.repository.jpa.aiprompt;
 
 import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Responsabilidade: consultar templates ativos de prompt e schema dos pipelines de IA. */
 public interface AiPromptSchemaTemplateRepository
@@ -10,4 +15,26 @@ public interface AiPromptSchemaTemplateRepository
     /** Busca o template ativo da etapa para o pipeline informado. */
     Optional<AiPromptSchemaTemplate> findFirstByPipelineCodeAndStageCodeAndActiveTrueOrderByVersionDesc(
             String pipelineCode, String stageCode);
+
+    /** Lista templates de um pipeline ordenando por etapa e versão. */
+    List<AiPromptSchemaTemplate> findByPipelineCodeOrderByStageCodeAscVersionDesc(String pipelineCode);
+
+    /** Lista templates de uma etapa ordenando por versão. */
+    List<AiPromptSchemaTemplate> findByPipelineCodeAndStageCodeOrderByVersionDesc(String pipelineCode, String stageCode);
+
+    /** Desativa outros templates da mesma etapa para manter um ativo canônico. */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update AiPromptSchemaTemplate template
+               set template.active = false,
+                   template.updatedAt = :updatedAt
+             where template.pipelineCode = :pipelineCode
+               and template.stageCode = :stageCode
+               and template.templateKey <> :templateKey
+            """)
+    void deactivateOthersForStage(
+            @Param("pipelineCode") String pipelineCode,
+            @Param("stageCode") String stageCode,
+            @Param("templateKey") String templateKey,
+            @Param("updatedAt") Instant updatedAt);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateServiceTest.java
@@ -1,0 +1,79 @@
+package com.marketinghub.aiprompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.aiprompt.service.AiPromptSchemaTemplateService;
+import com.marketinghub.aiprompt.service.alterar.UpdateAiPromptSchemaTemplateRequest;
+import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: validar regras administrativas dos templates operacionais de IA. */
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb-aiprompt;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+@org.springframework.transaction.annotation.Transactional
+class AiPromptSchemaTemplateServiceTest {
+    @Autowired
+    AiPromptSchemaTemplateRepository repository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    /** Deve ativar apenas um template por etapa do pipeline. */
+    @Test
+    void activateShouldDeactivateOtherTemplatesForSameStage() {
+        AiPromptSchemaTemplate first = saveTemplate("gera-sales-page-v1:sales-page-html:v1", "v1", true);
+        AiPromptSchemaTemplate second = saveTemplate("gera-sales-page-v1:sales-page-html:v2", "v2", false);
+        AiPromptSchemaTemplateService service = new AiPromptSchemaTemplateService(repository, objectMapper);
+
+        service.activate(second.getTemplateKey());
+
+        assertThat(repository.findById(first.getTemplateKey())).get().extracting(AiPromptSchemaTemplate::isActive).isEqualTo(false);
+        assertThat(repository.findById(second.getTemplateKey())).get().extracting(AiPromptSchemaTemplate::isActive).isEqualTo(true);
+    }
+
+    /** Deve bloquear JSON schema inválido antes de persistir alteração operacional. */
+    @Test
+    void updateShouldRejectInvalidSchemaJson() {
+        AiPromptSchemaTemplate template = saveTemplate("gera-sales-page-v1:sales-page-html:v1", "v1", true);
+        AiPromptSchemaTemplateService service = new AiPromptSchemaTemplateService(repository, objectMapper);
+
+        UpdateAiPromptSchemaTemplateRequest request = new UpdateAiPromptSchemaTemplateRequest(
+                "v1", "gpt-5.5", "sales_page_html", "Prompt", "{invalid", true);
+
+        assertThatThrownBy(() -> service.update(template.getTemplateKey(), request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("schemaJson must be valid JSON");
+    }
+
+    /** Persiste um template mínimo para os cenários de teste. */
+    private AiPromptSchemaTemplate saveTemplate(String key, String version, boolean active) {
+        Instant now = Instant.now();
+        return repository.save(AiPromptSchemaTemplate.builder()
+                .templateKey(key)
+                .pipelineCode("gera-sales-page-v1")
+                .stageCode("sales-page-html")
+                .version(version)
+                .openAiModel("gpt-5.5")
+                .schemaName("sales_page_html")
+                .promptMarkdownContent("Prompt")
+                .schemaJson("{\"type\":\"object\"}")
+                .active(active)
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
+    }
+}

--- a/docs/swagger/ai-prompt-schema-templates-swagger.yaml
+++ b/docs/swagger/ai-prompt-schema-templates-swagger.yaml
@@ -1,0 +1,141 @@
+openapi: 3.0.3
+info:
+  title: AI Prompt Schema Templates API
+  version: 1.0.0
+  description: Administração de prompts e schemas operacionais usados pelos pipelines de IA.
+paths:
+  /api/ai-prompt-schema-templates:
+    get:
+      summary: Lista templates operacionais de IA
+      parameters:
+        - in: query
+          name: pipelineCode
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: stageCode
+          schema:
+            type: string
+          required: false
+      responses:
+        "200":
+          description: Templates encontrados.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AiPromptSchemaTemplate"
+  /api/ai-prompt-schema-templates/{templateKey}:
+    get:
+      summary: Busca um template operacional
+      parameters:
+        - $ref: "#/components/parameters/TemplateKey"
+      responses:
+        "200":
+          description: Template encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AiPromptSchemaTemplate"
+    put:
+      summary: Atualiza prompt, schema, modelo e versão
+      parameters:
+        - $ref: "#/components/parameters/TemplateKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAiPromptSchemaTemplate"
+      responses:
+        "200":
+          description: Template atualizado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AiPromptSchemaTemplate"
+        "400":
+          description: Dados obrigatórios ausentes ou JSON schema inválido.
+  /api/ai-prompt-schema-templates/{templateKey}/activate:
+    post:
+      summary: Ativa um template para a etapa
+      parameters:
+        - $ref: "#/components/parameters/TemplateKey"
+      responses:
+        "200":
+          description: Template ativado e demais templates da etapa desativados.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AiPromptSchemaTemplate"
+components:
+  parameters:
+    TemplateKey:
+      in: path
+      name: templateKey
+      required: true
+      schema:
+        type: string
+      description: Identificador técnico do template.
+  schemas:
+    AiPromptSchemaTemplate:
+      type: object
+      required:
+        - templateKey
+        - pipelineCode
+        - stageCode
+        - version
+        - openAiModel
+        - schemaName
+        - promptMarkdownContent
+        - schemaJson
+        - active
+      properties:
+        templateKey:
+          type: string
+        pipelineCode:
+          type: string
+        stageCode:
+          type: string
+        version:
+          type: string
+        openAiModel:
+          type: string
+        schemaName:
+          type: string
+        promptMarkdownContent:
+          type: string
+        schemaJson:
+          type: string
+        active:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    UpdateAiPromptSchemaTemplate:
+      type: object
+      required:
+        - version
+        - openAiModel
+        - schemaName
+        - promptMarkdownContent
+        - schemaJson
+        - active
+      properties:
+        version:
+          type: string
+        openAiModel:
+          type: string
+        schemaName:
+          type: string
+        promptMarkdownContent:
+          type: string
+        schemaJson:
+          type: string
+        active:
+          type: boolean

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,6 +97,8 @@ import PaymentDetailPage from "./pages/payments/PaymentDetailPage";
 import PromptListPage from "./pages/promptTemplate/PromptListPage";
 import NewPromptPage from "./pages/promptTemplate/NewPromptPage";
 import EditPromptPage from "./pages/promptTemplate/EditPromptPage";
+import AiPromptSchemaTemplateListPage from "./pages/aiPromptSchemaTemplate/AiPromptSchemaTemplateListPage";
+import EditAiPromptSchemaTemplatePage from "./pages/aiPromptSchemaTemplate/EditAiPromptSchemaTemplatePage";
 import PromptDomainListPage from "./pages/promptDomain/PromptDomainListPage";
 import NewPromptDomainPage from "./pages/promptDomain/NewPromptDomainPage";
 import EditPromptDomainPage from "./pages/promptDomain/EditPromptDomainPage";
@@ -150,10 +152,7 @@ function LegacyHypothesisRedirect() {
   const { nicheId, hypothesisId } = useParams();
   if (nicheId && hypothesisId) {
     return (
-      <Navigate
-        to={`/niches/${nicheId}/hypotheses/${hypothesisId}`}
-        replace
-      />
+      <Navigate to={`/niches/${nicheId}/hypotheses/${hypothesisId}`} replace />
     );
   }
   return <Navigate to={nicheId ? `/niches/${nicheId}` : "/niches"} replace />;
@@ -549,6 +548,14 @@ export default function App() {
               <Route path="/prompts" element={<PromptListPage />} />
               <Route path="/prompts/new" element={<NewPromptPage />} />
               <Route path="/prompts/:id/edit" element={<EditPromptPage />} />
+              <Route
+                path="/ai-prompt-schema-templates"
+                element={<AiPromptSchemaTemplateListPage />}
+              />
+              <Route
+                path="/ai-prompt-schema-templates/:templateKey/edit"
+                element={<EditAiPromptSchemaTemplatePage />}
+              />
               <Route
                 path="/facebook-campaigns"
                 element={<FacebookCampaignExperimentsPage />}

--- a/frontend/src/api/aiPromptSchemaTemplate/types.ts
+++ b/frontend/src/api/aiPromptSchemaTemplate/types.ts
@@ -1,0 +1,22 @@
+export interface AiPromptSchemaTemplate {
+  templateKey: string;
+  pipelineCode: string;
+  stageCode: string;
+  version: string;
+  openAiModel: string;
+  schemaName: string;
+  promptMarkdownContent: string;
+  schemaJson: string;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UpdateAiPromptSchemaTemplatePayload {
+  version: string;
+  openAiModel: string;
+  schemaName: string;
+  promptMarkdownContent: string;
+  schemaJson: string;
+  active: boolean;
+}

--- a/frontend/src/api/aiPromptSchemaTemplate/useActivateAiPromptSchemaTemplate.ts
+++ b/frontend/src/api/aiPromptSchemaTemplate/useActivateAiPromptSchemaTemplate.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import type { AiPromptSchemaTemplate } from "./types";
+
+export function useActivateAiPromptSchemaTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (templateKey: string) => {
+      const { data } = await axios.post<AiPromptSchemaTemplate>(
+        `/api/ai-prompt-schema-templates/${encodeURIComponent(templateKey)}/activate`,
+      );
+      return data;
+    },
+    onSuccess: (template) => {
+      queryClient.invalidateQueries({ queryKey: ["aiPromptSchemaTemplates"] });
+      queryClient.setQueryData(
+        ["aiPromptSchemaTemplate", template.templateKey],
+        template,
+      );
+    },
+  });
+}

--- a/frontend/src/api/aiPromptSchemaTemplate/useAiPromptSchemaTemplate.ts
+++ b/frontend/src/api/aiPromptSchemaTemplate/useAiPromptSchemaTemplate.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { AiPromptSchemaTemplate } from "./types";
+
+export function useAiPromptSchemaTemplate(templateKey: string) {
+  return useQuery({
+    queryKey: ["aiPromptSchemaTemplate", templateKey],
+    enabled: Boolean(templateKey),
+    queryFn: async () => {
+      const { data } = await axios.get<AiPromptSchemaTemplate>(
+        `/api/ai-prompt-schema-templates/${encodeURIComponent(templateKey)}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/aiPromptSchemaTemplate/useAiPromptSchemaTemplates.ts
+++ b/frontend/src/api/aiPromptSchemaTemplate/useAiPromptSchemaTemplates.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { AiPromptSchemaTemplate } from "./types";
+
+export function useAiPromptSchemaTemplates(
+  pipelineCode?: string,
+  stageCode?: string,
+) {
+  return useQuery({
+    queryKey: ["aiPromptSchemaTemplates", pipelineCode ?? "", stageCode ?? ""],
+    queryFn: async () => {
+      const params = {
+        ...(pipelineCode ? { pipelineCode } : {}),
+        ...(stageCode ? { stageCode } : {}),
+      };
+      const { data } = await axios.get<AiPromptSchemaTemplate[]>(
+        "/api/ai-prompt-schema-templates",
+        { params },
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/aiPromptSchemaTemplate/useUpdateAiPromptSchemaTemplate.ts
+++ b/frontend/src/api/aiPromptSchemaTemplate/useUpdateAiPromptSchemaTemplate.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  AiPromptSchemaTemplate,
+  UpdateAiPromptSchemaTemplatePayload,
+} from "./types";
+
+export function useUpdateAiPromptSchemaTemplate(templateKey: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: UpdateAiPromptSchemaTemplatePayload) => {
+      const { data } = await axios.put<AiPromptSchemaTemplate>(
+        `/api/ai-prompt-schema-templates/${encodeURIComponent(templateKey)}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: (template) => {
+      queryClient.invalidateQueries({ queryKey: ["aiPromptSchemaTemplates"] });
+      queryClient.setQueryData(
+        ["aiPromptSchemaTemplate", template.templateKey],
+        template,
+      );
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -165,6 +165,11 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/prompt-entities", label: "Objetos de Prompt", icon: Shapes },
       { to: "/prompt-domains", label: "Domínios de Prompt", icon: Map },
       { to: "/prompts", label: "Prompts (templates)", icon: ScrollText },
+      {
+        to: "/ai-prompt-schema-templates",
+        label: "Prompts operacionais",
+        icon: ScrollText,
+      },
       { to: "/angles", label: "Angles", icon: Compass },
       { to: "/visual-proofs", label: "Provas Visuais", icon: BadgeCheck },
       {

--- a/frontend/src/pages/aiPromptSchemaTemplate/AiPromptSchemaTemplateListPage.tsx
+++ b/frontend/src/pages/aiPromptSchemaTemplate/AiPromptSchemaTemplateListPage.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import { useActivateAiPromptSchemaTemplate } from "../../api/aiPromptSchemaTemplate/useActivateAiPromptSchemaTemplate";
+import { useAiPromptSchemaTemplates } from "../../api/aiPromptSchemaTemplate/useAiPromptSchemaTemplates";
+import PageTitle from "../../components/PageTitle";
+
+const DEFAULT_PIPELINE = "gera-sales-page-v1";
+
+export default function AiPromptSchemaTemplateListPage() {
+  const [pipelineCode, setPipelineCode] = useState(DEFAULT_PIPELINE);
+  const [stageCode, setStageCode] = useState("");
+  const { data, isLoading } = useAiPromptSchemaTemplates(
+    pipelineCode || undefined,
+    stageCode || undefined,
+  );
+  const templates = data ?? [];
+  const navigate = useNavigate();
+  const activateTemplate = useActivateAiPromptSchemaTemplate();
+  const stageOptions = useMemo(() => {
+    return Array.from(
+      new Set(templates.map((template) => template.stageCode)),
+    ).sort();
+  }, [templates]);
+
+  async function handleActivate(templateKey: string) {
+    await activateTemplate.mutateAsync(templateKey);
+    toast.success("Template ativado");
+  }
+
+  return (
+    <div className="d-flex flex-column gap-3">
+      <PageTitle>Prompts operacionais de IA</PageTitle>
+
+      <div className="row g-3 align-items-end">
+        <div className="col-md-4">
+          <label htmlFor="ai-prompt-pipeline" className="form-label">
+            Pipeline
+          </label>
+          <input
+            id="ai-prompt-pipeline"
+            className="form-control"
+            value={pipelineCode}
+            onChange={(event) => setPipelineCode(event.target.value)}
+            placeholder="gera-sales-page-v1"
+          />
+        </div>
+        <div className="col-md-4">
+          <label htmlFor="ai-prompt-stage" className="form-label">
+            Etapa
+          </label>
+          <input
+            id="ai-prompt-stage"
+            className="form-control"
+            value={stageCode}
+            onChange={(event) => setStageCode(event.target.value)}
+            list="ai-prompt-stage-options"
+            placeholder="Todas"
+          />
+          <datalist id="ai-prompt-stage-options">
+            {stageOptions.map((stage) => (
+              <option key={stage} value={stage} />
+            ))}
+          </datalist>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <p>Carregando...</p>
+      ) : (
+        <div className="table-responsive">
+          <table className="table align-middle">
+            <thead>
+              <tr>
+                <th>Etapa</th>
+                <th>Versão</th>
+                <th>Modelo</th>
+                <th>Schema</th>
+                <th>Status</th>
+                <th>Atualizado</th>
+                <th className="text-end">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {templates.map((template) => (
+                <tr
+                  key={template.templateKey}
+                  className={template.active ? "table-success" : ""}
+                >
+                  <td>
+                    <div className="fw-semibold">{template.stageCode}</div>
+                    <small className="text-body-secondary">
+                      {template.templateKey}
+                    </small>
+                  </td>
+                  <td>{template.version}</td>
+                  <td>{template.openAiModel}</td>
+                  <td>{template.schemaName}</td>
+                  <td>
+                    {template.active ? (
+                      <span className="badge text-bg-success">Ativo</span>
+                    ) : (
+                      <span className="badge text-bg-secondary">Inativo</span>
+                    )}
+                  </td>
+                  <td>
+                    {template.updatedAt
+                      ? new Date(template.updatedAt).toLocaleString()
+                      : "-"}
+                  </td>
+                  <td className="text-end">
+                    <div className="d-flex justify-content-end gap-2">
+                      {!template.active ? (
+                        <button
+                          type="button"
+                          className="btn btn-outline-success btn-sm"
+                          onClick={() => handleActivate(template.templateKey)}
+                          disabled={activateTemplate.isPending}
+                        >
+                          {activateTemplate.isPending ? (
+                            <span
+                              className="spinner-border spinner-border-sm"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            "Ativar"
+                          )}
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="btn btn-outline-primary btn-sm"
+                        onClick={() =>
+                          navigate(
+                            `/ai-prompt-schema-templates/${encodeURIComponent(template.templateKey)}/edit`,
+                          )
+                        }
+                      >
+                        Editar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {templates.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="text-center text-body-secondary">
+                    Nenhum template operacional encontrado.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/aiPromptSchemaTemplate/EditAiPromptSchemaTemplatePage.tsx
+++ b/frontend/src/pages/aiPromptSchemaTemplate/EditAiPromptSchemaTemplatePage.tsx
@@ -1,0 +1,210 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { useAiPromptSchemaTemplate } from "../../api/aiPromptSchemaTemplate/useAiPromptSchemaTemplate";
+import { useUpdateAiPromptSchemaTemplate } from "../../api/aiPromptSchemaTemplate/useUpdateAiPromptSchemaTemplate";
+import PageTitle from "../../components/PageTitle";
+
+export default function EditAiPromptSchemaTemplatePage() {
+  const { templateKey } = useParams();
+  const resolvedTemplateKey = templateKey
+    ? decodeURIComponent(templateKey)
+    : "";
+  const { data, isLoading } = useAiPromptSchemaTemplate(resolvedTemplateKey);
+  const updateTemplate = useUpdateAiPromptSchemaTemplate(resolvedTemplateKey);
+  const navigate = useNavigate();
+  const [version, setVersion] = useState("");
+  const [openAiModel, setOpenAiModel] = useState("");
+  const [schemaName, setSchemaName] = useState("");
+  const [promptMarkdownContent, setPromptMarkdownContent] = useState("");
+  const [schemaJson, setSchemaJson] = useState("");
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (!data) return;
+    setVersion(data.version);
+    setOpenAiModel(data.openAiModel);
+    setSchemaName(data.schemaName);
+    setPromptMarkdownContent(data.promptMarkdownContent);
+    setSchemaJson(data.schemaJson);
+    setActive(data.active);
+  }, [data]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    try {
+      JSON.parse(schemaJson);
+    } catch {
+      toast.error("Schema JSON inválido");
+      return;
+    }
+    await updateTemplate.mutateAsync({
+      version,
+      openAiModel,
+      schemaName,
+      promptMarkdownContent,
+      schemaJson,
+      active,
+    });
+    toast.success("Template operacional atualizado");
+    navigate("/ai-prompt-schema-templates");
+  }
+
+  if (!resolvedTemplateKey) return <p>Template não encontrado.</p>;
+  if (isLoading) return <p>Carregando...</p>;
+  if (!data) return <p>Template não encontrado.</p>;
+
+  return (
+    <form onSubmit={handleSubmit} className="d-flex flex-column gap-3">
+      <div className="d-flex align-items-center justify-content-between">
+        <PageTitle>Editar prompt operacional</PageTitle>
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          onClick={() => navigate("/ai-prompt-schema-templates")}
+        >
+          Voltar
+        </button>
+      </div>
+
+      <div className="card">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="row g-3">
+            <div className="col-md-4">
+              <label className="form-label">Pipeline</label>
+              <input
+                className="form-control"
+                value={data.pipelineCode}
+                disabled
+              />
+            </div>
+            <div className="col-md-4">
+              <label className="form-label">Etapa</label>
+              <input className="form-control" value={data.stageCode} disabled />
+            </div>
+            <div className="col-md-4">
+              <label className="form-label">Template key</label>
+              <input
+                className="form-control"
+                value={data.templateKey}
+                disabled
+              />
+            </div>
+            <div className="col-md-4">
+              <label htmlFor="ai-prompt-version" className="form-label">
+                Versão *
+              </label>
+              <input
+                id="ai-prompt-version"
+                className="form-control"
+                value={version}
+                onChange={(event) => setVersion(event.target.value)}
+                required
+                disabled={updateTemplate.isPending}
+              />
+            </div>
+            <div className="col-md-4">
+              <label htmlFor="ai-prompt-model" className="form-label">
+                Modelo OpenAI *
+              </label>
+              <input
+                id="ai-prompt-model"
+                className="form-control"
+                value={openAiModel}
+                onChange={(event) => setOpenAiModel(event.target.value)}
+                required
+                disabled={updateTemplate.isPending}
+              />
+            </div>
+            <div className="col-md-4">
+              <label htmlFor="ai-prompt-schema-name" className="form-label">
+                Nome do schema *
+              </label>
+              <input
+                id="ai-prompt-schema-name"
+                className="form-control"
+                value={schemaName}
+                onChange={(event) => setSchemaName(event.target.value)}
+                required
+                disabled={updateTemplate.isPending}
+              />
+            </div>
+          </div>
+
+          <div className="form-check">
+            <input
+              id="ai-prompt-active"
+              className="form-check-input"
+              type="checkbox"
+              checked={active}
+              onChange={(event) => setActive(event.target.checked)}
+              disabled={updateTemplate.isPending}
+            />
+            <label className="form-check-label" htmlFor="ai-prompt-active">
+              Manter ativo para esta etapa
+            </label>
+          </div>
+
+          <div>
+            <label htmlFor="ai-prompt-content" className="form-label">
+              Prompt Markdown *
+            </label>
+            <textarea
+              id="ai-prompt-content"
+              className="form-control"
+              rows={18}
+              style={{ fontFamily: "monospace" }}
+              value={promptMarkdownContent}
+              onChange={(event) => setPromptMarkdownContent(event.target.value)}
+              required
+              disabled={updateTemplate.isPending}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="ai-prompt-schema-json" className="form-label">
+              JSON schema *
+            </label>
+            <textarea
+              id="ai-prompt-schema-json"
+              className="form-control"
+              rows={14}
+              style={{ fontFamily: "monospace" }}
+              value={schemaJson}
+              onChange={(event) => setSchemaJson(event.target.value)}
+              required
+              disabled={updateTemplate.isPending}
+            />
+          </div>
+
+          <div className="d-flex justify-content-end gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={() => navigate("/ai-prompt-schema-templates")}
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={updateTemplate.isPending}
+            >
+              {updateTemplate.isPending ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                  Salvando
+                </>
+              ) : (
+                "Salvar"
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Modelo: Segui e deixei o A/B real preparado no Marketing Hub para o **experimento 60**.

**Feito**
- Criei o teste A/B: `id 1`
- Variante A: `id 1` — página tradicional
- Variante B: `id 2` — página com vídeo humano
- Criei o ativo de vídeo planejado: `videoAsset id 2`
- Vinculei o vídeo à variante B
- Mantive tudo em `DRAFT`, corretamente bloqueado para mídia

**Validação**
- A fila do Facebook continua vazia, como deveria.
- O GeraSalesPage foi testado e bloqueou corretamente com:
  `GeraSalesPage v1 exige URL real de checkout antes de iniciar.`

**Bloqueio atual**
Falta a **URL real de checkout** do Kit Agenda Fechada 7D. Sem isso, não dá para iniciar a página de venda auditada pelo GeraSalesPage sem cair no erro antigo de liberar low-ticket sem página canônica.

**Próximo passo**
Me envie a URL real de checkout do produto de R$ 27. Com ela eu sigo nesta ordem:

1. cadastrar a URL no experimento 60;
2. iniciar o GeraSalesPage v1;
3. acompanhar a geração/publicação auditada;
4. vincular as páginas às variantes A/B;
5. liberar só quando vídeo, criativos, público, coletores e variantes estiverem prontos.

Usuário: execute os proximos passos

Modelo: Executei os próximos passos possíveis em produção.

**Feito**
- Confirmei que o A/B do experimento **60** existe:
  - Variante A: página tradicional
  - Variante B: página com vídeo humano
- Confirmei que o vídeo da variante B está planejado e vinculado.
- Testei o início do **GeraSalesPage v1**.
- Testei a liberação para Facebook.
- Confirmei que a fila do Facebook segue vazia, corretamente, sem risco de gasto.

**Bloqueio atual**
O sistema bloqueou corretamente:

`GeraSalesPage v1 exige URL real de checkout antes de iniciar.`

E a liberação para mídia também bloqueou:

`Experimento com intenção de compra exige página de venda criada pelo GeraSalesPage v1 antes da campanha.`

**Também faltam para o 60**
- URL real de checkout do produto de R$ 27.
- Página de venda gerada/auditada pelo GeraSalesPage.
- Criativos aprovados.
- Vídeo aprovado.
- Público Meta selecionado.
- Variantes A/B com URLs, checkout, coletores e status `READY`.

Não alterei arquivos, não criei PR e não liberei mídia.

Próximo passo obrigatório: me envie a **URL real de checkout** do Kit Agenda Fechada 7D. Com ela eu consigo cadastrar no experimento, iniciar o GeraSalesPage e avançar para vincular as duas páginas do teste A/B.

Usuário: faça teste A/B no 63 tbm colocando video de pessoa explicando

Modelo: Feito no experimento **63**.

**Criado**
- Teste A/B `id 2`
- Variante A `id 3`: página tradicional
- Variante B `id 4`: página com vídeo humano
- Ativo de vídeo planejado `id 3`
- Vídeo vinculado à variante B

**Status**
- Tudo ficou em `DRAFT`, corretamente bloqueado para mídia.
- A fila do Facebook continua vazia, como esperado.
- O vídeo está como `PLANNED` e `PENDING` de revisão.

**Próximo bloqueio real**
Para liberar o teste, ainda precisamos das páginas finais e do destino de conversão:
- URL da página tradicional;
- URL da página com vídeo;
- URL de checkout ou conversão;
- coletores/eventos ativos.

Não criei PR nem alterei arquivos. Executei direto na estrutura já publicada do Marketing Hub.

Usuário: continue com o que falta para o experimento 60 se precisar alterar funcionalidade no marketing hub me avise

Modelo: Continuei o experimento 60 até o ponto seguro.

**Estado confirmado**
- Teste A/B do 60 existe e está em `DRAFT`.
- Variante A: página tradicional.
- Variante B: página com vídeo humano, já vinculada ao `videoAssetId=2`.
- O vídeo está planejado, mas ainda não está `READY/APPROVED`.
- Existem 3 criativos gerados, todos em `DRAFT`.
- Público Meta ainda não foi selecionado.
- Não existe publicação do GeraSalesPage.
- Fila do Facebook continua vazia, corretamente.

**Bloqueio real**
Tentei iniciar o GeraSalesPage e o backend bloqueou com:

`GeraSalesPage v1 exige URL real de checkout antes de iniciar.`

Então ainda falta a **URL real de checkout do Kit Agenda Fechada 7D**.

**Ponto de funcionalidade**
Para fazer A/B completo dentro do Marketing Hub, precisa alterar funcionalidade.

Hoje o GeraSalesPage publica **uma página única por experimento** (`exp-60-gerasalespage-v1`). Para o teste A/B correto, precisamos evoluir para publicar páginas por variante, por exemplo:

- `exp-60-gerasalespage-v1-a`
- `exp-60-gerasalespage-v1-b-video`

Sem isso, dá para cadastrar URLs manualmente nas variantes, mas o Marketing Hub não gera/audita automaticamente as duas páginas separadas.

**Melhor caminho**
1. Você me envia a URL real de checkout.
2. Eu faço a alteração funcional para o GeraSalesPage suportar variantes A/B.
3. Depois gero/publico as duas páginas auditadas e vinculo cada URL à variante correta.
4. Só então seguimos para vídeo aprovado, público Meta, criativos aprovados e liberação controlada.

Não liberei mídia e não criei PR.

Usuário: faça teste A/B no 61 tbm colocando video de pessoa explicando

Modelo: Feito no experimento **61**.

Criei a mesma estrutura A/B:

- Teste A/B `id 3`
- Variante A `id 5`: página tradicional
- Variante B `id 6`: página com vídeo humano
- Vídeo planejado `id 4`
- Vídeo vinculado à variante B

Status atual:

- Teste A/B segue em `DRAFT`.
- Vídeo está `PLANNED` com revisão `PENDING`.
- Fila do Facebook continua vazia, corretamente.
- Nenhum anúncio foi liberado e nenhum gasto foi iniciado.

Não precisei alterar funcionalidade no Marketing Hub e não criei PR.

Próximos bloqueios para liberar o 61: URLs finais das duas páginas, destino de conversão/checkout ou formulário, coletores/eventos ativos e aprovação do vídeo.

Usuário: gere tudo que precisar direto no mercado pago para os 3 experimentos: 60,61 e 63

Usuário: gere tudo que precisar direto no mercado pago para os 3 experimentos: 60,61 e 63

Modelo: Executei o que dava com segurança.

**Criado no Mercado Pago**
- Exp. 60 — `Kit Agenda Fechada 7D` — R$ 27  
  Checkout: `https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-57b91b27-1edd-4a88-af41-d9f61cff8ed3`

- Exp. 61 — `Checklist de Elegancia Sofisticada Acessivel` — R$ 47  
  Checkout: `https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-691e9f0a-3e01-4f7d-8715-3a97940643b2`

- Exp. 63 — `Scripts de Negociacao com Firmeza` — R$ 97  
  Checkout: `https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-a581cb81-e5e6-4eff-96eb-4675f8f19b62`

Usei Checkout Pro/preferências, que é o caminho correto para gerar uma URL de pagamento no Mercado Pago. Referência: https://www.mercadopago.com.br/developers/en/reference/online-payments/checkout-pro/preferences/create-preference/post

**Registrado no Marketing Hub**
- Exp. 60: checkout registrado no experimento e nas duas variantes A/B.
- Exp. 60: GeraSalesPage v1 iniciado com sucesso. Job: `dd05cdd6-4e2d-46cb-ace7-e62add9703d1`.
- Exp. 61 e 63: checkout registrado nas variantes A/B.
- Mantive todos os testes A/B em `DRAFT`, sem liberar mídia.

**Bloqueio funcional identificado**
Para 61 e 63, o backend não aceitou registrar o checkout diretamente no experimento porque eles ainda estão como `LEADS/NICHE_TEST` e com `metricPresetId` nulo. Além disso, a entrega pós-compra automática do serviço de pagamentos hoje está preparada para fluxos específicos antigos, não para os produtos 60/61/63.

**Precisa alterar funcionalidade no Marketing Hub**
Sim. Para fechar a causa-raiz, precisa evoluir o Marketing Hub para:
- suportar checkout de produto digital por experimento, não só por pacote Lead Portal;
- registrar `preferenceId`, `checkoutUrl`, preço e produto por experimento;
- tratar webhook do Mercado Pago para 60/61/63;
- acionar entrega pós-compra correta;
- permitir transformar 61/63 em venda/A-B sem depender de campos antigos faltantes.

Não criei PR.

Usuário: agora pode continuar nos experimentos, já tem os checkouts. Preciamos ter os entregaveis tbm, importante !

Modelo: Continuei os três experimentos.

**Feito**
- Exp. **60**: criei o pacote de entregáveis `Kit Agenda Fechada 7D` com 5 entregáveis.
- Exp. **61**: criei o pacote `Checklist de Elegância Sofisticada Acessível` com 5 entregáveis.
- Exp. **63**: criei o pacote `Scripts de Negociação com Firmeza` com 5 entregáveis.
- Exp. **60**: GeraSalesPage avançou até HTML e passou na auditoria comercial de checkout.

**Bloqueio atual**
O 60 falhou só na publicação final. A página foi aprovada, mas o backend exige pelo menos **3 cenas visuais marcadas tecnicamente** como transformação (`data-transform-visual`). A IA criou a página com bons blocos visuais, mas sem essa marcação, então o backend bloqueou a publicação.

**Precisa alterar funcionalidade no Marketing Hub**
Sim. Precisa ajustar o GeraSalesPage para obrigar/injetar essas marcações visuais antes da publicação. Também ainda precisamos evoluir 61 e 63 porque o checkout está nas variantes A/B, mas o GeraSalesPage ainda olha o checkout do experimento principal.

Não liberei mídia e não criei PR.

Usuário: vamos seguir no 60 resolva os bloqueios execute novamente ou se necessário melhore os prompts

Modelo: Resolvi a causa-raiz do bloqueio do experimento 60.

Feito:
- O `ai-worker` agora garante as 3 cenas visuais mínimas antes da auditoria final.
- Se a IA gerar bons blocos visuais sem `data-transform-visual`, o worker marca.
- Se a IA gerar página sem imagem nenhuma, o worker injeta uma faixa visual mínima auditável com SVGs.
- Criei prompts `v6` do GeraSalesPage exigindo visual de transformação desde o planejamento, HTML, quality review e pacote de publicação.
- Atualizei o cânone do GeraSalesPage.

Arquivos principais:
- [GeraSalesPageProcessor.java](/root/ai-hub/src/ai-hub-6a8fb2a5-aa2b-4855-9c61-439359815094-C0jeBT/repo/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java)
- [2026-07-09-gera-sales-page-visual-transform-v6.yaml](/root/ai-hub/src/ai-hub-6a8fb2a5-aa2b-4855-9c61-439359815094-C0jeBT/repo/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-09-gera-sales-page-visual-transform-v6.yaml)
- [gerasalespage-arquitetura-canon.v1.md](/root/ai-hub/src/ai-hub-6a8fb2a5-aa2b-4855-9c61-439359815094-C0jeBT/repo/docs/canonical/gerasalespage-arquitetura-canon.v1.md)

Validei:
- `GeraSalesPageProcessorTest`
- `GeraSalesPagePublicationAuditServiceTest`
- `ai-worker compile`
- `Liquibase validate`
- include Liquibase com `relativeToChangelogFile: true`

Não reexecutei o 60 em produção ainda porque produção segue com templates antigos `v4/v3` e worker antigo. Reexecutar agora provavelmente repetiria o mesmo erro e gastaria IA à toa.

Próximo passo: fazer deploy de backend + ai-worker. Depois do deploy, eu rodo o rebuild do GeraSalesPage no experimento 60 e acompanho até publicar a página. Não criei PR.

Usuário: vamos seguir o experimento 61

Modelo: Segui o experimento **61** até o bloqueio real.

**Feito**
- Transformei o 61 de captação para **venda low-ticket**:
  - `LOW_TICKET_PRODUCT`
  - objetivo `SALES`
  - preço `R$ 47`
  - checkout principal Mercado Pago registrado
- Iniciei o **GeraSalesPage v1**.
- O pipeline avançou por:
  - brief da oferta
  - wireframe
  - copy
  - plano visual
  - HTML
  - revisão comercial de checkout

**Resultado**
A página foi aprovada comercialmente, mas falhou na publicação final.

**Causa-raiz**
Produção ainda está usando templates antigos do GeraSalesPage:

- HTML ativo: `v4`
- visual-plan ativo: `v3`
- publication-package ativo: `v4`

O repositório já possui o template `v6`, que exige `data-transform-visual`, mas ele **não está aplicado no banco de produção**. Por isso o HTML saiu com `0` cenas marcadas e o backend bloqueou corretamente:

`GeraSalesPage bloqueou a publicacao por menos de 3 cenas visuais de transformacao.`

**Melhor caminho**
Entre as opções:

1. Rebuild agora: baixo esforço, mas vai repetir a falha.
2. Ajustar só prompt: melhora, mas ainda depende da IA obedecer.
3. Aplicar `v6` + usar a injeção automática já existente no worker: melhor causa-raiz.

Recomendo **deploy/aplicação do v6 em produção** e depois rebuild do 61.

Não liberei mídia, não criei PR e não alterei arquivos.

Usuário: vamos seguir o experimento 63

Modelo: Segui o experimento **63** até o limite seguro.

**Feito**
- Corrigi o 63 para usar `LEAN_100`, que estava faltando e bloqueava atualização.
- Registrei o checkout também no experimento principal.
- Reiniciei o **GeraSalesPage v1**.
- O pipeline avançou com sucesso por:
  - briefing da oferta;
  - wireframe;
  - copy;
  - plano visual;
  - HTML;
  - auditoria de checkout.

**Resultado**
A página foi aprovada comercialmente na auditoria de checkout, mas falhou na **publicação final** com `409`.

**Causa provável**
O HTML gerado ainda não cumpriu o contrato técnico de publicação com as marcações visuais obrigatórias (`data-transform-visual`). É o mesmo tipo de bloqueio que apareceu no 60: a IA cria uma página boa comercialmente, mas não entrega o marcador técnico que o backend exige para considerar a prova visual válida.

**Precisa alterar funcionalidade no Marketing Hub**
Sim. Para fechar a causa-raiz, o melhor caminho é ajustar o GeraSalesPage para **injetar/validar automaticamente** essas marcações antes da publicação, em vez de depender só do prompt.

**Ainda não liberei mídia**
O 63 continua bloqueado corretamente porque faltam:
- página publicada;
- vídeo humano aprovado;
- criativos aprovados;
- público Meta selecionado;
- variantes A/B com URLs publicadas e coletores confirmados.

Não criei PR.

Última mensagem do usuário:
esses prompts que vc teve que alterar diretamente no banco de dados. Precisamos criar tela para alterar pela propria aplicação.

**Resumo das alterações:**
Implementei a tela para alterar os prompts operacionais pela própria aplicação, sem PR.

**Feito**
- Nova tela: `/ai-prompt-schema-templates`
- Menu: **IA e Conteúdo → Prompts operacionais**
- Lista por pipeline/etapa, já abrindo com `gera-sales-page-v1`
- Edição de:
  - versão
  - modelo OpenAI
  - nome do schema
  - prompt Markdown
  - JSON schema
  - status ativo
- Validação de JSON schema antes de salvar
- Ativação canônica: ao ativar um template de uma etapa, os outros da mesma etapa são desativados
- Swagger criado em `docs/swagger/ai-prompt-schema-templates-swagger.yaml`

**Validação**
- Backend: `AiPromptSchemaTemplateServiceTest` passou
- Frontend: `npm run typecheck` passou
- Frontend: `npm run build` passou
- `git diff --check` passou
- `spotless:check` não rodou porque o plugin não está configurado/resolvido nesse módulo Maven

**Ambiente local**
Frontend rodando em:

`http://localhost:5173/`

Observação importante: a tela só funcionará contra produção depois de deploy do backend com o novo endpoint. Não criei PR.