### PR TITLE
AI Hub: Feito. A aba `Teste A/B` agora mostra o botão `Ver sem métrica` usando uma URL segura entregue pelo backend (`metricsSafeUrl`) com `mh_test=1`, em vez de o frontend montar isso sozinho.

Principais ajustes:
- Backend expõe `metricsSafeUrl` por var…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbVariantDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/dto/ExperimentSalesPageAbVariantDto.java
@@ -16,6 +16,7 @@ public record ExperimentSalesPageAbVariantDto(
         String salesPageUrl,
         String checkoutUrl,
         String adDestinationUrl,
+        String metricsSafeUrl,
         String analyticsVariantParam,
         Long publicationAuditId,
         Long experimentVideoAssetId,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
@@ -33,6 +33,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Responsabilidade: criar e manter testes A/B de pagina de venda ligados ao experimento. */
@@ -437,12 +438,35 @@ public class ExperimentSalesPageAbTestService {
                 variant.getSalesPageUrl(),
                 variant.getCheckoutUrl(),
                 variant.getAdDestinationUrl(),
+                buildMetricsSafeUrl(variant),
                 variant.getAnalyticsVariantParam(),
                 variant.getPublicationAudit() != null ? variant.getPublicationAudit().getId() : null,
                 variant.getExperimentVideoAsset() != null ? variant.getExperimentVideoAsset().getId() : null,
                 variant.isRequiredCollectorsPresent(),
                 variant.getCreatedAt(),
                 variant.getUpdatedAt());
+    }
+
+    /** Monta URL de revisao interna que o Lead Portal ignora nos coletores de metricas. */
+    private String buildMetricsSafeUrl(ExperimentSalesPageAbVariant variant) {
+        String rawUrl = StringUtils.hasText(variant.getSalesPageUrl())
+                ? variant.getSalesPageUrl()
+                : variant.getAdDestinationUrl();
+        if (!StringUtils.hasText(rawUrl)) {
+            return null;
+        }
+        try {
+            return UriComponentsBuilder.fromUriString(rawUrl.trim())
+                    .replaceQueryParam("mh_test", "1")
+                    .build(true)
+                    .toUriString();
+        } catch (IllegalArgumentException ex) {
+            String trimmed = rawUrl.trim();
+            if (trimmed.contains("mh_test=1")) {
+                return trimmed;
+            }
+            return trimmed + (trimmed.contains("?") ? "&" : "?") + "mh_test=1";
+        }
     }
 
     /** Mapeia a agregacao SQL de analytics da variante para o contrato interno do servico. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestService.java
@@ -12,6 +12,8 @@ import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbVariantD
 import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbVariantResultDto;
 import com.marketinghub.experiment.salespageab.dto.UpdateExperimentSalesPageAbVariantRequest;
 import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbTestRepository;
@@ -134,10 +136,19 @@ public class ExperimentSalesPageAbTestService {
     /** Verifica se o teste A/B ativo possui duas variantes prontas e equivalentes para campanha. */
     @Transactional(readOnly = true)
     public boolean hasReadyActiveTest(Long experimentId) {
-        return findActiveForCampaign(experimentId)
-                .map(test -> test.variants().size() == 2
-                        && test.variants().stream().allMatch(this::isVariantReadyForTraffic))
+        return testRepository.findTopByExperimentIdAndStatusInOrderByUpdatedAtDesc(experimentId, ACTIVE_STATUSES)
+                .map(test -> test.getVariants().size() == 2
+                        && test.getVariants().stream().allMatch(this::isVariantReadyForTraffic))
                 .orElse(true);
+    }
+
+    /** Verifica se existe variante ativa de pagina com vídeo humano no teste A/B. */
+    @Transactional(readOnly = true)
+    public boolean hasHumanVideoVariant(Long experimentId) {
+        return testRepository.findTopByExperimentIdAndStatusInOrderByUpdatedAtDesc(experimentId, ACTIVE_STATUSES)
+                .map(test -> test.getVariants().stream()
+                        .anyMatch(variant -> variant.getVariantType() == ExperimentSalesPageAbVariantType.HUMAN_VIDEO))
+                .orElse(false);
     }
 
     /** Cria uma variante inicial com divisao de trafego 50/50. */
