### PR TITLE
AI Hub: Implementei a base do novo conceito sem abrir PR.

**O que ficou pronto**
- Novo catálogo no banco para tipos de página de venda.
- Novo tipo principal: `AI_CHAT_DIGITAL_BAIT`.
- Vínculo experimento/campanha → um ou mais tipos de página de venda p…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/ExperimentSalesPageTypeSelection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/ExperimentSalesPageTypeSelection.java
@@ -1,0 +1,67 @@
+package com.marketinghub.experiment.salespagetype;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Responsabilidade: vincular um experimento aos tipos de pagina de venda escolhidos para teste. */
+@Entity
+@Table(name = "experiment_sales_page_type_selection")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentSalesPageTypeSelection {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    @ToString.Exclude
+    private Experiment experiment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sales_page_type_code", nullable = false)
+    @ToString.Exclude
+    private SalesPageType salesPageType;
+
+    @Column(name = "variant_key", nullable = false, length = 16)
+    private String variantKey;
+
+    @Column(name = "traffic_weight", nullable = false, precision = 5, scale = 2)
+    private BigDecimal trafficWeight;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "notes", length = 1024)
+    private String notes;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/SalesPageType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/SalesPageType.java
@@ -1,0 +1,57 @@
+package com.marketinghub.experiment.salespagetype;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Responsabilidade: catalogar formatos comerciais de pagina de venda que podem ser testados em campanhas. */
+@Entity
+@Table(name = "sales_page_type")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SalesPageType {
+    @Id
+    @Column(name = "code", nullable = false, length = 64)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "description", nullable = false, length = 1024)
+    private String description;
+
+    @Column(name = "commercial_mechanism", nullable = false, length = 1024)
+    private String commercialMechanism;
+
+    @Column(name = "lead_capture_strategy", nullable = false, length = 1024)
+    private String leadCaptureStrategy;
+
+    @Column(name = "digital_bait_delivery", nullable = false, length = 1024)
+    private String digitalBaitDelivery;
+
+    @Column(name = "default_for_ab_test", nullable = false)
+    private boolean defaultForAbTest;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/controller/SalesPageTypeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/controller/SalesPageTypeController.java
@@ -1,0 +1,45 @@
+package com.marketinghub.experiment.salespagetype.controller;
+
+import com.marketinghub.experiment.salespagetype.service.SalesPageTypeService;
+import com.marketinghub.experiment.salespagetype.service.listtypes.ExperimentSalesPageTypeSelectionResponse;
+import com.marketinghub.experiment.salespagetype.service.listtypes.SalesPageTypeResponse;
+import com.marketinghub.experiment.salespagetype.service.updateselection.UpdateExperimentSalesPageTypeSelectionRequest;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor catalogo e selecao de tipos de pagina de venda para campanhas. */
+@RestController
+@RequestMapping("/api")
+public class SalesPageTypeController {
+    private final SalesPageTypeService service;
+
+    /** Inicializa o controller com o servico de tipos de pagina de venda. */
+    public SalesPageTypeController(SalesPageTypeService service) {
+        this.service = service;
+    }
+
+    /** Lista os tipos de pagina de venda ativos. */
+    @GetMapping("/sales-page-types")
+    public List<SalesPageTypeResponse> listTypes() {
+        return service.listActiveTypes();
+    }
+
+    /** Lista os tipos de pagina de venda selecionados para o experimento. */
+    @GetMapping("/experiments/{experimentId}/sales-page-types")
+    public List<ExperimentSalesPageTypeSelectionResponse> listExperimentSelections(@PathVariable Long experimentId) {
+        return service.listExperimentSelections(experimentId);
+    }
+
+    /** Substitui os tipos de pagina de venda selecionados para o experimento. */
+    @PutMapping("/experiments/{experimentId}/sales-page-types")
+    public List<ExperimentSalesPageTypeSelectionResponse> replaceExperimentSelections(
+            @PathVariable Long experimentId,
+            @RequestBody UpdateExperimentSalesPageTypeSelectionRequest request) {
+        return service.replaceExperimentSelections(experimentId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeService.java
@@ -1,0 +1,179 @@
+package com.marketinghub.experiment.salespagetype.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.salespagetype.ExperimentSalesPageTypeSelection;
+import com.marketinghub.experiment.salespagetype.SalesPageType;
+import com.marketinghub.experiment.salespagetype.service.listtypes.ExperimentSalesPageTypeSelectionResponse;
+import com.marketinghub.experiment.salespagetype.service.listtypes.SalesPageTypeResponse;
+import com.marketinghub.experiment.salespagetype.service.updateselection.UpdateExperimentSalesPageTypeSelectionItem;
+import com.marketinghub.experiment.salespagetype.service.updateselection.UpdateExperimentSalesPageTypeSelectionRequest;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.salespagetype.ExperimentSalesPageTypeSelectionRepository;
+import com.marketinghub.repository.jpa.experiment.salespagetype.SalesPageTypeRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: orquestrar catalogo e selecao de tipos de pagina de venda por experimento. */
+@Service
+public class SalesPageTypeService {
+    private static final BigDecimal DEFAULT_WEIGHT = new BigDecimal("50.00");
+
+    private final SalesPageTypeRepository typeRepository;
+    private final ExperimentSalesPageTypeSelectionRepository selectionRepository;
+    private final ExperimentRepository experimentRepository;
+
+    /** Inicializa o servico com repositories de catalogo, selecao e experimento. */
+    public SalesPageTypeService(
+            SalesPageTypeRepository typeRepository,
+            ExperimentSalesPageTypeSelectionRepository selectionRepository,
+            ExperimentRepository experimentRepository) {
+        this.typeRepository = typeRepository;
+        this.selectionRepository = selectionRepository;
+        this.experimentRepository = experimentRepository;
+    }
+
+    /** Lista todos os tipos ativos disponiveis para campanhas e testes A/B. */
+    @Transactional(readOnly = true)
+    public List<SalesPageTypeResponse> listActiveTypes() {
+        return typeRepository.findByActiveTrueOrderByNameAsc().stream()
+                .map(this::toTypeResponse)
+                .toList();
+    }
+
+    /** Lista os tipos selecionados para o experimento informado. */
+    @Transactional(readOnly = true)
+    public List<ExperimentSalesPageTypeSelectionResponse> listExperimentSelections(Long experimentId) {
+        ensureExperimentExists(experimentId);
+        return selectionRepository.findByExperimentIdOrderByVariantKeyAsc(experimentId).stream()
+                .map(this::toSelectionResponse)
+                .toList();
+    }
+
+    /** Substitui a selecao completa de tipos de pagina de venda de um experimento. */
+    @Transactional
+    public List<ExperimentSalesPageTypeSelectionResponse> replaceExperimentSelections(
+            Long experimentId,
+            UpdateExperimentSalesPageTypeSelectionRequest request) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "experiment not found"));
+        List<UpdateExperimentSalesPageTypeSelectionItem> requestedSelections =
+                request == null || request.selections() == null ? List.of() : request.selections();
+        if (requestedSelections.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "at least one sales page type is required");
+        }
+
+        selectionRepository.deleteByExperimentId(experimentId);
+        List<ExperimentSalesPageTypeSelection> entities = new ArrayList<>();
+        Set<String> typeCodes = new HashSet<>();
+        Set<String> variantKeys = new HashSet<>();
+        int index = 0;
+        for (UpdateExperimentSalesPageTypeSelectionItem item : requestedSelections) {
+            index++;
+            String typeCode = normalizeRequired(item.typeCode(), "typeCode");
+            if (!typeCodes.add(typeCode)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "duplicated typeCode: " + typeCode);
+            }
+            SalesPageType type = typeRepository.findById(typeCode)
+                    .filter(SalesPageType::isActive)
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.BAD_REQUEST, "active sales page type not found: " + typeCode));
+            String variantKey = normalizeVariantKey(item.variantKey(), index);
+            if (!variantKeys.add(variantKey)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "duplicated variantKey: " + variantKey);
+            }
+            entities.add(ExperimentSalesPageTypeSelection.builder()
+                    .experiment(experiment)
+                    .salesPageType(type)
+                    .variantKey(variantKey)
+                    .trafficWeight(normalizeTrafficWeight(item.trafficWeight()))
+                    .active(item.active() == null || Boolean.TRUE.equals(item.active()))
+                    .notes(normalizeOptional(item.notes(), 1024))
+                    .build());
+        }
+        return selectionRepository.saveAll(entities).stream()
+                .map(this::toSelectionResponse)
+                .toList();
+    }
+
+    /** Confirma que o experimento existe antes de consultar selecoes. */
+    private void ensureExperimentExists(Long experimentId) {
+        if (!experimentRepository.existsById(experimentId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "experiment not found");
+        }
+    }
+
+    /** Normaliza campos obrigatorios textuais. */
+    private String normalizeRequired(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " is required");
+        }
+        return value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    /** Normaliza a chave da variante ou gera uma chave sequencial para A/B. */
+    private String normalizeVariantKey(String value, int index) {
+        if (!StringUtils.hasText(value)) {
+            return String.valueOf((char) ('A' + index - 1));
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if (normalized.length() > 16) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "variantKey must have at most 16 characters");
+        }
+        return normalized;
+    }
+
+    /** Normaliza o peso de trafego da variante. */
+    private BigDecimal normalizeTrafficWeight(BigDecimal value) {
+        BigDecimal normalized = value == null ? DEFAULT_WEIGHT : value;
+        if (normalized.compareTo(BigDecimal.ZERO) <= 0 || normalized.compareTo(new BigDecimal("100.00")) > 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "trafficWeight must be between 0 and 100");
+        }
+        return normalized.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /** Normaliza texto opcional com limite de tamanho. */
+    private String normalizeOptional(String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.length() <= maxLength ? normalized : normalized.substring(0, maxLength);
+    }
+
+    /** Converte entidade de catalogo para contrato de resposta. */
+    private SalesPageTypeResponse toTypeResponse(SalesPageType type) {
+        return new SalesPageTypeResponse(
+                type.getCode(),
+                type.getName(),
+                type.getDescription(),
+                type.getCommercialMechanism(),
+                type.getLeadCaptureStrategy(),
+                type.getDigitalBaitDelivery(),
+                type.isDefaultForAbTest(),
+                type.isActive());
+    }
+
+    /** Converte selecao persistida para contrato de resposta. */
+    private ExperimentSalesPageTypeSelectionResponse toSelectionResponse(ExperimentSalesPageTypeSelection selection) {
+        SalesPageTypeResponse type = toTypeResponse(selection.getSalesPageType());
+        return new ExperimentSalesPageTypeSelectionResponse(
+                selection.getId(),
+                type.code(),
+                type.name(),
+                selection.getVariantKey(),
+                selection.getTrafficWeight(),
+                selection.isActive(),
+                selection.getNotes(),
+                type);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/listtypes/ExperimentSalesPageTypeSelectionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/listtypes/ExperimentSalesPageTypeSelectionResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.experiment.salespagetype.service.listtypes;
+
+import java.math.BigDecimal;
+
+/** Descreve um tipo de pagina de venda selecionado para um experimento. */
+public record ExperimentSalesPageTypeSelectionResponse(
+        Long id,
+        String typeCode,
+        String typeName,
+        String variantKey,
+        BigDecimal trafficWeight,
+        boolean active,
+        String notes,
+        SalesPageTypeResponse type) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/listtypes/SalesPageTypeResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/listtypes/SalesPageTypeResponse.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.salespagetype.service.listtypes;
+
+/** Descreve um tipo de pagina de venda disponivel para uso comercial. */
+public record SalesPageTypeResponse(
+        String code,
+        String name,
+        String description,
+        String commercialMechanism,
+        String leadCaptureStrategy,
+        String digitalBaitDelivery,
+        boolean defaultForAbTest,
+        boolean active) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/updateselection/UpdateExperimentSalesPageTypeSelectionItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/updateselection/UpdateExperimentSalesPageTypeSelectionItem.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.salespagetype.service.updateselection;
+
+import java.math.BigDecimal;
+
+/** Representa um tipo escolhido para compor o teste de pagina de venda do experimento. */
+public record UpdateExperimentSalesPageTypeSelectionItem(
+        String typeCode,
+        String variantKey,
+        BigDecimal trafficWeight,
+        Boolean active,
+        String notes) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/updateselection/UpdateExperimentSalesPageTypeSelectionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/updateselection/UpdateExperimentSalesPageTypeSelectionRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.experiment.salespagetype.service.updateselection;
+
+import java.util.List;
+
+/** Recebe a selecao completa de tipos de pagina de venda para substituir a configuracao atual. */
+public record UpdateExperimentSalesPageTypeSelectionRequest(
+        List<UpdateExperimentSalesPageTypeSelectionItem> selections) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/ExperimentSalesPageTypeSelectionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/ExperimentSalesPageTypeSelectionRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.experiment.salespagetype;
+
+import com.marketinghub.experiment.salespagetype.ExperimentSalesPageTypeSelection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: persistir os tipos de pagina de venda selecionados por experimento. */
+public interface ExperimentSalesPageTypeSelectionRepository
+        extends JpaRepository<ExperimentSalesPageTypeSelection, Long> {
+    /** Lista as selecoes de um experimento mantendo a ordem de variantes A/B. */
+    List<ExperimentSalesPageTypeSelection> findByExperimentIdOrderByVariantKeyAsc(Long experimentId);
+
+    /** Remove as selecoes anteriores antes de gravar uma nova configuracao A/B. */
+    void deleteByExperimentId(Long experimentId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/SalesPageTypeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/SalesPageTypeRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.repository.jpa.experiment.salespagetype;
+
+import com.marketinghub.experiment.salespagetype.SalesPageType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Responsabilidade: consultar o catalogo de tipos de pagina de venda. */
+public interface SalesPageTypeRepository extends JpaRepository<SalesPageType, String> {
+    /** Lista os tipos ativos em ordem alfabetica para selecao operacional. */
+    List<SalesPageType> findByActiveTrueOrderByNameAsc();
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-13-sales-page-types.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-13-sales-page-types.yaml
@@ -1,0 +1,123 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-13-01-create-sales-page-type
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: sales_page_type
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE sales_page_type (
+                  code VARCHAR(64) NOT NULL,
+                  name VARCHAR(191) NOT NULL,
+                  description VARCHAR(1024) NOT NULL,
+                  commercial_mechanism VARCHAR(1024) NOT NULL,
+                  lead_capture_strategy VARCHAR(1024) NOT NULL,
+                  digital_bait_delivery VARCHAR(1024) NOT NULL,
+                  default_for_ab_test BIT(1) NOT NULL DEFAULT b'0',
+                  active BIT(1) NOT NULL DEFAULT b'1',
+                  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  PRIMARY KEY (code)
+              );
+
+  - changeSet:
+      id: 2026-07-13-02-create-experiment-sales-page-type-selection
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_sales_page_type_selection
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_sales_page_type_selection (
+                  id BIGINT NOT NULL AUTO_INCREMENT,
+                  experiment_id BIGINT NOT NULL,
+                  sales_page_type_code VARCHAR(64) NOT NULL,
+                  variant_key VARCHAR(16) NOT NULL,
+                  traffic_weight DECIMAL(5, 2) NOT NULL DEFAULT 50.00,
+                  active BIT(1) NOT NULL DEFAULT b'1',
+                  notes VARCHAR(1024) NULL,
+                  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id),
+                  CONSTRAINT fk_exp_sales_page_type_selection_experiment
+                      FOREIGN KEY (experiment_id) REFERENCES experiment (id),
+                  CONSTRAINT fk_exp_sales_page_type_selection_type
+                      FOREIGN KEY (sales_page_type_code) REFERENCES sales_page_type (code),
+                  CONSTRAINT uk_exp_sales_page_type_selection_type
+                      UNIQUE (experiment_id, sales_page_type_code),
+                  CONSTRAINT uk_exp_sales_page_type_selection_variant
+                      UNIQUE (experiment_id, variant_key)
+              );
+              CREATE INDEX idx_exp_sales_page_type_selection_experiment
+                  ON experiment_sales_page_type_selection (experiment_id, active);
+
+  - changeSet:
+      id: 2026-07-13-03-seed-sales-page-types
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT IGNORE INTO sales_page_type
+                  (code, name, description, commercial_mechanism, lead_capture_strategy, digital_bait_delivery, default_for_ab_test, active)
+              VALUES
+                  (
+                      'TRADITIONAL_LONG_FORM',
+                      'Pagina tradicional de venda',
+                      'Pagina linear com promessa, mecanismo, prova, oferta, FAQ e chamada para checkout.',
+                      'Conduz o lead por uma narrativa de convencimento antes do clique de compra.',
+                      'Captura lead por formulario ou CTA secundario quando a compra nao acontece.',
+                      'Entrega isca por formulario, e-mail ou portal do lead antes da oferta completa.',
+                      b'1',
+                      b'1'
+                  ),
+                  (
+                      'HUMAN_VIDEO_SALES_PAGE',
+                      'Pagina com video humano',
+                      'Pagina de venda com video principal de apresentador humano ou avatar revisado.',
+                      'Usa presenca humana, demonstracao e transferencia de confianca para aumentar intencao.',
+                      'Captura lead por CTA abaixo do video, formulario de interesse ou evento de checkout.',
+                      'Entrega isca por bloco visual ou portal apos interacao inicial.',
+                      b'1',
+                      b'1'
+                  ),
+                  (
+                      'AI_CHAT_DIGITAL_BAIT',
+                      'Chat IA com isca imediata',
+                      'Experiencia chat-first em que uma IA conversa, coleta dados do lead e entrega a propria isca digital no chat, como uma imagem personalizada.',
+                      'Gera valor percebido antes da venda: o lead recebe uma amostra personalizada, sente progresso imediato e fica mais propenso a comprar o produto completo.',
+                      'Coleta dados em conversa curta, com consentimento e campos minimos para personalizar a amostra e atribuir campanha.',
+                      'Entrega imagem, preview, mini-relatorio ou outro ativo leve diretamente no chat antes da oferta.',
+                      b'1',
+                      b'1'
+                  ),
+                  (
+                      'DIAGNOSTIC_QUIZ',
+                      'Quiz diagnostico',
+                      'Pagina guiada por perguntas fechadas que segmenta o lead e recomenda uma solucao.',
+                      'Aumenta relevancia da oferta ao devolver um diagnostico simples antes do pitch.',
+                      'Captura lead ao final do diagnostico ou antes de revelar recomendacao completa.',
+                      'Entrega score, diagnostico ou plano resumido como isca digital.',
+                      b'0',
+                      b'1'
+                  );

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-13-sales-page-types.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-09-experiment-creation-source.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeServiceTest.java
@@ -1,0 +1,107 @@
+package com.marketinghub.experiment.salespagetype.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.salespagetype.ExperimentSalesPageTypeSelection;
+import com.marketinghub.experiment.salespagetype.SalesPageType;
+import com.marketinghub.experiment.salespagetype.service.updateselection.UpdateExperimentSalesPageTypeSelectionItem;
+import com.marketinghub.experiment.salespagetype.service.updateselection.UpdateExperimentSalesPageTypeSelectionRequest;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.salespagetype.ExperimentSalesPageTypeSelectionRepository;
+import com.marketinghub.repository.jpa.experiment.salespagetype.SalesPageTypeRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/** Valida a selecao de tipos de pagina de venda por experimento. */
+@ExtendWith(MockitoExtension.class)
+class SalesPageTypeServiceTest {
+    @Mock
+    private SalesPageTypeRepository typeRepository;
+    @Mock
+    private ExperimentSalesPageTypeSelectionRepository selectionRepository;
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    private SalesPageTypeService service;
+
+    /** Inicializa o servico com dependencias simuladas. */
+    @BeforeEach
+    void setUp() {
+        service = new SalesPageTypeService(typeRepository, selectionRepository, experimentRepository);
+    }
+
+    /** Garante que o tipo chat IA pode ser salvo como variante de teste. */
+    @Test
+    void shouldSelectAiChatDigitalBaitAsSalesPageType() {
+        Experiment experiment = Experiment.builder().id(64L).name("MUSA-H001-E003").build();
+        SalesPageType chatType = chatType();
+        given(experimentRepository.findById(64L)).willReturn(Optional.of(experiment));
+        given(typeRepository.findById("AI_CHAT_DIGITAL_BAIT")).willReturn(Optional.of(chatType));
+        given(selectionRepository.saveAll(anyList())).willAnswer(invocation -> {
+            List<ExperimentSalesPageTypeSelection> selections = invocation.getArgument(0);
+            selections.get(0).setId(1L);
+            return selections;
+        });
+
+        var response = service.replaceExperimentSelections(
+                64L,
+                new UpdateExperimentSalesPageTypeSelectionRequest(List.of(
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "AI_CHAT_DIGITAL_BAIT",
+                                "A",
+                                new BigDecimal("100.00"),
+                                true,
+                                "Coletar dados e entregar imagem no chat"))));
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).typeCode()).isEqualTo("AI_CHAT_DIGITAL_BAIT");
+        assertThat(response.get(0).variantKey()).isEqualTo("A");
+        assertThat(response.get(0).type().digitalBaitDelivery())
+                .contains("imagem personalizada");
+        verify(selectionRepository).deleteByExperimentId(64L);
+    }
+
+    /** Garante que o mesmo tipo nao pode ser duplicado na selecao A/B. */
+    @Test
+    void shouldRejectDuplicatedTypeCode() {
+        Experiment experiment = Experiment.builder().id(64L).build();
+        given(experimentRepository.findById(64L)).willReturn(Optional.of(experiment));
+        given(typeRepository.findById("AI_CHAT_DIGITAL_BAIT")).willReturn(Optional.of(chatType()));
+
+        assertThatThrownBy(() -> service.replaceExperimentSelections(
+                64L,
+                new UpdateExperimentSalesPageTypeSelectionRequest(List.of(
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "AI_CHAT_DIGITAL_BAIT", "A", BigDecimal.TEN, true, null),
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "AI_CHAT_DIGITAL_BAIT", "B", BigDecimal.TEN, true, null)))))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("duplicated typeCode");
+    }
+
+    /** Cria o tipo chat IA usado nos testes. */
+    private SalesPageType chatType() {
+        return SalesPageType.builder()
+                .code("AI_CHAT_DIGITAL_BAIT")
+                .name("Chat IA com isca imediata")
+                .description("Experiencia chat-first com coleta de dados e entrega de isca.")
+                .commercialMechanism("Gera valor percebido antes da venda.")
+                .leadCaptureStrategy("Coleta dados em conversa curta.")
+                .digitalBaitDelivery("Entrega imagem personalizada diretamente no chat.")
+                .defaultForAbTest(true)
+                .active(true)
+                .build();
+    }
+}

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -23,6 +23,24 @@ Campo adicionado na entidade/tabela `experiment` para suportar o novo passo can�
   - armazena o HTML consolidado produzido no fluxo Gera Landing (a partir do `DesignPresetProvisionalHtmlAssembler`);
   - objetivo: manter `landing_page_design_preset` como JSON bruto do modelo e separar o HTML operacional para publicação/preview.
 
