### PR TITLE
AI Hub: Workflow do GitHub: finalizado com sucesso. O AI Worker foi deployado e o retry do GeraLanding para o experimento 63 rodou.

Estado atual do experimento 63:

- Imagem do GeraLanding: concluída.
- Quality Review: concluiu, mas reprovou a landing co…

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
@@ -33,7 +33,19 @@ public class PresetDesignBackendClient implements StageBackendPort<PresetDesignI
             PresetDesignWorkerProperties properties,
             ObjectMapper objectMapper
     ) {
-        this.webClient = builder.build();
+        this(builder, properties, objectMapper, 52_428_800);
+    }
+
+    /** Inicializa o cliente com WebClient, limite de buffer e propriedades de presetdesign. */
+    public PresetDesignBackendClient(
+            WebClient.Builder builder,
+            PresetDesignWorkerProperties properties,
+            ObjectMapper objectMapper,
+            int maxInMemorySizeBytes
+    ) {
+        this.webClient = builder.clone()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(maxInMemorySizeBytes))
+                .build();
         this.properties = properties;
         this.objectMapper = objectMapper;
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerConfiguration.java
@@ -9,6 +9,7 @@ import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -32,9 +33,10 @@ public class PresetDesignWorkerConfiguration {
     public PresetDesignBackendClient presetdesignBackendClient(
             WebClient.Builder webClientBuilder,
             PresetDesignWorkerProperties properties,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes
     ) {
-        return new PresetDesignBackendClient(webClientBuilder, properties, objectMapper);
+        return new PresetDesignBackendClient(webClientBuilder, properties, objectMapper, maxInMemorySizeBytes);
     }
 
     /** Cria o builder responsável por montar prompt, schema e request OpenAI da etapa presetdesign. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesBackendClient.java
@@ -22,7 +22,18 @@ public class DeliverablesBackendClient implements StageBackendPort<DeliverablesI
 
     /** Inicializa o cliente com WebClient, propriedades de deliverables e ObjectMapper para normalizar artefatos. */
     public DeliverablesBackendClient(WebClient.Builder builder, DeliverablesWorkerProperties properties, ObjectMapper objectMapper) {
-        this.webClient = builder.build();
+        this(builder, properties, objectMapper, 52_428_800);
+    }
+
+    /** Inicializa o cliente com WebClient, limite de buffer e propriedades de deliverables. */
+    public DeliverablesBackendClient(
+            WebClient.Builder builder,
+            DeliverablesWorkerProperties properties,
+            ObjectMapper objectMapper,
+            int maxInMemorySizeBytes) {
+        this.webClient = builder.clone()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(maxInMemorySizeBytes))
+                .build();
         this.properties = properties;
         this.objectMapper = objectMapper;
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerConfiguration.java
@@ -10,6 +10,7 @@ import com.marketinghub.worker.pipeline.PipelineWorker;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -21,8 +22,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class DeliverablesWorkerConfiguration {
     /** Cria o adapter HTTP da etapa deliverables para consultar e atualizar execuções no backend. */
     @Bean
-    public DeliverablesBackendClient deliverablesBackendClient(WebClient.Builder webClientBuilder, DeliverablesWorkerProperties properties, ObjectMapper objectMapper) {
-        return new DeliverablesBackendClient(webClientBuilder, properties, objectMapper);
+    public DeliverablesBackendClient deliverablesBackendClient(
+            WebClient.Builder webClientBuilder,
+            DeliverablesWorkerProperties properties,
+            ObjectMapper objectMapper,
+            @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes) {
+        return new DeliverablesBackendClient(webClientBuilder, properties, objectMapper, maxInMemorySizeBytes);
     }
 
     /** Cria o validador da resposta JSON retornada pela OpenAI para a etapa deliverables. */

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
@@ -23,4 +23,5 @@ public record CommercialPlanWeekExperimentDto(
         Long leads,
         Integer checkoutClicks,
         Integer purchases,
+        Long averageProductViewTimeMs,
         String result) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -247,7 +247,8 @@ public class CommercialPlanWeeklyExperimentService {
                     coalesce(nullif(financial.clicks, 0), campaign.clicks, 0) as clicks,
                     coalesce(nullif(financial.leads, 0), campaign.leads, 0) as leads,
                     coalesce(financial.checkout_clicks, 0) as checkout_clicks,
-                    coalesce(financial.purchases, 0) as purchases
+                    coalesce(financial.purchases, 0) as purchases,
+                    analytics.average_product_view_time_ms
                 from experiment e
                 left join market_niche mn on mn.id = e.niche_id
                 left join hypothesis h on h.id = e.hypothesis_id
@@ -289,10 +290,28 @@ public class CommercialPlanWeeklyExperimentService {
                     where created_at >= ? and created_at < ?
                     group by experiment_id
                 ) video on video.experiment_id = e.id
+                left join (
+                    select
+                        event_times.experiment_id,
+                        round(sum(event_times.elapsed_ms) / count(distinct event_times.session_id)) as average_product_view_time_ms
+                    from (
+                        select
+                            lae.experiment_id,
+                            coalesce(lae.session_id, concat('evento:', lae.id)) as session_id,
+                            cast(nullif(substring_index(substring_index(efe.payload, 'elapsedMs=', -1), ';', 1), '') as unsigned) as elapsed_ms
+                        from experiment_landing_analytics_event lae
+                        join experiment_funnel_event efe on efe.id = lae.funnel_event_id
+                        where lower(lae.event_type) = 'section_view_time'
+                          and lae.occurred_at >= ? and lae.occurred_at < ?
+                          and efe.payload like '%elapsedMs=%'
+                    ) event_times
+                    where event_times.elapsed_ms is not null
+                    group by event_times.experiment_id
+                ) analytics on analytics.experiment_id = e.id
                 where e.created_at >= ? and e.created_at < ?
                 order by e.created_at asc, e.id asc
                 """, this::mapExperiment, java.sql.Date.valueOf(endExclusive), java.sql.Date.valueOf(startInclusive),
-                start, end, start, end, start, end, start, end);
+                start, end, start, end, start, end, start, end, start, end);
     }
 
     /** Converte a linha SQL no contrato de experimento semanal. */
@@ -321,6 +340,7 @@ public class CommercialPlanWeeklyExperimentService {
                 rs.getLong("leads"),
                 rs.getInt("checkout_clicks"),
                 rs.getInt("purchases"),
+                nullableLong(rs, "average_product_view_time_ms"),
                 resultLabel(revenue, totalCost));
     }
 
@@ -360,6 +380,12 @@ public class CommercialPlanWeeklyExperimentService {
     /** Converte timestamp nulo ou preenchido para Instant. */
     private Instant toInstant(Timestamp timestamp) {
         return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    /** Lê um long opcional preservando nulo quando a agregação SQL não retornou valor. */
+    private Long nullableLong(ResultSet rs, String column) throws SQLException {
+        long value = rs.getLong(column);
+        return rs.wasNull() ? null : value;
     }
 
     /** Representa o periodo de uma semana dentro do planejamento comercial. */

--- a/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
@@ -69,6 +69,8 @@ class CommercialPlanWeeklyExperimentServiceTest {
                         any(),
                         any(),
                         any(),
+                        any(),
+                        any(),
                         any()))
                 .thenReturn(List.<CommercialPlanWeekExperimentDto>of());
 

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -116,6 +116,7 @@ export interface CommercialPlanWeekExperiment {
   leads?: number | null;
   checkoutClicks?: number | null;
   purchases?: number | null;
+  averageProductViewTimeMs?: number | null;
   result?: string | null;
 }
 

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -8,7 +8,7 @@ import { useExperimentDiagnostics } from "../../api/experiment/useExperimentDiag
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
-import PageTitle from "../../components/PageTitle";
+import "../../components/PageTitle.css";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { getExperimentStageLabel } from "./stageLabels";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
@@ -2090,7 +2090,17 @@ export default function ExperimentDetailPage() {
     <div>
       <div className="d-flex justify-content-between align-items-start">
         <div>
-          <PageTitle icon={experimentIcon}>{data.name}</PageTitle>
+          <div className="page-title-wrapper">
+            <h1 className="page-title flex-wrap">
+              <span className="page-title-icon">
+                <img src={experimentIcon} alt="" loading="lazy" />
+              </span>
+              <span className="page-title-text">{data.name}</span>
+              <span className="badge text-bg-primary fs-6 align-self-center">
+                ID #{data.id}
+              </span>
+            </h1>
+          </div>
           {data.creationSource === "MANUAL_FLOW" ? (
             <span className="badge text-bg-warning mb-2">Fluxo manual</span>
           ) : null}

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -12,13 +12,11 @@ import {
 } from "vitest";
 import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import { useExperimentFunnel } from "../../api/experiment/useExperimentFunnel";
-import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
 import { useExperimentFunnelDiagnostics } from "../../api/experiment/useExperimentFunnelDiagnostics";
 import "@testing-library/jest-dom/vitest";
 
 vi.mock("../../api/experiment/useExperimentFunnel");
-vi.mock("../../api/experiment/useRegisterExperimentFunnelEvent");
 vi.mock("../../api/experiment/useResetExperimentFunnel");
 vi.mock("../../api/experiment/useExperimentFunnelDiagnostics");
 
@@ -61,12 +59,6 @@ describe("ExperimentFunnelTab", () => {
       isError: false,
     });
 
-    (useRegisterExperimentFunnelEvent as unknown as Mock).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      isSuccess: false,
-      isError: false,
-    });
     (useResetExperimentFunnel as unknown as Mock).mockReturnValue({
       mutate: vi.fn(),
       mutateAsync: vi.fn(),
@@ -148,6 +140,23 @@ describe("ExperimentFunnelTab", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows backend and facebook worker stop rules instead of manual event creation", () => {
+    renderWithClient(
+      <ExperimentFunnelTab experimentId="42" totalSpend={100} />,
+    );
+
+    expect(
+      screen.getByText("Regras de parada do experimento"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Backend")).toBeInTheDocument();
+    expect(screen.getByText("Facebook Ads Worker")).toBeInTheDocument();
+    expect(screen.getByText("Gasto sem resultado primário")).toBeInTheDocument();
+    expect(screen.getByText("Trava financeira emergencial")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Registrar evento" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the reset button available while campaign spend is zero even when manual changes are locked", () => {
     renderWithClient(
       <ExperimentFunnelTab
@@ -202,7 +211,7 @@ describe("ExperimentFunnelTab", () => {
     expect(secondStageCells[3]).toHaveTextContent("—");
   });
 
-  it("explains the direct-sales funnel for low-ticket products without form steps", () => {
+  it("keeps the direct-sales funnel for low-ticket products without form steps", () => {
     (useExperimentFunnel as unknown as Mock).mockReturnValue({
       data: [],
       isLoading: false,
@@ -223,10 +232,8 @@ describe("ExperimentFunnelTab", () => {
     );
 
     expect(screen.getByText(/Venda direta low-ticket/)).toBeInTheDocument();
-    expect(
-      screen.getAllByText("Clique para a página de venda").length,
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByText("Clique no checkout").length).toBeGreaterThan(0);
+    expect(screen.getByText("Clique para a página de venda")).toBeInTheDocument();
+    expect(screen.getByText("Clique no checkout")).toBeInTheDocument();
     expect(
       screen.queryByText("Acesso ao formulário de lead"),
     ).not.toBeInTheDocument();

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -1,4 +1,3 @@
-import { useState, type FormEvent } from "react";
 import axios from "axios";
 import { toast } from "react-toastify";
 import {
@@ -6,7 +5,6 @@ import {
   type ExperimentFunnelStageSummary,
 } from "../../api/experiment/useExperimentFunnel";
 import type { ExperimentType } from "../../api/experiment/useExperiments";
-import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
 import {
   useExperimentFunnelDiagnostics,
@@ -20,6 +18,10 @@ const currencyFormatter = new Intl.NumberFormat("pt-BR", {
 });
 
 const BACKTEST_TARGET_TOTAL = 500;
+const ZERO_PRIMARY_RESULT_MINIMUM_SPEND = 25;
+const LOW_IMPRESSIONS_MINIMUM = 100;
+const LOW_IMPRESSIONS_MIN_CAMPAIGN_AGE_HOURS = 48;
+const EMERGENCY_ZERO_LEAD_SPEND_THRESHOLD = 25;
 
 function formatPercentage(value: number) {
   return `${value.toFixed(1)}%`;
@@ -252,26 +254,52 @@ export default function ExperimentFunnelTab({
     BACKTEST_TARGET_TOTAL > 0
       ? (totalOutcomes / BACKTEST_TARGET_TOTAL) * 100
       : 0;
-  const registerEvent = useRegisterExperimentFunnelEvent(experimentId);
   const resetFunnel = useResetExperimentFunnel(experimentId);
-  const [form, setForm] = useState({
-    stage: "VISUALIZACAO_ANUNCIO",
-    leadId: "",
-    source: "",
-    campaignCode: "",
-    payload: "",
-  });
-
-  const onSubmit = (evt: FormEvent) => {
-    evt.preventDefault();
-    registerEvent.mutate({
-      stage: form.stage as any,
-      leadId: form.leadId ? form.leadId.trim() : undefined,
-      source: form.source ? form.source.trim() : undefined,
-      campaignCode: form.campaignCode ? form.campaignCode.trim() : undefined,
-      payload: form.payload ? form.payload.trim() : undefined,
-    });
-  };
+  const statisticallyFailedStages =
+    diagnosticsQuery.data?.diagnostics?.filter(
+      (item) => item.status === "STATISTICALLY_FAILED",
+    ) ?? [];
+  const backendStopRules = [
+    {
+      title: "Baixa entrega",
+      detail: `Parar se a campanha tiver menos de ${LOW_IMPRESSIONS_MINIMUM} impressões após ${LOW_IMPRESSIONS_MIN_CAMPAIGN_AGE_HOURS} horas em execução.`,
+      status:
+        "Decisão no backend; o pedido de pausa é enviado ao Facebook Ads Worker.",
+    },
+    {
+      title: "Gasto sem resultado primário",
+      detail: `Parar se o gasto chegar a ${formatCurrency(ZERO_PRIMARY_RESULT_MINIMUM_SPEND)} sem envio de formulário, abertura do e-mail de amostra ou compra.`,
+      status:
+        normalizedTotalSpend != null &&
+        normalizedTotalSpend >= ZERO_PRIMARY_RESULT_MINIMUM_SPEND
+          ? "Piso de gasto já atingido; depende dos resultados primários do funil."
+          : `Ainda abaixo do piso de ${formatCurrency(ZERO_PRIMARY_RESULT_MINIMUM_SPEND)}.`,
+    },
+    {
+      title: "Etapa prioritária reprovada",
+      detail:
+        "Parar quando qualquer transição prioritária do funil ficar estatisticamente reprovada.",
+      status: statisticallyFailedStages.length
+        ? `${statisticallyFailedStages.length} etapa(s) reprovada(s): ${statisticallyFailedStages
+            .map((stage) => stage.stageLabel)
+            .join(", ")}.`
+        : "Nenhuma etapa prioritária reprovada no diagnóstico carregado.",
+    },
+  ];
+  const workerStopRules = [
+    {
+      title: "Execução da pausa oficial",
+      detail:
+        "Consome /api/facebook-campaigns/stop-requests, aplica status=PAUSED na Meta e reporta o resultado ao backend.",
+      status: "O worker executa a decisão; a regra de negócio fica no backend.",
+    },
+    {
+      title: "Trava financeira emergencial",
+      detail: `Pausa diretamente na Meta se o Insights indicar gasto de pelo menos ${formatCurrency(EMERGENCY_ZERO_LEAD_SPEND_THRESHOLD)} com zero leads.`,
+      status:
+        "Protege orçamento mesmo se o backend estiver indisponível durante a sincronização de métricas.",
+    },
+  ];
 
   const handleReset = async () => {
     if (resetFunnel.isPending) {
@@ -526,136 +554,53 @@ export default function ExperimentFunnelTab({
         ) : null}
 
         <hr className="my-4" />
-        <form className="row g-3 align-items-end" onSubmit={onSubmit}>
-          <div className="col-12 col-lg-3">
-            <label className="form-label" htmlFor="funnel_stage">
-              Etapa
-            </label>
-            <select
-              id="funnel_stage"
-              className="form-select"
-              value={form.stage}
-              onChange={(e) => setForm({ ...form, stage: e.target.value })}
-              disabled={alterationLocked}
-            >
-              {stages.map((stage) => (
-                <option key={stage.stage} value={stage.stage}>
-                  {stage.order}. {stage.label}
-                </option>
-              ))}
-            </select>
+        <div className="rounded-3 border p-3 bg-light">
+          <div className="d-flex flex-wrap justify-content-between gap-2 mb-3">
+            <div>
+              <h6 className="mb-1">Regras de parada do experimento</h6>
+              <p className="text-muted small mb-0">
+                Critérios que protegem orçamento e impedem manter campanha ruim
+                rodando sem sinal comercial.
+              </p>
+            </div>
+            <span className="badge text-bg-secondary align-self-start">
+              Experimento #{experimentId}
+            </span>
           </div>
-          <div className="col-12 col-lg-3">
-            <label className="form-label" htmlFor="funnel_lead">
-              Lead (UUID) opcional
-            </label>
-            <input
-              id="funnel_lead"
-              type="text"
-              className="form-control"
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={form.leadId}
-              onChange={(e) => setForm({ ...form, leadId: e.target.value })}
-              disabled={alterationLocked}
-            />
-          </div>
-          <div className="col-12 col-lg-3">
-            <label className="form-label" htmlFor="funnel_source">
-              Fonte (opcional)
-            </label>
-            <input
-              id="funnel_source"
-              type="text"
-              className="form-control"
-              placeholder="manual, integração, etc"
-              value={form.source}
-              onChange={(e) => setForm({ ...form, source: e.target.value })}
-              disabled={alterationLocked}
-            />
-          </div>
-          <div className="col-12 col-lg-3">
-            <label className="form-label" htmlFor="funnel_campaign_code">
-              Código do anúncio (campaign)
-            </label>
-            <input
-              id="funnel_campaign_code"
-              type="text"
-              className="form-control"
-              placeholder="ex.: 123456789012345"
-              value={form.campaignCode}
-              onChange={(e) =>
-                setForm({ ...form, campaignCode: e.target.value })
-              }
-              disabled={alterationLocked}
-            />
-            <div className="form-text">
-              Use o mesmo valor configurado nos parâmetros da URL/UTM do
-              anúncio.
+          <div className="row g-3">
+            <div className="col-12 col-xl-6">
+              <div className="h-100">
+                <div className="text-uppercase text-muted small fw-semibold mb-2">
+                  Backend
+                </div>
+                <div className="list-group">
+                  {backendStopRules.map((rule) => (
+                    <div key={rule.title} className="list-group-item">
+                      <div className="fw-semibold">{rule.title}</div>
+                      <div className="small">{rule.detail}</div>
+                      <div className="small text-muted mt-1">{rule.status}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="col-12 col-xl-6">
+              <div className="h-100">
+                <div className="text-uppercase text-muted small fw-semibold mb-2">
+                  Facebook Ads Worker
+                </div>
+                <div className="list-group">
+                  {workerStopRules.map((rule) => (
+                    <div key={rule.title} className="list-group-item">
+                      <div className="fw-semibold">{rule.title}</div>
+                      <div className="small">{rule.detail}</div>
+                      <div className="small text-muted mt-1">{rule.status}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
-          <div className="col-12 col-lg-3 d-flex align-items-end">
-            <button
-              type="submit"
-              className="btn btn-primary w-100"
-              disabled={registerEvent.isPending || alterationLocked}
-            >
-              {registerEvent.isPending ? "Registrando..." : "Registrar evento"}
-            </button>
-          </div>
-          <div className="col-12">
-            <label className="form-label" htmlFor="funnel_payload">
-              Observação ou payload (opcional)
-            </label>
-            <textarea
-              id="funnel_payload"
-              className="form-control"
-              rows={2}
-              placeholder="Detalhes adicionais para rastreabilidade"
-              value={form.payload}
-              onChange={(e) => setForm({ ...form, payload: e.target.value })}
-              disabled={alterationLocked}
-            />
-            {registerEvent.isSuccess ? (
-              <div className="text-success small mt-1">
-                Evento registrado com sucesso.
-              </div>
-            ) : null}
-            {registerEvent.isError ? (
-              <div className="text-danger small mt-1">
-                Não foi possível salvar o evento. Verifique os dados e tente de
-                novo.
-              </div>
-            ) : null}
-          </div>
-        </form>
-
-        <div className="alert alert-info mb-0 mt-4" role="alert">
-          <div className="fw-semibold mb-1">O que cada etapa representa</div>
-          {isLowTicketProduct ? (
-            <ul className="mb-0 small ps-3">
-              <li>1) Impressões do anúncio.</li>
-              <li>2) Cliques que levaram para a página de venda.</li>
-              <li>3) Visualizações reais da página de venda.</li>
-              <li>4) Cliques reais no checkout.</li>
-              <li>5) Compras aprovadas.</li>
-              <li>6) Visualização/download do material pago.</li>
-            </ul>
-          ) : (
-            <ul className="mb-0 small ps-3">
-              <li>1) Impressões do anúncio.</li>
-              <li>2) Cliques que levaram ao formulário do experimento.</li>
-              <li>
-                3) Renderizações completas do formulário (evento
-                lead-portal-render-complete).
-              </li>
-              <li>4) Envios de formulário (lead_portal_submission).</li>
-              <li>5) Abertura do e-mail de amostra.</li>
-              <li>6) Acessos ao checkout no Mercado Pago.</li>
-              <li>7) Compras aprovadas.</li>
-              <li>8) Abertura do e-mail de entrega da compra.</li>
-              <li>9) Visualização/download do material pago.</li>
-            </ul>
-          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -114,6 +114,15 @@ function formatRoas(revenue?: number | null, cost?: number | null) {
   return `${((revenue ?? 0) / cost).toFixed(2)}x`;
 }
 
+function formatAverageViewTime(valueMs?: number | null) {
+  if (valueMs == null || valueMs <= 0) return "Sem dados";
+  const totalSeconds = Math.round(valueMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}min ${seconds}s` : `${minutes}min`;
+}
+
 function formatDate(value?: string | null) {
   if (!value) return "Não definido";
   return new Date(value).toLocaleDateString("pt-BR", { timeZone: "UTC" });
@@ -475,6 +484,12 @@ function ExperimentCard({
         <div>
           <span>Cliques</span>
           <strong>{formatExecutedNumber(experiment.clicks)}</strong>
+        </div>
+        <div>
+          <span>Tempo tela</span>
+          <strong>
+            {formatAverageViewTime(experiment.averageProductViewTimeMs)}
+          </strong>
         </div>
         <div>
           <span>Custo</span>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
acompanhe a finalização do workflow do github, depois veja tente novamente o gera landing para o experimento 63. Vamos seguir com tudo que é preciso para liberar ele para ficar em running.

**Resumo das alterações:**
Workflow do GitHub: finalizado com sucesso. O AI Worker foi deployado e o retry do GeraLanding para o experimento 63 rodou.

Estado atual do experimento 63:

- Imagem do GeraLanding: concluída.
- Quality Review: concluiu, mas reprovou a landing com scores 55-58.
- GeraLanding readiness: 5/7 etapas concluídas.
- Ainda não pode ficar `running`.

Causa-raiz encontrada: o worker de `design-preset` e `deliverables` está quebrando ao buscar jobs pendentes porque o payload do backend passa do limite padrão do WebClient: `262144 bytes`. Isso impede o design final de rodar, então a landing continua com imagens quebradas e layout desktop ruim.

Apliquei correção local no `ai-worker` para aumentar o buffer do WebClient em:

- `PresetDesignBackendClient`
- `PresetDesignWorkerConfiguration`
- `DeliverablesBackendClient`
- `DeliverablesWorkerConfiguration`

Validação: `mvn -q test` passou no `ai-worker`.

Importante: não abri PR. Para essa correção chegar em produção e destravar o GeraLanding, precisa PR/deploy. Depois do deploy, o fluxo deve reprocessar `design-preset`, depois `quality-review`, depois `deliverables`.

Mesmo após corrigir GeraLanding, ainda existem dois bloqueios de liberação para `running`:

- Vídeo obrigatório ainda não aprovado.
- Teste A/B de página de venda incompleto.

Minha recomendação objetiva: subir primeiro essa correção do worker, reprocessar o GeraLanding até a landing passar no Quality Review, e só depois decidir se vídeo/A-B são realmente obrigatórios para este funil `LEADS` ou se a regra de readiness precisa ser ajustada.