### PR TITLE
AI Hub: Executei o próximo passo e encontrei uma nova causa-raiz antes de reprocessar o vídeo.

- O `video-management-service` já está correto em produção: VEO habilitado, chave configurada, `REAL` aceito como alias e serviço `UP`.
- O bloqueio atual está…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
@@ -88,6 +88,7 @@ public class TenantContextFilter extends OncePerRequestFilter {
         }
         return path.startsWith("/api/sales-videos")
                 || MATCHER.match("/api/products/*/sales-videos/**", path)
+                || MATCHER.match("/api/experiments/*/video-assets/**", path)
                 || MATCHER.match("/api/landing-pages/*/video-slots/**", path);
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
@@ -45,6 +45,24 @@ class TenantContextFilterTest {
         assertThat(response.getContentAsString()).contains("TENANT_HEADER_REQUIRED");
     }
 
+    /** Deve proteger criação de vídeo de experimento com o mesmo contexto de tenant do módulo de vídeo. */
+    @Test
+    void shouldApplyTenantContextToExperimentVideoAssetsEndpoints() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "POST", "/api/experiments/63/video-assets/veo-render-requests");
+        request.addHeader("X-Tenant-ID", "default");
+        request.addHeader("X-User-Email", "codex@marketinghub.io");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            assertThat(TenantContextHolder.requireTenant()).isEqualTo("default");
+            assertThat(TenantContextHolder.resolveUserEmail(null)).isEqualTo("codex@marketinghub.io");
+        };
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
     /** Deve manter leitura legado de perfil sem tenant para o renderizador externo atual. */
     @Test
     void shouldAllowReadOnlyProfileCompatibilityWithoutTenantHeader() throws Exception {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-12 — Experimento 63: tenant no endpoint canônico de vídeo do experimento
+
+- Problema confirmado ao tentar o próximo passo operacional: o endpoint `/api/experiments/63/video-assets/veo-render-requests` recebia `X-Tenant-ID`, mas o filtro do backend não classificava essa rota como parte do módulo de vídeo; ao criar o perfil internamente, o contexto permanecia `system` e o service retornava `TENANT_HEADER_REQUIRED`.
+- Causa-raiz: o contrato de vídeo do experimento usa serviços do Avatar Sales Video, mas estava fora da lista de rotas protegidas por tenant em `TenantContextFilter`.
+- Correção aplicada localmente: `/api/experiments/*/video-assets/**` passa a carregar contexto de tenant, com teste cobrindo a rota de render VEO do experimento.
+- Validação: testes focados do backend passaram após `clean` e o `video-management-service` subiu localmente com VEO habilitado, `REAL` como alias e health `UP`.
+- Próximo passo operacional: publicar o backend corrigido e então acionar nova solicitação canônica de vídeo para o experimento 63; antes do deploy, a produção ainda rejeita a criação do job novo por tenant.
+
 ## 2026-07-12 — Experimento 63: correção da busca interna do perfil de vídeo
 
 - causa-raiz confirmada no banco: o job VEO/REAL `10108` falhou antes de chamar o provider, porque o `video-management-service` buscava o perfil pela rota administrativa `/api/sales-videos/profiles/{id}`, que exigia `X-Tenant-ID`.


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: acompanhe o termino do workflow do action github e ao final verifique se o video para o experimento 63 foi gerado.

Modelo: Workflow finalizado.

- `Build & Deploy containers`: **sucesso**
- Finalizou em **12/07/2026 04:01:46 UTC**
- Jobs principais:
  - `Video management – build image`: sucesso
  - `Deploy video management`: sucesso
  - `Backend – build image`: sucesso
  - `Deploy backend + frontend`: sucesso

Verificação do experimento 63:

- O vídeo **não foi gerado**.
- A API `/api/experiments/63/video-assets` retornou o vídeo ainda como `status: PLANNED`.
- `assetUrl`: `null`
- `assetId`: `null`
- Job vinculado: `sales_video_job_id = 10108`
- Status do job: `VIDEO_FAILED`

Causa provável confirmada no banco: o módulo de vídeo tentou carregar o perfil `3`, mas o backend respondeu erro por ausência do cabeçalho `X-Tenant-ID`:

`TENANT_HEADER_REQUIRED — Cabeçalho X-Tenant-ID é obrigatório para operações do módulo de vídeo`

Melhor próximo passo: corrigir a integração do `video-management-service` para enviar `X-Tenant-ID` ao chamar o backend e depois reprocessar o job `10108` ou solicitar nova renderização do vídeo do experimento 63.

Última mensagem do usuário:
executa o proximo passo mas executa backend e modulo de video no seu ambiente para verificar o que acontece e ir ajustando até funcionar.

**Resumo das alterações:**
Executei o próximo passo e encontrei uma nova causa-raiz antes de reprocessar o vídeo.

- O `video-management-service` já está correto em produção: VEO habilitado, chave configurada, `REAL` aceito como alias e serviço `UP`.
- O bloqueio atual está no backend: o endpoint `/api/experiments/63/video-assets/veo-render-requests` usa serviços do módulo de vídeo, mas não entrava no filtro de tenant. Mesmo com `X-Tenant-ID`, o backend tratava como `system` e retornava `TENANT_HEADER_REQUIRED`.
- Corrigi localmente o filtro para incluir `/api/experiments/*/video-assets/**`.
- Adicionei teste cobrindo essa rota.
- Registrei em `docs/registros/experimentos.md`.

Validações:
- `video-management-service`: testes passaram, 16/16.
- Backend focado: testes passaram, 10/10.
- Serviço de vídeo local subiu com health `UP`.
- Backend real segue `UP`.
- O vídeo do experimento 63 ainda não foi gerado porque a correção do backend precisa ser publicada antes de chamar o render canônico.

Observação importante: tentei subir o backend local, mas o perfil de execução conectou no MySQL real em vez de H2; interrompi o processo e validei via MCP que as tabelas críticas continuam existentes, o backend está saudável e não houve tabela criada/atualizada no intervalo da tentativa.

Próximo passo: publicar essa correção do backend; depois disso, acionar nova solicitação VEO para o experimento 63.