+## Atualização incremental — Tipos de página de venda por experimento (13/07/2026)
+
+Novas tabelas para permitir que cada experimento/campanha selecione um ou mais tipos de página de venda para teste A/B:
+
+- `sales_page_type`
+  - catálogo canônico de formatos comerciais de página de venda;
+  - inclui o novo tipo `AI_CHAT_DIGITAL_BAIT`, focado em chat com IA que coleta dados do lead e entrega a isca digital no próprio chat, como uma imagem personalizada.
+- `experiment_sales_page_type_selection`
+  - vincula o experimento aos tipos escolhidos;
+  - guarda `variant_key`, `traffic_weight`, status ativo e observações operacionais.
+
+Conceito comercial inicial:
+
+- `TRADITIONAL_LONG_FORM`: página linear de venda.
+- `HUMAN_VIDEO_SALES_PAGE`: página de venda com vídeo humano/avatar revisado.
+- `AI_CHAT_DIGITAL_BAIT`: chat-first com coleta de dados, entrega imediata de amostra e oferta depois do valor percebido.
+- `DIAGNOSTIC_QUIZ`: quiz diagnóstico com recomendação.
+
 Atualização incremental — vínculo do wireframe com execução Gera Landing (07/05/2026):
 
 - `landing_page_wireframe_job_id` (`BINARY(36)`, FK -> `gera_landing_stage_execution.id_job`)

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5760,3 +5760,8 @@
 - Causa-raiz tratada: a tela dependia diretamente de `crypto.randomUUID`, API que pode ficar indisponível em contexto HTTP não seguro fora de `localhost`.
 - Correção aplicada: a geração de ID de mensagens passou a usar `crypto.randomUUID` quando disponível e fallback local quando não disponível.
 - Validação: teste de regressão cobre navegador sem `randomUUID`; Chromium local confirmou envio pelo IP HTTP inseguro sem `pageerror` e renderização da resposta com API mockada.
