### PR TITLE
AI Hub: Corrigido.

**O que estava acontecendo**
A causa-raiz era o fallback visual do GeraSalesPage: quando a IA não entregava cenas visuais suficientes, o worker injetava blocos de apoio com rótulos internos visíveis como “Dor atual”, “Depois desejado” …

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java
@@ -181,18 +181,18 @@ public class GeraSalesPageProcessor implements StageProcessor<GeraSalesPageInput
         return html + block;
     }
 
-    /** Cria um card SVG simples que materializa dor, depois ou preview do produto digital. */
+    /** Cria um card SVG simples com texto comercial seguro para materializar a transformacao. */
     private String fallbackTransformationVisualCard(int index) {
         String kind = transformationVisualKind(index);
         String title = switch (index) {
-            case 0 -> "Depois desejado";
-            case 1 -> "Dor atual";
-            default -> "Preview do produto";
+            case 0 -> "Imagem mais alinhada";
+            case 1 -> "Mais clareza nas escolhas";
+            default -> "Conteudo pratico e organizado";
         };
         String subtitle = switch (index) {
-            case 0 -> "rotina organizada e decisao facil";
-            case 1 -> "perda de tempo, inseguranca e retrabalho";
-            default -> "material pratico pronto para usar";
+            case 0 -> "presenca mais cuidada com detalhes simples";
+            case 1 -> "menos tentativa e mais direcao no dia a dia";
+            default -> "passos objetivos para aplicar na rotina";
         };
         String accent = switch (index) {
             case 0 -> "#1f8a70";

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessorTest.java
@@ -66,7 +66,11 @@ class GeraSalesPageProcessorTest {
                 .contains("data-transform-visual=\"after\"")
                 .contains("data-transform-visual=\"pain\"")
                 .contains("data-transform-visual=\"preview\"")
-                .contains("<svg");
+                .contains("<svg")
+                .doesNotContain("Depois desejado")
+                .doesNotContain("Dor atual")
+                .doesNotContain("Preview do produto")
+                .doesNotContain("Prova do produto");
     }
 
     /** Cria processor mínimo para exercitar métodos puros por reflexão. */

--- a/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java
@@ -54,6 +54,11 @@ public class GeraSalesPagePublicationAuditService {
             "(?iu)(?<![\\p{L}])(" 
                     + "nao|voce|informacao|producao|pendencia|endereco|proximo|almoco|atencao|solucao"
                     + ")(?![\\p{L}@-])");
+    private static final List<String> FORBIDDEN_VISIBLE_OPERATIONAL_LABELS = List.of(
+            "depois desejado:",
+            "dor atual:",
+            "preview do produto:",
+            "prova do produto:");
     private static final Pattern NON_TRACK_SECTION_CHARS = Pattern.compile("[^a-z0-9_-]+");
     private static final int MIN_TRANSFORMATION_VISUAL_SCENES = 3;
 
@@ -340,10 +345,37 @@ public class GeraSalesPagePublicationAuditService {
         validatePublicPortugueseAccentuation(experiment, publicationExecution, html);
         Document document = Jsoup.parse(html, "", Parser.htmlParser());
         document.outputSettings().prettyPrint(false);
+        validateNoVisibleOperationalLabels(experiment, publicationExecution, document);
         validateTransformationVisualScenes(experiment, publicationExecution, document);
         markTrackableSections(document);
         injectAnalyticsScriptIfMissing(document, flowSlug);
         return document.outerHtml();
+    }
+
+    /** Bloqueia rotulos internos de auditoria que nao podem aparecer para o comprador. */
+    private void validateNoVisibleOperationalLabels(
+            Experiment experiment,
+            GeraSalesPageStageExecution publicationExecution,
+            Document document) {
+        String visibleText = document.body() == null
+                ? document.text()
+                : document.body().text();
+        String normalizedText = visibleText.toLowerCase(Locale.ROOT);
+        List<String> leakedLabels = FORBIDDEN_VISIBLE_OPERATIONAL_LABELS.stream()
+                .filter(normalizedText::contains)
+                .toList();
+        if (leakedLabels.isEmpty()) {
+            return;
+        }
+        log.warn(
+                "GeraSalesPage bloqueou publicacao com rotulo operacional visivel: experimentId={}, idJob={}, labels={}",
+                experiment.getId(),
+                publicationExecution != null ? publicationExecution.getIdJob() : null,
+                leakedLabels);
+        throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "GeraSalesPage bloqueou a publicacao por conter rotulo operacional visivel: "
+                        + String.join(", ", leakedLabels));
     }
 
     /** Bloqueia paginas de venda sem prova visual suficiente da transformacao prometida. */

--- a/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditServiceTest.java
@@ -223,6 +223,37 @@ class GeraSalesPagePublicationAuditServiceTest {
                 .hasMessageContaining("endereco");
     }
 
+    /** Deve bloquear pagina publica com rotulos operacionais visiveis para o comprador. */
+    @Test
+    void shouldBlockPublicationWithVisibleOperationalLabels() {
+        Experiment experiment = new Experiment();
+        experiment.setId(53L);
+        experiment.setFollowUpActionUrl("https://pagamentopalf.site/checkout");
+        GeraSalesPageStageExecution publication = execution(
+                "job-publication",
+                GeraSalesPageStageCode.PUBLICATION_PACKAGE.code(),
+                "{\"html\":\"<html><body><main>"
+                        + "<section data-transform-visual='after'><h1>Venda</h1>"
+                        + "<img src='https://cdn.test/depois.jpg' alt='Imagem alinhada'></section>"
+                        + "<section data-transform-visual='pain'><img src='https://cdn.test/clareza.jpg' "
+                        + "alt='Clareza'><figcaption>Dor atual: muitos itens, pouca direcao.</figcaption></section>"
+                        + "<section data-transform-visual='preview'><img src='https://cdn.test/guia.jpg' "
+                        + "alt='Guia'><figcaption>Prova do produto: conteudo digital organizado.</figcaption></section>"
+                        + "</main></body></html>\",\"checkoutUrl\":\"https://mp.test/checkout\"}",
+                Instant.parse("2026-07-01T10:10:00Z"));
+
+        when(publicationRepository.existsByPublicationJobId("job-publication")).thenReturn(false);
+        when(experimentRepository.findById(53L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.findByExperimentIdOrderByExecutionRequestedAtAsc(53L))
+                .thenReturn(List.of(publication));
+
+        assertThatThrownBy(() -> service.snapshotPublication(publication))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("rotulo operacional visivel")
+                .hasMessageContaining("dor atual:")
+                .hasMessageContaining("prova do produto:");
+    }
+
     /** Deve bloquear pagina que fala da oferta sem cenas visuais suficientes da transformacao. */
     @Test
     void shouldBlockPublicationWithoutEnoughTransformationVisualScenes() {


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
temos problemas graves nessa página de vendas. Vazando informações que não deveria. Faça os ajustes e vamos evitar que volta a acontecer. Muito importante a campanha já está no ar. !!!!

**Resumo das alterações:**
Corrigido.

**O que estava acontecendo**
A causa-raiz era o fallback visual do GeraSalesPage: quando a IA não entregava cenas visuais suficientes, o worker injetava blocos de apoio com rótulos internos visíveis como “Dor atual”, “Depois desejado” e “Prova do produto”.

**Ação imediata na campanha**
Atualizei a página publicada `exp-61-gerasalespage-v1` no Lead Portal. Validei o HTML público e os termos vazados agora retornam `0` ocorrências.

**Prevenção**
Escolhi a abordagem 3 entre as alternativas:

1. Corrigir só a página no ar: rápido, mas o erro volta.
2. Alterar só prompt/IA: melhora, mas não garante bloqueio.
3. Corrigir página + remover fallback vazado + bloquear publicação com rótulo operacional: melhor equilíbrio para campanha ativa.

Alterei:
- [GeraSalesPageProcessor.java](/root/ai-hub/src/ai-hub-b2c83274-6f47-4470-8194-f824e01a397e-kYjqwZ/repo/ai-worker/src/main/java/com/marketinghub/worker/pipeline/gerasalespagev1/GeraSalesPageProcessor.java:184): fallback agora usa texto comercial seguro.
- [GeraSalesPagePublicationAuditService.java](/root/ai-hub/src/ai-hub-b2c83274-6f47-4470-8194-f824e01a397e-kYjqwZ/repo/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPagePublicationAuditService.java:57): backend bloqueia publicação com esses rótulos operacionais visíveis.

**Validação**
- Backend: `GeraSalesPagePublicationAuditServiceTest` passou, 5 testes.
- AI Worker: `GeraSalesPageProcessorTest` passou, 3 testes.
- Página pública: termos vazados não aparecem mais.

Não criei PR, conforme sua regra. A página no ar já foi corrigida; a trava de recorrência está pronta no código e precisa ser publicada pelo fluxo normal quando você pedir o PR/deploy.