### PR TITLE
AI Hub: Verifiquei no GitHub: o `main` falhou em dois checks do backend no commit `157b4f7`.

Problemas encontrados e ajustados localmente:

- `CommercialPlanExecutionSyncServiceTest`: o cálculo agora inclui custo de vídeo, então o total correto é `164.00…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
@@ -1,0 +1,77 @@
+package com.marketinghub.experiment.video.service;
+
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
+import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
+import com.marketinghub.salesvideo.SalesVideoJob;
+import com.marketinghub.salesvideo.dto.JobCompletionRequest;
+import com.marketinghub.salesvideo.service.SalesVideoCompletedRenderAssetSync;
+import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/**
+ * Atualiza ativos de video de experimento a partir do resultado final de um job SalesVideo.
+ */
+@Service
+public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRenderAssetSync {
+    private final ExperimentVideoAssetRepository repository;
+    private final SalesVideoProductionCostCalculator costCalculator;
+
+    /** Inicializa a sincronizacao com persistencia dos ativos e calculo oficial de custo. */
+    public ExperimentVideoAssetJobSyncService(ExperimentVideoAssetRepository repository,
+                                              SalesVideoProductionCostCalculator costCalculator) {
+        this.repository = repository;
+        this.costCalculator = costCalculator;
+    }
+
+    /** Propaga o asset final, poster, duracao, custo e metadata para os videos vinculados ao job. */
+    @Override
+    public void syncCompletedRender(SalesVideoJob job,
+                                    JobCompletionRequest request,
+                                    Integer durationSeconds,
+                                    String resolution) {
+        if (job == null || job.getId() == null) {
+            return;
+        }
+        List<ExperimentVideoAsset> videoAssets = repository.findBySalesVideoJobId(job.getId());
+        if (videoAssets.isEmpty()) {
+            return;
+        }
+        BigDecimal costUsd = Optional.ofNullable(request.getCostUsd())
+                .orElseGet(() -> costCalculator.estimateUsd(
+                        job.getProviderName(),
+                        job.getProviderName(),
+                        durationSeconds,
+                        resolution));
+        for (ExperimentVideoAsset videoAsset : videoAssets) {
+            applyCompletedRender(videoAsset, job, request, durationSeconds, costUsd);
+        }
+        repository.saveAll(videoAssets);
+    }
+
+    /** Aplica os campos auditaveis do render concluido em um ativo de experimento. */
+    private void applyCompletedRender(ExperimentVideoAsset videoAsset,
+                                      SalesVideoJob job,
+                                      JobCompletionRequest request,
+                                      Integer durationSeconds,
+                                      BigDecimal costUsd) {
+        if (job.getAsset() != null) {
+            videoAsset.setAsset(job.getAsset());
+            videoAsset.setAssetUrl(job.getAsset().getUrl());
+        }
+        if (job.getPosterAsset() != null) {
+            videoAsset.setThumbnailUrl(job.getPosterAsset().getUrl());
+        }
+        if (durationSeconds != null) {
+            videoAsset.setDurationSeconds(durationSeconds);
+        }
+        if (costUsd != null) {
+            videoAsset.setCost(costUsd);
+        }
+        videoAsset.setResponseJson(request.getMetadataJson());
+        videoAsset.setStatus(ExperimentVideoStatus.READY);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoCompletedRenderAssetSync.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoCompletedRenderAssetSync.java
@@ -1,0 +1,15 @@
+package com.marketinghub.salesvideo.service;
+
+import com.marketinghub.salesvideo.SalesVideoJob;
+import com.marketinghub.salesvideo.dto.JobCompletionRequest;
+
+/**
+ * Sincroniza dominios externos interessados quando um render de SalesVideo e concluido.
+ */
+public interface SalesVideoCompletedRenderAssetSync {
+    /** Propaga os dados finais do render para ativos comerciais associados ao job. */
+    void syncCompletedRender(SalesVideoJob job,
+                             JobCompletionRequest request,
+                             Integer durationSeconds,
+                             String resolution);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
@@ -3,10 +3,7 @@ package com.marketinghub.salesvideo.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.media.Asset;
-import com.marketinghub.experiment.video.ExperimentVideoAsset;
-import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.repository.jpa.media.AssetRepository;
-import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.salesvideo.*;
 import com.marketinghub.salesvideo.dto.*;
 import com.marketinghub.salesvideo.exception.VideoModuleErrorCode;
@@ -26,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
-import java.math.BigDecimal;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -44,19 +40,17 @@ public class SalesVideoJobService {
     private final SalesVideoScriptRepository scriptRepository;
     private final AssetRepository assetRepository;
     private final SalesVideoReprocessPolicy reprocessPolicy;
-    private final ExperimentVideoAssetRepository experimentVideoAssetRepository;
-    private final SalesVideoProductionCostCalculator costCalculator;
+    private final SalesVideoCompletedRenderAssetSync completedRenderAssetSync;
     private final ObjectMapper objectMapper;
 
-    /** Cria o serviço com repositórios, política de reprocessamento e cálculo de custo de vídeo. */
+    /** Cria o serviço com repositórios, política de reprocessamento e porta de sincronizacao. */
     public SalesVideoJobService(SalesVideoJobRepository jobRepository,
                                 SalesVideoJobEventRepository eventRepository,
                                 SalesVideoProfileRepository profileRepository,
                                 SalesVideoScriptRepository scriptRepository,
                                 AssetRepository assetRepository,
                                 SalesVideoReprocessPolicy reprocessPolicy,
-                                ExperimentVideoAssetRepository experimentVideoAssetRepository,
-                                SalesVideoProductionCostCalculator costCalculator,
+                                SalesVideoCompletedRenderAssetSync completedRenderAssetSync,
                                 ObjectMapper objectMapper) {
         this.jobRepository = jobRepository;
         this.eventRepository = eventRepository;
@@ -64,8 +58,7 @@ public class SalesVideoJobService {
         this.scriptRepository = scriptRepository;
         this.assetRepository = assetRepository;
         this.reprocessPolicy = reprocessPolicy;
-        this.experimentVideoAssetRepository = experimentVideoAssetRepository;
-        this.costCalculator = costCalculator;
+        this.completedRenderAssetSync = completedRenderAssetSync;
         this.objectMapper = objectMapper;
     }
 
@@ -295,40 +288,16 @@ public class SalesVideoJobService {
         return saved;
     }
 
-    /** Atualiza o ativo de vídeo do experimento com custo e asset final do job concluído. */
+    /** Notifica a porta de sincronizacao de ativos quando um render e concluido. */
     private void syncExperimentVideoAsset(SalesVideoJob job, JobCompletionRequest request) {
         if (job.getId() == null || job.getJobType() != SalesVideoJobType.RENDER) {
             return;
         }
-        List<ExperimentVideoAsset> videoAssets = experimentVideoAssetRepository.findBySalesVideoJobId(job.getId());
-        if (videoAssets.isEmpty()) {
-            return;
-        }
-        BigDecimal costUsd = Optional.ofNullable(request.getCostUsd())
-                .orElseGet(() -> costCalculator.estimateUsd(
-                        job.getProviderName(),
-                        job.getProviderName(),
-                        resolveDurationSeconds(job, request),
-                        resolveResolution(request)));
-        for (ExperimentVideoAsset videoAsset : videoAssets) {
-            if (job.getAsset() != null) {
-                videoAsset.setAsset(job.getAsset());
-                videoAsset.setAssetUrl(job.getAsset().getUrl());
-            }
-            if (job.getPosterAsset() != null) {
-                videoAsset.setThumbnailUrl(job.getPosterAsset().getUrl());
-            }
-            Integer durationSeconds = resolveDurationSeconds(job, request);
-            if (durationSeconds != null) {
-                videoAsset.setDurationSeconds(durationSeconds);
-            }
-            if (costUsd != null) {
-                videoAsset.setCost(costUsd);
-            }
-            videoAsset.setResponseJson(request.getMetadataJson());
-            videoAsset.setStatus(ExperimentVideoStatus.READY);
-        }
-        experimentVideoAssetRepository.saveAll(videoAssets);
+        completedRenderAssetSync.syncCompletedRender(
+                job,
+                request,
+                resolveDurationSeconds(job, request),
+                resolveResolution(request));
     }
 
     /** Extrai a duração auditada do metadata do worker quando disponível. */

--- a/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/planning/service/CommercialPlanExecutionSyncServiceTest.java
@@ -56,14 +56,14 @@ class CommercialPlanExecutionSyncServiceTest {
 
         assertThat(plan.getActualCampaignCost()).isEqualByComparingTo("120.00");
         assertThat(plan.getActualAiCost()).isEqualByComparingTo("14.00");
-        assertThat(plan.getActualTotalCost()).isEqualByComparingTo("140.00");
+        assertThat(plan.getActualTotalCost()).isEqualByComparingTo("164.00");
         assertThat(plan.getActualRevenue()).isEqualByComparingTo("81.00");
         assertThat(plan.getActualExperimentsCreated()).isEqualTo(3);
         assertThat(plan.getActualExperimentsPublished()).isEqualTo(2);
         assertThat(plan.getExecutionSyncedAt()).isNotNull();
         assertThat(milestone.getActualCampaignCost()).isEqualByComparingTo("120.00");
         assertThat(milestone.getActualAiCost()).isEqualByComparingTo("14.00");
-        assertThat(milestone.getActualTotalCost()).isEqualByComparingTo("140.00");
+        assertThat(milestone.getActualTotalCost()).isEqualByComparingTo("164.00");
         assertThat(milestone.getActualRevenue()).isEqualByComparingTo("81.00");
         assertThat(milestone.getActualExperimentsCreated()).isEqualTo(3);
         assertThat(milestone.getActualExperimentsPublished()).isEqualTo(2);

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
@@ -1,7 +1,6 @@
 package com.marketinghub.salesvideo.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.repository.jpa.media.AssetRepository;
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoJobType;
@@ -28,6 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
+/**
+ * Valida as regras de negocio dos jobs do modulo de video.
+ */
 @ExtendWith(MockitoExtension.class)
 class SalesVideoJobServiceTest {
 
@@ -49,10 +51,11 @@ class SalesVideoJobServiceTest {
     @Mock
     private SalesVideoReprocessPolicy reprocessPolicy;
     @Mock
-    private ExperimentVideoAssetRepository experimentVideoAssetRepository;
+    private SalesVideoCompletedRenderAssetSync completedRenderAssetSync;
 
     private SalesVideoJobService service;
 
+    /** Inicializa o service com dependencias simuladas para cada teste. */
     @BeforeEach
     void setUp() {
         service = new SalesVideoJobService(jobRepository,
@@ -61,11 +64,11 @@ class SalesVideoJobServiceTest {
                 scriptRepository,
                 assetRepository,
                 reprocessPolicy,
-                experimentVideoAssetRepository,
-                new SalesVideoProductionCostCalculator(),
+                completedRenderAssetSync,
                 new ObjectMapper());
     }
 
+    /** Garante que os jobs de um perfil sao retornados em contrato de leitura. */
     @Test
     void shouldListJobsByProfile() {
         long profileId = 10L;
@@ -94,6 +97,7 @@ class SalesVideoJobServiceTest {
         assertThat(result.get(0).getStatus()).isEqualTo(SalesVideoStatus.VIDEO_REQUESTED);
     }
 
+    /** Garante erro de negocio quando o perfil solicitado nao existe. */
     @Test
     void shouldRejectWhenProfileDoesNotExist() {
         long missingId = 404L;


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
eu fiz merge de varias branches verifica no github se teve problemas e ajusta se tiver.

**Resumo das alterações:**
Verifiquei no GitHub: o `main` falhou em dois checks do backend no commit `157b4f7`.

Problemas encontrados e ajustados localmente:

- `CommercialPlanExecutionSyncServiceTest`: o cálculo agora inclui custo de vídeo, então o total correto é `164.00`, não `140.00`.
- `ArquiteturaTest.salesVideoServicesShouldOnlyAccessAllowedMarketingHubClasses`: `SalesVideoJobService` estava alterando diretamente entidade de `experiment.video`. Corrigi a causa-raiz criando uma porta de sincronização e movendo a atualização do ativo para o domínio de Experiment Video.

Arquivos alterados:

- `SalesVideoJobService.java`
- `SalesVideoCompletedRenderAssetSync.java`
- `ExperimentVideoAssetJobSyncService.java`
- `CommercialPlanExecutionSyncServiceTest.java`
- `SalesVideoJobServiceTest.java`

Validação local:

- `mvn test` em `backend/ads-service`: passou.
- Resultado: `1078` testes, `0` falhas, `0` erros, `1` ignorado.
- `git diff --check`: passou.
- `spotless:check` não rodou porque o plugin `spotless` não está disponível nesse `pom`.

Não criei PR e não fiz push. O GitHub vai continuar vermelho até essas mudanças serem commitadas e enviadas.