+## 2026-07-13 — Tipos de página de venda para teste A/B
+
+- Criado o conceito operacional de tipos de página de venda por experimento/campanha.
+- Adicionado o tipo `AI_CHAT_DIGITAL_BAIT`: chat com IA coleta dados mínimos do lead, entrega uma isca digital imediata no próprio chat e usa esse momento de valor para apresentar a oferta.
+- Objetivo comercial: permitir A/B entre página tradicional, vídeo humano, chat IA com isca e quiz diagnóstico, preservando rastreabilidade por experimento.

--- a/docs/swagger/sales-page-types-swagger.yaml
+++ b/docs/swagger/sales-page-types-swagger.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub - Sales Page Types
+  version: 1.0.0
+paths:
+  /api/sales-page-types:
+    get:
+      summary: Lista tipos ativos de pagina de venda
+      responses:
+        "200":
+          description: Tipos ativos retornados com sucesso
+  /api/experiments/{experimentId}/sales-page-types:
+    get:
+      summary: Lista tipos selecionados para o experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Selecoes retornadas com sucesso
+    put:
+      summary: Substitui os tipos de pagina de venda selecionados para o experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                selections:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeCode:
+                        type: string
+                      variantKey:
+                        type: string
+                      trafficWeight:
+                        type: number
+                      active:
+                        type: boolean
+                      notes:
+                        type: string
+      responses:
+        "200":
+          description: Selecoes atualizadas com sucesso

