### PR TITLE
AI Hub: Ajustei somente o **AI Worker**.

O que mudou:
- Aumentei o limite de buffer dos WebClients que leem `pending` do GeraLanding em:
  - `image-generation`
  - `quality-review`
  - `deliverables`
- Usei a configuração já existente: `openai.max-in-mem…

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
@@ -27,12 +27,16 @@ public class GeraLandingDeliverablesBackendClient {
     private final String apiPrefix;
     private final ObjectMapper objectMapper;
 
+    /** Inicializa o cliente com limite de buffer suficiente para pendências grandes do GeraLanding. */
     public GeraLandingDeliverablesBackendClient(
             WebClient.Builder builder,
             @Value("${backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
             @Value("${backend.api-prefix:/api}") String apiPrefix,
+            @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes,
             ObjectMapper objectMapper) {
-        this.webClient = builder.build();
+        this.webClient = builder.clone()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(maxInMemorySizeBytes))
+                .build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
         this.objectMapper = objectMapper;

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClient.java
@@ -40,11 +40,14 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
             CreativeImageOptimizer imageOptimizer,
             WebClient.Builder webClientBuilder,
             ObjectMapper objectMapper,
-            ImageGenerationWorkerProperties properties
+            ImageGenerationWorkerProperties properties,
+            int maxInMemorySizeBytes
     ) {
         this.storageClient = storageClient;
         this.imageOptimizer = imageOptimizer;
-        this.webClient = webClientBuilder.build();
+        this.webClient = webClientBuilder.clone()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(maxInMemorySizeBytes))
+                .build();
         this.objectMapper = objectMapper;
         this.properties = properties;
         this.workerId = resolveWorkerId(properties.workerId());
@@ -87,10 +90,13 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
         body.put("jobidopenai", dispatch.openAiJobId());
 
         log.info(
-                "Envio para backend GeraLanding após despacho imagegeneration [jobId={}, experimentId={}, payload={}]",
+                "Envio para backend GeraLanding após despacho imagegeneration [jobId={}, experimentId={}, openAiJobId={}, promptChars={}, schemaChars={}, requestChars={}]",
                 execution.idJob(),
                 execution.aggregateId(),
-                body
+                dispatch.openAiJobId(),
+                textLength(dispatch.prompt()),
+                textLength(dispatch.schemaJson()),
+                textLength(dispatch.requestBodyJson())
         );
         webClient.post()
                 .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-prompt", execution.idJob())
@@ -127,10 +133,12 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
         body.put("errorDetail", null);
 
         log.info(
-                "Envio para backend GeraLanding concluindo imagegeneration [jobId={}, experimentId={}, payload={}]",
+                "Envio para backend GeraLanding concluindo imagegeneration [jobId={}, experimentId={}, openAiJobId={}, imageCount={}, manifestChars={}]",
                 execution.idJob(),
                 execution.aggregateId(),
-                body
+                result.openAiJobId(),
+                manifestImages.size(),
+                textLength(manifest)
         );
         webClient.post()
                 .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
@@ -155,10 +163,11 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
         body.put("errorDetail", error != null ? stackTraceSummary(error) : null);
 
         log.info(
-                "Envio para backend GeraLanding falhando imagegeneration [jobId={}, experimentId={}, payload={}]",
+                "Envio para backend GeraLanding falhando imagegeneration [jobId={}, experimentId={}, errorChars={}, detailChars={}]",
                 execution.idJob(),
                 execution.aggregateId(),
-                body
+                textLength(asString(body.get("errorMessage"))),
+                textLength(asString(body.get("errorDetail")))
         );
         webClient.post()
                 .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
@@ -392,6 +401,11 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
             }
         }
         return builder.toString();
+    }
+
+    /** Calcula tamanho de texto para logs sem registrar payloads grandes ou sensíveis. */
+    private int textLength(String value) {
+        return value != null ? value.length() : 0;
     }
 
     /** Verifica se o experimento pertence ao bucket de rollout configurado. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
@@ -29,9 +29,17 @@ public class ImageGenerationWorkerConfiguration {
             CreativeImageOptimizer imageOptimizer,
             WebClient.Builder webClientBuilder,
             ObjectMapper objectMapper,
-            ImageGenerationWorkerProperties properties
+            ImageGenerationWorkerProperties properties,
+            @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes
     ) {
-        return new ImageGenerationBackendClient(storageClient, imageOptimizer, webClientBuilder, objectMapper, properties);
+        return new ImageGenerationBackendClient(
+                storageClient,
+                imageOptimizer,
+                webClientBuilder,
+                objectMapper,
+                properties,
+                maxInMemorySizeBytes
+        );
     }
 
     /** Cria o builder responsável por montar o request de imagem da OpenAI para a etapa imagegeneration. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
@@ -21,9 +21,16 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
 
     private final WebClient webClient;
     private final QualityReviewWorkerProperties properties;
-    /** Inicializa o cliente com WebClient, propriedades da revisão visual e ObjectMapper mantido por compatibilidade de configuração. */
-    public QualityReviewBackendClient(WebClient.Builder builder, QualityReviewWorkerProperties properties, ObjectMapper objectMapper) {
-        this.webClient = builder.build();
+    /** Inicializa o cliente com WebClient, limite de buffer e propriedades da revisão visual. */
+    public QualityReviewBackendClient(
+            WebClient.Builder builder,
+            QualityReviewWorkerProperties properties,
+            ObjectMapper objectMapper,
+            int maxInMemorySizeBytes
+    ) {
+        this.webClient = builder.clone()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(maxInMemorySizeBytes))
+                .build();
         this.properties = properties;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerConfiguration.java
@@ -6,6 +6,7 @@ import com.marketinghub.worker.openai.core.StageWorker;
 import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
 import com.marketinghub.worker.openai.core.openai.ResponsesApiOpenAiClient;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -21,8 +22,13 @@ public class QualityReviewWorkerConfiguration {
 
     /** Cria o adapter HTTP da revisão visual para consultar e atualizar execuções no backend. */
     @Bean
-    public QualityReviewBackendClient qualityReviewBackendClient(WebClient.Builder webClientBuilder, QualityReviewWorkerProperties properties, ObjectMapper objectMapper) {
-        return new QualityReviewBackendClient(webClientBuilder, properties, objectMapper);
+    public QualityReviewBackendClient qualityReviewBackendClient(
+            WebClient.Builder webClientBuilder,
+            QualityReviewWorkerProperties properties,
+            ObjectMapper objectMapper,
+            @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes
+    ) {
+        return new QualityReviewBackendClient(webClientBuilder, properties, objectMapper, maxInMemorySizeBytes);
     }
 
     /** Cria o serviço que renderiza o HTML final em Chromium e publica screenshots públicos. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClientTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.worker.geralanding.deliverables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingStageExecutionDetailDto;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar o contrato HTTP do client deliverables do GeraLanding. */
+class GeraLandingDeliverablesBackendClientTest {
+
+    private MockWebServer server;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Inicializa o backend simulado usado para retornar pendências de deliverables. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado após cada teste do client deliverables. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve aceitar pending grande do GeraLanding sem estourar o buffer padrão de 256 KB. */
+    @Test
+    void listPendingExecutionsShouldAcceptLargeGeraLandingPayload() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "experimentId": 63,
+                            "stageCode": "landing-page-deliverables",
+                            "idJob": "job-deliverables-large",
+                            "status": "INICIADO",
+                            "executionRequestedAt": "2026-07-10T12:00:00Z",
+                            "htmlGeraLanding": "%s"
+                          }
+                        ]
+                        """.formatted("x".repeat(350_000))));
+        GeraLandingDeliverablesBackendClient client = new GeraLandingDeliverablesBackendClient(
+                WebClient.builder(),
+                server.url("/").toString(),
+                "/api",
+                1024 * 1024,
+                objectMapper);
+
+        List<GeraLandingStageExecutionDetailDto> pending = client.listPendingExecutions(5);
+
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/api/internal/geralanding/deliverables/stage-executions/pending?limit=5");
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().idJob()).isEqualTo("job-deliverables-large");
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClientTest.java
@@ -74,6 +74,35 @@ class ImageGenerationBackendClientTest {
         });
     }
 
+    /** Deve aceitar payload de pending maior que o limite padrão do WebClient para não travar GeraLanding. */
+    @Test
+    void listPendingShouldAcceptLargeGeraLandingPayload() throws Exception {
+        Map<String, Object> pendingExecution = Map.of(
+                "experimentId", 63,
+                "stageCode", "landing-page-image-generation",
+                "jobid", "job-geralanding-image-large",
+                "executionRequestedAt", "2026-07-10T12:00:00Z",
+                "landingPageDesignPreset", "x".repeat(350_000),
+                "experiment", Map.of(
+                        "landingPageImagePlanning", Map.of(
+                                "landingPageImagePlanning", Map.of(
+                                        "images", List.of(Map.of(
+                                                "sectionId", "hero",
+                                                "elementId", "hero-img",
+                                                "imageGoal", "Mostrar entrega",
+                                                "imagePrompt", "Imagem principal da promessa"))))));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(objectMapper.writeValueAsString(List.of(pendingExecution))));
+        ImageGenerationBackendClient client = newClient();
+
+        List<StageExecution<ImageGenerationInput>> result = client.listPending(5);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().idJob()).isEqualTo("job-geralanding-image-large");
+    }
+
     /** Cria o client imagegeneration apontando para o backend simulado do teste. */
     private ImageGenerationBackendClient newClient() {
         return new ImageGenerationBackendClient(
@@ -92,6 +121,7 @@ class ImageGenerationBackendClientTest {
                         Duration.ofMillis(300),
                         "worker-test",
                         100,
-                        0.01d));
+                        0.01d),
+                1024 * 1024);
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
@@ -55,7 +55,8 @@ class QualityReviewBackendClientTest {
         QualityReviewBackendClient client = new QualityReviewBackendClient(
                 WebClient.builder(),
                 properties(),
-                objectMapper);
+                objectMapper,
+                1024 * 1024);
 
         List<StageExecution<QualityReviewInput>> pending = client.listPending(5);
 
@@ -101,7 +102,8 @@ class QualityReviewBackendClientTest {
         QualityReviewBackendClient client = new QualityReviewBackendClient(
                 WebClient.builder(),
                 properties(),
-                objectMapper);
+                objectMapper,
+                1024 * 1024);
 
         List<StageExecution<QualityReviewInput>> pending = client.listPending(5);
 
@@ -111,6 +113,35 @@ class QualityReviewBackendClientTest {
         assertThat(pending.getFirst().input().promptData())
                 .containsOnlyKeys("htmlGeraLanding")
                 .doesNotContainKeys("landingPageHtml");
+    }
+
+    /** Deve aceitar pending grande do GeraLanding sem estourar o buffer padrão de 256 KB. */
+    @Test
+    void listPendingShouldAcceptLargeGeraLandingPayload() {
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "experimentId": 63,
+                            "jobid": "job-quality-large",
+                            "stageCode": "landing-page-quality-review",
+                            "executionRequestedAt": "2026-07-10T12:00:00Z",
+                            "landingPageDesignPreset": "%s",
+                            "htmlGeraLanding": "<!doctype html><html><body><h1>Landing final</h1></body></html>"
+                          }
+                        ]
+                        """.formatted("x".repeat(350_000))));
+        QualityReviewBackendClient client = new QualityReviewBackendClient(
+                WebClient.builder(),
+                properties(),
+                objectMapper,
+                1024 * 1024);
+
+        List<StageExecution<QualityReviewInput>> pending = client.listPending(5);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().idJob()).isEqualTo("job-quality-large");
     }
 
     /** Monta propriedades mínimas para o client quality-review usado no teste. */


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: precisamos colocar o experimento 63 para rodar.

Modelo: Coloquei o experimento 63 na fila de liberação: `facebookReleaseRequestedAt` foi registrado em **10/07/2026 12:09:58 UTC**.

Mas ele ainda **não entrou no ar**. O Facebook Ads Worker não gerou campanha porque o experimento não está “verde” nos pré-requisitos.

**Estado atual**
- Experimento: `63 / MPAE-H001-E001`
- Status: `PLANNED`
- Campanhas criadas: `0`
- Funil: `0` em todas as etapas
- Criativo pronto: `1`
- Formulário/Lead Portal aprovado: `1`
- Targeting: completo
- Bloqueios: GeraLanding incompleto, vídeo obrigatório não aprovado, A/B de página de venda incompleto

**Causa-raiz encontrada**
O AI Worker está tentando processar as etapas finais do GeraLanding, mas falha ao buscar pendências porque o payload retornado pelo backend é grande demais:

`DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144`

Resultado: jobs de `image-generation`, `quality-review` e `deliverables` ficam em `INICIADO`, sem `processingStartedAt`, e o experimento não fica pronto para campanha.

**Alternativas**
1. Forçar campanha agora: rápido, mas arriscado; geraria tráfego com landing/ativos incompletos.
2. Aguardar worker: baixo esforço, mas não resolve; os logs mostram falha recorrente por limite de buffer.
3. Corrigir a causa-raiz do payload do GeraLanding/worker: melhor opção; destrava o experimento 63 e evita recorrência nos próximos.

Escolha recomendada: **corrigir a causa-raiz antes de gastar mídia**. O experimento já está liberado operacionalmente; falta destravar a prontidão. Não criei PR nem alterei código.

Usuário: 3. Corrigir a causa-raiz do payload do GeraLanding/worker: melhor opção; destrava o experimento 63 e evita recorrência nos próximos.
Temos que ver pq esta tão grande e onde esta a limitação se for no Worker AI temos que aumentar o limite mas se for na openai temos que ajustar a solicitação.

Modelo: **Conclusão**

O erro atual **não é da OpenAI**. Ele acontece antes: o AI Worker falha ao baixar o `pending` do backend por limite padrão do WebClient:

`DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144`

**Evidências principais**
- Limite atual do Worker: **262 KB**.
- Payload real medido:
  - `quality-review`: ~428 KB
  - `image-generation`: ~458 KB
  - `deliverables`: ~465 KB
- Experimento 63 tem pendências duplicadas:
  - `image-generation`: 3 `INICIADO`, sem `processing_started_at`
  - `quality-review`: 3 `INICIADO`, sem `processing_started_at`
  - `deliverables`: 3 `INICIADO`, sem `processing_started_at`
- Banco também mostra que já houve:
  - 1 `image-generation` concluído
  - 1 `quality-review` concluído

**Por que ficou tão grande**
O endpoint `pending` está mandando artefatos grandes repetidos em cada job:
- `landingPageDesignPreset`: ~58 KB
- `landingPageWireframe`: ~46 KB
- `htmlGeraLanding`: ~27 KB

E isso é repetido 3 vezes por etapa. Em `image-generation`, por exemplo, o worker só precisa do `landingPageImagePlanning`, mas o backend manda também wireframe, design preset, HTML, etc.

**Alternativas**
1. **Só aumentar o limite do WebClient no AI Worker**  
   Rápido e desbloqueia, mas mantém payload inchado e custo operacional ruim.

2. **Só enxugar os contratos `pending` do backend**  
   Correto arquiteturalmente, mas pode exigir ajuste em DTOs/testes e não resolve se algum HTML legítimo passar de 262 KB no futuro.

3. **Fazer os dois: aumentar limite controlado no Worker + enxugar `pending` por etapa**  
   Melhor opção. Destrava agora e evita recorrência em escala.

**Recomendação**
Aplicar a opção 3.

Correção ideal:
- Configurar `maxInMemorySize` nos WebClients do GeraLanding no AI Worker, usando o padrão já existente `openai.max-in-memory-size-bytes=52428800`.
- Enxugar o `pending`:
  - `image-generation`: enviar só `landingPageImagePlanning` e identificadores.
  - `quality-review`: enviar `htmlGeraLanding` + contrato comercial mínimo; remover wireframe/design se não forem usados pelo prompt.
  - `deliverables`: revisar o prompt porque ele realmente inclui HTML, wireframe e design completos; aqui vale reduzir para dados funcionais/resumos, senão depois pode virar problema de custo/contexto na OpenAI.
- Limpar/neutralizar pendências duplicadas do experimento 63 antes de reprocessar, deixando apenas a execução válida necessária.

Não fiz alteração de código nem PR.

Última mensagem do usuário:
primeiro vamos somennte aumentar o limite do worker ai. Evitar de colocar tudo nos logs para esses casos.

**Resumo das alterações:**
Ajustei somente o **AI Worker**.

O que mudou:
- Aumentei o limite de buffer dos WebClients que leem `pending` do GeraLanding em:
  - `image-generation`
  - `quality-review`
  - `deliverables`
- Usei a configuração já existente: `openai.max-in-memory-size-bytes`, default `52428800` bytes.
- Removi logs que imprimiam payload completo em `imagegeneration`; agora registram só metadados: `jobId`, `experimentId`, `openAiJobId`, tamanhos e contagens.

Validação:
- Instalei o `ads-service` localmente porque o Maven tentou baixar o pacote privado e recebeu `401`.
- Rodei testes focados do `ai-worker`: **6 testes, 0 falhas**.
- Incluí testes com payload acima de 256 KB para prevenir a recorrência.

Não mexi no backend, não alterei contrato do `pending`, não alterei prompt/OpenAI e não criei PR. Próximo passo operacional: publicar/reiniciar o AI Worker e reprocessar as pendências do experimento 63.