### PR TITLE
AI Hub: Implementei o fluxo, sem criar PR.

Avaliei 3 caminhos:
- Shell genérico no MCP: máximo poder, risco alto demais porque o MCP está exposto sem autenticação.
- Endpoint HTTP no chat para logs: simples, mas exige expor log pela aplicação.
- `docker …

### DIFF
--- a/.github/workflows/fashion-chat-service-ci.yml
+++ b/.github/workflows/fashion-chat-service-ci.yml
@@ -1,0 +1,115 @@
+name: CI - Fashion Chat Service
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "fashion-chat-service/**"
+      - ".github/workflows/fashion-chat-service-ci.yml"
+  pull_request:
+    paths:
+      - "fashion-chat-service/**"
+      - ".github/workflows/fashion-chat-service-ci.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/fashion-chat-service
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: fashion-chat-service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: fashion-chat-service/package-lock.json
+      - name: Install deps
+        run: npm ci --include=dev
+      - name: Run tests
+        run: npm test
+
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./fashion-chat-service
+          file: ./fashion-chat-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy to MCP host
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      DEPLOY_HOST: 191.252.210.83
+      DEPLOY_USER: root
+      REMOTE_PATH: /opt/marketinghub/containers/fashion-chat-service
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${VPS_SSH_KEY}" ]; then
+            echo "Erro: nenhuma chave SSH foi encontrada nos secrets esperados." >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Sync compose files
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+          rsync -az --delete -e "ssh ${SSH_COMMON_ARGS}" \
+            --include 'docker-compose.yml' \
+            --include 'docker-compose.deploy.yml' \
+            --include '.env.example' \
+            --exclude '*' \
+            fashion-chat-service/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+      - name: Deploy with Docker Compose
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && export FASHION_CHAT_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA} \
+            && export COMPOSE_PROJECT_NAME=marketinghub-fashion-chat \
+            && docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -97,9 +97,12 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
+      MCP_CHAT_LOG_ALLOWED_CONTAINERS: ${MCP_CHAT_LOG_ALLOWED_CONTAINERS:-marketinghub-fashion-chat}
       TZ: America/Sao_Paulo
     ports:
       - "${MCP_SERVER_PORT:-8096}:8096"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   mcp-nginx:
     image: nginx:1.27-alpine

--- a/fashion-chat-service/Dockerfile
+++ b/fashion-chat-service/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --include=dev
+
+FROM deps AS builder
+COPY tsconfig.json ./
+COPY src ./src
+COPY tests ./tests
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=builder /app/dist ./dist
+EXPOSE 8094
+CMD ["node", "dist/src/index.js"]

--- a/fashion-chat-service/README.md
+++ b/fashion-chat-service/README.md
@@ -33,3 +33,25 @@ CODEX_APP_SERVER_ENABLED=true npm start
 ```
 
 O piloto nao clona repositorio. A sandbox e criada como diretorio temporario local, recebe contexto de pesquisa de moda e executa o turno do App Codex Server quando ele estiver disponivel e autenticado.
+
+## Deploy no host do MCP
+
+O workflow `.github/workflows/fashion-chat-service-ci.yml` publica a imagem no GHCR e faz deploy no mesmo host do MCP server (`191.252.210.83`), em:
+
+```bash
+/opt/marketinghub/containers/fashion-chat-service
+```
+
+Container padrao:
+
+- `marketinghub-fashion-chat`
+- porta publica: `8094`
+- health-check: `GET /health`
+
+Validacao operacional apos deploy:
+
+```bash
+curl -fsS http://191.252.210.83:8094/health
+```
+
+Os logs do container podem ser consultados pelo MCP via tool `chat_container_logs`, limitada por allowlist ao container `marketinghub-fashion-chat`.

--- a/fashion-chat-service/docker-compose.deploy.yml
+++ b/fashion-chat-service/docker-compose.deploy.yml
@@ -1,0 +1,3 @@
+services:
+  fashion-chat-service:
+    image: ${FASHION_CHAT_IMAGE:-ghcr.io/paulofor/marketing-hub/fashion-chat-service:latest}

