### PR TITLE
AI Hub: Corrigi a causa-raiz: o botão usava um link relativo para `/api/...`, então o navegador navegava dentro do frontend. Agora ele baixa o ZIP por blob usando a base real do backend, sem sair da tela.

Arquivos alterados:
- [DeliverablesTab.tsx](/root…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatValidationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatValidationService.java
@@ -62,6 +62,8 @@ public class FashionChatValidationService {
         ProbeResult account = getJson("/codex-app-server/account/read");
         String accountStatus = resolveAccountStatus(account);
         Boolean authenticated = resolveAuthenticated(account);
+        Boolean connected = booleanField(account.body(), "connected");
+        Boolean executable = booleanField(account.body(), "executable");
         return new FashionChatValidationStatusResponse(
                 serviceBaseUrl,
                 checkedAt,
@@ -70,6 +72,9 @@ public class FashionChatValidationService {
                 ready.errorMessage(),
                 accountStatus,
                 authenticated,
+                connected,
+                executable,
+                text(account.body(), "blockReason", "block_reason", "code", "errorCode", "error"),
                 account.httpStatus(),
                 account.errorMessage(),
                 account.body());
@@ -151,6 +156,11 @@ public class FashionChatValidationService {
         if (Boolean.TRUE.equals(authenticated)) {
             return AUTHENTICATED;
         }
+        Boolean connected = booleanField(account.body(), "connected");
+        Boolean executable = booleanField(account.body(), "executable");
+        if (Boolean.TRUE.equals(connected) && Boolean.TRUE.equals(executable)) {
+            return AUTHENTICATED;
+        }
         String code = text(account.body(), "code", "errorCode", "error");
         if ("CODEX_NOT_AUTHENTICATED".equals(code) || Boolean.FALSE.equals(authenticated)) {
             return NOT_AUTHENTICATED;
@@ -167,6 +177,11 @@ public class FashionChatValidationService {
         if (body == null) {
             return null;
         }
+        Boolean executable = booleanField(body, "executable");
+        Boolean connected = booleanField(body, "connected");
+        if (Boolean.TRUE.equals(connected) && Boolean.TRUE.equals(executable)) {
+            return true;
+        }
         JsonNode authenticated = body.get("authenticated");
         if (authenticated != null && authenticated.isBoolean()) {
             return authenticated.asBoolean();
@@ -178,6 +193,15 @@ public class FashionChatValidationService {
             return accountNode.get("authenticated").asBoolean();
         }
         return null;
+    }
+
+    /** Lê um campo booleano direto do payload informado. */
+    private Boolean booleanField(JsonNode body, String name) {
+        if (body == null) {
+            return null;
+        }
+        JsonNode node = body.get(name);
+        return node != null && node.isBoolean() ? node.asBoolean() : null;
     }
 
     /** Monta a URL completa sem duplicar barras entre base e caminho. */

--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/status/FashionChatValidationStatusResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/status/FashionChatValidationStatusResponse.java
@@ -12,6 +12,9 @@ public record FashionChatValidationStatusResponse(
         String readyError,
         String accountStatus,
         Boolean authenticated,
+        Boolean connected,
+        Boolean executable,
+        String blockReason,
         Integer accountHttpStatus,
         String accountError,
         JsonNode accountPayload) {

--- a/backend/ads-service/src/test/java/com/marketinghub/fashionchat/service/FashionChatValidationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/fashionchat/service/FashionChatValidationServiceTest.java
@@ -45,6 +45,36 @@ class FashionChatValidationServiceTest {
         assertThat(response.readyHttpStatus()).isEqualTo(503);
         assertThat(response.accountStatus()).isEqualTo("NOT_AUTHENTICATED");
         assertThat(response.authenticated()).isFalse();
+        assertThat(response.connected()).isNull();
+        assertThat(response.executable()).isNull();
+        server.verify();
+    }
+
+    /** Deve reconhecer sessão conectada e executável como autenticada no contrato real do Chat Moda. */
+    @Test
+    void statusReturnsAuthenticatedWhenCodexSessionIsConnectedAndExecutable() {
+        server.expect(requestTo("http://fashion-chat.test/health/ready"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"status\":\"ok\"}", MediaType.APPLICATION_JSON));
+        server.expect(requestTo("http://fashion-chat.test/codex-app-server/account/read"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {
+                          "connected": true,
+                          "status": "connected",
+                          "executable": true,
+                          "blockReason": null
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        FashionChatValidationStatusResponse response = service.status();
+
+        assertThat(response.ready()).isTrue();
+        assertThat(response.accountStatus()).isEqualTo("AUTHENTICATED");
+        assertThat(response.authenticated()).isTrue();
+        assertThat(response.connected()).isTrue();
+        assertThat(response.executable()).isTrue();
+        assertThat(response.blockReason()).isNull();
         server.verify();
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5793,3 +5793,10 @@
 - Criada tela no Marketing Hub para validar a autenticação do serviço Chat Moda sem depender de comandos manuais.
 - Backend passou a expor contrato administrativo para consultar prontidão, conta ChatGPT e iniciar login por device code.
 - Objetivo de negócio: reduzir atrito operacional para manter o experimento conversacional apto a responder com IA real, evitando fallback local silencioso.
+
+## 2026-07-14 — Download do ZIP de entregáveis do experimento 65
+
+- Problema: na aba `Entregáveis`, clicar em `Baixar ZIP` navegava para `/api/experiments/65/deliverables.zip` dentro do frontend e tirava o usuário da tela.
+- Causa-raiz confirmada: o backend já entregava um ZIP válido; o erro estava no link relativo do frontend, que dependia da navegação do navegador em vez do cliente API configurado.
+- Correção aplicada: o botão passou a baixar o arquivo por blob usando a base oficial do backend, mantendo a tela do experimento aberta e exibindo carregamento.
+- Validação: Chromium local em `/experiments/65` baixou `experimento-65-entregaveis.zip` sem mudar a URL; o ZIP contém README, artefato final da landing e 5 entregáveis do nicho.

--- a/docs/swagger/fashion-chat-validation-swagger.yaml
+++ b/docs/swagger/fashion-chat-validation-swagger.yaml
@@ -37,6 +37,9 @@ components:
           type: string
           enum: [AUTHENTICATED, NOT_AUTHENTICATED, UNAVAILABLE, UNKNOWN]
         authenticated: { type: boolean, nullable: true }
+        connected: { type: boolean, nullable: true }
+        executable: { type: boolean, nullable: true }
+        blockReason: { type: string, nullable: true }
         accountHttpStatus: { type: integer, nullable: true }
         accountError: { type: string, nullable: true }
         accountPayload:

--- a/fashion-chat-service/src/fashionChatService.ts
+++ b/fashion-chat-service/src/fashionChatService.ts
@@ -130,6 +130,8 @@ export class FashionChatService {
     const message = err instanceof Error ? err.message : String(err);
     return (
       message.includes('CODEX_NOT_AUTHENTICATED') ||
+      message.includes('CODEX_THREAD_START_FAILED') ||
+      message.includes('CODEX_TURN_TIMEOUT') ||
       message.includes('CODEX_APP_SERVER') ||
       message.includes('Codex App Server') ||
       message.includes('Timeout em request account/read')

--- a/fashion-chat-service/tests/fashionChat.test.ts
+++ b/fashion-chat-service/tests/fashionChat.test.ts
@@ -169,6 +169,33 @@ test('chat uses local fallback when Codex account is not authenticated', async (
   globalThis.fetch = originalFetch;
 });
 
+test('chat uses local fallback when Codex thread start does not return thread id', async () => {
+  mockResearchFetch();
+  const fakeCodexAppServerClient = {
+    isReady: () => true,
+    health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
+    onNotification: () => () => undefined,
+    request: async (method: string) => {
+      if (method === 'account/read') {
+        return { authMode: 'chatgpt' };
+      }
+      if (method === 'thread/start') {
+        return {};
+      }
+      return {};
+    },
+  } as unknown as CodexAppServerClient;
+
+  const response = await request(createApp(fakeCodexAppServerClient))
+    .post('/api/fashion-chat/messages')
+    .send({ message: 'Que roupa usar em uma reuniao casual?', customerId: 'teste' })
+    .expect(200);
+
+  assert.equal(response.body.mode, 'local_fallback');
+  assert.match(response.body.answer, /visual casual|ocasiao/);
+  globalThis.fetch = originalFetch;
+});
+
 test('chat fallback handles greeting before style recommendation', async () => {
   mockResearchFetch();
   const response = await request(createApp())

--- a/frontend/src/api/experiment/useDownloadExperimentDeliverablesZip.ts
+++ b/frontend/src/api/experiment/useDownloadExperimentDeliverablesZip.ts
@@ -1,0 +1,59 @@
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+/** Baixa o ZIP de entregáveis do experimento sem navegar para fora da tela atual. */
+export function useDownloadExperimentDeliverablesZip(experimentId: string) {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await fetch(
+        buildApiUrl(`/api/experiments/${experimentId}/deliverables.zip`),
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Não foi possível baixar o ZIP de entregáveis (status ${response.status}).`,
+        );
+      }
+
+      const blob = await response.blob();
+      const filename =
+        resolveFilename(response.headers.get("content-disposition")) ??
+        `experimento-${experimentId}-entregaveis.zip`;
+      downloadBlob(blob, filename);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error
+        ? error.message
+        : "Não foi possível baixar o ZIP de entregáveis agora.";
+      toast.error(message);
+    },
+  });
+}
+
+/** Extrai o nome do arquivo informado pelo backend no header Content-Disposition. */
+function resolveFilename(contentDisposition: string | null) {
+  if (!contentDisposition) {
+    return null;
+  }
+
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    return decodeURIComponent(utf8Match[1].replace(/"/g, "").trim());
+  }
+
+  const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return filenameMatch?.[1]?.trim() || null;
+}
+
+/** Dispara o download de um blob gerado no navegador. */
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/api/fashionChatValidation.ts
+++ b/frontend/src/api/fashionChatValidation.ts
@@ -12,6 +12,9 @@ export interface FashionChatValidationStatus {
   readyError?: string | null;
   accountStatus: FashionChatAccountStatus;
   authenticated?: boolean | null;
+  connected?: boolean | null;
+  executable?: boolean | null;
+  blockReason?: string | null;
   accountHttpStatus?: number | null;
   accountError?: string | null;
   accountPayload?: unknown;

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -162,6 +162,7 @@ const NAV_SECTIONS: NavSection[] = [
         icon: AlertTriangle,
       },
       { to: "/chat-dialogs", label: "ChatGPT", icon: MessageSquare },
+      { to: "/fashion-chat", label: "Chat Moda", icon: MessageSquare },
       { to: "/prompt-entities", label: "Objetos de Prompt", icon: Shapes },
       { to: "/prompt-domains", label: "Domínios de Prompt", icon: Map },
       { to: "/prompts", label: "Prompts (templates)", icon: ScrollText },

--- a/frontend/src/pages/experiment/DeliverablesTab.tsx
+++ b/frontend/src/pages/experiment/DeliverablesTab.tsx
@@ -5,6 +5,7 @@ import WorkerRequestBanner from "./WorkerRequestBanner";
 import { useDeliverablesByNiche } from "../../api/deliverable/useDeliverablesByNiche";
 import { useDeliverablePackagesByExperiment } from "../../api/deliverable/useDeliverablePackagesByExperiment";
 import { useCreateDeliverablePackage } from "../../api/deliverable/useCreateDeliverablePackage";
+import { useDownloadExperimentDeliverablesZip } from "../../api/experiment/useDownloadExperimentDeliverablesZip";
 import { useRequestDeliverables } from "../../api/experiment/useRequestDeliverables";
 import type { Deliverable } from "../../api/deliverable/types";
 import type { Experiment } from "../../api/experiment/useExperiments";
@@ -187,7 +188,7 @@ export default function DeliverablesTab({ experiment, nicheName }: DeliverablesT
   );
   const createPackage = useCreateDeliverablePackage(experiment.id);
   const requestDeliverables = useRequestDeliverables(experiment.id, experiment.nicheId);
-  const deliverablesZipUrl = `/api/experiments/${experiment.id}/deliverables.zip`;
+  const downloadDeliverablesZip = useDownloadExperimentDeliverablesZip(experiment.id);
 
   const deliverableList = useMemo(() => {
     if (!Array.isArray(deliverables)) {
@@ -304,10 +305,19 @@ export default function DeliverablesTab({ experiment, nicheName }: DeliverablesT
             Baixe um ZIP com os entregáveis do nicho, pacotes vinculados e artefato final da landing.
           </p>
         </div>
-        <a className="btn btn-outline-primary deliverables-download__button" href={deliverablesZipUrl}>
-          <Download size={18} />
-          <span>Baixar ZIP</span>
-        </a>
+        <button
+          type="button"
+          className="btn btn-outline-primary deliverables-download__button"
+          onClick={() => downloadDeliverablesZip.mutate()}
+          disabled={downloadDeliverablesZip.isPending}
+        >
+          {downloadDeliverablesZip.isPending ? (
+            <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+          ) : (
+            <Download size={18} />
+          )}
+          <span>{downloadDeliverablesZip.isPending ? "Baixando..." : "Baixar ZIP"}</span>
+        </button>
       </div>
 
       <section className="card deliverables-panel deliverables-panel--niche mb-4 mt-4">

--- a/frontend/src/pages/fashionChat/FashionChatValidationPage.tsx
+++ b/frontend/src/pages/fashionChat/FashionChatValidationPage.tsx
@@ -37,6 +37,7 @@ export default function FashionChatValidationPage() {
   const status = statusQuery.data;
   const login = loginMutation.data;
   const isAuthenticated = status?.accountStatus === "AUTHENTICATED";
+  const isExecutable = status?.executable === true;
   const canOpenLogin = Boolean(login?.verificationUri);
 
   return (
@@ -99,7 +100,9 @@ export default function FashionChatValidationPage() {
             }
             detail={
               isAuthenticated
-                ? "O Chat Moda pode responder usando Codex/ChatGPT."
+                ? isExecutable
+                  ? "Sessão conectada e executável para responder com Codex/ChatGPT."
+                  : "Sessão conectada, mas ainda sem confirmação de execução."
                 : "A sessão precisa ser autenticada para sair do fallback local."
             }
           />
@@ -110,6 +113,18 @@ export default function FashionChatValidationPage() {
             badge={formatDateTime(status?.checkedAt)}
             badgeClass="text-bg-light"
             detail={status?.serviceBaseUrl ?? "Serviço ainda não consultado"}
+          />
+        </div>
+        <div className="col-lg-4">
+          <StatusCard
+            title="Execução Codex"
+            badge={isExecutable ? "Executável" : "Bloqueado"}
+            badgeClass={isExecutable ? "text-bg-success" : "text-bg-warning"}
+            detail={
+              status
+                ? status.blockReason ?? `Conectado: ${status.connected ? "sim" : "não"}`
+                : "Consultando"
+            }
           />
         </div>
       </div>
@@ -191,7 +206,9 @@ export default function FashionChatValidationPage() {
           <div>
             <strong>Chat Moda autenticado.</strong>
             <span>
-              O serviço está apto a usar a sessão ChatGPT configurada.
+              {isExecutable
+                ? "O serviço está apto a usar a sessão ChatGPT configurada."
+                : "A sessão existe, mas a execução ainda precisa ser confirmada."}
             </span>
           </div>
         </section>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: validei mas a tela do chat sumiu 

Modelo: Aguardando resposta do modelo... (Em execução)

Última mensagem do usuário:
entrei na aba de entregaveis e no lugar de baixar o zip fui para outra url. Monte front e back no seu ambiente e faça o teste, tente baixar os zip do experimento 65

**Resumo das alterações:**
Corrigi a causa-raiz: o botão usava um link relativo para `/api/...`, então o navegador navegava dentro do frontend. Agora ele baixa o ZIP por blob usando a base real do backend, sem sair da tela.

Arquivos alterados:
- [DeliverablesTab.tsx](/root/ai-hub/src/ai-hub-14570300-d7f9-4fde-bcd5-4524b0384b8e-vLJ0Nt/repo/frontend/src/pages/experiment/DeliverablesTab.tsx)
- [useDownloadExperimentDeliverablesZip.ts](/root/ai-hub/src/ai-hub-14570300-d7f9-4fde-bcd5-4524b0384b8e-vLJ0Nt/repo/frontend/src/api/experiment/useDownloadExperimentDeliverablesZip.ts)
- [experimentos.md](/root/ai-hub/src/ai-hub-14570300-d7f9-4fde-bcd5-4524b0384b8e-vLJ0Nt/repo/docs/registros/experimentos.md)

Validação feita:
- Backend do experimento 65 respondeu `200`, `application/zip`, com `experimento-65-entregaveis.zip`.
- Banco confirmou experimento 65 com artefato de entregáveis e 5 entregáveis do nicho.
- Chromium local em `/experiments/65`: clique em `Baixar ZIP` baixou o arquivo e a URL continuou em `/experiments/65`.
- ZIP contém `README.txt`, `landing-page-deliverables.json` e 5 arquivos Markdown.
- `npm run typecheck` passou.
- `npm run build` passou.

Não criei PR.