### PR TITLE
AI Hub: Corrigi a causa-raiz: a validação dizia “autenticado” porque o contrato real vinha como `connected=true` e `executable=true`, mas o envio do chat só aceitava campos antigos (`authMode/account`). Resultado: mesmo autenticado, o chat caía em `local_…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/controller/FashionChatController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/controller/FashionChatController.java
@@ -1,0 +1,27 @@
+package com.marketinghub.fashionchat.controller;
+
+import com.marketinghub.fashionchat.service.FashionChatMessageService;
+import com.marketinghub.fashionchat.service.message.FashionChatMessageRequest;
+import com.marketinghub.fashionchat.service.message.FashionChatMessageResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe o contrato de conversa do Chat Moda para o frontend. */
+@RestController
+@RequestMapping("/api/fashion-chat")
+public class FashionChatController {
+    private final FashionChatMessageService service;
+
+    /** Inicializa o controller com o serviço de conversa do Chat Moda. */
+    public FashionChatController(FashionChatMessageService service) {
+        this.service = service;
+    }
+
+    /** Recebe a pergunta da tela e devolve a resposta gerada pelo executor. */
+    @PostMapping("/messages")
+    public FashionChatMessageResponse answer(@RequestBody FashionChatMessageRequest request) {
+        return service.answer(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatMessageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatMessageService.java
@@ -1,0 +1,97 @@
+package com.marketinghub.fashionchat.service;
+
+import com.marketinghub.fashionchat.service.message.FashionChatMessageRequest;
+import com.marketinghub.fashionchat.service.message.FashionChatMessageResponse;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+/** Encaminha mensagens da tela para o serviço executor do Chat Moda. */
+@Service
+public class FashionChatMessageService {
+    private static final Logger log = LoggerFactory.getLogger(FashionChatMessageService.class);
+
+    private final RestTemplate restTemplate;
+    private final String serviceBaseUrl;
+
+    /** Inicializa o serviço com cliente HTTP e URL base do executor do Chat Moda. */
+    @Autowired
+    public FashionChatMessageService(
+            RestTemplateBuilder restTemplateBuilder,
+            @Value("${integrations.fashion-chat.base-url:http://191.252.210.83:8094}") String serviceBaseUrl,
+            @Value("${integrations.fashion-chat.connect-timeout:PT2S}") Duration connectTimeout,
+            @Value("${integrations.fashion-chat.read-timeout:PT180S}") Duration readTimeout) {
+        this(restTemplateBuilder
+                .setConnectTimeout(connectTimeout)
+                .setReadTimeout(readTimeout)
+                .build(), serviceBaseUrl);
+    }
+
+    /** Permite montar o serviço em testes com cliente HTTP controlado. */
+    FashionChatMessageService(RestTemplate restTemplate, String serviceBaseUrl) {
+        this.restTemplate = restTemplate;
+        this.serviceBaseUrl = normalizeBaseUrl(serviceBaseUrl);
+    }
+
+    /** Envia a pergunta ao executor e retorna a resposta funcional preservada. */
+    public FashionChatMessageResponse answer(FashionChatMessageRequest request) {
+        if (request == null || request.message() == null || request.message().isBlank()) {
+            throw new ResponseStatusException(BAD_REQUEST, "message e obrigatorio");
+        }
+        String url = buildUrl("/api/fashion-chat/messages");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        FashionChatMessageRequest payload = new FashionChatMessageRequest(
+                blankToNull(request.customerId()),
+                request.message().trim());
+        try {
+            ResponseEntity<FashionChatMessageResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    new HttpEntity<>(payload, headers),
+                    FashionChatMessageResponse.class);
+            return response.getBody();
+        } catch (RestClientResponseException ex) {
+            log.error("Falha HTTP ao enviar mensagem ao Chat Moda no endpoint {}", url, ex);
+            throw new ResponseStatusException(SERVICE_UNAVAILABLE,
+                    "Chat Moda recusou a mensagem: " + ex.getRawStatusCode(), ex);
+        } catch (RestClientException ex) {
+            log.error("Erro ao enviar mensagem ao Chat Moda no endpoint {}", url, ex);
+            throw new ResponseStatusException(BAD_GATEWAY, "Erro ao conectar no serviço Chat Moda", ex);
+        }
+    }
+
+    /** Monta a URL completa sem duplicar barras entre base e caminho. */
+    private String buildUrl(String path) {
+        return UriComponentsBuilder.fromHttpUrl(serviceBaseUrl).path(path).build().toUriString();
+    }
+
+    /** Normaliza a URL base configurada para chamadas ao executor. */
+    private String normalizeBaseUrl(String value) {
+        String normalized = value == null || value.isBlank() ? "http://191.252.210.83:8094" : value.trim();
+        return normalized.endsWith("/") ? normalized.substring(0, normalized.length() - 1) : normalized;
+    }
+
+    /** Converte texto em branco para nulo antes de encaminhar ao executor. */
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/message/FashionChatMessageRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/message/FashionChatMessageRequest.java
@@ -1,0 +1,5 @@
+package com.marketinghub.fashionchat.service.message;
+
+/** Representa a pergunta enviada pela tela do Chat Moda. */
+public record FashionChatMessageRequest(String customerId, String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/message/FashionChatMessageResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/message/FashionChatMessageResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.fashionchat.service.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Representa a resposta preservada do serviço executor do Chat Moda. */
+public record FashionChatMessageResponse(
+        String answer,
+        String mode,
+        String sandboxId,
+        JsonNode research) {
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/fashionchat/service/FashionChatMessageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/fashionchat/service/FashionChatMessageServiceTest.java
@@ -1,0 +1,65 @@
+package com.marketinghub.fashionchat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.marketinghub.fashionchat.service.message.FashionChatMessageRequest;
+import com.marketinghub.fashionchat.service.message.FashionChatMessageResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Valida a ponte do backend para o executor do Chat Moda. */
+class FashionChatMessageServiceTest {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+    private final FashionChatMessageService service = new FashionChatMessageService(
+            restTemplate,
+            "http://fashion-chat.test/");
+
+    /** Deve encaminhar a mensagem ao executor e preservar a resposta funcional. */
+    @Test
+    void answerForwardsMessageToFashionChatExecutor() {
+        server.expect(requestTo("http://fashion-chat.test/api/fashion-chat/messages"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().json("""
+                        {
+                          "customerId": "marketing-hub-pilot",
+                          "message": "Que roupa usar em uma reuniao casual?"
+                        }
+                        """))
+                .andRespond(withSuccess("""
+                        {
+                          "answer": "Use alfaiataria leve.",
+                          "mode": "codex_app_server",
+                          "sandboxId": "fashion-chat-test",
+                          "research": {"query": "moda reuniao"}
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        FashionChatMessageResponse response = service.answer(new FashionChatMessageRequest(
+                " marketing-hub-pilot ",
+                " Que roupa usar em uma reuniao casual? "));
+
+        assertThat(response.answer()).isEqualTo("Use alfaiataria leve.");
+        assertThat(response.mode()).isEqualTo("codex_app_server");
+        assertThat(response.sandboxId()).isEqualTo("fashion-chat-test");
+        assertThat(response.research().get("query").asText()).isEqualTo("moda reuniao");
+        server.verify();
+    }
+
+    /** Deve bloquear chamada vazia antes de acionar o executor. */
+    @Test
+    void answerRejectsBlankMessage() {
+        assertThatThrownBy(() -> service.answer(new FashionChatMessageRequest("cliente", " ")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("message e obrigatorio");
+    }
+}

--- a/fashion-chat-service/src/codexAppServerClient.ts
+++ b/fashion-chat-service/src/codexAppServerClient.ts
@@ -115,7 +115,7 @@ export class CodexAppServerClient {
   async readAuthentication(): Promise<{ authenticated: boolean; authMode?: string }> {
     const account = await this.request<Record<string, unknown>>('account/read', { refreshToken: false });
     const authMode = this.extractAuthMode(account);
-    return { authenticated: !!authMode, authMode };
+    return { authenticated: this.isAuthenticatedAccount(account), authMode };
   }
 
   onNotification(method: string, listener: (params: unknown) => void): () => void {
@@ -252,6 +252,13 @@ export class CodexAppServerClient {
       }
     }
     return undefined;
+  }
+
+  private isAuthenticatedAccount(account: Record<string, unknown>): boolean {
+    if (this.extractAuthMode(account)) {
+      return true;
+    }
+    return account.connected === true && account.executable === true;
   }
 
   private sanitize(value: string): string {

--- a/fashion-chat-service/src/fashionChatService.ts
+++ b/fashion-chat-service/src/fashionChatService.ts
@@ -52,7 +52,7 @@ export class FashionChatService {
       throw new Error('CODEX_APP_SERVER_DISABLED');
     }
     const account = await client.request<Record<string, unknown>>('account/read', { refreshToken: false });
-    if (!account?.authMode && !account?.auth_mode && !account?.account) {
+    if (!this.isAuthenticatedAccount(account)) {
       throw new Error('CODEX_NOT_AUTHENTICATED');
     }
     const thread = await client.request<Record<string, unknown>>('thread/start', {
@@ -135,6 +135,16 @@ export class FashionChatService {
       message.includes('CODEX_APP_SERVER') ||
       message.includes('Codex App Server') ||
       message.includes('Timeout em request account/read')
+    );
+  }
+
+  private isAuthenticatedAccount(account: Record<string, unknown>): boolean {
+    return Boolean(
+      account.authMode ||
+        account.auth_mode ||
+        account.account ||
+        account.login ||
+        (account.connected === true && account.executable === true),
     );
   }
 

--- a/fashion-chat-service/tests/fashionChat.test.ts
+++ b/fashion-chat-service/tests/fashionChat.test.ts
@@ -246,6 +246,46 @@ test('chat answers only through Codex App Server', async () => {
   globalThis.fetch = originalFetch;
 });
 
+test('chat accepts connected executable account contract before starting Codex turn', async () => {
+  mockResearchFetch();
+  const listeners = new Map<string, (params: unknown) => void>();
+  const calls: string[] = [];
+  const fakeCodexAppServerClient = {
+    isReady: () => true,
+    health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
+    onNotification: (method: string, listener: (params: unknown) => void) => {
+      listeners.set(method, listener);
+      return () => listeners.delete(method);
+    },
+    request: async (method: string) => {
+      calls.push(method);
+      if (method === 'account/read') {
+        return { connected: true, status: 'connected', executable: true, blockReason: null };
+      }
+      if (method === 'thread/start') {
+        return { threadId: 'thread-fashion-connected-test' };
+      }
+      if (method === 'turn/start') {
+        setTimeout(() => {
+          listeners.get('turn/completed')?.({ text: 'Use camisa fluida, calca reta e um ponto de cor discreto.' });
+        }, 0);
+        return {};
+      }
+      return {};
+    },
+  } as unknown as CodexAppServerClient;
+
+  const response = await request(createApp(fakeCodexAppServerClient))
+    .post('/api/fashion-chat/messages')
+    .send({ message: 'Que roupa usar em uma reuniao casual?', customerId: 'teste' })
+    .expect(200);
+
+  assert.equal(response.body.mode, 'codex_app_server');
+  assert.match(response.body.answer, /camisa fluida/);
+  assert.deepEqual(calls, ['account/read', 'thread/start', 'turn/start']);
+  globalThis.fetch = originalFetch;
+});
+
 test('chat validates required message', async () => {
   await request(createApp()).post('/api/fashion-chat/messages').send({ message: ' ' }).expect(400);
 });

--- a/frontend/src/pages/fashionChat/FashionChatPage.test.ts
+++ b/frontend/src/pages/fashionChat/FashionChatPage.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMessageId } from "./FashionChatPage";
+import {
+  createMessageId,
+  fashionChatMessageEndpoint,
+} from "./FashionChatPage";
+
+describe("fashionChatMessageEndpoint", () => {
+  it("usa o backend como ponto unico de contato do frontend", () => {
+    expect(fashionChatMessageEndpoint).toBe("/api/fashion-chat/messages");
+  });
+});
 
 describe("createMessageId", () => {
   afterEach(() => {

--- a/frontend/src/pages/fashionChat/FashionChatPage.tsx
+++ b/frontend/src/pages/fashionChat/FashionChatPage.tsx
@@ -10,9 +10,6 @@ type ChatMessage = {
   sandboxId?: string;
 };
 
-const serviceUrl =
-  import.meta.env.VITE_FASHION_CHAT_SERVICE_URL || "http://191.252.210.83:8094";
-
 const nameCandidates = [
   "Mia Estilo",
   "Clara Look",
@@ -20,6 +17,8 @@ const nameCandidates = [
   "Lia Closet",
   "Bella Combina",
 ];
+
+export const fashionChatMessageEndpoint = "/api/fashion-chat/messages";
 
 function normalizeFashionText(value: string) {
   return value
@@ -226,7 +225,7 @@ export default function FashionChatPage() {
     setStatus("Consultando especialista");
 
     try {
-      const response = await fetch(`${serviceUrl}/api/fashion-chat/messages`, {
+      const response = await fetch(fashionChatMessageEndpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
Veja esta autenticado mas o chat não funcionou. Resolva isso faça os testes necessarios e entregue quando estiver funcioando corretamente.

**Resumo das alterações:**
Corrigi a causa-raiz: a validação dizia “autenticado” porque o contrato real vinha como `connected=true` e `executable=true`, mas o envio do chat só aceitava campos antigos (`authMode/account`). Resultado: mesmo autenticado, o chat caía em `local_fallback`.

O que foi ajustado:
- `fashion-chat-service`: agora reconhece `connected + executable` como sessão válida e inicia o turno Codex.
- Backend: adicionei `/api/fashion-chat/messages` como ponte oficial para o serviço de moda.
- Frontend: a tela `/fashion-chat` deixou de chamar IP/porta direta e passou a usar o backend.
- Testes adicionados para impedir regressão desse contrato.

Validações feitas:
- `fashion-chat-service`: 14 testes passaram.
- Backend: testes focados do Chat Moda passaram.
- Frontend: teste focado passou.
- Builds passaram: `fashion-chat-service`, `frontend` e pacote backend.

Limitação real: este sandbox não tem Docker daemon/systemd, então não consegui reiniciar o ambiente de produção daqui. Também tentei validar geração Codex localmente, mas o `codex app-server` do sandbox não iniciou corretamente; em produção ele já estava reportando `connected=true/executable=true`, que foi exatamente o contrato corrigido e coberto por teste.

Não criei PR.