--- a/fashion-chat-service/docker-compose.yml
+++ b/fashion-chat-service/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  fashion-chat-service:
+    build: .
+    image: ${FASHION_CHAT_IMAGE:-fashion-chat-service}:${FASHION_CHAT_IMAGE_TAG:-local}
+    container_name: marketinghub-fashion-chat
+    restart: unless-stopped
+    environment:
+      PORT: ${PORT:-8094}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      FASHION_CHAT_MODEL: ${FASHION_CHAT_MODEL:-gpt-4o-mini}
+      CODEX_APP_SERVER_ENABLED: ${CODEX_APP_SERVER_ENABLED:-false}
+      CODEX_APP_SERVER_COMMAND: ${CODEX_APP_SERVER_COMMAND:-codex}
+      CODEX_APP_SERVER_ARGS: ${CODEX_APP_SERVER_ARGS:-app-server --listen stdio://}
+      CODEX_APP_SERVER_SANDBOX_MODE: ${CODEX_APP_SERVER_SANDBOX_MODE:-danger-full-access}
+      FASHION_CHAT_FORCE_FALLBACK: ${FASHION_CHAT_FORCE_FALLBACK:-false}
+      TZ: America/Sao_Paulo
+    ports:
+      - "${FASHION_CHAT_PORT:-8094}:${PORT:-8094}"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:${PORT:-8094}/health >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -14,7 +14,7 @@ FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /workspace/target/app-exec.jar /app/app.jar

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -25,6 +25,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `github_actions_list_runs`: lista execuções (runs) de workflows do repositório configurado no GitHub Actions.
 - `github_actions_get_run_summary`: verifica se uma execução terminou com sucesso e detalha jobs/steps com falha.
 - `github_actions_get_run_logs`: baixa os logs compactados de uma execução e retorna um trecho em texto.
+- `chat_container_logs`: retorna logs Docker dos containers de chat permitidos no host do MCP. Por padrão, somente `marketinghub-fashion-chat`.
 
 ## Executar localmente
 
@@ -70,6 +71,20 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 Timeout de leitura HTTP por módulo: `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`).
 
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
+
+## Logs Docker dos containers de chat
+
+O tool `chat_container_logs` permite diagnosticar os containers de chat no mesmo host do MCP sem liberar shell genérico. Ele executa somente `docker logs` para containers aprovados na allowlist.
+
+Configuração:
+
+- `MCP_CHAT_LOG_ENABLED` (default `true`);
+- `MCP_CHAT_LOG_ALLOWED_CONTAINERS` (default `marketinghub-fashion-chat`);
+- `MCP_CHAT_LOG_DOCKER_COMMAND` (default `docker`);
+- `MCP_CHAT_LOG_MAX_LINES` (default `500`);
+- `MCP_CHAT_LOG_TIMEOUT_SECONDS` (default `20`).
+
+No Docker Compose do MCP, o socket `/var/run/docker.sock` é montado como somente leitura para viabilizar a leitura de logs. Não exponha essa permissão para execução de comandos arbitrários.
 
 ## Ferramentas de diagnóstico Meta
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
+      MCP_CHAT_LOG_ALLOWED_CONTAINERS: ${MCP_CHAT_LOG_ALLOWED_CONTAINERS:-marketinghub-fashion-chat}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     expose:
       - "8096"
     healthcheck:

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -19,6 +19,7 @@ public record McpProperties(
         @NotBlank String serverName,
         @NotBlank String serverVersion,
         @NotNull @Valid Logs logs,
+        @NotNull @Valid ChatLogs chatLogs,
         @NotNull @Valid Meta meta,
         @NotNull @Valid Github github
 ) {
@@ -44,6 +45,18 @@ public record McpProperties(
             @Positive int fetchRetryDelayMillis,
             @Positive int maxLines,
             @Positive int httpTailRangeBytes
+    ) {
+    }
+
+    /**
+     * Define os limites da leitura de logs de containers de chat via Docker.
+     */
+    public record ChatLogs(
+            boolean enabled,
+            @NotEmpty List<@NotBlank String> allowedContainers,
+            @NotBlank String dockerCommand,
+            @Positive int maxLines,
+            @Positive int timeoutSeconds
     ) {
     }
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mcpserver.controller;
 
 import com.marketinghub.mcpserver.config.McpProperties;
+import com.marketinghub.mcpserver.service.ChatContainerLogService;
 import com.marketinghub.mcpserver.service.DatabaseDiagnosticsService;
 import com.marketinghub.mcpserver.service.MetaDiagnosticsService;
 import com.marketinghub.mcpserver.service.GithubActionsService;
@@ -40,6 +41,7 @@ public class McpController {
     private final McpProperties properties;
     private final DatabaseDiagnosticsService databaseDiagnosticsService;
     private final ModuleLogService moduleLogService;
+    private final ChatContainerLogService chatContainerLogService;
     private final MetaDiagnosticsService metaDiagnosticsService;
     private final GithubActionsService githubActionsService;
 
@@ -49,11 +51,13 @@ public class McpController {
     public McpController(McpProperties properties,
                          DatabaseDiagnosticsService databaseDiagnosticsService,
                          ModuleLogService moduleLogService,
+                         ChatContainerLogService chatContainerLogService,
                          MetaDiagnosticsService metaDiagnosticsService,
                          GithubActionsService githubActionsService) {
         this.properties = properties;
         this.databaseDiagnosticsService = databaseDiagnosticsService;
         this.moduleLogService = moduleLogService;
+        this.chatContainerLogService = chatContainerLogService;
         this.metaDiagnosticsService = metaDiagnosticsService;
         this.githubActionsService = githubActionsService;
     }
@@ -152,6 +156,23 @@ public class McpController {
                                             "offset", Map.of("type", "integer", "minimum", 0, "description", "Offset para paginação dentro do conjunto filtrado."),
                                             "cursor", Map.of("type", "string", "description", "Cursor retornado em nextCursor para próxima página.")),
                                     "required", List.of("module"),
+                                    "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "chat_container_logs",
+                            "description", "Retorna logs Docker dos containers de chat permitidos no host do MCP.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "container", Map.of("type", "string",
+                                                    "enum", chatContainerLogService.allowedContainers(),
+                                                    "description", "Container de chat permitido para consulta."),
+                                            "lines", Map.of("type", "integer", "minimum", 1,
+                                                    "maximum", chatContainerLogService.maxLines(),
+                                                    "description", "Quantidade de linhas retornadas. Padrão: 200."),
+                                            "contains", Map.of("type", "string",
+                                                    "description", "Filtra linhas que contenham este texto literal.")),
+                                    "required", List.of("container"),
                                     "additionalProperties", false)
                     ),
                     Map.of(
@@ -261,6 +282,7 @@ public class McpController {
                 case "db_read_table" -> callReadTable(id, arguments);
                 case "db_query" -> callQueryTool(id, arguments);
                 case "java_module_logs" -> callJavaModuleLogsTool(id, arguments);
+                case "chat_container_logs" -> callChatContainerLogsTool(id, arguments);
                 case "meta_docs_get" -> callMetaDocsTool(id, arguments);
                 case "meta_graph_get" -> callMetaGraphGetTool(id, arguments);
                 case "meta_graph_debug_token" -> callMetaGraphDebugTokenTool(id, arguments);
@@ -366,6 +388,43 @@ public class McpController {
     @SuppressWarnings("unchecked")
     private String buildJavaModuleLogsText(Map<String, Object> result) {
         String header = "Read " + result.get("returnedLines") + " log lines from module " + result.get("module");
+        Object rawLines = result.get("lines");
+        if (!(rawLines instanceof List<?> lines) || lines.isEmpty()) {
+            return header;
+        }
+        String logLines = lines.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining("\n"));
+        return header + "\n" + logLines;
+    }
+
+    /**
+     * Lê logs Docker de um container de chat permitido.
+     */
+    private Map<String, Object> callChatContainerLogsTool(Object id, Map<String, Object> arguments) {
+        String container = stringArgument(arguments, "container");
+        Integer lines = intArgument(arguments, "lines");
+        String contains = stringArgument(arguments, "contains");
+
+        try {
+            Map<String, Object> result = chatContainerLogService.readLogs(container, lines, contains);
+            return successToolResult(id, result, buildChatContainerLogsText(result));
+        } catch (IllegalArgumentException ex) {
+            logger.warn("MCP chat_container_logs inválido: requestId={} container={} motivo={}", id, container, ex.getMessage());
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            logger.error("Falha ao executar chat_container_logs: requestId={} container={} lines={} contains={}",
+                    id, container, lines, contains, ex);
+            return error(id, -32603, "Failed to read chat container logs: " + ex.getMessage());
+        }
+    }
+
+    /**
+     * Formata a resposta textual do tool de logs de containers de chat.
+     */
+    private String buildChatContainerLogsText(Map<String, Object> result) {
+        String header = "Read " + result.get("returnedLines") + " Docker log lines from chat container "
+                + result.get("container");
         Object rawLines = result.get("lines");
         if (!(rawLines instanceof List<?> lines) || lines.isEmpty()) {
             return header;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ChatContainerLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ChatContainerLogService.java
@@ -1,0 +1,149 @@
+package com.marketinghub.mcpserver.service;
+
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Lê logs de containers de chat por Docker com escopo restrito aos containers permitidos.
+ */
+@Service
+public class ChatContainerLogService {
+    private static final Logger logger = LoggerFactory.getLogger(ChatContainerLogService.class);
+    private static final int DEFAULT_LINES = 200;
+
+    private final McpProperties properties;
+
+    /**
+     * Inicializa o serviço com a lista de containers permitidos e limites operacionais.
+     */
+    public ChatContainerLogService(McpProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Retorna os containers de chat que podem ter logs consultados pelo MCP.
+     */
+    public List<String> allowedContainers() {
+        return properties.chatLogs().allowedContainers();
+    }
+
+    /**
+     * Retorna o limite máximo de linhas por chamada.
+     */
+    public int maxLines() {
+        return properties.chatLogs().maxLines();
+    }
+
+    /**
+     * Executa docker logs para o container permitido e aplica filtro textual opcional.
+     */
+    public Map<String, Object> readLogs(String container, Integer requestedLines, String contains) {
+        if (!properties.chatLogs().enabled()) {
+            throw new IllegalArgumentException("chat container logs are disabled");
+        }
+
+        String normalizedContainer = normalizeContainer(container);
+        int lines = sanitizeLines(requestedLines);
+        List<String> outputLines = executeDockerLogs(normalizedContainer, lines);
+        List<String> filteredLines = applyContainsFilter(outputLines, contains);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("container", normalizedContainer);
+        response.put("requestedLines", lines);
+        response.put("returnedLines", filteredLines.size());
+        response.put("contains", contains == null ? "" : contains);
+        response.put("lines", filteredLines);
+        return response;
+    }
+
+    /**
+     * Valida se o container solicitado faz parte da lista operacional permitida.
+     */
+    private String normalizeContainer(String container) {
+        if (!StringUtils.hasText(container)) {
+            throw new IllegalArgumentException("container is required");
+        }
+        String normalized = container.trim();
+        if (!properties.chatLogs().allowedContainers().contains(normalized)) {
+            throw new IllegalArgumentException("container must be one of: "
+                    + String.join(", ", properties.chatLogs().allowedContainers()));
+        }
+        return normalized;
+    }
+
+    /**
+     * Ajusta a quantidade de linhas ao intervalo permitido pela configuração.
+     */
+    private int sanitizeLines(Integer requestedLines) {
+        if (requestedLines == null) {
+            return Math.min(DEFAULT_LINES, properties.chatLogs().maxLines());
+        }
+        if (requestedLines < 1 || requestedLines > properties.chatLogs().maxLines()) {
+            throw new IllegalArgumentException("lines must be between 1 and " + properties.chatLogs().maxLines());
+        }
+        return requestedLines;
+    }
+
+    /**
+     * Chama o Docker CLI local com timeout para evitar bloqueio do endpoint MCP.
+     */
+    private List<String> executeDockerLogs(String container, int lines) {
+        List<String> command = List.of(
+                properties.chatLogs().dockerCommand(),
+                "logs",
+                "--tail",
+                String.valueOf(lines),
+                "--timestamps",
+                container
+        );
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        processBuilder.redirectErrorStream(true);
+        try {
+            Process process = processBuilder.start();
+            boolean finished = process.waitFor(properties.chatLogs().timeoutSeconds(), TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new IllegalArgumentException("docker logs timed out after "
+                        + Duration.ofSeconds(properties.chatLogs().timeoutSeconds()).toSeconds() + " seconds");
+            }
+
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            List<String> outputLines = output.isBlank() ? List.of() : output.lines().toList();
+            if (process.exitValue() != 0) {
+                throw new IllegalArgumentException("docker logs failed: " + String.join("\n", outputLines));
+            }
+            return outputLines;
+        } catch (IOException ex) {
+            logger.error("mcp-server executeDockerLogs failed to start docker command for container={}", container, ex);
+            throw new IllegalArgumentException("failed to execute docker logs: " + ex.getMessage());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.error("mcp-server executeDockerLogs interrupted for container={}", container, ex);
+            throw new IllegalArgumentException("docker logs interrupted");
+        }
+    }
+
+    /**
+     * Filtra linhas por texto literal quando o argumento contains é informado.
+     */
+    private List<String> applyContainsFilter(List<String> lines, String contains) {
+        if (!StringUtils.hasText(contains)) {
+            return new ArrayList<>(lines);
+        }
+        return lines.stream()
+                .filter(line -> line.contains(contains))
+                .toList();
+    }
+}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -59,6 +59,12 @@ mcp:
     fetch-retry-delay-millis: ${MCP_LOG_FETCH_RETRY_DELAY_MILLIS:400}
     max-lines: ${MCP_LOG_MAX_LINES:500}
     http-tail-range-bytes: ${MCP_LOG_HTTP_TAIL_RANGE_BYTES:262144}
+  chat-logs:
+    enabled: ${MCP_CHAT_LOG_ENABLED:true}
+    allowed-containers: ${MCP_CHAT_LOG_ALLOWED_CONTAINERS:marketinghub-fashion-chat}
+    docker-command: ${MCP_CHAT_LOG_DOCKER_COMMAND:docker}
+    max-lines: ${MCP_CHAT_LOG_MAX_LINES:500}
+    timeout-seconds: ${MCP_CHAT_LOG_TIMEOUT_SECONDS:20}
   meta:
     enabled: ${MCP_META_ENABLED:true}
     graph-base-url: ${MCP_META_GRAPH_BASE_URL:https://graph.facebook.com}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -56,9 +56,15 @@ class McpControllerTest {
         registry.add("mcp.logs.mois-sales-library-worker-path",
                 () -> TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
+        registry.add("mcp.logs.clickbank-coletor-mois-path", () -> TEST_LOG_DIR.resolve("clickbank-coletor-mois.log").toString());
         registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
         registry.add("mcp.logs.ops-monitor-worker-path", () -> TEST_LOG_DIR.resolve("ops-monitor-worker.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
+        registry.add("mcp.chat-logs.enabled", () -> "true");
+        registry.add("mcp.chat-logs.allowed-containers", () -> "marketinghub-fashion-chat");
+        registry.add("mcp.chat-logs.docker-command", () -> TEST_LOG_DIR.resolve("docker-fake.sh").toString());
+        registry.add("mcp.chat-logs.max-lines", () -> "500");
+        registry.add("mcp.chat-logs.timeout-seconds", () -> "5");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");
         registry.add("mcp.meta.graph-version", () -> "v23.0");
@@ -89,6 +95,13 @@ class McpControllerTest {
         Files.writeString(TEST_LOG_DIR.resolve("ops-monitor-worker.log"),
                 "ops-monitor-worker-line-1\nops-monitor-worker-line-2\n",
                 StandardCharsets.UTF_8);
+        Path fakeDocker = TEST_LOG_DIR.resolve("docker-fake.sh");
+        Files.writeString(fakeDocker,
+                "#!/usr/bin/env sh\n"
+                        + "echo \"2026-07-12T10:00:00Z Fashion chat service listening on port 8094\"\n"
+                        + "echo \"2026-07-12T10:00:01Z health ok\"\n",
+                StandardCharsets.UTF_8);
+        fakeDocker.toFile().setExecutable(true);
     }
 
     /**
@@ -276,6 +289,38 @@ class McpControllerTest {
                         .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita, ops-monitor-worker"));
     }
 
+    /**
+     * Garante que a tool chat_container_logs lê logs Docker apenas do container de chat permitido.
+     */
+    @Test
+    void shouldReadChatContainerLogs() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":18,"method":"tools/call","params":{"name":"chat_container_logs","arguments":{"container":"marketinghub-fashion-chat","lines":2,"contains":"Fashion"}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.structuredContent.container").value("marketinghub-fashion-chat"))
+                .andExpect(jsonPath("$.result.structuredContent.returnedLines").value(1))
+                .andExpect(jsonPath("$.result.structuredContent.lines[0]")
+                        .value("2026-07-12T10:00:00Z Fashion chat service listening on port 8094"));
+    }
+
+    /**
+     * Garante que a tool chat_container_logs rejeita containers fora da allowlist.
+     */
+    @Test
+    void shouldRejectChatContainerOutsideAllowList() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":19,"method":"tools/call","params":{"name":"chat_container_logs","arguments":{"container":"marketinghub-backend","lines":2}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error.code").value(-32602))
+                .andExpect(jsonPath("$.error.message").value("container must be one of: marketinghub-fashion-chat"));
+    }
+
 
 
     /**
@@ -316,14 +361,15 @@ class McpControllerTest {
         mockMvc.perform(post("/mcp")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"jsonrpc":"2.0","id":12,"method":"tools/list","params":{}}
+                {"jsonrpc":"2.0","id":12,"method":"tools/list","params":{}}
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.tools[7].name").value("meta_graph_debug_token"))
-                .andExpect(jsonPath("$.result.tools[8].name").value("github_actions_list_workflows"))
-                .andExpect(jsonPath("$.result.tools[9].name").value("github_actions_list_runs"))
-                .andExpect(jsonPath("$.result.tools[10].name").value("github_actions_get_run_summary"))
-                .andExpect(jsonPath("$.result.tools[11].name").value("github_actions_get_run_logs"));
+                .andExpect(jsonPath("$.result.tools[*].name").value(org.hamcrest.Matchers.hasItems(
+                        "meta_graph_debug_token",
+                        "github_actions_list_workflows",
+                        "github_actions_list_runs",
+                        "github_actions_get_run_summary",
+                        "github_actions_get_run_logs")));
     }
 
 

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ChatContainerLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ChatContainerLogServiceTest.java
@@ -1,0 +1,114 @@
+package com.marketinghub.mcpserver.service;
+
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Valida a leitura restrita de logs Docker dos containers de chat pelo MCP.
+ */
+class ChatContainerLogServiceTest {
+
+    @TempDir
+    private Path tempDir;
+
+    /**
+     * Garante que apenas containers permitidos são aceitos para consulta de logs.
+     */
+    @Test
+    void shouldRejectContainerOutsideAllowList() throws Exception {
+        ChatContainerLogService service = new ChatContainerLogService(buildProperties(fakeDockerCommand()));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> service.readLogs("marketinghub-backend", 10, null));
+
+        assertEquals("container must be one of: marketinghub-fashion-chat", exception.getMessage());
+    }
+
+    /**
+     * Garante execução do Docker CLI configurado e filtro textual sobre as linhas retornadas.
+     */
+    @Test
+    void shouldReadAllowedContainerLogsAndFilterByText() throws Exception {
+        ChatContainerLogService service = new ChatContainerLogService(buildProperties(fakeDockerCommand()));
+
+        Map<String, Object> result = service.readLogs("marketinghub-fashion-chat", 20, "Fashion");
+
+        assertEquals("marketinghub-fashion-chat", result.get("container"));
+        assertEquals(1, result.get("returnedLines"));
+        assertEquals(List.of("2026-07-12T10:00:00Z Fashion chat service listening on port 8094"),
+                result.get("lines"));
+    }
+
+    /**
+     * Cria um executável falso para simular o comando docker logs durante o teste.
+     */
+    private String fakeDockerCommand() throws Exception {
+        Path script = tempDir.resolve("docker-fake.sh");
+        Files.writeString(script, """
+                #!/usr/bin/env sh
+                echo "2026-07-12T10:00:00Z Fashion chat service listening on port 8094"
+                echo "2026-07-12T10:00:01Z health ok"
+                """, StandardCharsets.UTF_8);
+        script.toFile().setExecutable(true);
+        return script.toString();
+    }
+
+    /**
+     * Monta propriedades MCP mínimas para testar logs de chat.
+     */
+    private McpProperties buildProperties(String dockerCommand) {
+        McpProperties.Logs logs = new McpProperties.Logs(
+                "/tmp/backend.log",
+                "/tmp/ai-worker.log",
+                "/tmp/lead-portal.log",
+                "/tmp/facebook-ads.log",
+                "/tmp/email-service.log",
+                "/tmp/lead-portal-payment.log",
+                "/tmp/mds.log",
+                "/tmp/mois.log",
+                "/tmp/mois-sales-library-worker.log",
+                "/tmp/mois-hotmart.log",
+                "/tmp/clickbank-coletor-mois.log",
+                "/tmp/oprm-coletor-receita.log",
+                "/tmp/ops-monitor-worker.log",
+                2,
+                3,
+                1,
+                500,
+                1024
+        );
+        McpProperties.ChatLogs chatLogs = new McpProperties.ChatLogs(
+                true,
+                List.of("marketinghub-fashion-chat"),
+                dockerCommand,
+                500,
+                5
+        );
+        McpProperties.Meta meta = new McpProperties.Meta(
+                true,
+                "https://graph.facebook.com",
+                "v23.0",
+                "",
+                "",
+                List.of("developers.facebook.com")
+        );
+        McpProperties.Github github = new McpProperties.Github(
+                false,
+                "https://api.github.com",
+                "owner",
+                "repo",
+                ""
+        );
+        return new McpProperties("marketing-hub-mcp", "1.0.0", logs, chatLogs, meta, github);
+    }
+}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaDiagnosticsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaDiagnosticsServiceTest.java
@@ -104,6 +104,7 @@ class MetaDiagnosticsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 45, 3, 400, 500, 262144),
+                new McpProperties.ChatLogs(true, List.of("marketinghub-fashion-chat"), "docker", 500, 20),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -38,6 +38,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 45, 3, 400, 500, 262144),
+                new McpProperties.ChatLogs(true, List.of("marketinghub-fashion-chat"), "docker", 500, 20),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -97,6 +97,14 @@ class ModuleLogServiceTest {
                 List.of("developers.facebook.com")
         );
 
