### PR TITLE
AI Hub: Feito na tela de Planejamento.

Alterei:

- Semanas iniciam todas fechadas.
- Tabela semanal ganhou coluna `Lucro`.
- No final da tela agora aparece `Top 5 por lucro`.
- Ordenação do Top 5:
  - primeiro por maior lucro;
  - em empate ou lucro zera…

### DIFF
--- a/frontend/src/pages/planning/CommercialPlanningPage.css
+++ b/frontend/src/pages/planning/CommercialPlanningPage.css
@@ -549,6 +549,118 @@
   text-decoration: underline;
 }
 
+.commercial-planning-top-ranking {
+  display: grid;
+  min-width: 0;
+  gap: 0.875rem;
+  padding: 1rem;
+  border: 1px solid #d9dee7;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-top-ranking-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.commercial-planning-top-ranking-header h3 {
+  margin: 0;
+  color: #101828;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.commercial-planning-top-ranking-header > span {
+  max-width: 260px;
+  color: #667085;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  text-align: right;
+}
+
+.commercial-planning-ranking-list {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.commercial-planning-ranking-item {
+  display: grid;
+  grid-template-columns: 2.25rem minmax(0, 1fr) minmax(340px, 0.9fr);
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #fcfcfd;
+}
+
+.commercial-planning-ranking-position {
+  display: inline-grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border-radius: 999px;
+  background: #101828;
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.commercial-planning-ranking-main {
+  display: grid;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.commercial-planning-ranking-main a {
+  color: #1d4ed8;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.commercial-planning-ranking-main span {
+  color: #667085;
+  font-size: 0.86rem;
+  overflow-wrap: anywhere;
+}
+
+.commercial-planning-ranking-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.commercial-planning-ranking-metrics div {
+  min-width: 0;
+  padding: 0.5rem;
+  border: 1px solid #e4e7ec;
+  border-radius: 0.5rem;
+  background: #ffffff;
+}
+
+.commercial-planning-ranking-metrics span {
+  display: block;
+  color: #667085;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.commercial-planning-ranking-metrics strong {
+  display: block;
+  margin-top: 0.1rem;
+  color: #101828;
+  font-size: 0.9rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
 .commercial-planning-experiment-card {
   display: grid;
   min-width: 0;
@@ -740,6 +852,23 @@
     flex-direction: column;
   }
 
+  .commercial-planning-top-ranking-header {
+    display: grid;
+  }
+
+  .commercial-planning-top-ranking-header > span {
+    max-width: none;
+    text-align: left;
+  }
+
+  .commercial-planning-ranking-item {
+    grid-template-columns: 2.25rem minmax(0, 1fr);
+  }
+
+  .commercial-planning-ranking-metrics {
+    grid-column: 1 / -1;
+  }
+
   .commercial-planning-hierarchy-summary {
     justify-content: flex-start;
     text-align: left;
@@ -760,7 +889,8 @@
   }
 
   .commercial-planning-experiment-grid,
-  .commercial-planning-experiment-metrics {
+  .commercial-planning-experiment-metrics,
+  .commercial-planning-ranking-metrics {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -235,19 +235,30 @@ describe("CommercialPlanningPage", () => {
     expect(screen.queryByText("Novo Plano de Primeira Venda")).toBeNull();
   });
 
-  it("renderiza experimentos criados por semana em tabela ordenada por media de tempo", () => {
-    renderPage();
+  it("inicializa semanas fechadas e abre a tabela ordenada por media de tempo", async () => {
+    const user = userEvent.setup();
+    const { container } = renderPage();
+
+    const weekDetails = container.querySelector(
+      ".commercial-planning-week-card",
+    ) as HTMLDetailsElement;
+    expect(weekDetails.open).toBe(false);
 
     expect(screen.getByText("Semana 1")).toBeTruthy();
+
+    await user.click(screen.getByText("Semana 1"));
+
+    expect(weekDetails.open).toBe(true);
     expect(screen.getByText("Nome do experimento")).toBeTruthy();
     expect(screen.getByText("Média de tempo")).toBeTruthy();
     expect(screen.getByText("Tipo de produto")).toBeTruthy();
     expect(screen.getByText("Teste A/B")).toBeTruthy();
+    expect(screen.getAllByText("Lucro").length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("link", { name: "Kit manutenção" }),
+      screen.getAllByRole("link", { name: "Kit manutenção" })[0],
     ).toHaveAttribute("href", "/experiments/39");
     expect(
-      screen.getByRole("link", { name: "Agenda recorrente" }),
+      screen.getAllByRole("link", { name: "Agenda recorrente" })[0],
     ).toHaveAttribute("href", "/experiments/40");
 
     const rows = screen.getAllByRole("row");
@@ -255,12 +266,64 @@ describe("CommercialPlanningPage", () => {
     expect(rows[1]).toHaveTextContent("1min 30s");
     expect(rows[2]).toHaveTextContent("Kit manutenção");
     expect(rows[2]).toHaveTextContent("45s");
-    expect(screen.getAllByText("Manicure profissional")).toHaveLength(2);
+    expect(screen.getAllByText("Manicure profissional").length).toBeGreaterThan(
+      1,
+    );
     expect(
       screen.getAllByText("Kit de manutenção guiada para manicures"),
     ).toHaveLength(2);
     expect(screen.getByText("LOW_TICKET")).toBeTruthy();
     expect(screen.getByText("LEAD_MAGNET")).toBeTruthy();
+  });
+
+  it("renderiza top 5 no final por lucro e usa tempo medio como desempate", () => {
+    mockWeeks = [
+      {
+        ...(mockWeeks[0] as Record<string, unknown>),
+        experiments: [
+          {
+            id: 39,
+            name: "Kit manutenção",
+            nicheName: "Manicure profissional",
+            totalCost: 37,
+            revenue: 47,
+            averageProductViewTimeMs: 45000,
+          },
+          {
+            id: 40,
+            name: "Agenda recorrente",
+            nicheName: "Manicure profissional",
+            totalCost: 12,
+            revenue: 12,
+            averageProductViewTimeMs: 90000,
+          },
+          {
+            id: 41,
+            name: "Amostra rápida",
+            nicheName: "Manicure profissional",
+            totalCost: 8,
+            revenue: 8,
+            averageProductViewTimeMs: 120000,
+          },
+        ],
+      },
+    ];
+
+    const { container } = renderPage();
+
+    expect(screen.getByText("Top 5 por lucro")).toBeTruthy();
+    expect(screen.getByText(/lucro zerado/)).toBeTruthy();
+
+    const rankingItems = Array.from(
+      container.querySelectorAll(".commercial-planning-ranking-item"),
+    );
+    expect(rankingItems).toHaveLength(3);
+    expect(rankingItems[0]).toHaveTextContent("Kit manutenção");
+    expect(rankingItems[0]).toHaveTextContent("R$ 10,00");
+    expect(rankingItems[1]).toHaveTextContent("Amostra rápida");
+    expect(rankingItems[1]).toHaveTextContent("2min");
+    expect(rankingItems[2]).toHaveTextContent("Agenda recorrente");
+    expect(rankingItems[2]).toHaveTextContent("1min 30s");
   });
 
   it("renderiza objetivos semanais como texto e mostra campo apenas para novo objetivo", async () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -333,8 +333,26 @@ function formatBoolean(value?: boolean | null) {
   return value ? "Sim" : "Não";
 }
 
+function experimentProfit(experiment: CommercialPlanWeek["experiments"][number]) {
+  return (experiment.revenue ?? 0) - (experiment.totalCost ?? 0);
+}
+
 function sortedByAverageTime(experiments: CommercialPlanWeek["experiments"]) {
   return [...experiments].sort((first, second) => {
+    const firstTime = first.averageProductViewTimeMs ?? -1;
+    const secondTime = second.averageProductViewTimeMs ?? -1;
+    if (secondTime !== firstTime) return secondTime - firstTime;
+    return first.id - second.id;
+  });
+}
+
+function sortedByProfitThenAverageTime(
+  experiments: CommercialPlanWeek["experiments"],
+) {
+  return [...experiments].sort((first, second) => {
+    const firstProfit = experimentProfit(first);
+    const secondProfit = experimentProfit(second);
+    if (secondProfit !== firstProfit) return secondProfit - firstProfit;
     const firstTime = first.averageProductViewTimeMs ?? -1;
     const secondTime = second.averageProductViewTimeMs ?? -1;
     if (secondTime !== firstTime) return secondTime - firstTime;
@@ -363,6 +381,7 @@ function ExperimentsTable({
             <th>Hipótese</th>
             <th>Custo</th>
             <th>Receita</th>
+            <th>Lucro</th>
             <th>Média de tempo</th>
             <th>Tipo de produto</th>
             <th>Manual</th>
@@ -382,6 +401,7 @@ function ExperimentsTable({
               <td>{experiment.hypothesisTitle ?? "Hipótese não informada"}</td>
               <td>{formatExecutedCurrency(experiment.totalCost)}</td>
               <td>{formatExecutedCurrency(experiment.revenue)}</td>
+              <td>{formatExecutedCurrency(experimentProfit(experiment))}</td>
               <td>
                 {formatAverageViewTime(experiment.averageProductViewTimeMs)}
               </td>
@@ -393,6 +413,75 @@ function ExperimentsTable({
         </tbody>
       </table>
     </div>
+  );
+}
+
+function TopExperimentsRanking({ weeks }: { weeks: CommercialPlanWeek[] }) {
+  const topExperiments = useMemo(
+    () =>
+      sortedByProfitThenAverageTime(
+        weeks.flatMap((week) => week.experiments ?? []),
+      ).slice(0, 5),
+    [weeks],
+  );
+
+  return (
+    <section className="commercial-planning-top-ranking">
+      <div className="commercial-planning-top-ranking-header">
+        <div>
+          <p className="commercial-planning-month-eyebrow mb-1">
+            Ranking de experimentos
+          </p>
+          <h3>Top 5 por lucro</h3>
+        </div>
+        <span>Empate ou lucro zerado: maior tempo médio primeiro</span>
+      </div>
+
+      {topExperiments.length > 0 ? (
+        <div className="commercial-planning-ranking-list">
+          {topExperiments.map((experiment, index) => (
+            <article
+              className="commercial-planning-ranking-item"
+              key={experiment.id}
+            >
+              <span className="commercial-planning-ranking-position">
+                {index + 1}
+              </span>
+              <div className="commercial-planning-ranking-main">
+                <Link to={`/experiments/${experiment.id}`}>
+                  {experiment.name}
+                </Link>
+                <span>{experiment.nicheName ?? "Nicho não informado"}</span>
+              </div>
+              <div className="commercial-planning-ranking-metrics">
+                <div>
+                  <span>Lucro</span>
+                  <strong>
+                    {formatExecutedCurrency(experimentProfit(experiment))}
+                  </strong>
+                </div>
+                <div>
+                  <span>Receita</span>
+                  <strong>{formatExecutedCurrency(experiment.revenue)}</strong>
+                </div>
+                <div>
+                  <span>Tempo médio</span>
+                  <strong>
+                    {formatAverageViewTime(
+                      experiment.averageProductViewTimeMs,
+                    )}
+                  </strong>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="commercial-planning-empty-week">
+          Nenhum experimento disponível para ranking.
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -409,7 +498,6 @@ function WeeklyExperimentList({
         <details
           className="commercial-planning-week-card"
           key={week.weekNumber}
-          open={week.weekNumber === 1}
         >
           <summary className="commercial-planning-week-card-header">
             <div>
@@ -556,7 +644,10 @@ export default function CommercialPlanningPage() {
       ) : null}
 
       {weeks.length > 0 ? (
-        <WeeklyExperimentList planId={currentMonthPlan.id} weeks={weeks} />
+        <>
+          <WeeklyExperimentList planId={currentMonthPlan.id} weeks={weeks} />
+          <TopExperimentsRanking weeks={weeks} />
+        </>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Contexto selecionado pelo usuário: conversa salva "veja" (20 mensagem(ns), atualizada em 11/07/2026, 02:48:10).

Histórico da conversa:
Usuário: veja

Modelo: Está correto.

Pode clicar em:

```text
Criar usuário
```

O que a tela mostra está adequado:

- usuário: `codex-ses-temp`
- sem acesso ao console
- permissão: `AmazonSESFullAccess`

Depois de criar, faça o próximo passo:

1. Abra o usuário `codex-ses-temp`.
2. Vá em **Credenciais de segurança**.
3. Clique em **Criar chave de acesso**.
4. Escolha **Command Line Interface / CLI**.
5. Confirme a recomendação/aviso se aparecer.
6. Copie e me envie:

```text
AWS_ACCESS_KEY_ID=...
AWS_SECRET_ACCESS_KEY=...
AWS_DEFAULT_REGION=us-east-1
```

Com isso eu consigo acessar o SES daqui e verificar domínio, DKIM, sandbox, limites e o caminho para colocar `digicomdigital.com.br` no envio do Marketing Hub.

Usuário: AWS_ACCESS_KEY_ID=AKIA5ZUDABQPMQQVSMOA
AWS_SECRET_ACCESS_KEY=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
AWS_DEFAULT_REGION=us-east-1

Modelo: Acessei o SES com sucesso.

**Status do SES**

- Conta SES está em **produção**, não sandbox.
- Envio habilitado.
- Limite atual: **50.000 e-mails/dia**.
- Taxa: **14 e-mails/segundo**.
- Domínios antigos verificados:
  - `vitrineproduto.online`
  - `vitrineproduto.shop`
- DKIM dos domínios antigos está funcionando.
- O SES ainda estava ligado comercialmente ao site antigo `https://vitrineproduto.online`.

**O que eu fiz agora**

Criei no SES a identidade do novo domínio:

```text
digicomdigital.com.br
```

Ela ficou como:

```text
VerificationStatus: Pending
DkimVerificationStatus: Pending
```

Agora falta colocar estes registros no DNS do Registro.br.

**Registros DNS para adicionar**

TXT de verificação SES:

```text
Nome: _amazonses.digicomdigital.com.br
Tipo: TXT
Valor: qT32hvkBCKSf4OfREEjNAlPlVBhIxcwO1PUugPwzSaw=
```

DKIM:

```text
Nome: ajhqluz4zmklxybeth74edl5qqtqo53q._domainkey.digicomdigital.com.br
Tipo: CNAME
Valor: ajhqluz4zmklxybeth74edl5qqtqo53q.dkim.amazonses.com
```

```text
Nome: kouar4wmbbu4a3ly6pguyhektivatonl._domainkey.digicomdigital.com.br
Tipo: CNAME
Valor: kouar4wmbbu4a3ly6pguyhektivatonl.dkim.amazonses.com
```

```text
Nome: vwxszejysvayid3hewvvdoclz64wgbfg._domainkey.digicomdigital.com.br
Tipo: CNAME
Valor: vwxszejysvayid3hewvvdoclz64wgbfg.dkim.amazonses.com
```

**Minha orientação**

Configure esses 4 registros no DNS do `digicomdigital.com.br`. Depois me avise que eu verifico novamente no SES até aparecer como **Success**.

Importante: quando terminarmos tudo, apague o usuário IAM temporário `codex-ses-temp`, porque a chave já foi exposta nesta conversa.

Usuário: aqui ?

Modelo: Sim, é aí mesmo.

Clique em:

```text
Configurar endereçamento
```

Depois procure a opção para **editar zona DNS** ou **adicionar registros DNS**.

Você vai adicionar estes registros:

**1. Verificação SES**

```text
Tipo: TXT
Nome: _amazonses
Valor: qT32hvkBCKSf4OfREEjNAlPlVBhIxcwO1PUugPwzSaw=
```

**2. DKIM**

```text
Tipo: CNAME
Nome: ajhqluz4zmklxybeth74edl5qqtqo53q._domainkey
Valor: ajhqluz4zmklxybeth74edl5qqtqo53q.dkim.amazonses.com
```

```text
Tipo: CNAME
Nome: kouar4wmbbu4a3ly6pguyhektivatonl._domainkey
Valor: kouar4wmbbu4a3ly6pguyhektivatonl.dkim.amazonses.com
```

```text
Tipo: CNAME
Nome: vwxszejysvayid3hewvvdoclz64wgbfg._domainkey
Valor: vwxszejysvayid3hewvvdoclz64wgbfg.dkim.amazonses.com
```

No Registro.br, normalmente você não precisa colocar `.digicomdigital.com.br` no campo **Nome**. Coloque só a parte inicial, como acima.

Depois de salvar, me avise. Eu verifico no SES se o domínio passou para **Success**.

Usuário: e agora ?

Modelo: Sim. Agora clique em:

```text
MODO AVANÇADO
```

Essa tela simples serve para site e servidor de e-mail, mas os registros do SES precisam ser configurados na **zona DNS avançada**.

No modo avançado, adicione os 4 registros:

**TXT**

```text
Tipo: TXT
Nome: _amazonses
Valor: qT32hvkBCKSf4OfREEjNAlPlVBhIxcwO1PUugPwzSaw=
```

**CNAME 1**

```text
Tipo: CNAME
Nome: ajhqluz4zmklxybeth74edl5qqtqo53q._domainkey
Valor: ajhqluz4zmklxybeth74edl5qqtqo53q.dkim.amazonses.com
```

**CNAME 2**

```text
Tipo: CNAME
Nome: kouar4wmbbu4a3ly6pguyhektivatonl._domainkey
Valor: kouar4wmbbu4a3ly6pguyhektivatonl.dkim.amazonses.com
```

**CNAME 3**

```text
Tipo: CNAME
Nome: vwxszejysvayid3hewvvdoclz64wgbfg._domainkey
Valor: vwxszejysvayid3hewvvdoclz64wgbfg.dkim.amazonses.com
```

Não preencha agora “Endereço do site” nem “Servidor de e-mail” nessa tela simples.

Depois de salvar os registros no modo avançado, me avise. Aí eu verifico no SES se o domínio `digicomdigital.com.br` já mudou para verificado.

Usuário: e agora ?

Modelo: Sim, agora você está na tela certa.

Clique em:

```text
Configurar zona DNS
```

Depois adicione os registros do SES no DNS avançado.

Use assim:

**TXT**

```text
Tipo: TXT
Nome: _amazonses
Valor: qT32hvkBCKSf4OfREEjNAlPlVBhIxcwO1PUugPwzSaw=
```

**CNAME 1**

```text
Tipo: CNAME
Nome: ajhqluz4zmklxybeth74edl5qqtqo53q._domainkey
Valor: ajhqluz4zmklxybeth74edl5qqtqo53q.dkim.amazonses.com
```

**CNAME 2**

```text
Tipo: CNAME
Nome: kouar4wmbbu4a3ly6pguyhektivatonl._domainkey
Valor: kouar4wmbbu4a3ly6pguyhektivatonl.dkim.amazonses.com
```

**CNAME 3**

```text
Tipo: CNAME
Nome: vwxszejysvayid3hewvvdoclz64wgbfg._domainkey
Valor: vwxszejysvayid3hewvvdoclz64wgbfg.dkim.amazonses.com
```

Esse aviso de “DNS em transição” é normal porque o domínio é novo. Pode continuar configurando.

Depois de salvar, me mande a próxima tela ou diga “salvei”, que eu verifico no SES se o `digicomdigital.com.br` já começou a validar.

Usuário: acho que vamos ter que esperar

Modelo: Sim, aqui é caso de esperar.

O Registro.br está mostrando:

```text
Domínio em transição. Por favor, aguarde alguns minutos e tente novamente.
```

Isso significa que a zona DNS ainda não foi liberada para edição. Enquanto estiver assim, você não consegue adicionar os registros do SES.

Faça assim:

1. Feche essa janela no `X`.
2. Aguarde uns **10 a 30 minutos**.
3. Volte em:

```text
Registro.br → domínio digicomdigital.com.br → DNS → Configurar zona DNS
```

4. Quando a mensagem de “domínio em transição” sumir, adicionamos os registros TXT e CNAME do SES.

Não precisa mexer em mais nada agora. Assim que liberar, me mande a tela que eu te digo exatamente onde colocar cada registro. Depois eu verifico no SES se o domínio passou para verificado.

Usuário: feito

Modelo: Feito, mas ainda **não validou no SES**.

Eu verifiquei agora:

```text
SES digicomdigital.com.br: Pending
DKIM: Pending
```

E a consulta pública de DNS ainda não encontra os registros. Isso pode ser uma destas 3 coisas:

1. **Propagação normal**
   - Mais provável.
   - Aguarde de 10 a 30 minutos e eu verifico de novo.

2. **Faltou clicar em “Salvar alterações”**
   - Na tela aparece o botão **Salvar alterações**.
   - Se ele ainda estiver clicável, clique nele.

3. **Registro.br ainda está publicando a zona**
   - Como o domínio é novo, pode demorar um pouco mais.

Pela tela, os registros parecem corretos. Agora o próximo passo é esperar um pouco e depois eu consulto novamente no SES.

Importante: quando terminarmos a validação, apague o usuário IAM temporário `codex-ses-temp`, porque a chave da AWS já foi exposta na conversa.

Usuário: tenta novamente agora

Modelo: Ainda não validou.

**Resultado agora**

- SES domínio: `Pending`
- SES DKIM: `Pending`
- DNS público: os 4 registros ainda **não aparecem**
- O domínio já responde pelo Registro.br, mas o TXT `_amazonses` e os 3 CNAME DKIM ainda não foram encontrados.

**O que isso indica**

As 3 hipóteses boas são:

1. **Ainda está propagando**
   - Possível, mas menos provável se já passou bastante tempo.

2. **As alterações não foram salvas/publicadas no Registro.br**
   - Bem provável.
   - Verifique se ficou algum botão tipo **Salvar alterações** ou **Publicar**.

3. **Os nomes foram cadastrados com o domínio duplicado**
   - Exemplo errado: `_amazonses.digicomdigital.com.br.digicomdigital.com.br`
   - Também é comum no Registro.br.

**Melhor próximo passo**

Volte na zona DNS e confirme se aparecem exatamente estes nomes, sem repetir o domínio:

```text
_amazonses
ajhqluz4zmklxybeth74edl5qqtqo53q._domainkey
kouar4wmbbu4a3ly6pguyhektivatonl._domainkey
vwxszejysvayid3hewvvdoclz64wgbfg._domainkey
```

Se puder, me mande print da lista dos registros já cadastrados. Aí eu identifico rápido se é só propagação ou se algum campo ficou preenchido errado.

Usuário: veja

Modelo: Está quase certo.

Pelo print, os registros parecem cadastrados corretamente. O Registro.br está mostrando o nome completo, mas isso é normal nessa lista:

```text
_amazonses.digicomdigital.com.br
..._domainkey.digicomdigital.com.br
```

O ponto importante agora: eu consultei o DNS público e **ainda não aparece fora do Registro.br**. Então o SES ainda não vai validar.

Faça só isto agora:

1. Se o botão **Salvar alterações** estiver clicável, clique nele.
2. Se ele estiver cinza/desabilitado, não mexa em mais nada.
3. Aguarde mais alguns minutos.

Não apague nem recrie os registros. Eles estão com aparência correta. O problema agora é publicação/propagação da zona DNS.

Me avise daqui a uns 10-15 minutos com “tenta de novo” que eu verifico novamente.

Usuário: tenta novamente

Modelo: Ainda não validou.

**Resultado agora**

- SES `digicomdigital.com.br`: `Pending`
- DKIM: `Pending`
- DNS público: os registros ainda não existem
- A consulta voltou como `Status: 3`, ou seja: o DNS do Registro.br está respondendo, mas não encontra os registros `_amazonses` e DKIM.

**Interpretação**

Aqui temos 3 possibilidades:

1. **Propagação lenta**
   - Menos provável agora, porque o próprio DNS autoritativo do Registro.br ainda não mostra os registros.

2. **Faltou salvar/publicar**
   - Mais provável.
   - Verifique se existe botão **Salvar alterações**, **Publicar**, **Confirmar** ou algo parecido.

3. **Registros foram criados em uma zona/tela errada**
   - Também possível.
   - A lista pode aparecer no painel, mas não ter sido efetivamente publicada na zona DNS ativa.

**Melhor próximo passo**

Volte na tela da zona DNS e veja se os registros ainda aparecem lá. Se aparecer algum botão de salvar/publicar, clique nele.

Se puder, me mande print da tela completa da zona DNS, principalmente a parte de baixo onde ficam botões de confirmação. O problema agora não é o SES; é o Registro.br ainda não estar publicando esses registros no DNS.

Usuário: o link é esse : https://developers.facebook.com/support/ me ajuda a fazer

Modelo: Sim, o link é esse:

```text
https://developers.facebook.com/support/
```

Faça assim:

1. Entre logado na conta Meta que é **admin** da Digicom.
2. Clique em **Create a case** / **Criar caso**.
3. Quando pedir o tema, escolha algo próximo de:

```text
Business Manager / Business Management / WhatsApp Business Account
```

Se aparecer a opção:

```text
Gerenciamento de negócios e anúncios
```

escolha essa.

Evite escolher **Engenharia** se o formulário permitir, porque o problema não é código/API. O problema é ativo empresarial/WABA invisível ou restrita.

No campo de descrição, cole isto:

```text
Hello Meta Developer Support,

Meta Business Support redirected me here after case #1409570317651411.

My Business Manager, Digicom Comunicação Digital, appears active and without direct restrictions, but the associated WhatsApp Business Accounts and/or phone numbers are not visible or available for appeal.

I identify as a Direct Developer because we use WhatsApp Business/API for our own business operations, lead follow-up, sales support and customer communication.

The issue is not an API implementation error. We need help recovering visibility of the affected WABA/phone numbers and submitting the restriction review for the WhatsApp Business Account.

Please help us identify the affected WABA, restore visibility in Business Manager if applicable, or provide the correct path to appeal the restriction.

Thank you.
```

Se tiver campo para anexos, anexe prints de:

- Business Support Home mostrando conta sem restrição;
- tela onde a WABA/número não aparece;
- resposta da Meta citando o caso `#1409570317651411`;
- qualquer tela de bloqueio ou ausência de apelação.

Objetivo do chamado: **não pedir “libera minha conta” direto**. O objetivo é fazer a Meta localizar a WABA/número e liberar o caminho correto de recurso.

Usuário: veja

Modelo: Sim, você está na tela certa.

Clique em:

```text
WhatsApp Business API
```

É a opção mais alinhada com o caso agora, porque a Meta te encaminhou para suporte de desenvolvedor e o problema envolve WABA/número/API.

Se depois aparecer uma lista de subtópicos, escolha algo parecido com:

```text
WhatsApp Business Account
```

ou

```text
Account access / WABA access / Phone number
```

Evite escolher tema de erro técnico de código, webhook ou mensagem, porque o problema principal é:

- WABA/número não aparece;
- não consegue apelar;
- conta empresarial parece ativa;
- precisa recuperar visibilidade e caminho de revisão.

No campo de descrição, use o texto que te passei antes. Se quiser, eu ajustaria o começo para ficar ainda mais direto:

```text
Hello Meta Developer Support,

Meta Business Support redirected me here after case #1409570317651411.

My Business Manager, Digicom Comunicação Digital, appears active and without direct restrictions, but the associated WhatsApp Business Account and/or phone numbers are not visible and I cannot submit an appeal.

I identify as a Direct Developer because we use WhatsApp Business/API for our own business operations, lead follow-up, sales support and customer communication.

The issue is not an API implementation error. We need help recovering visibility of the affected WABA/phone numbers and submitting the restriction review.

Please help us identify the affected WABA, restore visibility in Business Manager if applicable, or provide the correct path to appeal the restriction.

Thank you.
```

Usuário: acessa esse link é so coisa generica : https://developers.facebook.com/support/

Modelo: Sim, esse link é genérico mesmo:

`https://developers.facebook.com/support/`

Ele é só a porta de entrada do suporte de desenvolvedor. O caminho certo é procurar dentro dele por algo como:

- **Contact Support**
- **Create a case**
- **WhatsApp Business API**
- **Business Manager / WABA / Phone Number Access**

Se ele só mostrar artigos e FAQ, use este caminho mais forte:

`https://business.facebook.com/business-support-home/`

E responda no caso aberto dizendo:

```text
Meta Business Support redirected me to Developer Support, but the Developer Support page only shows generic resources and I cannot find a specific path to appeal or restore access to the affected WhatsApp Business Account.

Please escalate this case internally or provide the exact direct link/category where I can submit the WABA restriction review.

Case reference: #1409570317651411
Business: Digicom Comunicação Digital
Issue: WABA/phone numbers not visible and appeal unavailable.
```

Minha leitura: a Meta está empurrando entre canais. O melhor agora é manter tudo centralizado no caso `#1409570317651411` e pedir **link exato ou escalonamento interno**, porque “Developer Support” genérico não resolve bloqueio comercial de WABA.

Usuário: voltando ao caso dos email quero delegar pra vc criar sozinho tudo eu confiro depois 

Modelo: Consigo assumir quase tudo, mas existe um limite real: **não consigo criar sozinho Google Workspace/caixas reais sem login, pagamento e validação do dono do domínio**. Essa parte exige ação manual sua no navegador. Depois disso, eu consigo orientar/validar DNS e deixar a arquitetura pronta.

Status que verifiquei agora:

- Os registros SES/DKIM do `digicomdigital.com.br` **já aparecem no DNS público**.
- O domínio ainda **não tem MX**, então ainda não recebe e-mails profissionais.
- O domínio ainda **não tem SPF/DMARC raiz**, então falta a parte de reputação/entregabilidade.
- O repositório confirma que e-mail é canal importante no funil: entrega de amostra, abertura de e-mail, entrega premium e recuperação de lead.

**3 opções**

1. **Google Workspace + SES**
   - Melhor opção.
   - Google recebe/responde e-mails profissionais.
   - SES envia automações em escala pelo Marketing Hub.
   - Mais confiável para vendas.

2. **Zoho/Microsoft + SES**
   - Também funciona.
   - Pode ser mais barato, mas menos simples que Google para operação.

3. **Só SES**
   - Bom para disparo automático.
   - Ruim para atendimento, resposta humana e confiança comercial.

**Minha escolha**

Fazer **Google Workspace + Amazon SES**.

Estrutura inicial:

```text
paulo@digicomdigital.com.br
contato@digicomdigital.com.br
vendas@digicomdigital.com.br
suporte@digicomdigital.com.br
financeiro@digicomdigital.com.br
```

Mas para não pagar várias caixas no começo, eu criaria:

```text
paulo@digicomdigital.com.br
```

E os outros como aliases/grupos encaminhando para ela:

```text
contato@
vendas@
suporte@
financeiro@
```

**O que você precisa fazer agora**

Criar o Google Workspace pelo navegador. Eu não recomendo você me passar senha ou acesso pessoal.

Quando chegar na etapa de DNS, me mande a tela/registros que o Google pedir. Aí eu te digo exatamente o que colocar e valido daqui:

- MX do Google;
- SPF combinando Google + SES;
- DKIM do Google;
- DMARC;
- depois validação final de recebimento/envio.

Importante: quando fecharmos isso, apague o usuário IAM temporário da AWS que foi usado antes. A chave já ficou exposta na conversa.

Usuário: faz uma pesquisa mais detalhada na documentação do aws. Estou achando muito estranho o aws não ter um serviço novo para isso. Pesquise e teste usando o aws cli se for necessario.

Modelo: Pesquisei a documentação oficial da AWS e testei o CLI local. Minha conclusão: **a AWS não tem hoje uma solução nova boa para substituir Google Workspace como e-mail profissional humano**.

**O que existe na AWS**

1. **Amazon WorkMail**
   - É o serviço da AWS para caixa de e-mail profissional.
   - Mas a própria AWS informa fim de suporte em **31 de março de 2027**.
   - Então eu **não recomendo começar por ele agora**.
   - Fonte: https://docs.aws.amazon.com/workmail/latest/adminguide/workmail-end-of-support.html

2. **Amazon SES**
   - Excelente para envio em escala, transacional e marketing.
   - Também recebe e-mail, mas recebe para processamento: S3, SNS, Lambda, WorkMail etc.
   - Não é uma caixa de entrada profissional para uso humano.
   - Fonte: https://docs.aws.amazon.com/ses/latest/dg/Welcome.html

3. **SES Mail Manager**
   - É o serviço novo/mais moderno que você suspeitou.
   - Mas ele é um **gateway de entrada, roteamento, regras, relay e arquivamento**.
   - Serve para automação e infraestrutura de e-mail, não para substituir uma caixa tipo Gmail/Outlook.
   - Fonte: https://docs.aws.amazon.com/ses/latest/dg/eb.html

**Validação técnica que fiz**

- O CLI local existe, mas está sem credenciais AWS configuradas agora.
- A versão instalada do AWS CLI não tem o comando `sesmailmanager`, então não consegui consultar Mail Manager pela conta.
- Consultei DNS público:
  - `_amazonses.digicomdigital.com.br` já aparece.
  - Os 3 CNAME DKIM do SES já aparecem.
  - Ainda **não existe MX** para receber e-mail.
  - Ainda **não existe SPF raiz**.
  - Ainda **não existe DMARC**.

**As 3 alternativas reais**

1. **Google Workspace + SES**
   - Melhor para vendas.
   - Google cuida da caixa profissional, respostas, reputação humana e operação.
   - SES cuida dos disparos automáticos em escala pelo Marketing Hub.
   - Minha recomendação.

2. **Zoho/Microsoft + SES**
   - Também funciona.
   - Pode ser mais barato no Zoho ou mais corporativo no Microsoft.
   - Ainda prefiro Google pela simplicidade operacional.

3. **AWS-only com SES/Mail Manager/S3/Lambda**
   - Dá para fazer tecnicamente.
   - Mas vira infraestrutura customizada, não caixa profissional.
   - Custo operacional e risco maiores para pouco ganho agora.

**Decisão recomendada**

Manter o plano:

```text
Google Workspace para caixas profissionais
Amazon SES para automações e escala
```

Estrutura inicial enxuta:

```text
paulo@digicomdigital.com.br
contato@digicomdigital.com.br
vendas@digicomdigital.com.br
suporte@digicomdigital.com.br
financeiro@digicomdigital.com.br
```

Mas pagando só uma caixa principal no começo, usando os outros como aliases/grupos.

Próximo passo prático: criar o Google Workspace e me mandar a tela de DNS/MX que ele pedir. Eu valido e monto os registros corretos combinando Google + SES + DMARC.  
E reforço: a chave IAM temporária exposta antes deve ser apagada assim que fecharmos essa configuração.

Usuário: eu quero que vc inicialmente e depois o marketing hub controle toda a parte de email. recebimento e envio não quero fazer nada manualmente.

Modelo: Sim. Então a decisão muda.

Você não quer “caixas de e-mail profissionais” no modelo Gmail. Você quer **e-mail como canal operacional do Marketing Hub**, controlado por sistema:

- recebe e-mails;
- classifica;
- registra no banco;
- responde automaticamente quando fizer sentido;
- abre tarefa quando precisar de humano;
- envia campanhas, recuperação, suporte e follow-up;
- mede entrega, abertura, clique, resposta, bounce e reclamação.

Isso é possível com AWS. Não usando WorkMail, porque ele vai acabar em **31/03/2027**. O caminho certo é **SES + recebimento + S3/Lambda/backend + Marketing Hub**. A AWS confirma que o SES pode receber e-mails, armazenar em S3 e acionar Lambda/SNS para processamento. Fontes: [SES receiving](https://docs.aws.amazon.com/ses/latest/dg/receiving-email.html), [SES S3 action](https://docs.aws.amazon.com/ses/latest/dg/receiving-email-action-s3.html), [SES Lambda action](https://docs.aws.amazon.com/ses/latest/dg/receiving-email-action-lambda.html), [WorkMail end of support](https://docs.aws.amazon.com/workmail/latest/adminguide/workmail-end-of-support.html).

**3 alternativas**

1. **Google Workspace + SES**
   - Melhor para caixa humana.
   - Pior para seu objetivo, porque mantém operação manual.
   - Eu descartaria agora.

2. **AWS-only com SES recebendo e enviando**
   - Melhor aderência ao Marketing Hub.
   - E-mail vira dado, evento, funil e automação.
   - Exige construir a camada de inbox/roteamento dentro do sistema.
   - Minha escolha.

3. **SES Mail Manager + backend**
   - Mais sofisticado para roteamento, regras, relay e arquivamento.
   - Pode entrar depois.
   - Para começar, SES receiving clássico já resolve melhor e mais simples.

**Arquitetura recomendada**

- DNS do domínio em **Route 53**, para eu/Marketing Hub controlar registros sem depender do Registro.br toda hora.
- MX do domínio apontando para **Amazon SES inbound**.
- SES recebe e-mails para:
  - `contato@digicomdigital.com.br`
  - `vendas@digicomdigital.com.br`
  - `suporte@digicomdigital.com.br`
  - `financeiro@digicomdigital.com.br`
- SES salva o e-mail bruto no **S3**.
- SES dispara **Lambda/SNS**.
- Lambda chama o backend do Marketing Hub.
- Backend grava:
  - mensagem recebida;
  - remetente;
  - destinatário;
  - assunto;
  - corpo;
  - anexos;
  - origem;
  - lead/cliente vinculado;
  - intenção provável;
  - status de atendimento;
  - próxima ação.
- Envio sai pelo **Amazon SES**.
- Bounces/complaints também voltam para o Marketing Hub.

**Ponto importante**

Para não fazer nada manualmente no futuro, provavelmente precisamos fazer **uma ação manual inicial**: mover o DNS do domínio do Registro.br para a Route 53. Depois disso, quase tudo fica controlável por API/CLI.

A melhor decisão para vendas em escala é:

```text
Marketing Hub como central de e-mail
Amazon SES como infraestrutura de envio/recebimento
S3 como arquivo bruto/auditoria
Backend como fonte de verdade
IA para triagem, resposta e classificação
```

Próximo passo que eu faria: desenhar o plano técnico mínimo para ativar o recebimento no SES sem Google Workspace, incluindo DNS, tabelas, endpoints, eventos e fluxo de automação. Não vou alterar código nem preparar PR até você pedir.

Usuário: recebi novo email da Meta

Hi Paulo,

Thank you for following up and for sharing the difficulty you're experiencing with finding the appeal path. We understand how important it is to have clear direction, and we want to help.

To address your questions directly:
The specific policy violation: The business account (Digicom Comunicação Digital) and its associated WhatsApp Business accounts have been disabled due to activity flagged as not compliant with WhatsApp's Business Terms of Service: breach of Terms of Acceptable Use.

The exact activity or behavior that triggered the restriction: Due to privacy and security protocols, we are unable to share the specific trigger. We recognize this makes it harder to pinpoint what happened, and we're sorry we can't be more specific here. We understand this is not the level of detail you were hoping for, and we appreciate your understanding.

How to appeal: If your account is eligible for an appeal, you can submit one directly through Business Support Home. This is the fastest way to have your case reviewed by the appropriate team. The review team will assess your appeal and determine whether the restriction can be lifted.
We understand that you mentioned being redirected between teams and having difficulty finding the right path. To clarify, the appeal is not submitted through Developer Support — it is specifically through Business Support Home. Here is the direct link: https://www.facebook.com/business-support-home

Once there:

Select your business profile (Digicom Comunicação Digital)
Scroll to the "WhatsApp accounts" section
Select the restricted WABA and follow the on-screen steps to request a review

Please ensure you are logged in as an admin of the account, as only admins can initiate the appeal. If the WABAs are not visible in Business Support Home, try selecting any available WABA under the business profile to access the restriction details and appeal option.

Please note that this ticket will be closed, and further assistance on this matter should be directed through Business Support Home as outlined above.

We appreciate your willingness to make adjustments for compliance, and we hope the appeal process brings a positive resolution. If you have any other questions, please feel free to reach out.

Best regards,
Ruru
Meta support for business messaging

 

Modelo: A Meta finalmente confirmou o ponto central:

**A restrição não é técnica. É política/compliance.**

Eles disseram que a conta empresarial e as WABAs associadas foram desativadas por violação dos **WhatsApp Business Terms of Service**, especificamente **Acceptable Use**. Mas, como esperado, não informam o gatilho exato.

**Leitura estratégica**

Agora o caminho correto é **Business Support Home**, não Developer Support:

```text
https://www.facebook.com/business-support-home
```

O objetivo é localizar a seção:

```text
WhatsApp accounts
```

Selecionar a WABA restrita e abrir o pedido de revisão.

**3 caminhos possíveis agora**

1. **Apelar direto pela Business Support Home**
   - Melhor opção.
   - É o caminho oficial indicado pela Meta.
   - Deve ser feito agora.

2. **Responder esse e-mail pedindo mais detalhes**
   - Baixa chance.
   - Eles já disseram que vão fechar o ticket e não revelam o gatilho.

3. **Criar nova WABA/número**
   - Eu evitaria.
   - Pode parecer tentativa de contornar restrição e piorar a reputação da empresa.

**Melhor ação**

Entre no Business Support Home logado como admin da Digicom e procure a WABA restrita.

Se aparecer o botão de recurso/revisão, use este texto:

```text
Hello Meta Review Team,

I am requesting a review of the restriction applied to Digicom Comunicação Digital and its associated WhatsApp Business Account.

We understand that the account was flagged under WhatsApp Business Terms of Service / Acceptable Use. We are committed to full compliance with Meta policies and are willing to make any required adjustments.

Digicom Comunicação Digital uses WhatsApp Business/API only for its own business operations, customer communication, lead follow-up, sales support and digital product/service communication. We do not sell prohibited goods or services, and we do not intend to send spam, misleading messages, or unauthorized communications.

Our intended use is:
- communicating with users who have shown interest or requested contact;
- supporting customers and leads;
- sending business-related follow-up messages;
- promoting legitimate digital products and services;
- respecting opt-in, user consent and opt-out requests.

Because we were not provided with the specific activity that triggered the restriction, we respectfully ask the review team to reassess the account and, if possible, indicate what needs to be corrected so we can remain fully compliant.

We are ready to adjust message templates, flows, opt-in language, landing pages, campaigns or any business asset required to comply with WhatsApp Business policies.

Please review and restore access to the WhatsApp Business Account if it is eligible.

Thank you.
```

**Se a WABA não aparecer**

Use exatamente o argumento que a própria Meta deu contra eles:

```text
Meta Support instructed me to appeal through Business Support Home, but the restricted WhatsApp Business Account is not visible under the WhatsApp accounts section for Digicom Comunicação Digital, even though I am logged in as an admin.

Please restore visibility of the restricted WABA or provide the exact appeal path for the affected asset.
```

Minha recomendação: agora não discutir mais com Developer Support. Vamos focar 100% em encontrar a WABA no Business Support Home e enviar uma apelação com postura de compliance, não de contestação agressiva.

Usuário: De qualquer forma vamos fazer o 2. AWS-only com SES recebendo e enviando
Veja se tem as permissões para criar os emails

Modelo: Verifiquei agora: **nesta sessão não há credenciais AWS configuradas**, então ainda não consigo testar as permissões reais da conta.

Resultado técnico:

```text
aws sts get-caller-identity
→ Unable to locate credentials
```

Também não existe perfil local em `~/.aws`.

**Conclusão**

Eu ainda **não tenho permissão operacional ativa daqui** para criar/configurar a estrutura AWS-only.

Mas o caminho está correto: no modelo AWS-only, não criamos “caixas” tipo Gmail. Criamos endereços operacionais via **SES Receiving Rules**, por exemplo:

```text
contato@digicomdigital.com.br
vendas@digicomdigital.com.br
suporte@digicomdigital.com.br
financeiro@digicomdigital.com.br
```

Esses e-mails seriam recebidos pelo SES, salvos no S3 e processados pelo Marketing Hub.

**Permissões necessárias**

Para eu montar isso de ponta a ponta, a credencial precisa permitir:

- SES envio e recebimento;
- criação de regras de recebimento SES;
- S3 para armazenar e-mails brutos;
- SNS ou Lambda para notificar/processar entrada;
- IAM limitado para permissões entre SES/S3/Lambda;
- Route 53 apenas se formos migrar DNS para controle total via AWS.

**3 alternativas**

1. **Nova chave temporária com `AdministratorAccess`**
   - Mais rápida.
   - Maior risco.
   - Serve para configurar tudo e apagar depois.

2. **Nova chave temporária com permissões limitadas**
   - Melhor prática.
   - Exige montar política IAM específica.
   - Minha recomendação.

3. **Você configura AWS CLI localmente e eu só oriento**
   - Mais seguro para credenciais.
   - Mais manual para você.
   - Menos alinhado com seu objetivo de delegar.

**Minha recomendação**

Criar uma **nova chave temporária**, não reutilizar a anterior, com permissões limitadas para:

```text
SES
S3
SNS
Lambda
IAM limitado
Route53, se migrarmos DNS
```

Importante: a chave AWS que apareceu antes nesta conversa deve ser apagada. Para eu executar daqui, crie uma nova credencial temporária e me envie somente quando quiser que eu configure a infraestrutura AWS-only.

Usuário: quai permissões vc vai precisar ?

Modelo: Para eu criar o modelo **AWS-only com SES recebendo e enviando**, a credencial temporária precisa destas permissões.

**Obrigatórias agora**

1. **Amazon SES**
   - verificar domínio/e-mails;
   - configurar DKIM;
   - criar regras de recebimento;
   - configurar envio;
   - consultar reputação, limites, bounces e complaints.

2. **Amazon S3**
   - criar bucket para guardar e-mails brutos recebidos;
   - permitir o SES gravar nesse bucket;
   - consultar objetos para validação.

3. **AWS Lambda**
   - criar função para processar e-mail recebido;
   - configurar variáveis de ambiente;
   - conectar SES/SNS/backend.

4. **Amazon SNS**
   - criar tópicos para eventos de bounce, complaint, delivery e recebimento;
   - assinar Lambda ou endpoints.

5. **IAM limitado**
   - criar roles/policies necessárias para:
     - SES gravar no S3;
     - Lambda ler S3;
     - Lambda escrever logs;
     - SES/SNS acionar Lambda.

6. **CloudWatch Logs**
   - ver logs da Lambda e erros de execução.

**Opcional, mas recomendado**

7. **Route 53**
   - só preciso se formos migrar o DNS do `digicomdigital.com.br` para AWS.
   - Isso permitiria o Marketing Hub controlar DNS no futuro sem depender manualmente do Registro.br.

**Política prática recomendada**

Crie um usuário temporário tipo:

```text
codex-email-setup-temp
```

E anexe permissões gerenciadas AWS para começar:

```text
AmazonSESFullAccess
AmazonS3FullAccess
AWSLambda_FullAccess
AmazonSNSFullAccess
CloudWatchLogsFullAccess
IAMFullAccess
```

Se formos usar Route 53 também:

```text
AmazonRoute53FullAccess
```

**Mais seguro**

Essa chave deve ser temporária. Depois que eu configurar e validar tudo, você apaga o usuário `codex-email-setup-temp`.

Se quiser reduzir risco agora, pode começar **sem Route 53**. Eu configuro SES/S3/Lambda/SNS e depois te passo apenas os registros DNS que ainda precisam entrar no Registro.br.

Usuário: use essa temporaria

AWS_ACCESS_KEY_ID=AKIA5ZUDABQPMQQVSMOA
AWS_SECRET_ACCESS_KEY=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
AWS_DEFAULT_REGION=us-east-1

Modelo: Usei a chave temporária e confirmei: **as permissões estão suficientes**.

Também já deixei criada a base AWS-only:

- SES `digicomdigital.com.br`: **verificado**
- DKIM: **Success**
- Limite SES: **50.000 e-mails/dia**
- Regra de recebimento SES ativa para o domínio inteiro
- Bucket S3 criado para e-mails recebidos:
  - `mh-digicom-email-948388760606`
- SNS criado para:
  - e-mails recebidos
  - bounce
  - complaint
  - delivery
- Hosted Zone criada no Route 53 com MX, SPF, DKIM, DMARC e MAIL FROM

Na prática, isso aceita endereços como:

```text
contato@digicomdigital.com.br
vendas@digicomdigital.com.br
suporte@digicomdigital.com.br
financeiro@digicomdigital.com.br
```

Como a regra está para o domínio, qualquer endereço `@digicomdigital.com.br` pode ser recebido e armazenado no S3.

**O que falta para ativar de verdade**

Ainda falta trocar os nameservers no Registro.br para estes da AWS:

```text
ns-1821.awsdns-35.co.uk
ns-1322.awsdns-37.org
ns-80.awsdns-10.com
ns-972.awsdns-57.net
```

Essa é a única ação manual inevitável agora. Depois disso, o DNS passa para a Route 53 e eu consigo controlar os próximos registros pela AWS.

Atenção: se já existir site ou outro serviço usando `digicomdigital.com.br`, precisamos copiar esses registros antes de trocar os nameservers. Se não houver site ativo ainda, pode trocar direto.

Depois da troca, eu valido recebimento, envio, SPF, DKIM, DMARC e MAIL FROM. A chave AWS temporária ficou exposta na conversa; quando terminarmos a validação, apague o usuário `codex-ses-temp`.

Última mensagem do usuário:
Nessa tela
- Inicializa assim com todas fechadas
- coloca no final um top5 dos 5 experimentos com mais lucro. Se tiver zerado ordena por tempo medio de sessão em ordem decrescente.

**Resumo das alterações:**
Feito na tela de Planejamento.

Alterei:

- Semanas iniciam todas fechadas.
- Tabela semanal ganhou coluna `Lucro`.
- No final da tela agora aparece `Top 5 por lucro`.
- Ordenação do Top 5:
  - primeiro por maior lucro;
  - em empate ou lucro zerado, por maior tempo médio de sessão.

Arquivos alterados:

- [CommercialPlanningPage.tsx](/root/ai-hub/src/ai-hub-07346e6c-707d-407c-958d-677a6a9b87a6-KItzsd/repo/frontend/src/pages/planning/CommercialPlanningPage.tsx)
- [CommercialPlanningPage.css](/root/ai-hub/src/ai-hub-07346e6c-707d-407c-958d-677a6a9b87a6-KItzsd/repo/frontend/src/pages/planning/CommercialPlanningPage.css)
- [CommercialPlanningPage.test.tsx](/root/ai-hub/src/ai-hub-07346e6c-707d-407c-958d-677a6a9b87a6-KItzsd/repo/frontend/src/pages/planning/CommercialPlanningPage.test.tsx)

Validação:

```text
NODE_ENV=test npm test -- --run src/pages/planning/CommercialPlanningPage.test.tsx
7 testes passaram
```

```text
npm run typecheck
passou sem erros
```

Subi o frontend local para conferência:

```text
http://localhost:5173/planning
```

Não criei PR.