--- a/frontend/src/api/experiment/useSalesPageTypes.ts
+++ b/frontend/src/api/experiment/useSalesPageTypes.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface SalesPageType {
+  code: string;
+  name: string;
+  description: string;
+  commercialMechanism: string;
+  leadCaptureStrategy: string;
+  digitalBaitDelivery: string;
+  defaultForAbTest: boolean;
+  active: boolean;
+}
+
+export interface ExperimentSalesPageTypeSelection {
+  id: number;
+  typeCode: string;
+  typeName: string;
+  variantKey: string;
+  trafficWeight: number;
+  active: boolean;
+  notes?: string | null;
+  type: SalesPageType;
+}
+
+export interface UpdateExperimentSalesPageTypeSelection {
+  typeCode: string;
+  variantKey?: string;
+  trafficWeight?: number;
+  active?: boolean;
+  notes?: string | null;
+}
+
+export function useSalesPageTypes() {
+  return useQuery<SalesPageType[]>({
+    queryKey: ["sales-page-types"],
+    queryFn: async () => {
+      const { data } = await axios.get<SalesPageType[]>("/api/sales-page-types");
+      return data;
+    },
+  });
+}
+
+export function useExperimentSalesPageTypeSelections(experimentId?: string) {
+  return useQuery<ExperimentSalesPageTypeSelection[]>({
+    queryKey: ["experiment", experimentId, "sales-page-types"],
+    enabled: Boolean(experimentId),
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentSalesPageTypeSelection[]>(
+        `/api/experiments/${experimentId}/sales-page-types`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useUpdateExperimentSalesPageTypeSelections(experimentId?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (selections: UpdateExperimentSalesPageTypeSelection[]) => {
+      const { data } = await axios.put<ExperimentSalesPageTypeSelection[]>(
+        `/api/experiments/${experimentId}/sales-page-types`,
+        { selections },
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["experiment", experimentId, "sales-page-types"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["experiment", experimentId, "sales-page-ab-results"],
+      });
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
@@ -1,9 +1,16 @@
 import { BarChart3, CheckCircle2, ExternalLink, FlaskConical } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useExperimentSalesPageAbResults,
   type ExperimentSalesPageAbTestResult,
   type ExperimentSalesPageAbVariant,
 } from "../../api/experiment/useExperimentSalesPageAbResults";
+import {
+  useExperimentSalesPageTypeSelections,
+  useSalesPageTypes,
+  useUpdateExperimentSalesPageTypeSelections,
+  type SalesPageType,
+} from "../../api/experiment/useSalesPageTypes";
 
 interface ExperimentSalesPageAbTabProps {
   experimentId: string;
@@ -97,11 +104,73 @@ function totalCheckoutClicks(result: ExperimentSalesPageAbTestResult) {
   return result.variants.reduce((total, item) => total + item.checkoutClicks, 0);
 }
 
+function splitTrafficWeight(total: number) {
+  if (total <= 0) return 50;
+  return Number((100 / total).toFixed(2));
+}
+
 export default function ExperimentSalesPageAbTab({
   experimentId,
 }: ExperimentSalesPageAbTabProps) {
   const { data, isLoading, isError } =
     useExperimentSalesPageAbResults(experimentId);
+  const { data: types, isLoading: isLoadingTypes } = useSalesPageTypes();
+  const { data: selections, isLoading: isLoadingSelections } =
+    useExperimentSalesPageTypeSelections(experimentId);
+  const updateSelections =
+    useUpdateExperimentSalesPageTypeSelections(experimentId);
+  const [selectedTypeCodes, setSelectedTypeCodes] = useState<string[]>([]);
+  const [selectionFeedback, setSelectionFeedback] = useState<
+    "success" | "error" | null
+  >(null);
+
+  useEffect(() => {
+    if (selections && selections.length > 0) {
+      setSelectedTypeCodes(selections.map((selection) => selection.typeCode));
+      return;
+    }
+    if (types && types.length > 0 && selectedTypeCodes.length === 0) {
+      setSelectedTypeCodes(
+        types
+          .filter((type) => type.defaultForAbTest)
+          .map((type) => type.code),
+      );
+    }
+  }, [selections, selectedTypeCodes.length, types]);
+
+  const selectedTypes = useMemo(() => {
+    const allTypes = types ?? [];
+    return selectedTypeCodes
+      .map((code) => allTypes.find((type) => type.code === code))
+      .filter((type): type is SalesPageType => Boolean(type));
+  }, [selectedTypeCodes, types]);
+
+  const toggleType = (typeCode: string) => {
+    setSelectionFeedback(null);
+    setSelectedTypeCodes((current) => {
+      if (current.includes(typeCode)) {
+        return current.filter((code) => code !== typeCode);
+      }
+      return [...current, typeCode];
+    });
+  };
+
+  const saveTypeSelection = async () => {
+    setSelectionFeedback(null);
+    try {
+      await updateSelections.mutateAsync(
+        selectedTypeCodes.map((typeCode, index) => ({
+          typeCode,
+          variantKey: String.fromCharCode(65 + index),
+          trafficWeight: splitTrafficWeight(selectedTypeCodes.length),
+          active: true,
+        })),
+      );
+      setSelectionFeedback("success");
+    } catch {
+      setSelectionFeedback("error");
+    }
+  };
 
   if (isLoading) {
     return (
@@ -123,16 +192,103 @@ export default function ExperimentSalesPageAbTab({
 
   const results = data ?? [];
 
-  if (results.length === 0) {
-    return (
-      <div className="alert alert-light border mt-3 mb-0">
-        Nenhum teste A/B de página de venda foi configurado para este experimento.
-      </div>
-    );
-  }
-
   return (
     <div className="d-flex flex-column gap-3 mt-3">
+      <div className="creative-toolbar align-items-start">
+        <div>
+          <h5 className="mb-1 d-flex align-items-center gap-2">
+            <FlaskConical size={18} /> Tipos de página de venda
+          </h5>
+          <p className="text-muted small mb-0">
+            Defina quais experiências comerciais a campanha pode testar. O tipo
+            chat IA entrega valor no próprio atendimento antes de apresentar a
+            oferta completa.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={saveTypeSelection}
+          disabled={
+            updateSelections.isPending ||
+            selectedTypeCodes.length === 0 ||
+            isLoadingTypes ||
+            isLoadingSelections
+          }
+        >
+          {updateSelections.isPending ? (
+            <>
+              <span className="spinner-border spinner-border-sm me-2" />
+              Salvando
+            </>
+          ) : (
+            "Salvar tipos"
+          )}
+        </button>
+      </div>
+
+      {selectionFeedback === "success" ? (
+        <div className="alert alert-success mb-0" role="status">
+          Tipos de página de venda salvos para este experimento.
+        </div>
+      ) : null}
+      {selectionFeedback === "error" ? (
+        <div className="alert alert-danger mb-0" role="alert">
+          Não foi possível salvar os tipos de página de venda.
+        </div>
+      ) : null}
+
+      {isLoadingTypes || isLoadingSelections ? (
+        <div className="text-muted small">Carregando tipos disponíveis...</div>
+      ) : (
+        <div className="row g-3">
+          {(types ?? []).map((type) => {
+            const checked = selectedTypeCodes.includes(type.code);
+            return (
+              <div className="col-12 col-xl-6" key={type.code}>
+                <label className="border rounded-3 p-3 h-100 d-flex gap-3">
+                  <input
+                    className="form-check-input mt-1"
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleType(type.code)}
+                  />
+                  <span>
+                    <span className="d-flex align-items-center gap-2 mb-1">
+                      <span className="fw-semibold">{type.name}</span>
+                      {type.code === "AI_CHAT_DIGITAL_BAIT" ? (
+                        <span className="badge text-bg-primary">Novo</span>
+                      ) : null}
+                    </span>
+                    <span className="d-block text-muted small mb-2">
+                      {type.description}
+                    </span>
+                    <span className="d-block small">
+                      <strong>Mecanismo:</strong> {type.commercialMechanism}
+                    </span>
+                    <span className="d-block small">
+                      <strong>Captura:</strong> {type.leadCaptureStrategy}
+                    </span>
+                    <span className="d-block small">
+                      <strong>Isca:</strong> {type.digitalBaitDelivery}
+                    </span>
+                  </span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {selectedTypes.length > 0 ? (
+        <div className="alert alert-info mb-0" role="status">
+          <strong>Planejamento A/B:</strong>{" "}
+          {selectedTypes
+            .map((type, index) => `Variante ${String.fromCharCode(65 + index)}: ${type.name}`)
+            .join(" · ")}
+        </div>
+      ) : null}
+
       <div className="creative-toolbar align-items-start">
         <div>
           <h5 className="mb-1 d-flex align-items-center gap-2">
@@ -144,6 +300,12 @@ export default function ExperimentSalesPageAbTab({
           </p>
         </div>
       </div>
+
+      {results.length === 0 ? (
+        <div className="alert alert-light border mb-0">
+          Nenhum teste A/B de página de venda foi configurado para este experimento.
+        </div>
+      ) : null}
 
       {results.map((result) => (
         <div className="card" key={result.test.id}>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: precisamos parar essa campanha com erro e iniciar uma nova e correta.

Modelo: A campanha errada foi parada pelo Hub.

**O que fiz agora**
- Identifiquei a campanha da tela: `MUSA-H001-E002`, experimento `64`.
- Alterei o experimento para `PAUSED`.
- O backend criou o pedido de pausa para a Meta:
  - campanha Meta: `120250256634350326`
  - motivo: `ADMIN_EXPERIMENT_PAUSED`
  - stop solicitado em `2026-07-13T14:45:03Z`

**Causa provável do erro**
A campanha existe como `ACTIVE`, o conjunto está `ACTIVE`, mas o anúncio está `PAUSED` e o Hub mostra o problema: “Conjunto não está vinculado à segmentação aprovada do experimento”.

Além disso, o checklist interno do experimento ainda acusa: **GeraLanding incompleto**. Então não recomendo iniciar uma nova campanha agora, porque repetiríamos o erro com outro nome.

**Próxima ação correta**
1. Confirmar no Ads Manager que campanha, conjunto e anúncio `MUSA-H001-E002` estão pausados.
2. Corrigir o experimento antes de nova liberação:
   - concluir o GeraLanding;
   - garantir segmentação vinculada ao ad set aprovado;
   - validar landing, criativo, público e pixel.
3. Só depois liberar uma nova campanha, idealmente como `MUSA-H001-E003`, com funil limpo e checklist 100%.

Evidência usada: cânone de publicação Facebook, regra de stop do Hub e estado real do experimento/campanha no backend.

Última mensagem do usuário:
vamos pensar em um novo tipo de pagina de venda. Focado em um chat com uma IA coletando dados do lead e dando a propria isca digital ali pelo chat. Uma imagem por exemplo. Pense em como isso poderia ser. Crie o conceito de tipos de página de venda, coloque no banco de dados, backend e front-end. Cada campanha pode ter um ou mais tipo de página de venda ( poder fazer testes A/B )

**Resumo das alterações:**
Implementei a base do novo conceito sem abrir PR.

**O que ficou pronto**
- Novo catálogo no banco para tipos de página de venda.
- Novo tipo principal: `AI_CHAT_DIGITAL_BAIT`.
- Vínculo experimento/campanha → um ou mais tipos de página de venda para A/B.
- Backend com endpoints:
  - `GET /api/sales-page-types`
  - `GET /api/experiments/{id}/sales-page-types`
  - `PUT /api/experiments/{id}/sales-page-types`
- Frontend na aba de teste A/B da página de venda para selecionar:
  - Página tradicional
  - Página com vídeo humano
  - Chat IA com isca imediata
  - Quiz diagnóstico
- Documentação atualizada em modelo de dados, Swagger e registro de experimentos.

**Conceito escolhido**
A melhor opção é o **chat IA com isca imediata**: o lead conversa, informa dados mínimos, recebe uma imagem/amostra personalizada ali no chat e depois é conduzido para a oferta completa. Isso entrega valor antes da venda e melhora a chance de conversão.

**Validações**
- Backend compile: passou.
- Teste unitário focado: passou.
- Frontend typecheck: passou após instalar devDependencies com `npm ci --include=dev`.

Ainda não implementei o runtime real do chat com IA, geração da imagem e auditoria da conversa. Essa é a próxima etapa e deve ficar no worker/Lead Portal, não hardcoded no backend.