+        McpProperties.ChatLogs chatLogs = new McpProperties.ChatLogs(
+                true,
+                List.of("marketinghub-fashion-chat"),
+                "docker",
+                500,
+                20
+        );
+
         McpProperties.Github github = new McpProperties.Github(
                 false,
                 "https://api.github.com",
@@ -105,6 +113,6 @@ class ModuleLogServiceTest {
                 ""
         );
 
-        return new McpProperties("marketing-hub-mcp", "1.0.0", logs, meta, github);
+        return new McpProperties("marketing-hub-mcp", "1.0.0", logs, chatLogs, meta, github);
     }
 }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: sobre o novo modulo de chat onde estão os fontes ? em qual diretorio ?

Modelo: Os fontes do novo módulo de chat estão espalhados em 3 pontos principais:

**1. Chat no backend principal**
- [backend/ads-service/src/main/java/com/marketinghub/chat](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/backend/ads-service/src/main/java/com/marketinghub/chat)
- Repositórios JPA: [backend/ads-service/src/main/java/com/marketinghub/repository/jpa/chat](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/chat)
- Endpoints:
  - `/api/chat`
  - `/api/chat-dialogs`

**2. Telas/API no frontend**
- Páginas ChatGPT/dialogs: [frontend/src/pages/chatDialog](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/frontend/src/pages/chatDialog)
- Hooks/API: [frontend/src/api/chatDialog](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/frontend/src/api/chatDialog)
- Rotas encontradas:
  - `/chat-dialogs`
  - `/chat-dialogs/new`

