### PR TITLE
AI Hub: Corrigi a causa-raiz do gerador de vídeo do experimento 63.

**O que encontrei**
- O job `10108` não chegou a chamar o VEO.
- Ele falhou antes, ao carregar o perfil 3 pela rota errada:
  `/api/sales-videos/profiles/3`
- Essa rota exige `X-Tenant-I…

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,10 @@
+## 2026-07-12 — Experimento 63: correção da busca interna do perfil de vídeo
+
+- causa-raiz confirmada no banco: o job VEO/REAL `10108` falhou antes de chamar o provider, porque o `video-management-service` buscava o perfil pela rota administrativa `/api/sales-videos/profiles/{id}`, que exigia `X-Tenant-ID`.
+- foi feito: o client do `video-management-service` passou a buscar perfil pela rota interna `/internal/video/sales-videos/profiles/{id}`, já existente no backend para o executor de vídeo.
+- validação: simulação local com backend/VEO mockado passou, cobrindo criação da operação, polling, download do MP4 e processamento do job; também foi adicionado teste para impedir regressão para a rota administrativa.
+- próximo passo operacional: publicar o `video-management-service` corrigido e criar retry limpo do vídeo do experimento 63; o perfil 3 já possui roteiro aprovado.
+
 ## 2026-07-06 — Experimentos: camada Experiment Video Asset
 
 - decisão aplicada: vídeo passa a ser registrado como artefato mensurável do experimento, com slot no funil, objetivo comercial e métrica principal.

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
@@ -96,7 +96,7 @@ public class BackendVideoClient {
     public SalesVideoProfile fetchProfile(Long profileId) {
         try {
             return executeWithRetry("fetch profile " + profileId, () -> authorized(webClient.get()
-                            .uri("/api/sales-videos/profiles/{profileId}", profileId))
+                            .uri("/internal/video/sales-videos/profiles/{profileId}", profileId))
                     .retrieve()
                     .onStatus(status -> !status.is2xxSuccessful(), response ->
                             mapError("Erro ao carregar perfil %d".formatted(profileId), response))

--- a/video-management-service/src/test/java/com/marketinghub/videomanagement/client/BackendVideoClientTest.java
+++ b/video-management-service/src/test/java/com/marketinghub/videomanagement/client/BackendVideoClientTest.java
@@ -1,0 +1,67 @@
+package com.marketinghub.videomanagement.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.videomanagement.client.dto.SalesVideoProfile;
+import com.marketinghub.videomanagement.config.VideoManagementProperties;
+import com.marketinghub.videomanagement.service.VideoJobObservabilityService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar o contrato HTTP usado pelo worker de vídeo contra o backend. */
+class BackendVideoClientTest {
+    private MockWebServer server;
+
+    /** Inicializa o backend simulado antes de cada teste de contrato. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado para liberar a porta usada pelo teste. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve buscar perfil pela rota interna de vídeo, sem depender da rota administrativa com tenant. */
+    @Test
+    void shouldFetchProfileThroughInternalVideoEndpoint() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": 3,
+                          "productId": 63,
+                          "videoKind": "HERO",
+                          "title": "Video do experimento",
+                          "status": "SCRIPT_READY"
+                        }
+                        """));
+        BackendVideoClient client = new BackendVideoClient(
+                WebClient.builder(),
+                properties(),
+                new VideoJobObservabilityService(new SimpleMeterRegistry()));
+
+        SalesVideoProfile profile = client.fetchProfile(3L);
+
+        assertThat(profile.id()).isEqualTo(3L);
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/internal/video/sales-videos/profiles/3");
+    }
+
+    /** Configura o client para apontar para o backend simulado. */
+    private VideoManagementProperties properties() {
+        VideoManagementProperties properties = new VideoManagementProperties();
+        properties.setBackendBaseUrl(URI.create(server.url("/").toString()));
+        return properties;
+    }
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: O que esta faltando para o experimento 63 ?

Modelo: Para o experimento 63, **não falta oferta, landing, criativo ou segmentação básica**. O que falta é liberar o **vídeo obrigatório da variante B do teste A/B**.

**Estado atual validado:**
- Criativo: `READY`
- Lead Portal / landing: presente
- Targeting: completo
- GeraLanding: 7/7 etapas concluídas
- Campanha Facebook: ainda não criada
- Vídeo obrigatório: `PLANNED`, `reviewStatus=PENDING`, `assetUrl=null`
- A/B: variante A tradicional está `READY`; variante B com vídeo humano está `DRAFT`

**O bloqueio real**
O readiness do backend aponta dois problemas:
1. **“Vídeo obrigatório ainda não aprovado”**
2. **“Teste A/B de página incompleto”**

Na prática, o segundo depende do primeiro: a variante B só fica pronta quando o vídeo do asset `3` for gerado, publicado em URL pública e aprovado.

**Causa operacional registrada**
Pelos registros em `docs/registros/experimentos.md`, o job VEO `10108` falhou e entrou em loop de auto-retry. Primeiro por falta de `X-Tenant-ID`; depois por provider `REAL`/VEO não configurado corretamente no `video-management-service`.

**O que precisa fazer agora**
1. Publicar backend e `video-management-service` com a correção já preparada.
2. Confirmar que o serviço de vídeo está ativo com VEO habilitado e chave configurada.
3. Criar um retry manual limpo para o perfil/vídeo do experimento 63.
4. Quando o vídeo voltar com `assetUrl`, marcar o asset como `READY` e `APPROVED`.
5. Só então liberar o A/B e criar/publicar a campanha Facebook.

**Alternativas analisadas**
- Rodar só a variante tradicional agora: mais rápido, mas perde o aprendizado principal do A/B.
- Desativar vídeo obrigatório: libera tráfego, mas contamina o desenho do experimento.
- Corrigir/reprocessar o vídeo e liberar o A/B completo: melhor opção, porque preserva o aprendizado comercial e evita escalar um teste incompleto.

Minha recomendação: **não liberar Facebook ainda**. O experimento 63 está comercialmente montado, mas operacionalmente bloqueado pelo vídeo humano da variante B.

Usuário: nos temos os scripts prontos para enviar ? temos que integrar isso com o SES
- crie um email para voce testar o recebimento dos scripts

Modelo: Aguardando resposta do modelo... (Em execução)

Usuário: pq o video do experimento 63 ainda naõ foi produzido ?

Modelo: Aguardando resposta do modelo... (Pendente)

Última mensagem do usuário:
tenta simular a criaçaõ do video para testar no seu ambiente. Temos que consertar o gerador de video. Se tiver dificuldade consulta a documentação do google sobre o gemini veo

**Resumo das alterações:**
Corrigi a causa-raiz do gerador de vídeo do experimento 63.

**O que encontrei**
- O job `10108` não chegou a chamar o VEO.
- Ele falhou antes, ao carregar o perfil 3 pela rota errada:
  `/api/sales-videos/profiles/3`
- Essa rota exige `X-Tenant-ID`, então o backend respondeu `400 TENANT_HEADER_REQUIRED`.
- O perfil 3 já tem roteiro aprovado, então o bloqueio não é script.

**Correção aplicada**
- Alterei o `video-management-service` para buscar o perfil pela rota interna correta:
  `/internal/video/sales-videos/profiles/{profileId}`
- Arquivo: [BackendVideoClient.java](/root/ai-hub/src/ai-hub-578f8d3b-f412-4ccc-b511-cd839d49ea2c-bo7vuP/repo/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java:96)
- Adicionei teste de contrato para impedir regressão:
  [BackendVideoClientTest.java](/root/ai-hub/src/ai-hub-578f8d3b-f412-4ccc-b511-cd839d49ea2c-bo7vuP/repo/video-management-service/src/test/java/com/marketinghub/videomanagement/client/BackendVideoClientTest.java:1)
- Registrei em [docs/registros/experimentos.md](/root/ai-hub/src/ai-hub-578f8d3b-f412-4ccc-b511-cd839d49ea2c-bo7vuP/repo/docs/registros/experimentos.md:1)

**Simulação**
- Simulei localmente o fluxo do VEO com backend/provider mockado:
  criação da operação, polling, download do MP4 e conclusão do job.
- Rodei `mvn -q test` no `video-management-service`: passou.
- Também consultei a documentação atual do Google; o REST oficial ainda usa `:predictLongRunning`, polling da operação e download com `x-goog-api-key`: https://ai.google.dev/gemini-api/docs/veo

**Alternativas avaliadas**
- Enviar `X-Tenant-ID` pelo worker: mais rápido, mas acopla executor a regra administrativa.
- Liberar exceção na rota `/api`: mantém legado e aumenta risco.
- Usar rota interna já existente: melhor opção, menor risco e arquitetura correta.

**Próximo passo**
Publicar o `video-management-service` corrigido, confirmar `GEMINI_API_KEY` e VEO habilitado, depois criar retry limpo do vídeo do experimento 63. Não criei PR.