### PR TITLE
AI Hub: Implementei o cálculo de custo de produção de vídeo.

Causa-raiz: o vídeo já tinha campo `cost`, mas o fluxo VEO criava o ativo sem estimativa e o worker finalizava o job sem devolver custo. Agora:

- O backend estima o custo no pedido inicial do …

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -29,7 +29,9 @@ import com.marketinghub.salesvideo.dto.CreateSalesVideoProfileRequest;
 import com.marketinghub.salesvideo.dto.RequestVideoRenderRequest;
 import com.marketinghub.salesvideo.dto.SalesVideoJobDto;
 import com.marketinghub.salesvideo.dto.SalesVideoProfileDto;
+import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
 import com.marketinghub.salesvideo.service.SalesVideoService;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;
@@ -52,6 +54,7 @@ public class ExperimentVideoAssetService {
     private final ProductRepository productRepository;
     private final LandingPageRepository landingPageRepository;
     private final SalesVideoService salesVideoService;
+    private final SalesVideoProductionCostCalculator costCalculator;
 
     /** Inicializa o serviço com os repositórios dos vínculos de experimento e vídeo. */
     public ExperimentVideoAssetService(ExperimentVideoAssetRepository repository,
@@ -62,7 +65,8 @@ public class ExperimentVideoAssetService {
                                        LandingVideoSlotRepository landingVideoSlotRepository,
                                        ProductRepository productRepository,
                                        LandingPageRepository landingPageRepository,
-                                       SalesVideoService salesVideoService) {
+                                       SalesVideoService salesVideoService,
+                                       SalesVideoProductionCostCalculator costCalculator) {
         this.repository = repository;
         this.experimentRepository = experimentRepository;
         this.profileRepository = profileRepository;
@@ -72,6 +76,7 @@ public class ExperimentVideoAssetService {
         this.productRepository = productRepository;
         this.landingPageRepository = landingPageRepository;
         this.salesVideoService = salesVideoService;
+        this.costCalculator = costCalculator;
     }
 
     /** Lista todos os vídeos registrados para um experimento. */
@@ -103,7 +108,7 @@ public class ExperimentVideoAssetService {
                 .aspectRatio(request.aspectRatio())
                 .requestJson(request.requestJson())
                 .responseJson(request.responseJson())
-                .cost(request.cost())
+                .cost(resolveCost(request.cost(), request.provider(), request.model(), request.durationSeconds(), null))
                 .reviewStatus(request.reviewStatus() == null ? ExperimentVideoReviewStatus.PENDING : request.reviewStatus())
                 .requiredForRelease(request.requiredForRelease())
                 .salesVideoProfile(resolveProfile(request.salesVideoProfileId()))
@@ -146,6 +151,12 @@ public class ExperimentVideoAssetService {
         renderRequest.setProviderName(Optional.ofNullable(trimToNull(request.providerName())).orElse("VEO"));
         renderRequest.setExecutionMode(request.executionMode());
         SalesVideoJobDto job = salesVideoService.requestRender(profile.getId(), renderRequest);
+        String providerName = Optional.ofNullable(trimToNull(request.providerName())).orElse("VEO");
+        BigDecimal estimatedCost = costCalculator.estimateUsd(
+                providerName,
+                providerName,
+                request.targetDurationSeconds(),
+                "720p");
 
         ExperimentVideoAsset videoAsset = ExperimentVideoAsset.builder()
                 .experiment(experiment)
@@ -155,8 +166,10 @@ public class ExperimentVideoAssetService {
                 .script(request.scriptText().trim())
                 .prompt(buildVeoPromptSnapshot(request))
                 .provider("VEO")
-                .model(Optional.ofNullable(trimToNull(request.providerName())).orElse("VEO"))
+                .model(providerName)
                 .status(ExperimentVideoStatus.GENERATING)
+                .durationSeconds(request.targetDurationSeconds())
+                .cost(estimatedCost)
                 .reviewStatus(ExperimentVideoReviewStatus.PENDING)
                 .requiredForRelease(request.requiredForRelease())
                 .salesVideoProfile(resolveProfile(profile.getId()))
@@ -236,6 +249,16 @@ public class ExperimentVideoAssetService {
         }
         if (request.cost() != null) {
             videoAsset.setCost(request.cost());
+        } else if (request.durationSeconds() != null || request.provider() != null || request.model() != null) {
+            BigDecimal estimatedCost = resolveCost(
+                    null,
+                    videoAsset.getProvider(),
+                    videoAsset.getModel(),
+                    videoAsset.getDurationSeconds(),
+                    null);
+            if (estimatedCost != null) {
+                videoAsset.setCost(estimatedCost);
+            }
         }
         if (request.reviewStatus() != null) {
             videoAsset.setReviewStatus(request.reviewStatus());
@@ -307,6 +330,18 @@ public class ExperimentVideoAssetService {
                 Script:
                 %s
                 """.formatted(request.objective().trim(), request.primaryMetric().trim(), request.scriptText().trim());
+    }
+
+    /** Resolve o custo em USD informado ou calculado pela tabela oficial do provider. */
+    private BigDecimal resolveCost(BigDecimal informedCost,
+                                   String provider,
+                                   String model,
+                                   Integer durationSeconds,
+                                   String resolution) {
+        if (informedCost != null) {
+            return informedCost;
+        }
+        return costCalculator.estimateUsd(provider, model, durationSeconds, resolution);
     }
 
     /** Normaliza textos opcionais em branco para nulo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncService.java
@@ -102,11 +102,12 @@ public class CommercialPlanExecutionSyncService {
                 where measured_at >= ? and measured_at < ?
                 """, start, end));
         BigDecimal aiCost = money(currencyConversionService.usdToBrl(aiCostUsd).add(aiCostFromMetrics));
-        BigDecimal videoCost = money(queryDecimal("""
+        BigDecimal videoCostUsd = money(queryDecimal("""
                 select coalesce(sum(cost), 0)
                 from experiment_video_asset
                 where created_at >= ? and created_at < ?
                 """, start, end));
+        BigDecimal videoCost = money(currencyConversionService.usdToBrl(videoCostUsd));
         BigDecimal revenue = money(queryDecimal("""
                 select coalesce(sum(revenue_cents), 0) / 100.0
                 from experiment_financial_metric

--- a/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.planning.service;
 
+import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.planning.CommercialPlan;
 import com.marketinghub.planning.CommercialPlanWeekObjective;
 import com.marketinghub.planning.dto.CommercialPlanWeekDto;
@@ -39,6 +40,7 @@ public class CommercialPlanWeeklyExperimentService {
     private final CommercialPlanService planService;
     private final JdbcTemplate jdbcTemplate;
     private final CommercialPlanWeekObjectiveRepository objectiveRepository;
+    private final CurrencyConversionService currencyConversionService;
     private final Clock clock;
 
     /** Inicializa o serviço com a fonte de plano e acesso SQL de leitura operacional. */
@@ -46,8 +48,9 @@ public class CommercialPlanWeeklyExperimentService {
     public CommercialPlanWeeklyExperimentService(
             CommercialPlanService planService,
             JdbcTemplate jdbcTemplate,
-            CommercialPlanWeekObjectiveRepository objectiveRepository) {
-        this(planService, jdbcTemplate, objectiveRepository, Clock.systemUTC());
+            CommercialPlanWeekObjectiveRepository objectiveRepository,
+            CurrencyConversionService currencyConversionService) {
+        this(planService, jdbcTemplate, objectiveRepository, currencyConversionService, Clock.systemUTC());
     }
 
     /** Inicializa o serviço permitindo controlar o relogio em testes de janela semanal. */
@@ -55,10 +58,12 @@ public class CommercialPlanWeeklyExperimentService {
             CommercialPlanService planService,
             JdbcTemplate jdbcTemplate,
             CommercialPlanWeekObjectiveRepository objectiveRepository,
+            CurrencyConversionService currencyConversionService,
             Clock clock) {
         this.planService = planService;
         this.jdbcTemplate = jdbcTemplate;
         this.objectiveRepository = objectiveRepository;
+        this.currencyConversionService = currencyConversionService;
         this.clock = clock;
     }
 
@@ -244,7 +249,7 @@ public class CommercialPlanWeeklyExperimentService {
                     e.created_at,
                     coalesce(campaign.cost, 0) as campaign_cost,
                     coalesce(financial.ai_cost, 0) as ai_cost,
-                    coalesce(video.cost, 0) as video_cost,
+                    coalesce(video.cost, 0) as video_cost_usd,
                     coalesce(financial.revenue, 0) as revenue,
                     coalesce(nullif(financial.clicks, 0), campaign.clicks, 0) as clicks,
                     coalesce(nullif(financial.leads, 0), campaign.leads, 0) as leads,
@@ -325,7 +330,7 @@ public class CommercialPlanWeeklyExperimentService {
     private CommercialPlanWeekExperimentDto mapExperiment(ResultSet rs, int rowNum) throws SQLException {
         BigDecimal campaignCost = money(rs.getBigDecimal("campaign_cost"));
         BigDecimal aiCost = money(rs.getBigDecimal("ai_cost"));
-        BigDecimal videoCost = money(rs.getBigDecimal("video_cost"));
+        BigDecimal videoCost = money(currencyConversionService.usdToBrl(rs.getBigDecimal("video_cost_usd")));
         BigDecimal revenue = money(rs.getBigDecimal("revenue"));
         BigDecimal totalCost = money(campaignCost.add(aiCost).add(videoCost));
         return new CommercialPlanWeekExperimentDto(

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
@@ -17,6 +17,10 @@ public interface ExperimentVideoAssetRepository extends JpaRepository<Experiment
     @EntityGraph(attributePaths = {"experiment", "salesVideoProfile", "salesVideoJob", "asset", "landingVideoSlot"})
     List<ExperimentVideoAsset> findByExperimentIdOrderByCreatedAtDesc(Long experimentId);
 
+    /** Busca o ativo de experimento vinculado ao job de vídeo canônico. */
+    @EntityGraph(attributePaths = {"experiment", "salesVideoProfile", "salesVideoJob", "asset", "landingVideoSlot"})
+    List<ExperimentVideoAsset> findBySalesVideoJobId(Long salesVideoJobId);
+
     /** Verifica se existem vídeos obrigatórios que ainda bloqueiam a publicação. */
     @Query("""
             select case when count(v) > 0 then true else false end

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/JobCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/JobCompletionRequest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.salesvideo.dto;
 
 import com.marketinghub.salesvideo.SalesVideoStatus;
+import java.math.BigDecimal;
 import lombok.Data;
 
 /**
@@ -14,6 +15,7 @@ public class JobCompletionRequest {
     private Long vttAssetId;
     private String providerJobId;
     private String metadataJson;
+    private BigDecimal costUsd;
     private String message;
     private String detailsJson;
     private GeneratedScriptResultPayload scriptResult;

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
@@ -1,7 +1,12 @@
 package com.marketinghub.salesvideo.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.media.Asset;
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.repository.jpa.media.AssetRepository;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.salesvideo.*;
 import com.marketinghub.salesvideo.dto.*;
 import com.marketinghub.salesvideo.exception.VideoModuleErrorCode;
@@ -21,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
+import java.math.BigDecimal;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -38,19 +44,29 @@ public class SalesVideoJobService {
     private final SalesVideoScriptRepository scriptRepository;
     private final AssetRepository assetRepository;
     private final SalesVideoReprocessPolicy reprocessPolicy;
+    private final ExperimentVideoAssetRepository experimentVideoAssetRepository;
+    private final SalesVideoProductionCostCalculator costCalculator;
+    private final ObjectMapper objectMapper;
 
+    /** Cria o serviço com repositórios, política de reprocessamento e cálculo de custo de vídeo. */
     public SalesVideoJobService(SalesVideoJobRepository jobRepository,
                                 SalesVideoJobEventRepository eventRepository,
                                 SalesVideoProfileRepository profileRepository,
                                 SalesVideoScriptRepository scriptRepository,
                                 AssetRepository assetRepository,
-                                SalesVideoReprocessPolicy reprocessPolicy) {
+                                SalesVideoReprocessPolicy reprocessPolicy,
+                                ExperimentVideoAssetRepository experimentVideoAssetRepository,
+                                SalesVideoProductionCostCalculator costCalculator,
+                                ObjectMapper objectMapper) {
         this.jobRepository = jobRepository;
         this.eventRepository = eventRepository;
         this.profileRepository = profileRepository;
         this.scriptRepository = scriptRepository;
         this.assetRepository = assetRepository;
         this.reprocessPolicy = reprocessPolicy;
+        this.experimentVideoAssetRepository = experimentVideoAssetRepository;
+        this.costCalculator = costCalculator;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional
@@ -183,6 +199,7 @@ public class SalesVideoJobService {
             job.setScript(persistedScript);
         }
         jobRepository.save(job);
+        syncExperimentVideoAsset(job, request);
         maybeUpdateProfileStatus(job, finalStatus);
         registerEvent(job, SalesVideoJobEventType.COMPLETED, previous, finalStatus,
                 request.getMessage(), request.getDetailsJson());
@@ -276,6 +293,88 @@ public class SalesVideoJobService {
             job.getProfile().getScripts().add(saved);
         }
         return saved;
+    }
+
+    /** Atualiza o ativo de vídeo do experimento com custo e asset final do job concluído. */
+    private void syncExperimentVideoAsset(SalesVideoJob job, JobCompletionRequest request) {
+        if (job.getId() == null || job.getJobType() != SalesVideoJobType.RENDER) {
+            return;
+        }
+        List<ExperimentVideoAsset> videoAssets = experimentVideoAssetRepository.findBySalesVideoJobId(job.getId());
+        if (videoAssets.isEmpty()) {
+            return;
+        }
+        BigDecimal costUsd = Optional.ofNullable(request.getCostUsd())
+                .orElseGet(() -> costCalculator.estimateUsd(
+                        job.getProviderName(),
+                        job.getProviderName(),
+                        resolveDurationSeconds(job, request),
+                        resolveResolution(request)));
+        for (ExperimentVideoAsset videoAsset : videoAssets) {
+            if (job.getAsset() != null) {
+                videoAsset.setAsset(job.getAsset());
+                videoAsset.setAssetUrl(job.getAsset().getUrl());
+            }
+            if (job.getPosterAsset() != null) {
+                videoAsset.setThumbnailUrl(job.getPosterAsset().getUrl());
+            }
+            Integer durationSeconds = resolveDurationSeconds(job, request);
+            if (durationSeconds != null) {
+                videoAsset.setDurationSeconds(durationSeconds);
+            }
+            if (costUsd != null) {
+                videoAsset.setCost(costUsd);
+            }
+            videoAsset.setResponseJson(request.getMetadataJson());
+            videoAsset.setStatus(ExperimentVideoStatus.READY);
+        }
+        experimentVideoAssetRepository.saveAll(videoAssets);
+    }
+
+    /** Extrai a duração auditada do metadata do worker quando disponível. */
+    private Integer resolveDurationSeconds(SalesVideoJob job, JobCompletionRequest request) {
+        Integer metadataDuration = readIntegerField(request.getMetadataJson(), "duration_seconds");
+        if (metadataDuration != null) {
+            return metadataDuration;
+        }
+        return job.getProfile() != null ? job.getProfile().getTargetDurationSeconds() : null;
+    }
+
+    /** Extrai a resolução auditada do metadata do worker quando disponível. */
+    private String resolveResolution(JobCompletionRequest request) {
+        return readStringField(request.getMetadataJson(), "resolution");
+    }
+
+    /** Lê um campo numérico simples de um payload JSON de metadata. */
+    private Integer readIntegerField(String json, String fieldName) {
+        JsonNode value = readJsonField(json, fieldName);
+        if (value == null || !value.canConvertToInt()) {
+            return null;
+        }
+        return value.asInt();
+    }
+
+    /** Lê um campo textual simples de um payload JSON de metadata. */
+    private String readStringField(String json, String fieldName) {
+        JsonNode value = readJsonField(json, fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.isTextual() ? value.asText() : value.toString();
+    }
+
+    /** Lê um campo simples de um payload JSON de metadata usando parser estruturado. */
+    private JsonNode readJsonField(String json, String fieldName) {
+        if (!StringUtils.hasText(json) || !StringUtils.hasText(fieldName)) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode value = root.path(fieldName);
+            return value.isMissingNode() ? null : value;
+        } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
+            return null;
+        }
     }
 
     private void attachAsset(java.util.function.Consumer<Asset> setter, Long assetId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoProductionCostCalculator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoProductionCostCalculator.java
@@ -1,0 +1,119 @@
+package com.marketinghub.salesvideo.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Calcula o custo de produção de vídeos gerados por providers de IA.
+ */
+@Component
+public class SalesVideoProductionCostCalculator {
+    private static final BigDecimal VEO_31_STANDARD_720_1080 = new BigDecimal("0.40");
+    private static final BigDecimal VEO_31_STANDARD_4K = new BigDecimal("0.60");
+    private static final BigDecimal VEO_31_FAST_720 = new BigDecimal("0.10");
+    private static final BigDecimal VEO_31_FAST_1080 = new BigDecimal("0.12");
+    private static final BigDecimal VEO_31_FAST_4K = new BigDecimal("0.30");
+    private static final BigDecimal VEO_31_LITE_720 = new BigDecimal("0.05");
+    private static final BigDecimal VEO_31_LITE_1080 = new BigDecimal("0.08");
+    private static final BigDecimal VEO_3_STANDARD = new BigDecimal("0.40");
+    private static final BigDecimal VEO_2 = new BigDecimal("0.35");
+    private static final BigDecimal GEMINI_OMNI_FLASH = new BigDecimal("0.10");
+
+    /** Estima o custo em USD com base no modelo, duração e resolução do vídeo. */
+    public BigDecimal estimateUsd(String providerName,
+                                  String model,
+                                  Integer durationSeconds,
+                                  String resolution) {
+        Integer normalizedDuration = normalizeDuration(durationSeconds);
+        if (normalizedDuration == null) {
+            return null;
+        }
+        BigDecimal pricePerSecond = pricePerSecondUsd(providerName, model, resolution);
+        if (pricePerSecond == null) {
+            return null;
+        }
+        return pricePerSecond
+                .multiply(BigDecimal.valueOf(normalizedDuration.longValue()))
+                .setScale(4, RoundingMode.HALF_UP);
+    }
+
+    /** Resolve o preço oficial por segundo em USD para o modelo de vídeo conhecido. */
+    public BigDecimal pricePerSecondUsd(String providerName, String model, String resolution) {
+        String normalizedModel = normalize(model);
+        String normalizedProvider = normalize(providerName);
+        if (contains(normalizedModel, "omni-flash") || contains(normalizedProvider, "omni-flash")) {
+            return GEMINI_OMNI_FLASH;
+        }
+        if (contains(normalizedModel, "veo-2")) {
+            return VEO_2;
+        }
+        if (contains(normalizedModel, "veo-3.0") || contains(normalizedModel, "veo-3-0")) {
+            return contains(normalizedModel, "fast")
+                    ? veoFastPrice(resolution)
+                    : VEO_3_STANDARD;
+        }
+        if (contains(normalizedModel, "lite") || contains(normalizedProvider, "lite")) {
+            return veoLitePrice(resolution);
+        }
+        if (contains(normalizedModel, "fast") || contains(normalizedProvider, "fast")) {
+            return veoFastPrice(resolution);
+        }
+        if (contains(normalizedModel, "veo")
+                || contains(normalizedProvider, "veo")
+                || contains(normalizedProvider, "real")) {
+            return is4k(resolution) ? VEO_31_STANDARD_4K : VEO_31_STANDARD_720_1080;
+        }
+        return null;
+    }
+
+    /** Normaliza duração inválida para impedir custo fictício. */
+    private Integer normalizeDuration(Integer durationSeconds) {
+        if (durationSeconds == null || durationSeconds <= 0) {
+            return null;
+        }
+        return durationSeconds;
+    }
+
+    /** Resolve preço do Veo Fast conforme resolução oficial. */
+    private BigDecimal veoFastPrice(String resolution) {
+        if (is4k(resolution)) {
+            return VEO_31_FAST_4K;
+        }
+        if (is1080p(resolution)) {
+            return VEO_31_FAST_1080;
+        }
+        return VEO_31_FAST_720;
+    }
+
+    /** Resolve preço do Veo Lite conforme resolução oficial. */
+    private BigDecimal veoLitePrice(String resolution) {
+        if (is1080p(resolution) || is4k(resolution)) {
+            return VEO_31_LITE_1080;
+        }
+        return VEO_31_LITE_720;
+    }
+
+    /** Verifica se a resolução solicitada é 1080p. */
+    private boolean is1080p(String resolution) {
+        return normalize(resolution).contains("1080");
+    }
+
+    /** Verifica se a resolução solicitada é 4k. */
+    private boolean is4k(String resolution) {
+        String normalized = normalize(resolution);
+        return normalized.contains("4k") || normalized.contains("2160");
+    }
+
+    /** Normaliza texto para comparação tolerante. */
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim().toLowerCase(Locale.ROOT).replace('_', '-') : "";
+    }
+
+    /** Testa presença de um marcador normalizado. */
+    private boolean contains(String value, String marker) {
+        return value.contains(marker);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -26,6 +26,7 @@ import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoProfile;
 import com.marketinghub.salesvideo.dto.SalesVideoJobDto;
 import com.marketinghub.salesvideo.dto.SalesVideoProfileDto;
+import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
 import com.marketinghub.salesvideo.service.SalesVideoService;
 import java.util.List;
 import java.util.Optional;
@@ -79,7 +80,8 @@ class ExperimentVideoAssetServiceTest {
                 landingVideoSlotRepository,
                 productRepository,
                 landingPageRepository,
-                salesVideoService);
+                salesVideoService,
+                new SalesVideoProductionCostCalculator());
     }
 
     /** Garante que um vídeo novo recebe estados padrão quando criado para o experimento. */
@@ -181,6 +183,7 @@ class ExperimentVideoAssetServiceTest {
         assertThat(dto.salesVideoProfileId()).isEqualTo(12L);
         assertThat(dto.salesVideoJobId()).isEqualTo(10108L);
         assertThat(dto.requiredForRelease()).isTrue();
+        assertThat(dto.cost()).isEqualByComparingTo("12.0000");
     }
 
     /** Garante que a landing de outro experimento não pode contaminar o aprendizado do funil atual. */

--- a/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanWeeklyExperimentServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.finance.CurrencyConversionProperties;
+import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.planning.CommercialPlan;
 import com.marketinghub.planning.dto.CommercialPlanWeekDto;
 import com.marketinghub.planning.dto.CommercialPlanWeekExperimentDto;
@@ -149,6 +151,12 @@ class CommercialPlanWeeklyExperimentServiceTest {
     /** Cria o servico com data fixa para testar a regra de disponibilidade. */
     private CommercialPlanWeeklyExperimentService serviceAt(LocalDate date) {
         Clock clock = Clock.fixed(date.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
-        return new CommercialPlanWeeklyExperimentService(planService, jdbcTemplate, objectiveRepository, clock);
+        CurrencyConversionService conversionService = new CurrencyConversionService(new CurrencyConversionProperties());
+        return new CommercialPlanWeeklyExperimentService(
+                planService,
+                jdbcTemplate,
+                objectiveRepository,
+                conversionService,
+                clock);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
@@ -1,5 +1,7 @@
 package com.marketinghub.salesvideo.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.repository.jpa.media.AssetRepository;
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoJobType;
@@ -46,6 +48,8 @@ class SalesVideoJobServiceTest {
 
     @Mock
     private SalesVideoReprocessPolicy reprocessPolicy;
+    @Mock
+    private ExperimentVideoAssetRepository experimentVideoAssetRepository;
 
     private SalesVideoJobService service;
 
@@ -56,7 +60,10 @@ class SalesVideoJobServiceTest {
                 profileRepository,
                 scriptRepository,
                 assetRepository,
-                reprocessPolicy);
+                reprocessPolicy,
+                experimentVideoAssetRepository,
+                new SalesVideoProductionCostCalculator(),
+                new ObjectMapper());
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5753,3 +5753,10 @@
 - Validação do arquivo: a URL pública respondeu `Content-Type: video/mp4`, `Content-Length: 2024034` e assinatura inicial `ftyp`, confirmando MP4 real.
 - Causa-raiz adicional tratada: o banco real tinha `asset.provider` e `asset.type` como `ENUM` físico defasado, sem `VIDEO_MODULE` e `CAPTION`; o VEO também precisava seguir redirect no download da Gemini e aumentar o limite de buffer do WebClient para baixar MP4 acima de 256 KB.
 - Prevenção preparada: changeset `2026-07-12-video-asset-enums` alinha os enums físicos do MySQL ao contrato Java, e o provider VEO local passa a seguir redirects, validar MP4 e bloquear JSON de erro salvo como vídeo.
+
+## 2026-07-12 — Chat de moda sem quebra em HTTP inseguro
+
+- Problema: o envio de pergunta na aba `Chat Moda` quebrava antes de chamar o serviço, com `crypto.randomUUID is not a function`.
+- Causa-raiz tratada: a tela dependia diretamente de `crypto.randomUUID`, API que pode ficar indisponível em contexto HTTP não seguro fora de `localhost`.
+- Correção aplicada: a geração de ID de mensagens passou a usar `crypto.randomUUID` quando disponível e fallback local quando não disponível.
+- Validação: teste de regressão cobre navegador sem `randomUUID`; Chromium local confirmou envio pelo IP HTTP inseguro sem `pageerror` e renderização da resposta com API mockada.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-12 — Experimentos: custo de produção de vídeo VEO
+
+- causa-raiz: o ativo `experiment_video_asset` já tinha campo de custo, mas o pedido VEO criava o vídeo sem estimativa e o callback final do `video-management-service` não enviava o custo calculado pelo provider.
+- regra aplicada: custo de produção de vídeo fica em USD, seguindo a cobrança oficial do Google Gemini API por segundo gerado; Veo 3.1 Standard usa US$ 0,40/s em 720p/1080p, Fast a partir de US$ 0,10/s em 720p e Lite a partir de US$ 0,05/s em 720p; Veo 2 usa US$ 0,35/s.
+- foi feito: o backend estima o custo no pedido inicial do vídeo e atualiza o ativo do experimento no callback final com duração/resolução reais informadas pelo worker.
+- foi feito: o resumo de custos do experimento passa a somar “Produção de vídeo” como custo técnico USD convertido para BRL, e a aba Vídeo mostra o custo por ativo.
+- prevenção de recorrência: o cálculo foi centralizado no backend e o worker passa a enviar `costUsd` junto da conclusão do job, impedindo novos vídeos VEO sem custo auditável.
+
 ## 2026-07-12 — Experimento 63: tenant no endpoint canônico de vídeo do experimento
 
 - Problema confirmado ao tentar o próximo passo operacional: o endpoint `/api/experiments/63/video-assets/veo-render-requests` recebia `X-Tenant-ID`, mas o filtro do backend não classificava essa rota como parte do módulo de vídeo; ao criar o perfil internamente, o contexto permanecia `system` e o service retornava `TENANT_HEADER_REQUIRED`.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -47,6 +47,7 @@ import {
 import { useExperimentCompleteMarkdownReport } from "../../api/experiment/useExperimentCompleteMarkdownReport";
 import { useGeraSalesPagePublications } from "../../api/experiment/useGeraSalesPagePublications";
 import { useExperimentPipelineJobHistory } from "../../api/experiment/useExperimentPipelineJobHistory";
+import { useExperimentVideoAssets } from "../../api/experiment/useExperimentVideoAssets";
 import { buildExperimentCostSummary } from "./experimentCostSummary";
 
 function formatPipelineStageModel(stageModel?: GeraLandingStageModel) {
@@ -319,6 +320,7 @@ export default function ExperimentDetailPage() {
   const expId = id as string;
   const navigate = useNavigate();
   const { data, isLoading } = useExperiment(expId);
+  const videoAssetsQuery = useExperimentVideoAssets(expId);
   const geraSalesPagePublications = useGeraSalesPagePublications(expId);
   const experimentPipelineJobHistory = useExperimentPipelineJobHistory({
     experimentId: expId,
@@ -344,9 +346,9 @@ export default function ExperimentDetailPage() {
   const { data: facebookCampaigns, isLoading: isLoadingFacebookCampaigns } =
     useExperimentFacebookCampaigns(expId);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
-  const [openAuditStageJobId, setOpenAuditStageJobId] = useState<
-    string | null
-  >(null);
+  const [openAuditStageJobId, setOpenAuditStageJobId] = useState<string | null>(
+    null,
+  );
   const [copiedCardKey, setCopiedCardKey] = useState<string | null>(null);
   const [copyingCardKey, setCopyingCardKey] = useState<string | null>(null);
   const [downloadingCardKey, setDownloadingCardKey] = useState<string | null>(
@@ -1804,6 +1806,11 @@ export default function ExperimentDetailPage() {
       : null);
   const salesPagePublications = geraSalesPagePublications.data ?? [];
   const latestSalesPagePublication = salesPagePublications[0];
+  const videoProductionCostUsd =
+    videoAssetsQuery.data?.reduce(
+      (sum, videoAsset) => sum + (videoAsset.cost ?? 0),
+      0,
+    ) ?? 0;
   const contentPipelineCostUsd =
     experimentPipelineJobHistory.data?.content.reduce(
       (sum, job) => sum + (job.costUsd ?? 0),
@@ -1823,6 +1830,7 @@ export default function ExperimentDetailPage() {
     contentPipelineCostUsd,
     geraLandingCostUsd: totalCompletedGeraLandingAllStagesCostUsd,
     geraSalesPageCostUsd,
+    videoProductionCostUsd,
   });
   const experimentPage = data.facebookPage;
   const instagramAccount = data.instagramAccount;
@@ -2375,7 +2383,10 @@ export default function ExperimentDetailPage() {
                       {latestSalesPagePublication.salesPageUrl ? (
                         <div className="d-flex flex-column gap-2">
                           <a
-                            href={latestSalesPagePublication.salesPageUrl ?? undefined}
+                            href={
+                              latestSalesPagePublication.salesPageUrl ??
+                              undefined
+                            }
                             target="_blank"
                             rel="noreferrer"
                             className="small text-break"
@@ -2405,7 +2416,9 @@ export default function ExperimentDetailPage() {
                       <div className="text-muted small">Checkout usado</div>
                       {latestSalesPagePublication.checkoutUrl ? (
                         <a
-                          href={latestSalesPagePublication.checkoutUrl ?? undefined}
+                          href={
+                            latestSalesPagePublication.checkoutUrl ?? undefined
+                          }
                           target="_blank"
                           rel="noreferrer"
                           className="small text-break"
@@ -2573,143 +2586,145 @@ export default function ExperimentDetailPage() {
         </div>
       </div>
       {false ? (
-      <div className="card border-0 shadow-sm rounded-3 mt-3">
-        <div className="card-body">
-          <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap mb-3">
-            <div>
-              <h5 className="card-title mb-1">Campanhas e funis publicados</h5>
-              <p className="text-muted small mb-0">
-                Campanhas, conjuntos, anúncios e etapas de funil atribuídas por
-                código de rastreamento.
-              </p>
+        <div className="card border-0 shadow-sm rounded-3 mt-3">
+          <div className="card-body">
+            <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap mb-3">
+              <div>
+                <h5 className="card-title mb-1">
+                  Campanhas e funis publicados
+                </h5>
+                <p className="text-muted small mb-0">
+                  Campanhas, conjuntos, anúncios e etapas de funil atribuídas
+                  por código de rastreamento.
+                </p>
+              </div>
+              <span className="badge text-bg-light border text-body">
+                {isLoadingFacebookCampaigns
+                  ? "Carregando"
+                  : `${facebookCampaigns?.length ?? 0} campanha(s)`}
+              </span>
             </div>
-            <span className="badge text-bg-light border text-body">
-              {isLoadingFacebookCampaigns
-                ? "Carregando"
-                : `${facebookCampaigns?.length ?? 0} campanha(s)`}
-            </span>
-          </div>
-          {isLoadingFacebookCampaigns ? (
-            <div className="text-muted small">Carregando campanhas...</div>
-          ) : facebookCampaigns?.length ? (
-            <div className="d-flex flex-column gap-3">
-              {(facebookCampaigns ?? []).map((campaign) => (
-                <div key={campaign.id} className="border rounded-3 p-3">
-                  <div className="d-flex justify-content-between gap-3 flex-wrap">
-                    <div>
-                      <div className="fw-semibold">{campaign.name}</div>
-                      <div className="text-muted small">
-                        {campaign.objective} · {campaign.status}
-                        {campaign.createdAt
-                          ? ` · ${formatDateTimeValue(campaign.createdAt)}`
-                          : ""}
-                      </div>
-                      {campaign.metricsLastError ? (
-                        <div className="text-danger small mt-1">
-                          {campaign.metricsLastError}
+            {isLoadingFacebookCampaigns ? (
+              <div className="text-muted small">Carregando campanhas...</div>
+            ) : facebookCampaigns?.length ? (
+              <div className="d-flex flex-column gap-3">
+                {(facebookCampaigns ?? []).map((campaign) => (
+                  <div key={campaign.id} className="border rounded-3 p-3">
+                    <div className="d-flex justify-content-between gap-3 flex-wrap">
+                      <div>
+                        <div className="fw-semibold">{campaign.name}</div>
+                        <div className="text-muted small">
+                          {campaign.objective} · {campaign.status}
+                          {campaign.createdAt
+                            ? ` · ${formatDateTimeValue(campaign.createdAt)}`
+                            : ""}
                         </div>
-                      ) : null}
+                        {campaign.metricsLastError ? (
+                          <div className="text-danger small mt-1">
+                            {campaign.metricsLastError}
+                          </div>
+                        ) : null}
+                      </div>
+                      <code className="small text-break">{campaign.id}</code>
                     </div>
-                    <code className="small text-break">{campaign.id}</code>
-                  </div>
-                  {campaign.issues?.length ? (
-                    <div className="alert alert-warning py-2 small mt-3 mb-0">
-                      {campaign.issues.join(" ")}
-                    </div>
-                  ) : null}
-                  <div className="d-flex flex-column gap-2 mt-3">
-                    {campaign.adSets.map((adSet) => (
-                      <div key={adSet.id} className="border rounded-3 p-3">
-                        <div className="d-flex justify-content-between gap-3 flex-wrap">
-                          <div>
-                            <div className="fw-semibold">{adSet.name}</div>
-                            <div className="text-muted small">
-                              {adSet.status}
-                              {adSet.createdAt
-                                ? ` · ${formatDateTimeValue(adSet.createdAt)}`
-                                : ""}
-                              {adSet.experimentAdSetId
-                                ? ` · Público #${adSet.experimentAdSetId}`
-                                : ""}
+                    {campaign.issues?.length ? (
+                      <div className="alert alert-warning py-2 small mt-3 mb-0">
+                        {campaign.issues.join(" ")}
+                      </div>
+                    ) : null}
+                    <div className="d-flex flex-column gap-2 mt-3">
+                      {campaign.adSets.map((adSet) => (
+                        <div key={adSet.id} className="border rounded-3 p-3">
+                          <div className="d-flex justify-content-between gap-3 flex-wrap">
+                            <div>
+                              <div className="fw-semibold">{adSet.name}</div>
+                              <div className="text-muted small">
+                                {adSet.status}
+                                {adSet.createdAt
+                                  ? ` · ${formatDateTimeValue(adSet.createdAt)}`
+                                  : ""}
+                                {adSet.experimentAdSetId
+                                  ? ` · Público #${adSet.experimentAdSetId}`
+                                  : ""}
+                              </div>
                             </div>
+                            <code className="small text-break">{adSet.id}</code>
                           </div>
-                          <code className="small text-break">{adSet.id}</code>
-                        </div>
-                        {adSet.issues?.length ? (
-                          <div className="alert alert-warning py-2 small mt-2 mb-0">
-                            {adSet.issues.join(" ")}
-                          </div>
-                        ) : null}
-                        {adSet.ads.length ? (
-                          <div className="table-responsive mt-3">
-                            <table className="table table-sm align-middle mb-0">
-                              <thead>
-                                <tr>
-                                  <th>Anúncio</th>
-                                  <th>Status</th>
-                                  <th>Código</th>
-                                  <th>Funil atribuído</th>
-                                </tr>
-                              </thead>
-                              <tbody>
-                                {adSet.ads.map((ad) => (
-                                  <tr key={ad.id}>
-                                    <td>
-                                      <div className="fw-semibold">
-                                        {ad.name}
-                                      </div>
-                                      <code className="small text-break">
-                                        {ad.id}
-                                      </code>
-                                    </td>
-                                    <td>{ad.status}</td>
-                                    <td>
-                                      <code className="small text-break">
-                                        {ad.trackingCode || "—"}
-                                      </code>
-                                    </td>
-                                    <td>
-                                      {ad.funnelStages.length ? (
-                                        <div className="d-flex flex-column gap-1">
-                                          {ad.funnelStages.map((stage) => (
-                                            <div
-                                              key={`${ad.id}-${stage.stage}`}
-                                              className="d-flex justify-content-between gap-3 small"
-                                            >
-                                              <span>
-                                                {stage.order}. {stage.label}
-                                              </span>
-                                              <strong>
-                                                {stage.totalCount}
-                                              </strong>
-                                            </div>
-                                          ))}
-                                        </div>
-                                      ) : (
-                                        <span className="text-muted small">
-                                          Sem eventos atribuídos
-                                        </span>
-                                      )}
-                                    </td>
+                          {adSet.issues?.length ? (
+                            <div className="alert alert-warning py-2 small mt-2 mb-0">
+                              {adSet.issues.join(" ")}
+                            </div>
+                          ) : null}
+                          {adSet.ads.length ? (
+                            <div className="table-responsive mt-3">
+                              <table className="table table-sm align-middle mb-0">
+                                <thead>
+                                  <tr>
+                                    <th>Anúncio</th>
+                                    <th>Status</th>
+                                    <th>Código</th>
+                                    <th>Funil atribuído</th>
                                   </tr>
-                                ))}
-                              </tbody>
-                            </table>
-                          </div>
-                        ) : null}
-                      </div>
-                    ))}
+                                </thead>
+                                <tbody>
+                                  {adSet.ads.map((ad) => (
+                                    <tr key={ad.id}>
+                                      <td>
+                                        <div className="fw-semibold">
+                                          {ad.name}
+                                        </div>
+                                        <code className="small text-break">
+                                          {ad.id}
+                                        </code>
+                                      </td>
+                                      <td>{ad.status}</td>
+                                      <td>
+                                        <code className="small text-break">
+                                          {ad.trackingCode || "—"}
+                                        </code>
+                                      </td>
+                                      <td>
+                                        {ad.funnelStages.length ? (
+                                          <div className="d-flex flex-column gap-1">
+                                            {ad.funnelStages.map((stage) => (
+                                              <div
+                                                key={`${ad.id}-${stage.stage}`}
+                                                className="d-flex justify-content-between gap-3 small"
+                                              >
+                                                <span>
+                                                  {stage.order}. {stage.label}
+                                                </span>
+                                                <strong>
+                                                  {stage.totalCount}
+                                                </strong>
+                                              </div>
+                                            ))}
+                                          </div>
+                                        ) : (
+                                          <span className="text-muted small">
+                                            Sem eventos atribuídos
+                                          </span>
+                                        )}
+                                      </td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="alert alert-light border small text-muted mb-0">
-              Nenhuma campanha publicada encontrada para este experimento.
-            </div>
-          )}
+                ))}
+              </div>
+            ) : (
+              <div className="alert alert-light border small text-muted mb-0">
+                Nenhuma campanha publicada encontrada para este experimento.
+              </div>
+            )}
+          </div>
         </div>
-      </div>
       ) : null}
       <div ref={tabsSectionRef}>
         <Tabs.Root value={tab} onValueChange={setTab} className="mt-3">

--- a/frontend/src/pages/experiment/ExperimentVideoTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentVideoTab.tsx
@@ -23,7 +23,10 @@ const VIDEO_SLOT_OPTIONS: ExperimentVideoSlot[] = [
   "PRE_CHECKOUT",
 ];
 
-const EXECUTION_MODE_OPTIONS: SalesVideoExecutionMode[] = ["TEST", "PRODUCTION"];
+const EXECUTION_MODE_OPTIONS: SalesVideoExecutionMode[] = [
+  "TEST",
+  "PRODUCTION",
+];
 
 function buildInitialScript(experiment: Experiment) {
   const sections = [
@@ -31,7 +34,9 @@ function buildInitialScript(experiment: Experiment) {
     experiment.singlePain ? `Dor: ${experiment.singlePain}` : null,
     experiment.primaryCta ? `CTA: ${experiment.primaryCta}` : null,
     experiment.adCopy ? `Copy do anúncio:\n${experiment.adCopy}` : null,
-    experiment.landingPageCopy ? `Copy da página:\n${experiment.landingPageCopy}` : null,
+    experiment.landingPageCopy
+      ? `Copy da página:\n${experiment.landingPageCopy}`
+      : null,
   ].filter(Boolean);
   return sections.join("\n\n").slice(0, 6000);
 }
@@ -50,17 +55,28 @@ function formatDate(value?: string | null) {
   }).format(new Date(value));
 }
 
+function formatUsd(value?: number | null) {
+  if (value == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
 export default function ExperimentVideoTab({
   experiment,
   alterationLocked = false,
 }: ExperimentVideoTabProps) {
   const tenantContext = useTenantContext();
-  const { data: videoAssets, isLoading } = useExperimentVideoAssets(experiment.id);
+  const { data: videoAssets, isLoading } = useExperimentVideoAssets(
+    experiment.id,
+  );
   const requestVeoVideo = useRequestExperimentVeoVideo(experiment.id);
   const [formState, setFormState] = useState({
     slot: "LANDING_HERO" as ExperimentVideoSlot,
     title: `Vídeo VEO - Experimento ${experiment.id}`,
-    objective: "Aumentar conversão da página de venda e destravar campanha com vídeo obrigatório.",
+    objective:
+      "Aumentar conversão da página de venda e destravar campanha com vídeo obrigatório.",
     primaryMetric: "CTR, tempo na página e conversão para checkout/lead.",
     personaName: "",
     personaStyle: "consultiva, direta e comercial",
@@ -88,8 +104,13 @@ export default function ExperimentVideoTab({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const targetDurationSeconds = parseOptionalNumber(formState.targetDurationSeconds);
-    if (formState.targetDurationSeconds.trim() && targetDurationSeconds === undefined) {
+    const targetDurationSeconds = parseOptionalNumber(
+      formState.targetDurationSeconds,
+    );
+    if (
+      formState.targetDurationSeconds.trim() &&
+      targetDurationSeconds === undefined
+    ) {
       toast.error("Duração alvo inválida");
       return;
     }
@@ -134,7 +155,8 @@ export default function ExperimentVideoTab({
             <div>
               <h5 className="card-title mb-1">Vídeos do experimento</h5>
               <p className="text-muted small mb-0">
-                Gestão operacional dos vídeos necessários para campanha e página.
+                Gestão operacional dos vídeos necessários para campanha e
+                página.
               </p>
             </div>
             <span className="badge text-bg-secondary">
@@ -150,6 +172,7 @@ export default function ExperimentVideoTab({
                   <th>Status</th>
                   <th>Revisão</th>
                   <th>Provider</th>
+                  <th>Custo</th>
                   <th>Profile / Job</th>
                   <th>Obrigatório</th>
                   <th>Atualizado</th>
@@ -159,13 +182,13 @@ export default function ExperimentVideoTab({
               <tbody>
                 {isLoading ? (
                   <tr>
-                    <td colSpan={9} className="text-muted">
+                    <td colSpan={10} className="text-muted">
                       Carregando vídeos...
                     </td>
                   </tr>
                 ) : sortedAssets.length === 0 ? (
                   <tr>
-                    <td colSpan={9} className="text-muted">
+                    <td colSpan={10} className="text-muted">
                       Nenhum vídeo registrado para este experimento.
                     </td>
                   </tr>
@@ -175,25 +198,36 @@ export default function ExperimentVideoTab({
                       <td>{asset.id}</td>
                       <td>{asset.slot}</td>
                       <td>
-                        <span className="badge text-bg-info">{asset.status}</span>
+                        <span className="badge text-bg-info">
+                          {asset.status}
+                        </span>
                       </td>
                       <td>{asset.reviewStatus}</td>
                       <td>{asset.provider}</td>
+                      <td>{formatUsd(asset.cost)}</td>
                       <td>
                         {asset.salesVideoProfileId ? (
-                          <Link to={`/sales-videos/profiles/${asset.salesVideoProfileId}`}>
+                          <Link
+                            to={`/sales-videos/profiles/${asset.salesVideoProfileId}`}
+                          >
                             Profile #{asset.salesVideoProfileId}
                           </Link>
                         ) : (
                           "—"
                         )}
-                        {asset.salesVideoJobId ? ` · Job #${asset.salesVideoJobId}` : ""}
+                        {asset.salesVideoJobId
+                          ? ` · Job #${asset.salesVideoJobId}`
+                          : ""}
                       </td>
                       <td>{asset.requiredForRelease ? "Sim" : "Não"}</td>
                       <td>{formatDate(asset.updatedAt)}</td>
                       <td>
                         {asset.assetUrl ? (
-                          <a href={asset.assetUrl} target="_blank" rel="noreferrer">
+                          <a
+                            href={asset.assetUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
                             Abrir
                           </a>
                         ) : (
@@ -238,7 +272,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.title}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, title: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    title: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -248,7 +285,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.providerName}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, providerName: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    providerName: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -258,7 +298,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.objective}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, objective: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    objective: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -268,7 +311,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.primaryMetric}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, primaryMetric: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    primaryMetric: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -295,7 +341,8 @@ export default function ExperimentVideoTab({
                 onChange={(event) =>
                   setFormState((prev) => ({
                     ...prev,
-                    executionMode: event.target.value as SalesVideoExecutionMode,
+                    executionMode: event.target
+                      .value as SalesVideoExecutionMode,
                   }))
                 }
               >
@@ -356,7 +403,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.hookText}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, hookText: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    hookText: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -366,7 +416,10 @@ export default function ExperimentVideoTab({
                 className="form-control"
                 value={formState.ctaText}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, ctaText: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    ctaText: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -377,7 +430,10 @@ export default function ExperimentVideoTab({
                 rows={10}
                 value={formState.scriptText}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, scriptText: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    scriptText: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -388,7 +444,10 @@ export default function ExperimentVideoTab({
                 rows={3}
                 value={formState.captionText}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, captionText: event.target.value }))
+                  setFormState((prev) => ({
+                    ...prev,
+                    captionText: event.target.value,
+                  }))
                 }
               />
             </div>
@@ -406,15 +465,24 @@ export default function ExperimentVideoTab({
                     }))
                   }
                 />
-                <label className="form-check-label" htmlFor="requiredForRelease">
+                <label
+                  className="form-check-label"
+                  htmlFor="requiredForRelease"
+                >
                   Obrigatório para liberar campanha
                 </label>
               </div>
             </div>
           </div>
           <div className="mt-3">
-            <button className="btn btn-primary" type="submit" disabled={!canSubmit}>
-              {requestVeoVideo.isPending ? "Solicitando..." : "Solicitar vídeo VEO"}
+            <button
+              className="btn btn-primary"
+              type="submit"
+              disabled={!canSubmit}
+            >
+              {requestVeoVideo.isPending
+                ? "Solicitando..."
+                : "Solicitar vídeo VEO"}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/experiment/experimentCostSummary.test.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.test.ts
@@ -31,12 +31,13 @@ describe("buildExperimentCostSummary", () => {
       contentPipelineCostUsd: 0.01,
       geraLandingCostUsd: 0,
       geraSalesPageCostUsd: 1.460795,
+      videoProductionCostUsd: 3.2,
     });
 
-    expect(summary.auditableTotalBrl).toBe(19.68);
-    expect(summary.technicalTotalBrl).toBe(7.35);
+    expect(summary.auditableTotalBrl).toBe(35.68);
+    expect(summary.technicalTotalBrl).toBe(23.35);
     expect(summary.legacyTotalBrl).toBe(91.31);
-    expect(summary.unreconciledLegacyCostBrl).toBe(71.63);
+    expect(summary.unreconciledLegacyCostBrl).toBe(55.63);
     expect(summary.brlRows.map((row) => row.currency)).toEqual([
       "BRL",
       "BRL",
@@ -46,11 +47,10 @@ describe("buildExperimentCostSummary", () => {
       "USD",
       "USD",
       "USD",
+      "USD",
     ]);
     expect(summary.technicalRows.map((row) => row.convertedValueBrl)).toEqual([
-      0.05,
-      0,
-      7.3,
+      0.05, 0, 7.3, 16,
     ]);
   });
 
@@ -68,6 +68,7 @@ describe("buildExperimentCostSummary", () => {
       contentPipelineCostUsd: 0,
       geraLandingCostUsd: 0,
       geraSalesPageCostUsd: 0,
+      videoProductionCostUsd: 0,
     });
 
     expect(summary.auditableTotalBrl).toBe(19.56);

--- a/frontend/src/pages/experiment/experimentCostSummary.ts
+++ b/frontend/src/pages/experiment/experimentCostSummary.ts
@@ -21,6 +21,7 @@ export interface ExperimentCostSummaryInput {
   contentPipelineCostUsd: number;
   geraLandingCostUsd: number;
   geraSalesPageCostUsd: number;
+  videoProductionCostUsd: number;
 }
 
 const toNumber = (value: number | string | null | undefined) => {
@@ -38,12 +39,16 @@ export function buildExperimentCostSummary({
   contentPipelineCostUsd,
   geraLandingCostUsd,
   geraSalesPageCostUsd,
+  videoProductionCostUsd,
 }: ExperimentCostSummaryInput): ExperimentCostSummary {
   const originCostBrl = toNumber(experiment.cost);
   const paidMediaCostBrl = toNumber(experiment.campaignMetric?.spend);
   const operationalExpenseBrl = toNumber(experiment.expense);
   const technicalTotalUsd =
-    contentPipelineCostUsd + geraLandingCostUsd + geraSalesPageCostUsd;
+    contentPipelineCostUsd +
+    geraLandingCostUsd +
+    geraSalesPageCostUsd +
+    videoProductionCostUsd;
   const technicalTotalBrl = roundMoney(
     technicalTotalUsd * TECHNICAL_COST_USD_TO_BRL,
   );
@@ -52,9 +57,7 @@ export function buildExperimentCostSummary({
   );
   const auditableBaseBrl =
     toNumber(experiment.auditableTotalCost) || computedAuditableBaseBrl;
-  const auditableTotalBrl = roundMoney(
-    auditableBaseBrl + technicalTotalBrl,
-  );
+  const auditableTotalBrl = roundMoney(auditableBaseBrl + technicalTotalBrl);
   const legacyTotalBrl = roundMoney(
     toNumber(experiment.legacyTotalCost) || toNumber(experiment.totalCost),
   );
@@ -111,6 +114,14 @@ export function buildExperimentCostSummary({
         currency: "USD",
         convertedValueBrl: roundMoney(
           geraSalesPageCostUsd * TECHNICAL_COST_USD_TO_BRL,
+        ),
+      },
+      {
+        label: "Produção de vídeo",
+        value: videoProductionCostUsd,
+        currency: "USD",
+        convertedValueBrl: roundMoney(
+          videoProductionCostUsd * TECHNICAL_COST_USD_TO_BRL,
         ),
       },
     ],

--- a/frontend/src/pages/fashionChat/FashionChatPage.test.ts
+++ b/frontend/src/pages/fashionChat/FashionChatPage.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMessageId } from "./FashionChatPage";
+
+describe("createMessageId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("usa crypto.randomUUID quando disponivel", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn(() => "uuid-do-navegador"),
+    });
+
+    expect(createMessageId()).toBe("uuid-do-navegador");
+  });
+
+  it("gera fallback quando crypto.randomUUID nao esta disponivel", () => {
+    vi.stubGlobal("crypto", {});
+    vi.spyOn(Date, "now").mockReturnValue(123456789);
+    vi.spyOn(Math, "random").mockReturnValue(0.123456789);
+
+    expect(createMessageId()).toMatch(/^msg-/);
+  });
+});

--- a/frontend/src/pages/fashionChat/FashionChatPage.tsx
+++ b/frontend/src/pages/fashionChat/FashionChatPage.tsx
@@ -21,6 +21,19 @@ const nameCandidates = [
   "Bella Combina",
 ];
 
+export function createMessageId() {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `msg-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
 export default function FashionChatPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -35,7 +48,7 @@ export default function FashionChatPage() {
     }
 
     const userMessage: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: createMessageId(),
       role: "user",
       text,
     };
@@ -60,7 +73,7 @@ export default function FashionChatPage() {
       setMessages((current) => [
         ...current,
         {
-          id: crypto.randomUUID(),
+          id: createMessageId(),
           role: "assistant",
           text: payload.answer || "Nao foi possivel responder agora.",
           mode: payload.mode,
@@ -73,7 +86,7 @@ export default function FashionChatPage() {
       setMessages((current) => [
         ...current,
         {
-          id: crypto.randomUUID(),
+          id: createMessageId(),
           role: "assistant",
           text: `Nao consegui acionar o modulo de moda agora. Detalhe: ${message}`,
         },

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobCompletionPayload.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobCompletionPayload.java
@@ -1,6 +1,7 @@
 package com.marketinghub.videomanagement.client.payload;
 
 import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
+import java.math.BigDecimal;
 
 /**
  * Payload para finalizar jobs no backend.
@@ -11,6 +12,7 @@ public record JobCompletionPayload(SalesVideoStatus status,
                                    Long vttAssetId,
                                    String providerJobId,
                                    String metadataJson,
+                                   BigDecimal costUsd,
                                    String message,
                                    String detailsJson) {
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -68,6 +69,7 @@ public class VideoJobProcessor {
                 throw new VideoProviderException("Provider não retornou o asset principal de vídeo");
             }
             UploadedAssets uploadedAssets = assetUploader.uploadAssets(job, artifacts);
+            BigDecimal costUsd = readCostUsd(artifacts.metadata());
             String metadataJson = serializeMetadata(artifacts.metadata());
             backendClient.completeJob(job.id(), new JobCompletionPayload(
                     SalesVideoStatus.VIDEO_READY,
@@ -76,6 +78,7 @@ public class VideoJobProcessor {
                     uploadedAssets.captionAssetId(),
                     artifacts.providerJobId(),
                     metadataJson,
+                    costUsd,
                     "Vídeo processado com sucesso",
                     metadataJson));
             observabilityService.incrementJobsCompleted(job.providerName());
@@ -221,5 +224,17 @@ public class VideoJobProcessor {
         } catch (JsonProcessingException ex) {
             throw new VideoProviderException("Falha ao serializar metadata do provider", ex);
         }
+    }
+
+    private BigDecimal readCostUsd(Map<String, Object> metadata) {
+        if (metadata == null || metadata.get("cost_usd") == null) {
+            return null;
+        }
+        Object value = metadata.get("cost_usd");
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        String text = String.valueOf(value);
+        return text.matches("\\d+(\\.\\d+)?") ? new BigDecimal(text) : null;
     }
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/VeoVideoProvider.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/VeoVideoProvider.java
@@ -9,6 +9,8 @@ import com.marketinghub.videomanagement.client.dto.SalesVideoProfile;
 import com.marketinghub.videomanagement.client.dto.SalesVideoScript;
 import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
 import com.marketinghub.videomanagement.config.VideoManagementProperties;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -105,6 +107,11 @@ public class VeoVideoProvider implements VideoProvider {
         metadata.put("aspect_ratio", properties.getProviders().getVeo().getAspectRatio());
         metadata.put("resolution", properties.getProviders().getVeo().getResolution());
         metadata.put("duration_seconds", properties.getProviders().getVeo().getDurationSeconds());
+        metadata.put("cost_usd", estimateCostUsd(
+                properties.getProviders().getVeo().getModel(),
+                properties.getProviders().getVeo().getDurationSeconds(),
+                properties.getProviders().getVeo().getResolution()));
+        metadata.put("pricing_source", "Google Gemini API pricing: Veo video generation billed per generated second");
         metadata.put("polled_at", Instant.now().toString());
         metadata.put("final_status", objectMapper.convertValue(finalStatus, Map.class));
 
@@ -211,6 +218,48 @@ public class VeoVideoProvider implements VideoProvider {
                 script.scriptText(),
                 nullToDefault(script.ctaText(), ""),
                 storyboard);
+    }
+
+    /** Calcula o custo oficial aproximado do VEO em USD por segundo gerado. */
+    private BigDecimal estimateCostUsd(String model, Integer durationSeconds, String resolution) {
+        if (durationSeconds == null || durationSeconds <= 0) {
+            return null;
+        }
+        BigDecimal pricePerSecond = pricePerSecondUsd(model, resolution);
+        return pricePerSecond.multiply(BigDecimal.valueOf(durationSeconds.longValue()))
+                .setScale(4, RoundingMode.HALF_UP);
+    }
+
+    /** Resolve o preço por segundo do VEO conforme modelo e resolução. */
+    private BigDecimal pricePerSecondUsd(String model, String resolution) {
+        String normalizedModel = normalize(model).toLowerCase(Locale.ROOT);
+        if (normalizedModel.contains("veo-2")) {
+            return new BigDecimal("0.35");
+        }
+        if (normalizedModel.contains("fast")) {
+            return veoFastPrice(resolution);
+        }
+        if (normalizedModel.contains("lite")) {
+            return normalize(resolution).toLowerCase(Locale.ROOT).contains("1080")
+                    ? new BigDecimal("0.08")
+                    : new BigDecimal("0.05");
+        }
+        String normalizedResolution = normalize(resolution).toLowerCase(Locale.ROOT);
+        return normalizedResolution.contains("4k") || normalizedResolution.contains("2160")
+                ? new BigDecimal("0.60")
+                : new BigDecimal("0.40");
+    }
+
+    /** Resolve preço por segundo do VEO Fast conforme resolução. */
+    private BigDecimal veoFastPrice(String resolution) {
+        String normalizedResolution = normalize(resolution).toLowerCase(Locale.ROOT);
+        if (normalizedResolution.contains("4k") || normalizedResolution.contains("2160")) {
+            return new BigDecimal("0.30");
+        }
+        if (normalizedResolution.contains("1080")) {
+            return new BigDecimal("0.12");
+        }
+        return new BigDecimal("0.10");
     }
 
     /** Garante que o perfil possui roteiro aprovado para renderização. */


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: pq as métricas estão todas zeradas ?

Modelo: Aguardando resposta do modelo... (Em execução)

Usuário: um player com o video deveria estar disponivel na aba video 

Modelo: Aguardando resposta do modelo... (Pendente)

Última mensagem do usuário:
precisamos ter o custo da produção do video tbm calculado. Pesquise na documentaçaõ do Google como é cobrado e coloque no sistema o calculo. Precisamos desse custo em todos os videos.

**Resumo das alterações:**
Implementei o cálculo de custo de produção de vídeo.

Causa-raiz: o vídeo já tinha campo `cost`, mas o fluxo VEO criava o ativo sem estimativa e o worker finalizava o job sem devolver custo. Agora:

- O backend estima o custo no pedido inicial do vídeo.
- O `video-management-service` calcula o custo real no final usando modelo, duração e resolução realmente enviados ao Google.
- O callback final envia `costUsd` para o backend.
- O ativo `experiment_video_asset` é atualizado com custo, asset final e status `READY`.
- A aba **Vídeo** mostra o custo por vídeo.
- O card **Custos do experimento** soma “Produção de vídeo” como custo técnico em USD convertido para BRL.
- O planejamento comercial converte o custo de vídeo USD para BRL antes de somar nos totais.

Base oficial usada: documentação Google Gemini API. Veo 3.1 cobra por segundo gerado: Standard US$ 0,40/s em 720p/1080p, Fast a partir de US$ 0,10/s em 720p, Lite a partir de US$ 0,05/s em 720p; cobrança só acontece se o vídeo for gerado com sucesso. Fontes: https://ai.google.dev/gemini-api/docs/pricing e https://ai.google.dev/gemini-api/docs/video.

Validação:
- Backend: `ExperimentVideoAssetServiceTest`, `SalesVideoJobServiceTest`, `CommercialPlanWeeklyExperimentServiceTest` passaram.
- Worker vídeo: `mvn test` passou.
- Frontend: `npm run typecheck` passou.
- Frontend: `experimentCostSummary.test.ts` passou.

Registrei a decisão em `docs/registros/experimentos.md`. Não criei PR.