### PR TITLE
AI Hub: Ajustei o cálculo do custo na tela do experimento.

Agora o **Custo rastreável** soma:

`custos em BRL + custos técnicos em USD convertidos por US$ 1 = R$ 5`

No exemplo do print, a lógica fica:

`R$ 25,04 + (US$ 0,18 + US$ 0,77) x 5 = R$ 29,79`

…

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2056,7 +2056,10 @@ export default function ExperimentDetailPage() {
       label: "Objetivo da campanha",
       value: campaignObjectiveLabel,
     },
-    { label: "Custo rastreável", value: formatCurrency(data.cost) },
+    {
+      label: "Custo rastreável",
+      value: formatCurrency(experimentCostSummary.auditableTotalBrl),
+    },
     {
       label: "Criativos aprovados",
       value: `${readinessCreativeCount}/3`,
@@ -2730,8 +2733,8 @@ export default function ExperimentDetailPage() {
                     <div>
                       <h5 className="card-title mb-1">Custos do experimento</h5>
                       <p className="text-muted small mb-0">
-                        Total rastreável em BRL separado da auditoria técnica em
-                        USD.
+                        Total rastreável em BRL com custos técnicos em USD
+                        convertidos pelo padrão US$ 1 = R$ 5.
                       </p>
                     </div>
                     <div className="text-end">
@@ -2760,6 +2763,15 @@ export default function ExperimentDetailPage() {
                               costRow.currency,
                             )}
                           </div>
+                          {costRow.convertedValueBrl != null ? (
+                            <div className="text-muted small">
+                              Equivale a{" "}
+                              {formatCurrencyValue(
+                                costRow.convertedValueBrl,
+                                "BRL",
+                              )}
+                            </div>
+                          ) : null}
                         </div>
                       </div>
                     ))}

--- a/frontend/src/pages/experiment/experimentCostSummary.test.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.test.ts
@@ -19,7 +19,7 @@ const baseExperiment = {
 } satisfies Experiment;
 
 describe("buildExperimentCostSummary", () => {
-  it("prioritizes auditable BRL cost and isolates unreconciled legacy difference", () => {
+  it("adds technical USD costs converted to BRL and isolates unreconciled legacy difference", () => {
     const summary = buildExperimentCostSummary({
       experiment: {
         ...baseExperiment,
@@ -33,9 +33,10 @@ describe("buildExperimentCostSummary", () => {
       geraSalesPageCostUsd: 1.460795,
     });
 
-    expect(summary.auditableTotalBrl).toBe(12.33);
+    expect(summary.auditableTotalBrl).toBe(19.68);
+    expect(summary.technicalTotalBrl).toBe(7.35);
     expect(summary.legacyTotalBrl).toBe(91.31);
-    expect(summary.unreconciledLegacyCostBrl).toBe(78.98);
+    expect(summary.unreconciledLegacyCostBrl).toBe(71.63);
     expect(summary.brlRows.map((row) => row.currency)).toEqual([
       "BRL",
       "BRL",
@@ -45,6 +46,11 @@ describe("buildExperimentCostSummary", () => {
       "USD",
       "USD",
       "USD",
+    ]);
+    expect(summary.technicalRows.map((row) => row.convertedValueBrl)).toEqual([
+      0.05,
+      0,
+      7.3,
     ]);
   });
 

--- a/frontend/src/pages/experiment/experimentCostSummary.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.ts
@@ -4,10 +4,12 @@ export interface ExperimentCostRow {
   label: string;
   value: number;
   currency: "BRL" | "USD";
+  convertedValueBrl?: number;
 }
 
 export interface ExperimentCostSummary {
   auditableTotalBrl: number;
+  technicalTotalBrl: number;
   legacyTotalBrl: number;
   unreconciledLegacyCostBrl: number;
   brlRows: ExperimentCostRow[];
@@ -29,6 +31,7 @@ const toNumber = (value: number | string | null | undefined) => {
 };
 
 const roundMoney = (value: number) => Math.round(value * 100) / 100;
+const TECHNICAL_COST_USD_TO_BRL = 5;
 
 export function buildExperimentCostSummary({
   experiment,
@@ -39,11 +42,18 @@ export function buildExperimentCostSummary({
   const originCostBrl = toNumber(experiment.cost);
   const paidMediaCostBrl = toNumber(experiment.campaignMetric?.spend);
   const operationalExpenseBrl = toNumber(experiment.expense);
-  const computedAuditableTotalBrl = roundMoney(
+  const technicalTotalUsd =
+    contentPipelineCostUsd + geraLandingCostUsd + geraSalesPageCostUsd;
+  const technicalTotalBrl = roundMoney(
+    technicalTotalUsd * TECHNICAL_COST_USD_TO_BRL,
+  );
+  const computedAuditableBaseBrl = roundMoney(
     originCostBrl + paidMediaCostBrl + operationalExpenseBrl,
   );
+  const auditableBaseBrl =
+    toNumber(experiment.auditableTotalCost) || computedAuditableBaseBrl;
   const auditableTotalBrl = roundMoney(
-    toNumber(experiment.auditableTotalCost) || computedAuditableTotalBrl,
+    auditableBaseBrl + technicalTotalBrl,
   );
   const legacyTotalBrl = roundMoney(
     toNumber(experiment.legacyTotalCost) || toNumber(experiment.totalCost),
@@ -58,6 +68,7 @@ export function buildExperimentCostSummary({
 
   return {
     auditableTotalBrl,
+    technicalTotalBrl,
     legacyTotalBrl,
     unreconciledLegacyCostBrl,
     brlRows: [
@@ -82,16 +93,25 @@ export function buildExperimentCostSummary({
         label: "Pipeline de conteúdo",
         value: contentPipelineCostUsd,
         currency: "USD",
+        convertedValueBrl: roundMoney(
+          contentPipelineCostUsd * TECHNICAL_COST_USD_TO_BRL,
+        ),
       },
       {
         label: "GeraLanding",
         value: geraLandingCostUsd,
         currency: "USD",
+        convertedValueBrl: roundMoney(
+          geraLandingCostUsd * TECHNICAL_COST_USD_TO_BRL,
+        ),
       },
       {
         label: "GeraSalesPage",
         value: geraSalesPageCostUsd,
         currency: "USD",
+        convertedValueBrl: roundMoney(
+          geraSalesPageCostUsd * TECHNICAL_COST_USD_TO_BRL,
+        ),
       },
     ],
   };


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
o custo precisa ter tambem somados os outros valores ( considere como padrão US$ 1 = R$ 5 )

**Resumo das alterações:**
Ajustei o cálculo do custo na tela do experimento.

Agora o **Custo rastreável** soma:

`custos em BRL + custos técnicos em USD convertidos por US$ 1 = R$ 5`

No exemplo do print, a lógica fica:

`R$ 25,04 + (US$ 0,18 + US$ 0,77) x 5 = R$ 29,79`

Também alinhei o cartão lateral para usar esse mesmo total, e os custos técnicos agora mostram o equivalente em BRL.

Validações:
- `npm test -- --run src/pages/experiment/experimentCostSummary.test.ts`: passou
- `npm run typecheck`: passou

Não criei PR.