### PR TITLE
AI Hub: Corrigi o workflow localmente. A falha do GitHub Actions não foi arquitetura: backend, frontend e vídeo passaram; o erro foi no deploy `Build & Deploy containers`, etapa `Upload images to APP VPS`, com `client_loop: send disconnect: Broken pipe` d…

### DIFF
--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -184,15 +184,37 @@ jobs:
         env:
           SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
         run: |
-          ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
-          rsync -az --delete -e "ssh ${SSH_OPTS}" deploy/ ${VPS_USER}@${APP_VPS_IP}:${DEPLOY_DIR}/
+          retry() {
+            local attempt=1
+            until "$@"; do
+              if [ "${attempt}" -ge 3 ]; then
+                return 1
+              fi
+              sleep $((attempt * 10))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          retry ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
+          retry rsync -az --delete -e "ssh ${SSH_OPTS}" deploy/ ${VPS_USER}@${APP_VPS_IP}:${DEPLOY_DIR}/
 
       - name: Upload images to APP VPS
         env:
           SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
         run: |
-          scp ${SSH_OPTS} artifacts/backend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/backend-image.tar
-          scp ${SSH_OPTS} artifacts/frontend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/frontend-image.tar
+          retry() {
+            local attempt=1
+            until "$@"; do
+              if [ "${attempt}" -ge 3 ]; then
+                return 1
+              fi
+              sleep $((attempt * 10))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/backend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/backend-image.tar
+          retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/frontend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/frontend-image.tar
 
       - name: Apply backend/frontend stack
         env:


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
verifica e ajusta o que aconteceu no github action. Se for problema de arquitetura ajuste a arquitetura e mantenha os testes.

**Resumo das alterações:**
Corrigi o workflow localmente. A falha do GitHub Actions não foi arquitetura: backend, frontend e vídeo passaram; o erro foi no deploy `Build & Deploy containers`, etapa `Upload images to APP VPS`, com `client_loop: send disconnect: Broken pipe` durante upload dos tarballs para a VPS.

Ajuste feito em [.github/workflows/deploy-containers.yml](/root/ai-hub/src/ai-hub-bd7108dc-0368-40f2-83bc-bab81aaaf9a1-m5fOvL/repo/.github/workflows/deploy-containers.yml:183):

- adicionei `retry` no deploy backend/frontend, igual ao padrão que já existia no deploy de vídeo;
- troquei o upload de imagens de `scp` para `rsync --partial --append-verify`, para permitir retomada em conexão instável;
- mantive todos os testes e validações existentes.

Validei:
- `git diff --check`: ok;
- sintaxe dos blocos shell alterados com `bash -n`: ok.

Limitação real: o ambiente não tem `gh`, `ruby`, `PyYAML` nem `actionlint`, então não consegui rodar validação completa de workflow YAML localmente. Não criei PR.