### PR TITLE
AI Hub: Feito.

Ajustei o ranking da tela de Planejamento para o **Top 5 por tempo médio**, em ordem decrescente de `averageProductViewTimeMs`. Também atualizei o texto da tela para não falar mais em lucro.

Arquivos alterados:
- [CommercialPlanningPage.t…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/salesvideo/SalesVideoJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/salesvideo/SalesVideoJobRepository.java
@@ -17,16 +17,24 @@ import java.util.Optional;
 public interface SalesVideoJobRepository extends JpaRepository<SalesVideoJob, Long>,
         JpaSpecificationExecutor<SalesVideoJob> {
 
+    /** Lista jobs de um perfil de vídeo do mais recente para o mais antigo. */
     List<SalesVideoJob> findByProfileIdOrderByRequestedAtDesc(Long profileId);
 
+    /** Busca o job mais recente de um perfil de vídeo. */
     Optional<SalesVideoJob> findFirstByProfileIdOrderByRequestedAtDesc(Long profileId);
 
+    /** Verifica se algum job usa o asset informado em qualquer papel de mídia. */
     @Query("select case when count(j) > 0 then true else false end from SalesVideoJob j " +
             "where (j.asset.id = :assetId or j.posterAsset.id = :assetId or j.vttAsset.id = :assetId)")
     boolean existsByAnyAssetReference(@Param("assetId") Long assetId);
 
+    /** Lista jobs falhos ou pendentes por status e data de corte operacional. */
     List<SalesVideoJob> findByStatusAndFinishedAtBefore(SalesVideoStatus status, Instant finishedAt);
 
+    /** Lista jobs pendentes antigos ainda não iniciados. */
     List<SalesVideoJob> findByStatusAndRequestedAtBeforeAndStartedAtIsNull(SalesVideoStatus status, Instant requestedAt);
+
+    /** Verifica se um job já originou outro job de retry. */
+    boolean existsByRetryOfJob_Id(Long jobId);
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
@@ -176,6 +176,12 @@ public class SalesVideoController {
         return salesVideoService.getProfile(profileId);
     }
 
+    /** Consulta perfil de vídeo para processamento interno do módulo externo de renderização. */
+    @GetMapping("/internal/video/sales-videos/profiles/{profileId}")
+    public SalesVideoProfileDto getInternalVideoProfile(@PathVariable Long profileId) {
+        return salesVideoService.getProfile(profileId);
+    }
+
     /** Faz claim de job OpenAI interno. */
     @PostMapping("/internal/ai/openai-jobs/{jobId}/claim")
     public SalesVideoJobDto claimOpenAiJob(@PathVariable Long jobId,

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoAutoRetryScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoAutoRetryScheduler.java
@@ -30,6 +30,7 @@ public class SalesVideoAutoRetryScheduler {
     private final Duration retryDelay;
     private final int scanLimit;
 
+    /** Inicializa o agendador com política e janela de retry automático. */
     public SalesVideoAutoRetryScheduler(SalesVideoJobRepository jobRepository,
                                         SalesVideoJobService jobService,
                                         SalesVideoReprocessPolicy reprocessPolicy,
@@ -44,6 +45,7 @@ public class SalesVideoAutoRetryScheduler {
         this.scanLimit = scanLimit;
     }
 
+    /** Reprocessa jobs falhos elegíveis sem duplicar filhos de retry já criados. */
     @Scheduled(fixedDelayString = "${sales-video.reprocess.auto.scan-interval-ms:300000}")
     public void retryFailedJobs() {
         if (!enabled) {
@@ -54,6 +56,9 @@ public class SalesVideoAutoRetryScheduler {
         int executed = 0;
         for (SalesVideoJob job : candidates) {
             if (!reprocessPolicy.hasAttemptsRemaining(job)) {
+                continue;
+            }
+            if (jobRepository.existsByRetryOfJob_Id(job.getId())) {
                 continue;
             }
             try {

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
@@ -31,6 +31,7 @@ public class TenantContextFilter extends OncePerRequestFilter {
     private static final AntPathMatcher MATCHER = new AntPathMatcher();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    /** Indica quando uma requisição não precisa passar pela validação de tenant de vídeo. */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         if (HttpMethod.OPTIONS.matches(request.getMethod())) {
@@ -46,6 +47,7 @@ public class TenantContextFilter extends OncePerRequestFilter {
         return !requiresTenant(path);
     }
 
+    /** Define o contexto de tenant para rotas administrativas e internas do módulo de vídeo. */
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
@@ -57,6 +59,11 @@ public class TenantContextFilter extends OncePerRequestFilter {
             } else if (requiresTenant(path)) {
                 String tenantId = request.getHeader(TENANT_HEADER);
                 if (!StringUtils.hasText(tenantId)) {
+                    if (isReadOnlyProfileCompatibilityRequest(request, path)) {
+                        TenantContextHolder.set(TenantContext.system());
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
                     writeErrorResponse(response, request.getRequestURI());
                     return;
                 }
@@ -74,6 +81,7 @@ public class TenantContextFilter extends OncePerRequestFilter {
         }
     }
 
+    /** Identifica rotas administrativas que precisam de tenant explícito. */
     private boolean requiresTenant(String path) {
         if (path == null) {
             return false;
@@ -83,6 +91,13 @@ public class TenantContextFilter extends OncePerRequestFilter {
                 || MATCHER.match("/api/landing-pages/*/video-slots/**", path);
     }
 
+    /** Permite leitura legado do perfil pelo renderizador externo enquanto ele migra para `/internal/video`. */
+    private boolean isReadOnlyProfileCompatibilityRequest(HttpServletRequest request, String path) {
+        return HttpMethod.GET.matches(request.getMethod())
+                && MATCHER.match("/api/sales-videos/profiles/*", path);
+    }
+
+    /** Escreve resposta padronizada quando o cabeçalho de tenant obrigatório está ausente. */
     private void writeErrorResponse(HttpServletResponse response, String path) throws IOException {
         response.setStatus(HttpStatus.BAD_REQUEST.value());
         response.setContentType("application/json");

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/controller/SalesVideoAssetControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/controller/SalesVideoAssetControllerTest.java
@@ -76,4 +76,20 @@ class SalesVideoAssetControllerTest {
 
         verify(salesVideoService).getProfile(59L);
     }
+
+    /** Deve expor perfil pelo endpoint interno genérico do módulo de renderização. */
+    @Test
+    void shouldGetProfileFromInternalVideoEndpointWithoutTenantHeader() throws Exception {
+        SalesVideoProfileDto profile = new SalesVideoProfileDto();
+        profile.setId(59L);
+        profile.setTitle("Manicure em domicílio");
+        when(salesVideoService.getProfile(59L)).thenReturn(profile);
+
+        mockMvc.perform(get("/internal/video/sales-videos/profiles/59"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(59L))
+                .andExpect(jsonPath("$.title").value("Manicure em domicílio"));
+
+        verify(salesVideoService).getProfile(59L);
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoAutoRetrySchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoAutoRetrySchedulerTest.java
@@ -1,0 +1,58 @@
+package com.marketinghub.salesvideo.service;
+
+import com.marketinghub.repository.jpa.salesvideo.SalesVideoJobRepository;
+import com.marketinghub.salesvideo.SalesVideoJob;
+import com.marketinghub.salesvideo.SalesVideoJobType;
+import com.marketinghub.salesvideo.SalesVideoStatus;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/** Responsabilidade: validar o retry automático dos jobs de vídeo. */
+@ExtendWith(MockitoExtension.class)
+class SalesVideoAutoRetrySchedulerTest {
+
+    @Mock
+    private SalesVideoJobRepository jobRepository;
+
+    @Mock
+    private SalesVideoJobService jobService;
+
+    @Mock
+    private SalesVideoReprocessPolicy reprocessPolicy;
+
+    /** Não deve reprocessar novamente um job que já possui filho de retry. */
+    @Test
+    void shouldSkipFailedJobWhenRetryChildAlreadyExists() {
+        SalesVideoJob job = SalesVideoJob.builder()
+                .id(10108L)
+                .jobType(SalesVideoJobType.RENDER)
+                .status(SalesVideoStatus.VIDEO_FAILED)
+                .finishedAt(Instant.parse("2026-07-10T03:20:47Z"))
+                .build();
+        given(jobRepository.findByStatusAndFinishedAtBefore(eq(SalesVideoStatus.VIDEO_FAILED), any()))
+                .willReturn(List.of(job));
+        given(reprocessPolicy.hasAttemptsRemaining(job)).willReturn(true);
+        given(jobRepository.existsByRetryOfJob_Id(10108L)).willReturn(true);
+        SalesVideoAutoRetryScheduler scheduler = new SalesVideoAutoRetryScheduler(
+                jobRepository,
+                jobService,
+                reprocessPolicy,
+                true,
+                15,
+                20);
+
+        scheduler.retryFailedJobs();
+
+        verify(jobService, never()).retry(eq(10108L), any());
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
@@ -44,4 +44,18 @@ class TenantContextFilterTest {
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getContentAsString()).contains("TENANT_HEADER_REQUIRED");
     }
+
+    /** Deve manter leitura legado de perfil sem tenant para o renderizador externo atual. */
+    @Test
+    void shouldAllowReadOnlyProfileCompatibilityWithoutTenantHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/sales-videos/profiles/3");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        Mockito.verify(chain).doFilter(Mockito.any(), Mockito.any());
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(TenantContextHolder.getContext().systemRequest()).isTrue();
+    }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5708,3 +5708,10 @@
 - Causa-raiz: o planejamento dividia o tempo visível apenas pelas sessões com evento de seção, enquanto o detalhe divide pelo total de sessões capturadas pela landing.
 - Correção: o planejamento passou a usar a mesma leitura conservadora do detalhe, somando `section_view_time` e dividindo por todas as sessões de analytics do experimento no período.
 - Impacto comercial: evita superestimar engajamento da landing e melhora a decisão de pausar, corrigir ou escalar campanhas.
+
+## 2026-07-11 — Experimento 63 bloqueado por vídeo do A/B
+
+- Problema: o experimento 63 estava com criativo e landing tradicional prontos, mas o A/B continuava bloqueado porque o vídeo obrigatório permanecia `PLANNED/PENDING` e o job VEO `10108` estava `VIDEO_FAILED`.
+- Causa-raiz confirmada: o `video-management-service` tentou carregar o perfil `3` por `GET /api/sales-videos/profiles/3` sem `X-Tenant-ID`, recebendo `TENANT_HEADER_REQUIRED`; além disso, o auto-retry reprocessava jobs que já tinham filho de retry, gerando repetição da mesma falha sem avançar o ativo comercial.
+- Correção preparada: o backend passa a expor perfil por contrato interno `/internal/video/sales-videos/profiles/{profileId}`, mantém compatibilidade somente leitura para o GET legado usado pelo renderizador atual e bloqueia retry automático quando o job falho já originou outro retry.
+- Próximo passo operacional: publicar a correção do backend e reprocessar o vídeo do experimento 63; só liberar Facebook quando o asset estiver `READY`, `APPROVED` e com `assetUrl` público.

--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -276,7 +276,7 @@ describe("CommercialPlanningPage", () => {
     expect(screen.getByText("LEAD_MAGNET")).toBeTruthy();
   });
 
-  it("renderiza top 5 no final por lucro e usa tempo medio como desempate", () => {
+  it("renderiza top 5 no final por tempo medio em ordem decrescente", () => {
     mockWeeks = [
       {
         ...(mockWeeks[0] as Record<string, unknown>),
@@ -286,7 +286,7 @@ describe("CommercialPlanningPage", () => {
             name: "Kit manutenção",
             nicheName: "Manicure profissional",
             totalCost: 37,
-            revenue: 47,
+            revenue: 137,
             averageProductViewTimeMs: 45000,
           },
           {
@@ -311,19 +311,19 @@ describe("CommercialPlanningPage", () => {
 
     const { container } = renderPage();
 
-    expect(screen.getByText("Top 5 por lucro")).toBeTruthy();
-    expect(screen.getByText(/lucro zerado/)).toBeTruthy();
+    expect(screen.getByText("Top 5 por tempo médio")).toBeTruthy();
+    expect(screen.getByText(/maior tempo médio de tela/)).toBeTruthy();
 
     const rankingItems = Array.from(
       container.querySelectorAll(".commercial-planning-ranking-item"),
     );
     expect(rankingItems).toHaveLength(3);
-    expect(rankingItems[0]).toHaveTextContent("Kit manutenção");
-    expect(rankingItems[0]).toHaveTextContent("R$ 10,00");
-    expect(rankingItems[1]).toHaveTextContent("Amostra rápida");
-    expect(rankingItems[1]).toHaveTextContent("2min");
-    expect(rankingItems[2]).toHaveTextContent("Agenda recorrente");
-    expect(rankingItems[2]).toHaveTextContent("1min 30s");
+    expect(rankingItems[0]).toHaveTextContent("Amostra rápida");
+    expect(rankingItems[0]).toHaveTextContent("2min");
+    expect(rankingItems[1]).toHaveTextContent("Agenda recorrente");
+    expect(rankingItems[1]).toHaveTextContent("1min 30s");
+    expect(rankingItems[2]).toHaveTextContent("Kit manutenção");
+    expect(rankingItems[2]).toHaveTextContent("45s");
   });
 
   it("renderiza objetivos semanais como texto e mostra campo apenas para novo objetivo", async () => {

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -346,20 +346,6 @@ function sortedByAverageTime(experiments: CommercialPlanWeek["experiments"]) {
   });
 }
 
-function sortedByProfitThenAverageTime(
-  experiments: CommercialPlanWeek["experiments"],
-) {
-  return [...experiments].sort((first, second) => {
-    const firstProfit = experimentProfit(first);
-    const secondProfit = experimentProfit(second);
-    if (secondProfit !== firstProfit) return secondProfit - firstProfit;
-    const firstTime = first.averageProductViewTimeMs ?? -1;
-    const secondTime = second.averageProductViewTimeMs ?? -1;
-    if (secondTime !== firstTime) return secondTime - firstTime;
-    return first.id - second.id;
-  });
-}
-
 function ExperimentsTable({
   experiments,
 }: {
@@ -419,7 +405,7 @@ function ExperimentsTable({
 function TopExperimentsRanking({ weeks }: { weeks: CommercialPlanWeek[] }) {
   const topExperiments = useMemo(
     () =>
-      sortedByProfitThenAverageTime(
+      sortedByAverageTime(
         weeks.flatMap((week) => week.experiments ?? []),
       ).slice(0, 5),
     [weeks],
@@ -432,9 +418,9 @@ function TopExperimentsRanking({ weeks }: { weeks: CommercialPlanWeek[] }) {
           <p className="commercial-planning-month-eyebrow mb-1">
             Ranking de experimentos
           </p>
-          <h3>Top 5 por lucro</h3>
+          <h3>Top 5 por tempo médio</h3>
         </div>
-        <span>Empate ou lucro zerado: maior tempo médio primeiro</span>
+        <span>Ordenado pelo maior tempo médio de tela</span>
       </div>
 
       {topExperiments.length > 0 ? (


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
coloca esse top 5 somente por ordem decrescente de tempo medio de tela

**Resumo das alterações:**
Feito.

Ajustei o ranking da tela de Planejamento para o **Top 5 por tempo médio**, em ordem decrescente de `averageProductViewTimeMs`. Também atualizei o texto da tela para não falar mais em lucro.

Arquivos alterados:
- [CommercialPlanningPage.tsx](/root/ai-hub/src/ai-hub-80337e10-c454-487b-8da0-cb86981b894f-KxMtOH/repo/frontend/src/pages/planning/CommercialPlanningPage.tsx)
- [CommercialPlanningPage.test.tsx](/root/ai-hub/src/ai-hub-80337e10-c454-487b-8da0-cb86981b894f-KxMtOH/repo/frontend/src/pages/planning/CommercialPlanningPage.test.tsx)

Validação:
- `NODE_ENV=test npm test -- CommercialPlanningPage.test.tsx --run` passou: 7 testes.
- `npm run typecheck` passou.

Não criei PR, conforme instrução.