**3. Módulo isolado Fashion Chat**
- Serviço independente: [fashion-chat-service](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/fashion-chat-service)
- Fontes: [fashion-chat-service/src](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/fashion-chat-service/src)
- Frontend da tela: [frontend/src/pages/fashionChat](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/frontend/src/pages/fashionChat)
- Endpoint documentado no README:
  - `POST /api/fashion-chat/messages`

**Banco / migrations**
- [backend/ads-service/src/main/resources/db/changelog/V2025_08_06__create_chat_tables.sql](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/backend/ads-service/src/main/resources/db/changelog/V2025_08_06__create_chat_tables.sql)
- [backend/ads-service/src/main/resources/db/changelog/V2025_09_15__create_chat_dialog_table.sql](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/backend/ads-service/src/main/resources/db/changelog/V2025_09_15__create_chat_dialog_table.sql)
- [backend/ads-service/src/main/resources/db/changelog/V2025_09_20__add_chat_dialog_fk_to_market_niche.sql](/root/ai-hub/src/ai-hub-b806258d-cf5f-4fb0-9ea1-51a5dda7661b-7lA7Fq/repo/backend/ads-service/src/main/resources/db/changelog/V2025_09_20__add_chat_dialog_fk_to_market_niche.sql)

Resumo: se você está falando do chat integrado ao Marketing Hub, olhe principalmente `backend/ads-service/src/main/java/com/marketinghub/chat` e `frontend/src/pages/chatDialog`. Se for o piloto conversacional de moda, o módulo é `fashion-chat-service`.