@@ -199,7 +210,7 @@ public class ExperimentSalesPageAbTestService {
     private void normalizeTestStatus(ExperimentSalesPageAbTest test) {
         boolean ready = test.getVariants() != null
                 && test.getVariants().size() == 2
-                && test.getVariants().stream().allMatch(variant -> isVariantReadyForTraffic(toVariantDto(variant)));
+                && test.getVariants().stream().allMatch(this::isVariantReadyForTraffic);
         if (ready && test.getStatus() == ExperimentSalesPageAbTestStatus.DRAFT) {
             test.setStatus(ExperimentSalesPageAbTestStatus.READY);
         }
@@ -242,6 +253,24 @@ public class ExperimentSalesPageAbTestService {
                 && variant.requiredCollectorsPresent()
                 && variant.trafficWeight() != null
                 && variant.trafficWeight().signum() > 0;
+    }
+
+    /** Confirma se a entidade da variante pode receber trafego, incluindo vídeo quando exigido. */
+    private boolean isVariantReadyForTraffic(ExperimentSalesPageAbVariant variant) {
+        return isVariantReadyForTraffic(toVariantDto(variant))
+                && (!requiresApprovedVideo(variant) || hasReadyApprovedVideo(variant.getExperimentVideoAsset()));
+    }
+
+    /** Identifica variantes cuja promessa comercial depende de vídeo humano. */
+    private boolean requiresApprovedVideo(ExperimentSalesPageAbVariant variant) {
+        return variant != null && variant.getVariantType() == ExperimentSalesPageAbVariantType.HUMAN_VIDEO;
+    }
+
+    /** Verifica se o vídeo vinculado está pronto e aprovado para tráfego pago. */
+    private boolean hasReadyApprovedVideo(ExperimentVideoAsset videoAsset) {
+        return videoAsset != null
+                && videoAsset.getStatus() == ExperimentVideoStatus.READY
+                && videoAsset.getReviewStatus() == ExperimentVideoReviewStatus.APPROVED;
     }
 
     /** Monta o resultado de um teste usando as URLs parametrizadas das variantes. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeService.java
@@ -27,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class SalesPageTypeService {
     private static final BigDecimal DEFAULT_WEIGHT = new BigDecimal("50.00");
+    private static final int MAX_AB_TEST_SELECTIONS = 2;
 
     private final SalesPageTypeRepository typeRepository;
     private final ExperimentSalesPageTypeSelectionRepository selectionRepository;
@@ -70,6 +71,9 @@ public class SalesPageTypeService {
                 request == null || request.selections() == null ? List.of() : request.selections();
         if (requestedSelections.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "at least one sales page type is required");
+        }
+        if (requestedSelections.size() > MAX_AB_TEST_SELECTIONS) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sales page A/B test accepts at most 2 variants");
         }
 
         selectionRepository.deleteByExperimentId(experimentId);

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -8,6 +8,7 @@ import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.repository.jpa.experiment.salespagetype.ExperimentSalesPageTypeSelectionRepository;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.targeting.TargetingElement;
@@ -65,6 +66,7 @@ public class ExperimentReadinessService {
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
     private final ExperimentVideoAssetService experimentVideoAssetService;
     private final ExperimentSalesPageAbTestService salesPageAbTestService;
+    private final ExperimentSalesPageTypeSelectionRepository salesPageTypeSelectionRepository;
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
@@ -72,7 +74,8 @@ public class ExperimentReadinessService {
                                       GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
                                       ExperimentCampaignDestinationPolicy campaignDestinationPolicy,
                                       ExperimentVideoAssetService experimentVideoAssetService,
-                                      ExperimentSalesPageAbTestService salesPageAbTestService) {
+                                      ExperimentSalesPageAbTestService salesPageAbTestService,
+                                      ExperimentSalesPageTypeSelectionRepository salesPageTypeSelectionRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
@@ -80,6 +83,7 @@ public class ExperimentReadinessService {
         this.campaignDestinationPolicy = campaignDestinationPolicy;
         this.experimentVideoAssetService = experimentVideoAssetService;
         this.salesPageAbTestService = salesPageAbTestService;
+        this.salesPageTypeSelectionRepository = salesPageTypeSelectionRepository;
     }
 
     /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
@@ -353,9 +357,23 @@ public class ExperimentReadinessService {
 
     /** Verifica se algum vídeo obrigatório do experimento ainda impede liberação comercial. */
     private boolean hasRequiredVideoBlockingRelease(Experiment experiment) {
-        return experiment != null
-                && experiment.getId() != null
-                && experimentVideoAssetService.hasRequiredVideoBlockingRelease(experiment.getId());
+        if (experiment == null || experiment.getId() == null) {
+            return false;
+        }
+        Long experimentId = experiment.getId();
+        if (experimentVideoAssetService.hasRequiredVideoBlockingRelease(experimentId)) {
+            return true;
+        }
+        return hasVideoDependentSalesPage(experimentId)
+                && !experimentVideoAssetService.hasReadyApprovedVideo(experimentId);
+    }
+
+    /** Verifica se o desenho comercial escolhido depende de página com vídeo humano. */
+    private boolean hasVideoDependentSalesPage(Long experimentId) {
+        return salesPageAbTestService.hasHumanVideoVariant(experimentId)
+                || salesPageTypeSelectionRepository.existsByExperimentIdAndSalesPageTypeCodeAndActiveTrue(
+                        experimentId,
+                        "HUMAN_VIDEO_SALES_PAGE");
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -203,6 +203,18 @@ public class ExperimentVideoAssetService {
                 ExperimentVideoReviewStatus.APPROVED);
     }
 
+    /** Verifica se existe vídeo pronto e aprovado para uma pagina/funil que depende de vídeo. */
+    @Transactional(readOnly = true)
+    public boolean hasReadyApprovedVideo(Long experimentId) {
+        if (experimentId == null) {
+            return false;
+        }
+        return repository.existsByExperimentIdAndStatusAndReviewStatus(
+                experimentId,
+                ExperimentVideoStatus.READY,
+                ExperimentVideoReviewStatus.APPROVED);
+    }
+
     /** Aplica os campos opcionais enviados na atualização do ativo de vídeo. */
     private void applyUpdate(ExperimentVideoAsset videoAsset, UpdateExperimentVideoAssetRequest request, Long experimentId) {
         if (request.slot() != null) {

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/ExperimentSalesPageTypeSelectionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/salespagetype/ExperimentSalesPageTypeSelectionRepository.java
@@ -3,12 +3,25 @@ package com.marketinghub.repository.jpa.experiment.salespagetype;
 import com.marketinghub.experiment.salespagetype.ExperimentSalesPageTypeSelection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Responsabilidade: persistir os tipos de pagina de venda selecionados por experimento. */
 public interface ExperimentSalesPageTypeSelectionRepository
         extends JpaRepository<ExperimentSalesPageTypeSelection, Long> {
     /** Lista as selecoes de um experimento mantendo a ordem de variantes A/B. */
     List<ExperimentSalesPageTypeSelection> findByExperimentIdOrderByVariantKeyAsc(Long experimentId);
+
+    /** Verifica se o experimento selecionou um tipo ativo de pagina de venda. */
+    @Query("""
+            select case when count(selection) > 0 then true else false end
+            from ExperimentSalesPageTypeSelection selection
+            where selection.experiment.id = :experimentId
+              and selection.salesPageType.code = :salesPageTypeCode
+              and selection.active = true
+            """)
+    boolean existsByExperimentIdAndSalesPageTypeCodeAndActiveTrue(@Param("experimentId") Long experimentId,
+                                                                  @Param("salesPageTypeCode") String salesPageTypeCode);
 
     /** Remove as selecoes anteriores antes de gravar uma nova configuracao A/B. */
     void deleteByExperimentId(Long experimentId);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
@@ -32,4 +32,9 @@ public interface ExperimentVideoAssetRepository extends JpaRepository<Experiment
     boolean existsRequiredReleaseBlocker(@Param("experimentId") Long experimentId,
                                          @Param("readyStatus") ExperimentVideoStatus readyStatus,
                                          @Param("approvedStatus") ExperimentVideoReviewStatus approvedStatus);
+
+    /** Verifica se o experimento possui ao menos um vídeo pronto e aprovado para uso comercial. */
+    boolean existsByExperimentIdAndStatusAndReviewStatus(Long experimentId,
+                                                         ExperimentVideoStatus status,
+                                                         ExperimentVideoReviewStatus reviewStatus);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
@@ -8,6 +8,9 @@ import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantStatu
 import com.marketinghub.experiment.salespageab.ExperimentSalesPageAbVariantType;
 import com.marketinghub.experiment.salespageab.dto.ExperimentSalesPageAbTestDto;
 import com.marketinghub.experiment.salespageab.dto.UpdateExperimentSalesPageAbVariantRequest;
+import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbTestRepository;
 import com.marketinghub.repository.jpa.experiment.salespageab.ExperimentSalesPageAbVariantRepository;
@@ -110,6 +113,7 @@ class ExperimentSalesPageAbTestServiceTest {
                 .build();
         ExperimentSalesPageAbVariant variantA = readyVariant(test, 21L, "A", ExperimentSalesPageAbVariantType.TRADITIONAL);
         ExperimentSalesPageAbVariant variantB = readyVariant(test, 22L, "B", ExperimentSalesPageAbVariantType.HUMAN_VIDEO);
+        variantB.setExperimentVideoAsset(readyApprovedVideo(experiment));
         test.getVariants().add(variantA);
         test.getVariants().add(variantB);
         given(experimentRepository.findById(60L)).willReturn(Optional.of(experiment));
@@ -131,6 +135,47 @@ class ExperimentSalesPageAbTestServiceTest {
                         true));
 
         assertThat(dto.status()).isEqualTo(ExperimentSalesPageAbTestStatus.READY);
+    }
+
+    /** Garante que variante de video humano nao fica pronta sem video pronto e aprovado. */
+    @Test
+    void shouldNotPromoteHumanVideoVariantWithoutReadyApprovedVideo() {
+        Experiment experiment = Experiment.builder().id(60L).build();
+        ExperimentSalesPageAbTest test = ExperimentSalesPageAbTest.builder()
+                .id(11L)
+                .experiment(experiment)
+                .name("A/B")
+                .status(ExperimentSalesPageAbTestStatus.DRAFT)
+                .hypothesis("Video aumenta confianca")
+                .primaryMetric("checkout_click_rate")
+                .winnerRule("menor custo por checkout")
+                .minimumRuntimeDays(7)
+                .minimumSampleSize(100)
+                .metaSplitTestRecommended(true)
+                .build();
+        ExperimentSalesPageAbVariant variantA = readyVariant(test, 21L, "A", ExperimentSalesPageAbVariantType.TRADITIONAL);
+        ExperimentSalesPageAbVariant variantB = readyVariant(test, 22L, "B", ExperimentSalesPageAbVariantType.HUMAN_VIDEO);
+        test.getVariants().add(variantA);
+        test.getVariants().add(variantB);
+        given(experimentRepository.findById(60L)).willReturn(Optional.of(experiment));
+        given(variantRepository.findByIdAndTestExperimentId(22L, 60L)).willReturn(Optional.of(variantB));
+        given(variantRepository.save(variantB)).willReturn(variantB);
+
+        ExperimentSalesPageAbTestDto dto = service.updateVariant(
+                60L,
+                22L,
+                new UpdateExperimentSalesPageAbVariantRequest(
+                        ExperimentSalesPageAbVariantStatus.READY,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        true));
+
+        assertThat(dto.status()).isEqualTo(ExperimentSalesPageAbTestStatus.DRAFT);
     }
 
     /** Garante que os resultados A/B calculam taxas por variante e sugerem vencedor apenas com amostra. */
@@ -214,6 +259,16 @@ class ExperimentSalesPageAbTestServiceTest {
                 .adDestinationUrl("https://example.com/sales-" + key.toLowerCase())
                 .analyticsVariantParam("ab=" + key.toLowerCase())
                 .requiredCollectorsPresent(true)
+                .build();
+    }
+
+    /** Cria um ativo de video pronto e revisado para variantes que dependem de video humano. */
+    private ExperimentVideoAsset readyApprovedVideo(Experiment experiment) {
+        return ExperimentVideoAsset.builder()
+                .id(501L)
+                .experiment(experiment)
+                .status(ExperimentVideoStatus.READY)
+                .reviewStatus(ExperimentVideoReviewStatus.APPROVED)
                 .build();
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/salespageab/service/ExperimentSalesPageAbTestServiceTest.java
@@ -172,6 +172,10 @@ class ExperimentSalesPageAbTestServiceTest {
                 .containsExactly(3L, 8L);
         assertThat(results.get(0).variants()).extracting("averageVisibleMsPerSession")
                 .containsExactly(90000L, 150000L);
+        assertThat(results.get(0).variants()).extracting(variant -> variant.variant().metricsSafeUrl())
+                .containsExactly(
+                        "https://example.com/sales-a?mh_test=1",
+                        "https://example.com/sales-b?mh_test=1");
     }
 
     /** Cria uma agregacao simulada para o JdbcTemplate do resumo A/B. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/salespagetype/service/SalesPageTypeServiceTest.java
@@ -91,6 +91,25 @@ class SalesPageTypeServiceTest {
                 .hasMessageContaining("duplicated typeCode");
     }
 
+    /** Garante que o teste A/B comercial nao aceita terceira variante selecionada. */
+    @Test
+    void shouldRejectMoreThanTwoSalesPageTypeSelections() {
+        Experiment experiment = Experiment.builder().id(64L).build();
+        given(experimentRepository.findById(64L)).willReturn(Optional.of(experiment));
+
+        assertThatThrownBy(() -> service.replaceExperimentSelections(
+                64L,
+                new UpdateExperimentSalesPageTypeSelectionRequest(List.of(
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "TRADITIONAL_LONG_FORM", "A", BigDecimal.TEN, true, null),
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "HUMAN_VIDEO_SALES_PAGE", "B", BigDecimal.TEN, true, null),
+                        new UpdateExperimentSalesPageTypeSelectionItem(
+                                "AI_CHAT_DIGITAL_BAIT", "C", BigDecimal.TEN, true, null)))))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("at most 2 variants");
+    }
+
     /** Cria o tipo chat IA usado nos testes. */
     private SalesPageType chatType() {
         return SalesPageType.builder()

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -11,6 +11,7 @@ import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
 import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
+import com.marketinghub.repository.jpa.experiment.salespagetype.ExperimentSalesPageTypeSelectionRepository;
 import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
@@ -63,6 +64,8 @@ class ExperimentReadinessServiceTest {
     private ExperimentVideoAssetService experimentVideoAssetService;
     @Mock
     private ExperimentSalesPageAbTestService salesPageAbTestService;
+    @Mock
+    private ExperimentSalesPageTypeSelectionRepository salesPageTypeSelectionRepository;
 
     private ExperimentReadinessService service;
 
@@ -78,7 +81,8 @@ class ExperimentReadinessServiceTest {
                 geraLandingStageExecutionRepository,
                 campaignDestinationPolicy,
                 experimentVideoAssetService,
-                salesPageAbTestService);
+                salesPageAbTestService,
+                salesPageTypeSelectionRepository);
         lenient().when(salesPageAbTestService.hasReadyActiveTest(org.mockito.ArgumentMatchers.anyLong())).thenReturn(true);
     }
 
@@ -161,6 +165,57 @@ class ExperimentReadinessServiceTest {
         assertThat(service.computeMissingConfiguration(experiment))
                 .containsExactly("experimentVideoAsset");
         assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    /** Garante que pagina de venda com video humano bloqueia campanha sem video pronto. */
+    @Test
+    void shouldBlockCampaignWhenHumanVideoSalesPageTypeHasNoReadyApprovedVideo() {
+        Experiment experiment = buildExperiment(46L, 56L);
+        experiment.setCampaignObjective(ExperimentCampaignObjective.SALES);
+        experiment.setFollowUpActionUrl("https://example.com/sales/46");
+        completeCommercialContract(experiment);
+
+        when(creativeRepository.existsByExperimentIdAndStatus(46L, CreativeStatus.READY)).thenReturn(true);
+        when(salesPageTypeSelectionRepository.existsByExperimentIdAndSalesPageTypeCodeAndActiveTrue(
+                46L,
+                "HUMAN_VIDEO_SALES_PAGE")).thenReturn(true);
+        when(experimentVideoAssetService.hasReadyApprovedVideo(46L)).thenReturn(false);
+        mockPublishableSelection(46L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(46L);
+        mockSalesPageAudit(
+                46L,
+                "https://example.com/sales/46",
+                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp46",
+                trackedSalesPageHtml());
+
+        assertThat(service.computeMissingConfiguration(experiment))
+                .containsExactly("experimentVideoAsset");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+    /** Garante que pagina de venda com video humano libera somente com video pronto e aprovado. */
+    @Test
+    void shouldAllowHumanVideoSalesPageTypeWithReadyApprovedVideo() {
+        Experiment experiment = buildExperiment(47L, 57L);
+        experiment.setCampaignObjective(ExperimentCampaignObjective.SALES);
+        experiment.setFollowUpActionUrl("https://example.com/sales/47");
+        completeCommercialContract(experiment);
+
+        when(creativeRepository.existsByExperimentIdAndStatus(47L, CreativeStatus.READY)).thenReturn(true);
+        when(salesPageTypeSelectionRepository.existsByExperimentIdAndSalesPageTypeCodeAndActiveTrue(
+                47L,
+                "HUMAN_VIDEO_SALES_PAGE")).thenReturn(true);
+        when(experimentVideoAssetService.hasReadyApprovedVideo(47L)).thenReturn(true);
+        mockPublishableSelection(47L, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
+        mockCompletedGeraSalesPagePublication(47L);
+        mockSalesPageAudit(
+                47L,
+                "https://example.com/sales/47",
+                "https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=exp47",
+                trackedSalesPageHtml());
+
+        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
+        assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
 
     /** Garante que teste A/B ativo incompleto bloqueia a liberacao para campanha. */

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -106,7 +106,17 @@ Regras obrigatórias:
 - o status `STANDBY` por primeiro envio não substitui a validação estatística de 30+ envios qualificados, nem a regra de reprovação por 100 acessos sem envio;
 - a tela administrativa deve deixar claro que o experimento parou por sinal inicial, não por validação completa.
 
-### 4.1.3.1 Regra mandatória — política única de parada por campanha
+### 4.1.3.1 Regra mandatória — página com vídeo exige vídeo aprovado
+
+Quando o experimento escolher uma página de venda que dependa de vídeo humano/avatar, a campanha não pode ser considerada pronta enquanto não existir vídeo vinculado, tecnicamente `READY` e com revisão humana `APPROVED`.
+
+Regras obrigatórias:
+- variante A/B `HUMAN_VIDEO` só pode participar de teste pronto para tráfego quando tiver vídeo associado em estado `READY + APPROVED`;
+- seleção de tipo `HUMAN_VIDEO_SALES_PAGE` bloqueia a liberação de campanha se o experimento não possuir ao menos um `experiment_video_asset` pronto e aprovado;
+- o bloqueio deve acontecer no readiness do backend, antes de o experimento entrar na fila de publicação de mídia paga;
+- a ausência de vídeo não deve ser interpretada como desempenho ruim da variante, pois contamina o aprendizado comercial.
+
+### 4.1.3.2 Regra mandatória — política única de parada por campanha
 
 Campanhas pagas não devem depender de regra operacional por tipo de experimento. A decisão de parada deve ser única por campanha e orientada a prova comercial objetiva: se a campanha não prova que pode gerar resultado, ela deve parar antes de consumir mais orçamento.
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -116,6 +116,16 @@ Regras obrigatórias:
 - o bloqueio deve acontecer no readiness do backend, antes de o experimento entrar na fila de publicação de mídia paga;
 - a ausência de vídeo não deve ser interpretada como desempenho ruim da variante, pois contamina o aprendizado comercial.
 
+### 4.1.3.1.1 Regra mandatória — teste A/B de página de venda com no máximo duas variantes
+
+Teste A/B de página de venda deve comparar no máximo duas experiências comerciais por vez. O sistema não deve permitir seleção, aprovação ou liberação de teste com três ou mais variantes simultâneas, porque isso dilui tráfego, aumenta risco de falso vencedor e torna o aprendizado menos acionável para escala de vendas.
+
+Regras obrigatórias:
+- a seleção de tipos de página de venda do experimento deve aceitar no máximo duas opções ativas;
+- quando houver três mecanismos comerciais plausíveis, o usuário deve escolher as duas hipóteses mais fortes para o teste atual e deixar a terceira para um novo ciclo;
+- nenhuma variante incompleta pode substituir uma das duas escolhas, pois isso contamina a leitura comercial;
+- o backend deve bloquear payload com mais de duas seleções e a interface deve impedir a marcação da terceira opção.
+
 ### 4.1.3.2 Regra mandatória — política única de parada por campanha
 
 Campanhas pagas não devem depender de regra operacional por tipo de experimento. A decisão de parada deve ser única por campanha e orientada a prova comercial objetiva: se a campanha não prova que pode gerar resultado, ela deve parar antes de consumir mais orçamento.

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -41,6 +41,11 @@ Conceito comercial inicial:
 - `AI_CHAT_DIGITAL_BAIT`: chat-first com coleta de dados, entrega imediata de amostra e oferta depois do valor percebido.
 - `DIAGNOSTIC_QUIZ`: quiz diagnóstico com recomendação.
 
+Regra de prontidão comercial:
+
+- qualquer seleção ativa `HUMAN_VIDEO_SALES_PAGE` exige vídeo do experimento em `experiment_video_asset` com `status=READY` e `review_status=APPROVED` antes da liberação de campanha;
+- qualquer variante A/B `HUMAN_VIDEO` também precisa de `experiment_video_asset_id` vinculado a vídeo `READY + APPROVED` para o teste ser considerado pronto para tráfego.
+
 Atualização incremental — vínculo do wireframe com execução Gera Landing (07/05/2026):
 
 - `landing_page_wireframe_job_id` (`BINARY(36)`, FK -> `gera_landing_stage_execution.id_job`)

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -43,6 +43,7 @@ Conceito comercial inicial:
 
 Regra de prontidão comercial:
 
+- a seleção de tipos de página de venda para teste A/B aceita no máximo duas opções ativas por experimento;
 - qualquer seleção ativa `HUMAN_VIDEO_SALES_PAGE` exige vídeo do experimento em `experiment_video_asset` com `status=READY` e `review_status=APPROVED` antes da liberação de campanha;
 - qualquer variante A/B `HUMAN_VIDEO` também precisa de `experiment_video_asset_id` vinculado a vídeo `READY + APPROVED` para o teste ser considerado pronto para tráfego.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-13 — Experimentos: página com vídeo bloqueia campanha sem vídeo aprovado
+
+- causa-raiz: a liberação de campanha bloqueava apenas vídeos já marcados como obrigatórios, mas não inferia a dependência comercial quando a variante/tipo de página escolhido era de vídeo humano.
+- foi feito: readiness do backend passa a bloquear campanha quando houver variante `HUMAN_VIDEO` ou tipo `HUMAN_VIDEO_SALES_PAGE` sem vídeo `READY + APPROVED`.
+- foi feito: teste A/B só é considerado pronto para tráfego quando a variante `HUMAN_VIDEO` possui vídeo vinculado, pronto e aprovado.
+- impacto esperado: o sistema evita campanha contaminada por página incompleta e preserva aprendizado confiável sobre oferta, criativo e mecanismo comercial.
+- prevenção de recorrência: testes unitários cobrem bloqueio por tipo de página com vídeo e bloqueio de variante A/B de vídeo sem asset aprovado.
+
 ## 2026-07-13 — Teste A/B: link seguro para revisar páginas de venda
 
 - solicitação: mostrar na aba `Teste A/B` o link de cada página de venda sem contaminar métricas da campanha.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-13 — Teste A/B: link seguro para revisar páginas de venda
+
+- solicitação: mostrar na aba `Teste A/B` o link de cada página de venda sem contaminar métricas da campanha.
+- causa-raiz: a tela montava localmente um link com `mh_test=1`, mas a regra de não contabilizar métricas precisa vir do backend como fonte de verdade.
+- foi feito: o contrato de resultados A/B agora expõe `metricsSafeUrl` por variante, calculado pelo backend a partir da URL da página/destino e sempre com `mh_test=1`.
+- impacto esperado: o usuário pode abrir cada variante para revisão interna sem gerar novos page views ou eventos de campanha no Lead Portal.
+- prevenção de recorrência: teste unitário do backend cobre a URL segura e o frontend deixou de inferir a URL localmente.
+
 ## 2026-07-12 — Experimentos: custo de produção de vídeo VEO
 
 - causa-raiz: o ativo `experiment_video_asset` já tinha campo de custo, mas o pedido VEO criava o vídeo sem estimativa e o callback final do `video-management-service` não enviava o custo calculado pelo provider.

--- a/docs/swagger/experiment-sales-page-ab-swagger.yaml
+++ b/docs/swagger/experiment-sales-page-ab-swagger.yaml
@@ -1,0 +1,122 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub - Teste A/B de Página de Venda
+  version: "1.0"
+paths:
+  /api/experiments/{experimentId}/sales-page-ab-tests/results:
+    get:
+      summary: Lista resultados do teste A/B de páginas de venda do experimento.
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Resultados por teste e variante.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ExperimentSalesPageAbTestResult"
+components:
+  schemas:
+    ExperimentSalesPageAbTestResult:
+      type: object
+      properties:
+        test:
+          $ref: "#/components/schemas/ExperimentSalesPageAbTest"
+        variants:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExperimentSalesPageAbVariantResult"
+        winnerVariantKey:
+          type: string
+          nullable: true
+        status:
+          type: string
+        recommendation:
+          type: string
+    ExperimentSalesPageAbTest:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        experimentId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        status:
+          type: string
+        primaryMetric:
+          type: string
+        minimumSampleSize:
+          type: integer
+        variants:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExperimentSalesPageAbVariant"
+    ExperimentSalesPageAbVariant:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        variantKey:
+          type: string
+        name:
+          type: string
+        variantType:
+          type: string
+        status:
+          type: string
+        trafficWeight:
+          type: number
+        salesPageUrl:
+          type: string
+          nullable: true
+        checkoutUrl:
+          type: string
+          nullable: true
+        adDestinationUrl:
+          type: string
+          nullable: true
+        metricsSafeUrl:
+          type: string
+          nullable: true
+          description: URL de revisão interna com mh_test=1 para acessar a página sem contaminar métricas da campanha.
+        analyticsVariantParam:
+          type: string
+    ExperimentSalesPageAbVariantResult:
+      type: object
+      properties:
+        variant:
+          $ref: "#/components/schemas/ExperimentSalesPageAbVariant"
+        pageViews:
+          type: integer
+          format: int64
+        sessions:
+          type: integer
+          format: int64
+        averageVisibleMsPerSession:
+          type: integer
+          format: int64
+        checkoutClicks:
+          type: integer
+          format: int64
+        purchases:
+          type: integer
+          format: int64
+        checkoutClickRate:
+          type: number
+        purchaseRate:
+          type: number
+        lastEventAt:
+          type: string
+          format: date-time
+          nullable: true

--- a/frontend/src/api/experiment/useExperimentSalesPageAbResults.ts
+++ b/frontend/src/api/experiment/useExperimentSalesPageAbResults.ts
@@ -11,6 +11,7 @@ export interface ExperimentSalesPageAbVariant {
   salesPageUrl?: string | null;
   checkoutUrl?: string | null;
   adDestinationUrl?: string | null;
+  metricsSafeUrl?: string | null;
   analyticsVariantParam?: string | null;
   publicationAuditId?: number | null;
   experimentVideoAssetId?: number | null;
@@ -41,6 +42,7 @@ export interface ExperimentSalesPageAbVariantResult {
   variant: ExperimentSalesPageAbVariant;
   pageViews: number;
   sessions: number;
+  averageVisibleMsPerSession: number;
   checkoutClicks: number;
   purchases: number;
   checkoutClickRate: number | string;

--- a/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from "react";
 import {
   useExperimentSalesPageAbResults,
   type ExperimentSalesPageAbTestResult,
-  type ExperimentSalesPageAbVariant,
 } from "../../api/experiment/useExperimentSalesPageAbResults";
 import {
   useExperimentSalesPageTypeSelections,
@@ -77,22 +76,6 @@ function resultStatusBadge(value?: string | null) {
       return "text-bg-warning";
     default:
       return "text-bg-secondary";
-  }
-}
-
-function safeTestUrl(variant: ExperimentSalesPageAbVariant) {
-  const rawUrl = variant.salesPageUrl || variant.adDestinationUrl;
-  if (!rawUrl) return null;
-  try {
-    const url = new URL(rawUrl);
-    if (!url.searchParams.has("mh_test")) {
-      url.searchParams.set("mh_test", "1");
-    }
-    return url.toString();
-  } catch {
-    return rawUrl.includes("mh_test=1")
-      ? rawUrl
-      : `${rawUrl}${rawUrl.includes("?") ? "&" : "?"}mh_test=1`;
   }
 }
 
@@ -375,7 +358,7 @@ export default function ExperimentSalesPageAbTab({
                 </thead>
                 <tbody>
                   {result.variants.map((item) => {
-                    const testUrl = safeTestUrl(item.variant);
+                    const testUrl = item.variant.metricsSafeUrl;
                     return (
                       <tr key={item.variant.id}>
                         <td>
@@ -425,7 +408,7 @@ export default function ExperimentSalesPageAbTab({
               <CheckCircle2 size={16} className="mt-1 text-success" />
               <span>
                 Use os links com mh_test=1 para revisar as páginas sem gerar
-                novos page views do teste.
+                novos page views do teste. A URL segura vem do backend.
               </span>
             </div>
           </div>

--- a/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentSalesPageAbTab.tsx
@@ -11,6 +11,8 @@ import {
   type SalesPageType,
 } from "../../api/experiment/useSalesPageTypes";
 
+const MAX_AB_TEST_TYPES = 2;
+
 interface ExperimentSalesPageAbTabProps {
   experimentId: string;
 }
@@ -104,7 +106,7 @@ export default function ExperimentSalesPageAbTab({
     useUpdateExperimentSalesPageTypeSelections(experimentId);
   const [selectedTypeCodes, setSelectedTypeCodes] = useState<string[]>([]);
   const [selectionFeedback, setSelectionFeedback] = useState<
-    "success" | "error" | null
+    "success" | "error" | "limit" | null
   >(null);
 
   useEffect(() => {
@@ -134,12 +136,20 @@ export default function ExperimentSalesPageAbTab({
       if (current.includes(typeCode)) {
         return current.filter((code) => code !== typeCode);
       }
+      if (current.length >= MAX_AB_TEST_TYPES) {
+        setSelectionFeedback("limit");
+        return current;
+      }
       return [...current, typeCode];
     });
   };
 
   const saveTypeSelection = async () => {
     setSelectionFeedback(null);
+    if (selectedTypeCodes.length > MAX_AB_TEST_TYPES) {
+      setSelectionFeedback("limit");
+      return;
+    }
     try {
       await updateSelections.mutateAsync(
         selectedTypeCodes.map((typeCode, index) => ({
@@ -195,6 +205,7 @@ export default function ExperimentSalesPageAbTab({
           disabled={
             updateSelections.isPending ||
             selectedTypeCodes.length === 0 ||
+            selectedTypeCodes.length > MAX_AB_TEST_TYPES ||
             isLoadingTypes ||
             isLoadingSelections
           }
@@ -220,6 +231,12 @@ export default function ExperimentSalesPageAbTab({
           Não foi possível salvar os tipos de página de venda.
         </div>
       ) : null}
+      {selectionFeedback === "limit" ? (
+        <div className="alert alert-warning mb-0" role="alert">
+          Teste A/B aceita somente 2 variantes. Remova uma opção antes de
+          escolher outra.
+        </div>
+      ) : null}
 
       {isLoadingTypes || isLoadingSelections ? (
         <div className="text-muted small">Carregando tipos disponíveis...</div>
@@ -227,6 +244,7 @@ export default function ExperimentSalesPageAbTab({
         <div className="row g-3">
           {(types ?? []).map((type) => {
             const checked = selectedTypeCodes.includes(type.code);
+            const disabled = !checked && selectedTypeCodes.length >= MAX_AB_TEST_TYPES;
             return (
               <div className="col-12 col-xl-6" key={type.code}>
                 <label className="border rounded-3 p-3 h-100 d-flex gap-3">
@@ -234,6 +252,7 @@ export default function ExperimentSalesPageAbTab({
                     className="form-check-input mt-1"
                     type="checkbox"
                     checked={checked}
+                    disabled={disabled}
                     onChange={() => toggleType(type.code)}
                   />
                   <span>

--- a/frontend/src/pages/fashionChat/FashionChatPage.css
+++ b/frontend/src/pages/fashionChat/FashionChatPage.css
@@ -116,6 +116,90 @@
   color: #697386;
 }
 
+.fashion-chat-sketch {
+  margin: 14px 0 0;
+  border: 1px solid #d9dee7;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fdfbf7;
+}
+
+.fashion-chat-sketch-art {
+  display: block;
+  width: 100%;
+  max-height: 340px;
+}
+
+.fashion-chat-sketch-paper {
+  fill: #fffaf1;
+  stroke: #e7dccb;
+  stroke-width: 2;
+}
+
+.fashion-chat-sketch-line,
+.fashion-chat-sketch-detail,
+.fashion-chat-sketch-note-line {
+  fill: none;
+  stroke: #2f3542;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.fashion-chat-sketch-line {
+  stroke-width: 3;
+}
+
+.fashion-chat-sketch-detail,
+.fashion-chat-sketch-note-line {
+  stroke-width: 2;
+}
+
+.fashion-chat-sketch-shadow {
+  fill: none;
+  stroke: #d8c8b2;
+  stroke-width: 4;
+  stroke-linecap: round;
+}
+
+.fashion-chat-sketch-hair {
+  fill: #24272f;
+  opacity: 0.92;
+}
+
+.fashion-chat-sketch-garment {
+  fill: #ece7df;
+  stroke: #202633;
+  stroke-width: 3;
+  stroke-linejoin: round;
+}
+
+.fashion-chat-sketch-coat {
+  fill: #c9d3dc;
+  stroke: #202633;
+  stroke-width: 3;
+  stroke-linejoin: round;
+}
+
+.fashion-chat-sketch-accessory {
+  fill: #30261f;
+  stroke: #202633;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+}
+
+.fashion-chat-sketch-pin {
+  fill: #b85c38;
+}
+
+.fashion-chat-sketch-caption {
+  border-top: 1px solid #e6ded2;
+  padding: 8px 10px;
+  color: #4b5563;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  white-space: normal;
+}
+
 .fashion-chat-form {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -144,5 +228,9 @@
 
   .fashion-chat-bubble {
     max-width: 94%;
+  }
+
+  .fashion-chat-sketch-art {
+    max-height: 280px;
   }
 }

--- a/frontend/src/pages/fashionChat/FashionChatPage.tsx
+++ b/frontend/src/pages/fashionChat/FashionChatPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useId, useState } from "react";
 import { Send } from "lucide-react";
 import "./FashionChatPage.css";
 
@@ -20,6 +20,174 @@ const nameCandidates = [
   "Lia Closet",
   "Bella Combina",
 ];
+
+function normalizeFashionText(value: string) {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+function FashionSuggestionSketch({ suggestion }: { suggestion: string }) {
+  const titleId = useId();
+  const lowerSuggestion = normalizeFashionText(suggestion);
+  const hasDress = lowerSuggestion.includes("vestido");
+  const hasCoat =
+    lowerSuggestion.includes("casaco") ||
+    lowerSuggestion.includes("terceira peca") ||
+    lowerSuggestion.includes("blazer");
+  const hasBoot =
+    lowerSuggestion.includes("bota") || lowerSuggestion.includes("inverno");
+  const captionParts = [
+    hasDress ? "vestido como peca principal" : "base bem ajustada",
+    hasCoat ? "terceira peca leve" : "proporcao limpa",
+    hasBoot ? "acabamento de inverno" : "acessorios discretos",
+  ];
+
+  return (
+    <figure
+      className="fashion-chat-sketch"
+      aria-label="Croqui ilustrativo da sugestao de look"
+    >
+      <svg
+        className="fashion-chat-sketch-art"
+        viewBox="0 0 360 420"
+        role="img"
+        aria-labelledby={titleId}
+      >
+        <title id={titleId}>
+          Desenho de estilista mostrando a sugestao de look
+        </title>
+        <rect
+          className="fashion-chat-sketch-paper"
+          x="8"
+          y="8"
+          width="344"
+          height="404"
+          rx="4"
+        />
+        <path
+          className="fashion-chat-sketch-shadow"
+          d="M135 375 C170 390 220 388 250 374"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M181 58 C166 62 158 77 161 94 C164 113 181 119 196 109 C209 100 211 78 200 66 C196 61 189 57 181 58 Z"
+        />
+        <path
+          className="fashion-chat-sketch-hair"
+          d="M160 88 C157 63 173 47 192 55 C213 63 216 90 202 111 C204 92 195 78 180 74 C169 72 162 77 160 88 Z"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M181 118 C178 145 178 176 181 204"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M181 204 C171 248 159 296 151 357"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M183 204 C201 248 214 297 230 359"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M161 145 C129 163 106 190 86 222"
+        />
+        <path
+          className="fashion-chat-sketch-line"
+          d="M202 145 C233 166 255 193 272 225"
+        />
+        {hasDress ? (
+          <path
+            className="fashion-chat-sketch-garment"
+            d="M152 142 L211 142 C222 202 236 256 255 318 C214 337 172 337 132 318 C147 257 152 204 152 142 Z"
+          />
+        ) : (
+          <>
+            <path
+              className="fashion-chat-sketch-garment"
+              d="M151 142 C170 133 194 133 213 142 L207 215 C187 225 166 224 145 215 Z"
+            />
+            <path
+              className="fashion-chat-sketch-garment"
+              d="M147 224 C166 232 188 232 207 224 L225 322 C197 334 170 333 139 322 Z"
+            />
+          </>
+        )}
+        {hasCoat ? (
+          <>
+            <path
+              className="fashion-chat-sketch-coat"
+              d="M138 142 C122 184 116 244 118 319 C133 329 148 331 164 324 C159 263 160 197 171 143 Z"
+            />
+            <path
+              className="fashion-chat-sketch-coat"
+              d="M224 143 C241 185 249 245 250 319 C236 329 220 331 205 324 C208 260 205 196 193 143 Z"
+            />
+            <path
+              className="fashion-chat-sketch-detail"
+              d="M171 150 C178 176 183 201 181 224"
+            />
+            <path
+              className="fashion-chat-sketch-detail"
+              d="M193 150 C188 177 185 201 186 224"
+            />
+          </>
+        ) : null}
+        <path
+          className="fashion-chat-sketch-detail"
+          d="M151 181 C170 189 195 189 214 181"
+        />
+        <path
+          className="fashion-chat-sketch-detail"
+          d="M142 246 C172 258 217 258 242 244"
+        />
+        {hasBoot ? (
+          <>
+            <path
+              className="fashion-chat-sketch-accessory"
+              d="M133 354 L159 354 L158 386 L124 386 C124 375 128 364 133 354 Z"
+            />
+            <path
+              className="fashion-chat-sketch-accessory"
+              d="M219 356 L245 356 L253 386 L221 386 C216 374 216 365 219 356 Z"
+            />
+          </>
+        ) : (
+          <>
+            <path
+              className="fashion-chat-sketch-accessory"
+              d="M134 357 C145 363 154 364 163 359 L158 382 L123 382 C124 373 128 365 134 357 Z"
+            />
+            <path
+              className="fashion-chat-sketch-accessory"
+              d="M220 359 C230 364 239 364 247 359 L258 382 L222 382 C218 373 217 365 220 359 Z"
+            />
+          </>
+        )}
+        <path
+          className="fashion-chat-sketch-note-line"
+          d="M249 93 C280 77 307 77 323 91"
+        />
+        <path
+          className="fashion-chat-sketch-note-line"
+          d="M250 122 C285 113 313 116 332 133"
+        />
+        <path
+          className="fashion-chat-sketch-note-line"
+          d="M51 291 C77 276 103 277 124 291"
+        />
+        <circle className="fashion-chat-sketch-pin" cx="246" cy="94" r="4" />
+        <circle className="fashion-chat-sketch-pin" cx="248" cy="123" r="4" />
+        <circle className="fashion-chat-sketch-pin" cx="127" cy="291" r="4" />
+      </svg>
+      <figcaption className="fashion-chat-sketch-caption">
+        Croqui da sugestao: {captionParts.join(", ")}.
+      </figcaption>
+    </figure>
+  );
+}
 
 export function createMessageId() {
   if (
@@ -110,9 +278,7 @@ export default function FashionChatPage() {
             className="fashion-chat-name-candidates"
             aria-label="Nomes candidatos para o chat consultor de moda"
           >
-            <span className="fashion-chat-name-label">
-              Nomes em avaliacao:
-            </span>
+            <span className="fashion-chat-name-label">Nomes em avaliacao:</span>
             {nameCandidates.map((name) => (
               <span className="fashion-chat-name-pill" key={name}>
                 {name}
@@ -143,12 +309,17 @@ export default function FashionChatPage() {
               >
                 <div className="fashion-chat-bubble">
                   {message.text}
+                  {message.role === "assistant" ? (
+                    <FashionSuggestionSketch suggestion={message.text} />
+                  ) : null}
                   {message.role === "assistant" &&
                   (message.mode || message.sandboxId) ? (
                     <div className="fashion-chat-meta">
                       {message.mode ? `modo: ${message.mode}` : null}
                       {message.mode && message.sandboxId ? " | " : null}
-                      {message.sandboxId ? `sandbox: ${message.sandboxId}` : null}
+                      {message.sandboxId
+                        ? `sandbox: ${message.sandboxId}`
+                        : null}
                     </div>
                   ) : null}
                 </div>
@@ -164,7 +335,11 @@ export default function FashionChatPage() {
             onChange={(event) => setInput(event.target.value)}
             placeholder="Pergunte algo sobre look, ocasiao, cores, estilo ou combinacao..."
           />
-          <button className="btn btn-primary" type="submit" disabled={isSending}>
+          <button
+            className="btn btn-primary"
+            type="submit"
+            disabled={isSending}
+          >
             <Send size={18} aria-hidden="true" />{" "}
             {isSending ? "Enviando" : "Enviar"}
           </button>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
aqui nessa tela do teste A/B coloque o link para cada uma das paginas de venda. Mas coloque um link em que eu acessando não contamine as métricas da campanha.

**Resumo das alterações:**
Feito. A aba `Teste A/B` agora mostra o botão `Ver sem métrica` usando uma URL segura entregue pelo backend (`metricsSafeUrl`) com `mh_test=1`, em vez de o frontend montar isso sozinho.

Principais ajustes:
- Backend expõe `metricsSafeUrl` por variante A/B.
- Frontend usa apenas esse campo para abrir a página sem contaminar métricas.
- Registro feito em [experimentos.md](/root/ai-hub/src/ai-hub-38477051-a342-454e-aaa1-d3485a3cb41d-X1eTSo/repo/docs/registros/experimentos.md).
- Swagger criado em [experiment-sales-page-ab-swagger.yaml](/root/ai-hub/src/ai-hub-38477051-a342-454e-aaa1-d3485a3cb41d-X1eTSo/repo/docs/swagger/experiment-sales-page-ab-swagger.yaml).

Validação:
- Backend: `ExperimentSalesPageAbTestServiceTest` passou.
- Frontend: `npm run build` passou.
- Frontend: `npm run typecheck` passou.
- Não havia teste específico `ExperimentSalesPageAbTab`, então o Vitest filtrado não encontrou arquivo.

Servidor local do frontend está rodando em:
`http://localhost:5173/`

Observação: para a tela em produção exibir o link seguro, o backend com esse novo campo precisa ser publicado.