### PR TITLE
AI Hub: Implementado sem criar PR.

**Travas adicionadas**
- O backend agora bloqueia `RUNNING` para experimento Facebook se não existir campanha registrada em `facebook_ads_campaign`.
- O endpoint de callback do Facebook Ads Worker agora rejeita publicaç…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -565,12 +565,7 @@ public class ExperimentService {
     public Experiment updateStatus(Long id, ExperimentStatus status) {
         Experiment exp = repository.findById(id).orElseThrow();
         if (status == ExperimentStatus.RUNNING) {
-            if (exp.getKpiTargetCpl() == null || exp.getStopLossCpl() == null || exp.getSampleSize() == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "financial fields not set");
-            }
-            if (exp.getDailyBudget() == null || exp.getDailyBudget().compareTo(java.math.BigDecimal.ZERO) <= 0) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dailyBudget not set");
-            }
+            validateRunningStatusTransition(exp);
         }
         exp.setStatus(status);
         if (status == ExperimentStatus.PAUSED) {
@@ -581,6 +576,22 @@ public class ExperimentService {
             );
         }
         return exp;
+    }
+
+    /** Valida as evidências mínimas antes de aceitar experimento como em execução. */
+    private void validateRunningStatusTransition(Experiment exp) {
+        if (exp.getKpiTargetCpl() == null || exp.getStopLossCpl() == null || exp.getSampleSize() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "financial fields not set");
+        }
+        if (exp.getDailyBudget() == null || exp.getDailyBudget().compareTo(java.math.BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "dailyBudget not set");
+        }
+        if (exp.getPlatform() == ExperimentPlatform.FACEBOOK
+                && !facebookAdsCampaignRepository.existsByExperimentId(exp.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Facebook campaign must be registered before setting experiment RUNNING");
+        }
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -254,6 +254,9 @@ public class FacebookAdsCampaignController {
     @ResponseStatus(HttpStatus.CREATED)
     // Executa a operação create da integração Facebook Ads.
     public void create(@RequestBody CreateCampaignRequest req) {
+        if (req == null || req.experimentId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campaign publication report is required");
+        }
         Experiment experiment;
         try {
             experiment = experimentService.get(req.experimentId());
@@ -276,6 +279,7 @@ public class FacebookAdsCampaignController {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Experiment already has a Facebook campaign: " + req.experimentId());
         }
+        validateCompleteCampaignPublicationReport(req);
         FacebookAccount account = accountRepository.findById(req.facebookAccountId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Facebook account not found: " + req.facebookAccountId()));
@@ -324,6 +328,44 @@ public class FacebookAdsCampaignController {
             }
         }
         experiment.setStatus(ExperimentStatus.RUNNING);
+    }
+
+    // Bloqueia callback parcial do worker para evitar experimento RUNNING sem publicação materializada.
+    private void validateCompleteCampaignPublicationReport(CreateCampaignRequest req) {
+        if (!StringUtils.hasText(resolveMetaId(req.externalId(), req.id()))) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Published Meta campaign id is required");
+        }
+        if (!StringUtils.hasText(req.adAccountId())
+                || !StringUtils.hasText(req.name())
+                || !StringUtils.hasText(req.objective())
+                || req.budgetMode() == null
+                || req.experimentId() == null
+                || req.facebookAccountId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campaign publication report is incomplete");
+        }
+        if (req.adSet() == null || !StringUtils.hasText(req.adSet().id())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Published Meta ad set is required");
+        }
+        List<CreateCampaignRequest.AdCreative> creativeRequests = resolveAdCreativeRequests(req);
+        List<CreateCampaignRequest.Ad> adRequests = resolveAdRequests(req);
+        if (creativeRequests.isEmpty() || adRequests.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Published Meta creative and ad are required");
+        }
+        Set<String> creativeIds = creativeRequests.stream()
+                .map(CreateCampaignRequest.AdCreative::id)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+        if (creativeIds.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Published Meta creative id is required");
+        }
+        for (CreateCampaignRequest.Ad adRequest : adRequests) {
+            if (adRequest == null
+                    || !StringUtils.hasText(adRequest.id())
+                    || !StringUtils.hasText(adRequest.creativeId())
+                    || !creativeIds.contains(adRequest.creativeId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Published Meta ad must reference a reported creative");
+            }
+        }
     }
 
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -708,6 +708,49 @@ class ExperimentServiceTest {
     }
 
     @Test
+    void updateStatusRunningRejectsFacebookExperimentWithoutRegisteredCampaign() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Running Guard").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("ARG").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("HRG")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150_RUNNING_GUARD")
+                .name("Lean-Startup 150 Running Guard")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("ExpRunningGuard");
+        req.setHypothesis("H");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150_RUNNING_GUARD");
+        req.setSampleSize(150);
+        req.setDailyBudget(new BigDecimal("25"));
+        req.setJourneyTemplateId(createJourneyTemplate().getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow(niche));
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        Experiment experiment = service.create(req);
+
+        assertThatThrownBy(() -> service.updateStatus(experiment.getId(), ExperimentStatus.RUNNING))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("Facebook campaign must be registered before setting experiment RUNNING");
+        assertThat(experimentRepository.findById(experiment.getId()).orElseThrow().getStatus())
+                .isEqualTo(ExperimentStatus.PLANNED);
+    }
+
+    @Test
     void updateStatusPausedRequestsStopForLinkedFacebookCampaigns() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Pause Stop").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("APS").build());

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -579,6 +579,40 @@ class FacebookAdsCampaignControllerTest {
     }
 
     @Test
+    void createCampaignRejectsPartialPublicationReportBeforeRunningExperiment() throws Exception {
+        var experiment = Experiment.builder()
+                .id(38L)
+                .name("Experimento 38")
+                .status(ExperimentStatus.PLANNED)
+                .build();
+        when(experimentService.get(38L)).thenReturn(experiment);
+        when(campaignRepository.findById("cmp-parcial")).thenReturn(Optional.empty());
+        when(campaignRepository.existsByExperimentId(38L)).thenReturn(false);
+
+        String payload = """
+            {
+              "id": "cmp-parcial",
+              "adAccountId": "act_888",
+              "name": "Experimento 38",
+              "objective": "OUTCOME_TRAFFIC",
+              "status": "ACTIVE",
+              "budgetMode": "ADSET",
+              "experimentId": 38,
+              "facebookAccountId": 88
+            }
+            """;
+
+        mockMvc.perform(post("/api/facebook-campaigns")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.PLANNED);
+        verify(campaignRepository, never()).save(any());
+        verify(facebookAccountRepository, never()).findById(88L);
+    }
+
+    @Test
     void syncStatusUpdatesCampaignAdSetAndAdsFromMetaSnapshot() throws Exception {
         var campaign = new FacebookAdsCampaign();
         campaign.setId("cmp-sync");


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: Nesse quadro marcado vamos mudar para uma tabela com os experimentos
- nas colunas vamos colocar id, nome do experimento, nicho, hipotese, custo, receita, media de tempo, tipo de produto, manual ou não, com teste a/b
- ordenado pela media de tempo decrescente 

Modelo: Implementado sem criar PR.

O que mudou:
- O quadro de cards da tela `/planning` virou uma tabela de experimentos.
- Colunas incluídas: `id`, nome, nicho, hipótese, custo, receita, média de tempo, tipo de produto, manual e teste A/B.
- A ordenação agora é por `média de tempo` decrescente.
- O backend passou a expor `manual` via `experiment.creation_source = MANUAL_FLOW`.
- O backend passou a expor `teste A/B` pela existência em `experiment_sales_page_ab_test`.

Validações feitas:
- Backend: `CommercialPlanWeeklyExperimentServiceTest` passou.
- Frontend: teste da página de planejamento passou com `NODE_ENV=test`.
- Frontend: `npm run typecheck` passou.
- `git diff --check` passou.

Servidor local ativo:
- `http://localhost:5173/planning`

Observação: precisei instalar dependências do frontend no ambiente local; o primeiro teste falhou porque o shell estava com `NODE_ENV=production`, então repeti corretamente com `NODE_ENV=test`.

Usuário: esse experimento : MPAE-H001-E001 esta marcado como running mas não vejo ele no geerenciador de anuncios do facebook. Verifique e ajuste se tiver problema.

Modelo: Verifiquei e ajustei.

**Conclusão**
O experimento `MPAE-H001-E001` estava marcado como `RUNNING` no Hub, mas não existe campanha vinculada no banco (`facebook_ads_campaign`) e também não existe campanha com esse nome na conta Meta Ads consultada. Então ele realmente não estava publicado no Gerenciador de Anúncios.

**Ajuste aplicado**
Voltei o experimento `id=63` para `PLANNED`.

Agora:
- `MPAE-H001-E001` não aparece mais como `RUNNING`.
- Não há mais experimento Facebook `RUNNING` sem campanha persistida.
- Ele ainda não voltou para a fila de publicação porque tem bloqueios reais de prontidão.

**O que falta para publicar**
O bloqueio atual é:
- vídeo obrigatório do experimento ainda está `PLANNED` / `PENDING`;
- teste A/B da página está `DRAFT`;
- variante B “Página com vídeo humano” está `DRAFT`.

Próximo passo operacional: concluir/aprovar o vídeo e ativar o teste A/B. Depois disso o experimento deve voltar para a fila do Facebook Ads Worker e aí sim poderá aparecer na Meta.

Última mensagem do usuário:
precisamos colocar travas para evitar esse tipo de erro

**Resumo das alterações:**
Implementado sem criar PR.

**Travas adicionadas**
- O backend agora bloqueia `RUNNING` para experimento Facebook se não existir campanha registrada em `facebook_ads_campaign`.
- O endpoint de callback do Facebook Ads Worker agora rejeita publicação parcial: precisa receber campanha Meta, ad set, criativo e anúncio antes de marcar o experimento como `RUNNING`.

**Arquivos principais**
- [ExperimentService.java](/root/ai-hub/src/ai-hub-d0b0c0a6-eafe-408c-91da-942ffab2559c-kMAtKx/repo/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java:565)
- [FacebookAdsCampaignController.java](/root/ai-hub/src/ai-hub-d0b0c0a6-eafe-408c-91da-942ffab2559c-kMAtKx/repo/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java:256)

**Testes adicionados**
- Bloqueia status `RUNNING` sem campanha persistida.
- Bloqueia callback incompleto do worker antes de alterar status para `RUNNING`.

**Validação**
- `../mvnw -Dtest=ExperimentServiceTest,FacebookAdsCampaignControllerTest test`
- Resultado: 41 testes passaram.
- `git diff --check` passou.