Última mensagem do usuário:
vamos criar um workflow para publicar os containers do chat no mesmo host do mcp server
de permissão no mcp server a executar comandos no linux para ver os logs dos containers do chat

**Resumo das alterações:**
Implementei o fluxo, sem criar PR.

Avaliei 3 caminhos:
- Shell genérico no MCP: máximo poder, risco alto demais porque o MCP está exposto sem autenticação.
- Endpoint HTTP no chat para logs: simples, mas exige expor log pela aplicação.
- `docker logs` restrito por allowlist no MCP: melhor equilíbrio. Dá diagnóstico operacional sem liberar comando Linux arbitrário.

O que ficou pronto:
- Workflow: [.github/workflows/fashion-chat-service-ci.yml](/root/ai-hub/src/ai-hub-9757e453-73fa-4cda-966a-ea386585a10a-mmm1O6/repo/.github/workflows/fashion-chat-service-ci.yml)
- Docker/compose do chat: [fashion-chat-service/Dockerfile](/root/ai-hub/src/ai-hub-9757e453-73fa-4cda-966a-ea386585a10a-mmm1O6/repo/fashion-chat-service/Dockerfile)
- Deploy no host do MCP `191.252.210.83`, container `marketinghub-fashion-chat`, porta `8094`.
- Nova tool MCP: `chat_container_logs`, limitada ao container `marketinghub-fashion-chat`.
- MCP monta `/var/run/docker.sock` como read-only e instala Docker CLI.
- README do chat e do MCP atualizados com operação e logs.

Validações:
- `npm ci --include=dev && npm test` no `fashion-chat-service`: passou.
- `mvn -B -s settings.xml test` no `mcp-server`: passou.
- `docker compose config` do chat e do deploy MCP: passou.

Limitação real da sandbox: não consegui subir container local porque o daemon Docker/socket não está disponível aqui, mas a sintaxe Compose foi validada.