### PR TITLE
AI Hub: Implementado sem criar PR.

O que mudou:
- O quadro de cards da tela `/planning` virou uma tabela de experimentos.
- Colunas incluídas: `id`, nome, nicho, hipótese, custo, receita, média de tempo, tipo de produto, manual e teste A/B.
- A ordenação…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/dto/CommercialPlanWeekExperimentDto.java
@@ -12,6 +12,8 @@ public record CommercialPlanWeekExperimentDto(
         String hypothesisId,
         String hypothesisTitle,
         String productType,
+        Boolean manual,
+        Boolean abTest,
         String status,
         Instant createdAt,
         BigDecimal campaignCost,

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -238,6 +238,8 @@ public class CommercialPlanWeeklyExperimentService {
                     )) as hypothesis_id,
                     h.title as hypothesis_title,
                     coalesce(e.product_ai_subtype, e.experiment_type) as product_type,
+                    case when e.creation_source = 'MANUAL_FLOW' then 1 else 0 end as manual,
+                    case when ab_test.experiment_id is null then 0 else 1 end as ab_test,
                     e.status,
                     e.created_at,
                     coalesce(campaign.cost, 0) as campaign_cost,
@@ -291,6 +293,10 @@ public class CommercialPlanWeeklyExperimentService {
                     group by experiment_id
                 ) video on video.experiment_id = e.id
                 left join (
+                    select distinct experiment_id
+                    from experiment_sales_page_ab_test
+                ) ab_test on ab_test.experiment_id = e.id
+                left join (
                     select
                         event_times.experiment_id,
                         round(sum(event_times.elapsed_ms) / count(distinct event_times.session_id)) as average_product_view_time_ms
@@ -309,7 +315,7 @@ public class CommercialPlanWeeklyExperimentService {
                     group by event_times.experiment_id
                 ) analytics on analytics.experiment_id = e.id
                 where e.created_at >= ? and e.created_at < ?
-                order by e.created_at asc, e.id asc
+                order by analytics.average_product_view_time_ms desc, e.created_at asc, e.id asc
                 """, this::mapExperiment, java.sql.Date.valueOf(endExclusive), java.sql.Date.valueOf(startInclusive),
                 start, end, start, end, start, end, start, end, start, end);
     }
@@ -329,6 +335,8 @@ public class CommercialPlanWeeklyExperimentService {
                 rs.getString("hypothesis_id"),
                 rs.getString("hypothesis_title"),
                 rs.getString("product_type"),
+                rs.getBoolean("manual"),
+                rs.getBoolean("ab_test"),
                 rs.getString("status"),
                 toInstant(rs.getTimestamp("created_at")),
                 campaignCost,

--- a/frontend/src/api/planning/useCommercialPlans.ts
+++ b/frontend/src/api/planning/useCommercialPlans.ts
@@ -105,6 +105,8 @@ export interface CommercialPlanWeekExperiment {
   hypothesisId?: string | null;
   hypothesisTitle?: string | null;
   productType?: string | null;
+  manual?: boolean | null;
+  abTest?: boolean | null;
   status?: string | null;
   createdAt?: string | null;
   campaignCost?: number | null;

--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -492,6 +492,61 @@
   margin-top: 0.75rem;
 }
 
+.commercial-planning-experiment-table-wrap {
+  min-width: 0;
+  margin-top: 0.75rem;
+  overflow-x: auto;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-experiment-table {
+  width: 100%;
+  min-width: 1120px;
+  margin: 0;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.commercial-planning-experiment-table th,
+.commercial-planning-experiment-table td {
+  padding: 0.7rem 0.75rem;
+  border-bottom: 1px solid #e4e7ec;
+  vertical-align: top;
+}
+
+.commercial-planning-experiment-table th {
+  color: #475467;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+  background: #f8fafc;
+}
+
+.commercial-planning-experiment-table td {
+  color: #344054;
+  line-height: 1.35;
+}
+
+.commercial-planning-experiment-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.commercial-planning-experiment-table a {
+  color: #101828;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.commercial-planning-experiment-table a:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
 .commercial-planning-experiment-card {
   display: grid;
   min-width: 0;

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -73,6 +73,8 @@ let mockWeeks: unknown[] = [
         hypothesisId: "11111111-1111-1111-1111-111111111111",
         hypothesisTitle: "Kit de manutenção guiada para manicures",
         productType: "LOW_TICKET",
+        manual: true,
+        abTest: true,
         status: "ACTIVE",
         createdAt: "2026-07-02T10:00:00Z",
         totalCost: 37,
@@ -82,7 +84,30 @@ let mockWeeks: unknown[] = [
         leads: 6,
         checkoutClicks: 2,
         purchases: 1,
+        averageProductViewTimeMs: 45000,
         result: "Receita parcial",
+      },
+      {
+        id: 40,
+        name: "Agenda recorrente",
+        nicheId: 21,
+        nicheName: "Manicure profissional",
+        hypothesisId: "11111111-1111-1111-1111-111111111111",
+        hypothesisTitle: "Kit de manutenção guiada para manicures",
+        productType: "LEAD_MAGNET",
+        manual: false,
+        abTest: false,
+        status: "ACTIVE",
+        createdAt: "2026-07-03T10:00:00Z",
+        totalCost: 12,
+        videoCost: 0,
+        revenue: 0,
+        clicks: 12,
+        leads: 3,
+        checkoutClicks: 0,
+        purchases: 0,
+        averageProductViewTimeMs: 90000,
+        result: "Sem receita rastreada",
       },
     ],
   },
@@ -152,6 +177,8 @@ afterEach(() => {
           hypothesisId: "11111111-1111-1111-1111-111111111111",
           hypothesisTitle: "Kit de manutenção guiada para manicures",
           productType: "LOW_TICKET",
+          manual: true,
+          abTest: true,
           status: "ACTIVE",
           createdAt: "2026-07-02T10:00:00Z",
           totalCost: 37,
@@ -161,7 +188,30 @@ afterEach(() => {
           leads: 6,
           checkoutClicks: 2,
           purchases: 1,
+          averageProductViewTimeMs: 45000,
           result: "Receita parcial",
+        },
+        {
+          id: 40,
+          name: "Agenda recorrente",
+          nicheId: 21,
+          nicheName: "Manicure profissional",
+          hypothesisId: "11111111-1111-1111-1111-111111111111",
+          hypothesisTitle: "Kit de manutenção guiada para manicures",
+          productType: "LEAD_MAGNET",
+          manual: false,
+          abTest: false,
+          status: "ACTIVE",
+          createdAt: "2026-07-03T10:00:00Z",
+          totalCost: 12,
+          videoCost: 0,
+          revenue: 0,
+          clicks: 12,
+          leads: 3,
+          checkoutClicks: 0,
+          purchases: 0,
+          averageProductViewTimeMs: 90000,
+          result: "Sem receita rastreada",
         },
       ],
     },
@@ -185,47 +235,32 @@ describe("CommercialPlanningPage", () => {
     expect(screen.queryByText("Novo Plano de Primeira Venda")).toBeNull();
   });
 
-  it("renderiza experimentos criados por semana do mes em slides", async () => {
-    const user = userEvent.setup();
+  it("renderiza experimentos criados por semana em tabela ordenada por media de tempo", () => {
     renderPage();
 
     expect(screen.getByText("Semana 1")).toBeTruthy();
-    expect(screen.getByText("Nicho")).toBeTruthy();
-    expect(screen.getByText("Manicure profissional")).toBeTruthy();
-    expect(screen.queryByText("Hipótese")).toBeNull();
-    expect(
-      screen.queryByText("Kit de manutenção guiada para manicures"),
-    ).toBeNull();
-
-    await user.click(
-      screen.getByRole("button", { name: /manicure profissional/i }),
-    );
-
-    expect(screen.getByText("Hipótese")).toBeTruthy();
-    expect(
-      screen.getByText("Kit de manutenção guiada para manicures"),
-    ).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Kit manutenção" })).toBeNull();
-
-    await user.click(
-      screen.getByRole("button", {
-        name: /kit de manutenção guiada para manicures/i,
-      }),
-    );
-
+    expect(screen.getByText("Nome do experimento")).toBeTruthy();
+    expect(screen.getByText("Média de tempo")).toBeTruthy();
+    expect(screen.getByText("Tipo de produto")).toBeTruthy();
+    expect(screen.getByText("Teste A/B")).toBeTruthy();
     expect(
       screen.getByRole("link", { name: "Kit manutenção" }),
     ).toHaveAttribute("href", "/experiments/39");
-    expect(screen.getByText("Checkout")).toBeTruthy();
-    expect(screen.getByText("Compras")).toBeTruthy();
-    expect(screen.getByText("Receita parcial")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Agenda recorrente" }),
+    ).toHaveAttribute("href", "/experiments/40");
 
-    await user.click(
-      screen.getByRole("button", { name: "Voltar para o nível anterior" }),
-    );
-
-    expect(screen.getByText("Hipótese")).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Kit manutenção" })).toBeNull();
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("Agenda recorrente");
+    expect(rows[1]).toHaveTextContent("1min 30s");
+    expect(rows[2]).toHaveTextContent("Kit manutenção");
+    expect(rows[2]).toHaveTextContent("45s");
+    expect(screen.getAllByText("Manicure profissional")).toHaveLength(2);
+    expect(
+      screen.getAllByText("Kit de manutenção guiada para manicures"),
+    ).toHaveLength(2);
+    expect(screen.getByText("LOW_TICKET")).toBeTruthy();
+    expect(screen.getByText("LEAD_MAGNET")).toBeTruthy();
   });
 
   it("renderiza objetivos semanais como texto e mostra campo apenas para novo objetivo", async () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, ChevronRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
@@ -107,11 +106,6 @@ function formatNumber(value?: number | null) {
 
 function formatExecutedNumber(value?: number | null) {
   return value == null ? "0" : String(value);
-}
-
-function formatRoas(revenue?: number | null, cost?: number | null) {
-  if (!cost || cost <= 0) return "Não definido";
-  return `${((revenue ?? 0) / cost).toFixed(2)}x`;
 }
 
 function formatAverageViewTime(valueMs?: number | null) {
@@ -327,116 +321,6 @@ function normalizeObjectives(
   return [];
 }
 
-interface ExperimentHierarchyMetricSummary {
-  experiments: number;
-  totalCost: number;
-  revenue: number;
-  clicks: number;
-  leads: number;
-  checkoutClicks: number;
-  purchases: number;
-}
-
-interface ExperimentHierarchyHypothesis {
-  key: string;
-  id?: string | null;
-  title: string;
-  summary: ExperimentHierarchyMetricSummary;
-  experiments: CommercialPlanWeek["experiments"];
-}
-
-interface ExperimentHierarchyNiche {
-  key: string;
-  id?: number | null;
-  name: string;
-  summary: ExperimentHierarchyMetricSummary;
-  hypotheses: ExperimentHierarchyHypothesis[];
-}
-
-function emptySummary(): ExperimentHierarchyMetricSummary {
-  return {
-    experiments: 0,
-    totalCost: 0,
-    revenue: 0,
-    clicks: 0,
-    leads: 0,
-    checkoutClicks: 0,
-    purchases: 0,
-  };
-}
-
-function addExperimentToSummary(
-  summary: ExperimentHierarchyMetricSummary,
-  experiment: CommercialPlanWeek["experiments"][number],
-) {
-  summary.experiments += 1;
-  summary.totalCost += experiment.totalCost ?? 0;
-  summary.revenue += experiment.revenue ?? 0;
-  summary.clicks += experiment.clicks ?? 0;
-  summary.leads += experiment.leads ?? 0;
-  summary.checkoutClicks += experiment.checkoutClicks ?? 0;
-  summary.purchases += experiment.purchases ?? 0;
-}
-
-function buildExperimentHierarchy(
-  experiments: CommercialPlanWeek["experiments"],
-): ExperimentHierarchyNiche[] {
-  const niches = new Map<string, ExperimentHierarchyNiche>();
-
-  experiments.forEach((experiment) => {
-    const nicheKey =
-      experiment.nicheId != null ? String(experiment.nicheId) : "sem-nicho";
-    const hypothesisKey =
-      experiment.hypothesisId ?? `sem-hipotese-${experiment.id}`;
-    let niche = niches.get(nicheKey);
-    if (!niche) {
-      niche = {
-        key: nicheKey,
-        id: experiment.nicheId,
-        name: experiment.nicheName ?? "Nicho não informado",
-        summary: emptySummary(),
-        hypotheses: [],
-      };
-      niches.set(nicheKey, niche);
-    }
-
-    let hypothesis = niche.hypotheses.find(
-      (item) => item.key === hypothesisKey,
-    );
-    if (!hypothesis) {
-      hypothesis = {
-        key: hypothesisKey,
-        id: experiment.hypothesisId,
-        title: experiment.hypothesisTitle ?? "Hipótese não informada",
-        summary: emptySummary(),
-        experiments: [],
-      };
-      niche.hypotheses.push(hypothesis);
-    }
-
-    addExperimentToSummary(niche.summary, experiment);
-    addExperimentToSummary(hypothesis.summary, experiment);
-    hypothesis.experiments.push(experiment);
-  });
-
-  return Array.from(niches.values());
-}
-
-function HierarchySummary({
-  summary,
-}: {
-  summary: ExperimentHierarchyMetricSummary;
-}) {
-  return (
-    <div className="commercial-planning-hierarchy-summary">
-      <span>{summary.experiments} exp.</span>
-      <span>{formatExecutedCurrency(summary.totalCost)} custo</span>
-      <span>{formatExecutedCurrency(summary.revenue)} receita</span>
-      <span>{summary.purchases} compras</span>
-    </div>
-  );
-}
-
 function CollapseIndicator() {
   return (
     <span className="commercial-planning-collapse-indicator" aria-hidden="true">
@@ -445,217 +329,74 @@ function CollapseIndicator() {
   );
 }
 
-type ExperimentSlideDirection = "forward" | "back";
-
-function ExperimentCard({
-  experiment,
-}: {
-  experiment: CommercialPlanWeek["experiments"][number];
-}) {
-  return (
-    <article className="commercial-planning-experiment-card">
-      <div className="commercial-planning-experiment-card-header">
-        <div>
-          <span>Experimento #{experiment.id}</span>
-          <Link to={`/experiments/${experiment.id}`}>{experiment.name}</Link>
-        </div>
-        <span className="badge text-bg-light border">
-          {experiment.status ?? "Não definido"}
-        </span>
-      </div>
-
-      <div className="commercial-planning-experiment-metrics">
-        <div>
-          <span>Receita</span>
-          <strong>{formatExecutedCurrency(experiment.revenue)}</strong>
-        </div>
-        <div>
-          <span>Compras</span>
-          <strong>{formatExecutedNumber(experiment.purchases)}</strong>
-        </div>
-        <div>
-          <span>Checkout</span>
-          <strong>{formatExecutedNumber(experiment.checkoutClicks)}</strong>
-        </div>
-        <div>
-          <span>Leads</span>
-          <strong>{formatExecutedNumber(experiment.leads)}</strong>
-        </div>
-        <div>
-          <span>Cliques</span>
-          <strong>{formatExecutedNumber(experiment.clicks)}</strong>
-        </div>
-        <div>
-          <span>Tempo tela</span>
-          <strong>
-            {formatAverageViewTime(experiment.averageProductViewTimeMs)}
-          </strong>
-        </div>
-        <div>
-          <span>Custo</span>
-          <strong>{formatExecutedCurrency(experiment.totalCost)}</strong>
-        </div>
-        <div>
-          <span>ROAS</span>
-          <strong>
-            {formatRoas(experiment.revenue, experiment.totalCost)}
-          </strong>
-        </div>
-        <div>
-          <span>Criado</span>
-          <strong>{formatDate(experiment.createdAt)}</strong>
-        </div>
-      </div>
-
-      <div className="commercial-planning-experiment-result">
-        {experiment.result ?? "Sem resultado"}
-      </div>
-    </article>
-  );
+function formatBoolean(value?: boolean | null) {
+  return value ? "Sim" : "Não";
 }
 
-function WeeklyExperimentSlides({
+function sortedByAverageTime(experiments: CommercialPlanWeek["experiments"]) {
+  return [...experiments].sort((first, second) => {
+    const firstTime = first.averageProductViewTimeMs ?? -1;
+    const secondTime = second.averageProductViewTimeMs ?? -1;
+    if (secondTime !== firstTime) return secondTime - firstTime;
+    return first.id - second.id;
+  });
+}
+
+function ExperimentsTable({
   experiments,
 }: {
   experiments: CommercialPlanWeek["experiments"];
 }) {
-  const hierarchy = useMemo(
-    () => buildExperimentHierarchy(experiments),
+  const orderedExperiments = useMemo(
+    () => sortedByAverageTime(experiments),
     [experiments],
   );
-  const [selectedNicheKey, setSelectedNicheKey] = useState<string | null>(null);
-  const [selectedHypothesisKey, setSelectedHypothesisKey] = useState<
-    string | null
-  >(null);
-  const [direction, setDirection] =
-    useState<ExperimentSlideDirection>("forward");
-
-  const selectedNiche = hierarchy.find(
-    (niche) => niche.key === selectedNicheKey,
-  );
-  const selectedHypothesis = selectedNiche?.hypotheses.find(
-    (hypothesis) => hypothesis.key === selectedHypothesisKey,
-  );
-
-  useEffect(() => {
-    if (!selectedNicheKey) return;
-    const hasSelectedNiche = hierarchy.some(
-      (niche) => niche.key === selectedNicheKey,
-    );
-    if (!hasSelectedNiche) {
-      setSelectedNicheKey(null);
-      setSelectedHypothesisKey(null);
-    }
-  }, [hierarchy, selectedNicheKey]);
-
-  function openNiche(niche: ExperimentHierarchyNiche) {
-    setDirection("forward");
-    setSelectedNicheKey(niche.key);
-    setSelectedHypothesisKey(null);
-  }
-
-  function openHypothesis(hypothesis: ExperimentHierarchyHypothesis) {
-    setDirection("forward");
-    setSelectedHypothesisKey(hypothesis.key);
-  }
-
-  function goBack() {
-    setDirection("back");
-    if (selectedHypothesisKey) {
-      setSelectedHypothesisKey(null);
-      return;
-    }
-    setSelectedNicheKey(null);
-  }
-
-  const slideClassName = `commercial-planning-slide ${
-    direction === "forward"
-      ? "commercial-planning-slide-forward"
-      : "commercial-planning-slide-reverse"
-  }`;
 
   return (
-    <div className="commercial-planning-slide-shell">
-      {selectedNiche ? (
-        <div className="commercial-planning-slide-bar">
-          <button
-            className="commercial-planning-slide-back"
-            type="button"
-            onClick={goBack}
-            aria-label="Voltar para o nível anterior"
-            title="Voltar"
-          >
-            <ArrowLeft size={16} aria-hidden="true" />
-          </button>
-          <div className="commercial-planning-slide-path">
-            <span>Nichos</span>
-            <strong>{selectedNiche.name}</strong>
-            {selectedHypothesis ? (
-              <strong>{selectedHypothesis.title}</strong>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-
-      {!selectedNiche ? (
-        <div className={slideClassName} key="niches">
-          <div className="commercial-planning-slide-grid">
-            {hierarchy.map((niche) => (
-              <button
-                className="commercial-planning-slide-card"
-                type="button"
-                key={niche.key}
-                onClick={() => openNiche(niche)}
-              >
-                <span className="commercial-planning-node-kicker">Nicho</span>
-                <strong>{niche.name}</strong>
-                <HierarchySummary summary={niche.summary} />
-                <span className="commercial-planning-slide-card-action">
-                  <ChevronRight size={16} aria-hidden="true" />
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : !selectedHypothesis ? (
-        <div className={slideClassName} key={`hypotheses-${selectedNiche.key}`}>
-          <div className="commercial-planning-slide-grid">
-            {selectedNiche.hypotheses.map((hypothesis) => (
-              <button
-                className="commercial-planning-slide-card"
-                type="button"
-                key={hypothesis.key}
-                onClick={() => openHypothesis(hypothesis)}
-              >
-                <span className="commercial-planning-node-kicker">
-                  Hipótese
-                </span>
-                <strong>{hypothesis.title}</strong>
-                <HierarchySummary summary={hypothesis.summary} />
-                <span className="commercial-planning-slide-card-action">
-                  <ChevronRight size={16} aria-hidden="true" />
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : (
-        <div
-          className={slideClassName}
-          key={`experiments-${selectedHypothesis.key}`}
-        >
-          <div className="commercial-planning-experiment-grid">
-            {selectedHypothesis.experiments.map((experiment) => (
-              <ExperimentCard experiment={experiment} key={experiment.id} />
-            ))}
-          </div>
-        </div>
-      )}
+    <div className="commercial-planning-experiment-table-wrap">
+      <table className="commercial-planning-experiment-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Nome do experimento</th>
+            <th>Nicho</th>
+            <th>Hipótese</th>
+            <th>Custo</th>
+            <th>Receita</th>
+            <th>Média de tempo</th>
+            <th>Tipo de produto</th>
+            <th>Manual</th>
+            <th>Teste A/B</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orderedExperiments.map((experiment) => (
+            <tr key={experiment.id}>
+              <td>#{experiment.id}</td>
+              <td>
+                <Link to={`/experiments/${experiment.id}`}>
+                  {experiment.name}
+                </Link>
+              </td>
+              <td>{experiment.nicheName ?? "Nicho não informado"}</td>
+              <td>{experiment.hypothesisTitle ?? "Hipótese não informada"}</td>
+              <td>{formatExecutedCurrency(experiment.totalCost)}</td>
+              <td>{formatExecutedCurrency(experiment.revenue)}</td>
+              <td>
+                {formatAverageViewTime(experiment.averageProductViewTimeMs)}
+              </td>
+              <td>{experiment.productType ?? "Não definido"}</td>
+              <td>{formatBoolean(experiment.manual)}</td>
+              <td>{formatBoolean(experiment.abTest)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
-function WeeklyExperimentTable({
+function WeeklyExperimentList({
   planId,
   weeks,
 }: {
@@ -688,7 +429,7 @@ function WeeklyExperimentTable({
           </summary>
 
           {week.experiments.length > 0 ? (
-            <WeeklyExperimentSlides experiments={week.experiments} />
+            <ExperimentsTable experiments={week.experiments} />
           ) : (
             <div className="commercial-planning-empty-week">
               Nenhum experimento criado nesta semana.
@@ -815,7 +556,7 @@ export default function CommercialPlanningPage() {
       ) : null}
 
       {weeks.length > 0 ? (
-        <WeeklyExperimentTable planId={currentMonthPlan.id} weeks={weeks} />
+        <WeeklyExperimentList planId={currentMonthPlan.id} weeks={weeks} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
Nesse quadro marcado vamos mudar para uma tabela com os experimentos
- nas colunas vamos colocar id, nome do experimento, nicho, hipotese, custo, receita, media de tempo, tipo de produto, manual ou não, com teste a/b
- ordenado pela media de tempo decrescente

**Resumo das alterações:**
Implementado sem criar PR.

O que mudou:
- O quadro de cards da tela `/planning` virou uma tabela de experimentos.
- Colunas incluídas: `id`, nome, nicho, hipótese, custo, receita, média de tempo, tipo de produto, manual e teste A/B.
- A ordenação agora é por `média de tempo` decrescente.
- O backend passou a expor `manual` via `experiment.creation_source = MANUAL_FLOW`.
- O backend passou a expor `teste A/B` pela existência em `experiment_sales_page_ab_test`.

Validações feitas:
- Backend: `CommercialPlanWeeklyExperimentServiceTest` passou.
- Frontend: teste da página de planejamento passou com `NODE_ENV=test`.
- Frontend: `npm run typecheck` passou.
- `git diff --check` passou.

Servidor local ativo:
- `http://localhost:5173/planning`

Observação: precisei instalar dependências do frontend no ambiente local; o primeiro teste falhou porque o shell estava com `NODE_ENV=production`, então repeti corretamente com `NODE_ENV=test`.