### PR TITLE
AI Hub: Ajustei duas causas-raiz:

1. **Erro `405` na tela**
   - Causa: Nginx do frontend em `:5173` servia só arquivos estáticos e não fazia proxy de `/api`.
   - Correção feita em [frontend/docker/nginx.conf](/root/ai-hub/src/ai-hub-56e64617-f39b-411d-…

### DIFF
--- a/fashion-chat-service/src/fashionChatService.ts
+++ b/fashion-chat-service/src/fashionChatService.ts
@@ -56,13 +56,13 @@ export class FashionChatService {
       throw new Error('CODEX_NOT_AUTHENTICATED');
     }
     const thread = await client.request<Record<string, unknown>>('thread/start', {
-      model: process.env.FASHION_CHAT_CODEX_MODEL?.trim() || 'gpt-5-codex',
+      model: process.env.FASHION_CHAT_CODEX_MODEL?.trim() || 'gpt-5.5',
       cwd,
       approvalPolicy: 'never',
       sandbox: process.env.CODEX_APP_SERVER_SANDBOX_MODE?.trim() || 'danger-full-access',
       serviceName: 'fashion_chat_service',
     });
-    const threadId = this.extractId(thread, ['threadId', 'id']);
+    const threadId = this.extractId(thread, ['threadId', 'id']) ?? this.extractNestedId(thread, 'thread', ['threadId', 'id']);
     if (!threadId) {
       throw new Error('CODEX_THREAD_START_FAILED');
     }
@@ -88,7 +88,7 @@ export class FashionChatService {
     try {
       await client.request<Record<string, unknown>>('turn/start', {
         threadId,
-        input: [{ role: 'user', content: prompt }],
+        input: [{ type: 'text', text: prompt }],
       });
       await this.waitForTurn(() => completed, () => failure);
       if (failure) {
@@ -233,6 +233,14 @@ export class FashionChatService {
       }
     }
     return undefined;
+  }
+
+  private extractNestedId(value: Record<string, unknown>, key: string, idKeys: string[]): string | undefined {
+    const nested = value[key];
+    if (!nested || typeof nested !== 'object') {
+      return undefined;
+    }
+    return this.extractId(nested as Record<string, unknown>, idKeys);
   }
 
   private extractAgentMessageText(value: unknown): string | undefined {

--- a/fashion-chat-service/tests/fashionChat.test.ts
+++ b/fashion-chat-service/tests/fashionChat.test.ts
@@ -250,6 +250,8 @@ test('chat accepts connected executable account contract before starting Codex t
   mockResearchFetch();
   const listeners = new Map<string, (params: unknown) => void>();
   const calls: string[] = [];
+  let threadStartParams: unknown;
+  let turnStartParams: unknown;
   const fakeCodexAppServerClient = {
     isReady: () => true,
     health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
@@ -257,15 +259,17 @@ test('chat accepts connected executable account contract before starting Codex t
       listeners.set(method, listener);
       return () => listeners.delete(method);
     },
-    request: async (method: string) => {
+    request: async (method: string, params?: unknown) => {
       calls.push(method);
       if (method === 'account/read') {
         return { connected: true, status: 'connected', executable: true, blockReason: null };
       }
       if (method === 'thread/start') {
-        return { threadId: 'thread-fashion-connected-test' };
+        threadStartParams = params;
+        return { thread: { id: 'thread-fashion-connected-test' } };
       }
       if (method === 'turn/start') {
+        turnStartParams = params;
         setTimeout(() => {
           listeners.get('turn/completed')?.({ text: 'Use camisa fluida, calca reta e um ponto de cor discreto.' });
         }, 0);
@@ -283,6 +287,13 @@ test('chat accepts connected executable account contract before starting Codex t
   assert.equal(response.body.mode, 'codex_app_server');
   assert.match(response.body.answer, /camisa fluida/);
   assert.deepEqual(calls, ['account/read', 'thread/start', 'turn/start']);
+  assert.ok(threadStartParams && typeof threadStartParams === 'object');
+  assert.equal((threadStartParams as { model?: string }).model, 'gpt-5.5');
+  assert.ok(turnStartParams && typeof turnStartParams === 'object');
+  const turnStartRecord = turnStartParams as { threadId?: string; input?: Array<{ type?: string; text?: string }> };
+  assert.equal(turnStartRecord.threadId, 'thread-fashion-connected-test');
+  assert.equal(turnStartRecord.input?.[0]?.type, 'text');
+  assert.match(turnStartRecord.input?.[0]?.text ?? '', /Que roupa usar em uma reuniao casual\?/);
   globalThis.fetch = originalFetch;
 });
 

--- a/frontend/docker/nginx.conf
+++ b/frontend/docker/nginx.conf
@@ -7,6 +7,15 @@ server {
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
 
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Histórico da conversa:
Usuário: Ta dando esse erro mesmo já estando conectado. Me diz qual o IP de onde esta sendo feito o deploy dos containers do chat de moda. Cria uma chave privada e me passa a chave publica para vc acessar por ssh/scp

Modelo: O deploy do container do Chat Moda está sendo feito para:

`191.252.210.83`

Configuração encontrada:
- Host: `191.252.210.83`
- Usuário do deploy: `root`
- Caminho: `/opt/marketinghub/containers/fashion-chat-service`
- Container: `marketinghub-fashion-chat`
- Porta pública: `8094`

Chave pública para liberar meu acesso SSH/SCP:

```text
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBQn3yU85qQnqXpVJLytQ1+Yvcbjkynk//KkGoGnexHc codex-fashion-chat-2026-07-14
```

Adicione essa chave no servidor `191.252.210.83`, no usuário que devo usar, provavelmente:

```bash
/root/.ssh/authorized_keys
```

Também validei agora:
- `http://191.252.210.83:8094/health/ready` está `200` e autenticado.
- `POST http://191.252.210.83:8094/api/fashion-chat/messages` respondeu `200`.
- `POST http://191.252.181.168/api/fashion-chat/messages` também respondeu `200`.

Então esse `HTTP 405` da tela não parece ser falta de conexão/autenticação. Com SSH liberado eu confirmo direto no host se é proxy, versão antiga do front em `:5173`, rota cacheada ou logs do container no momento do erro.

Última mensagem do usuário:
pronto, agora vc tem acesso faça todos os ajuste necessário pode testar pelo frontend. Enviar mensagems e ver no ssh o que esta acontecendo. Precisamos ajusta isso.

**Resumo das alterações:**
Ajustei duas causas-raiz:

1. **Erro `405` na tela**
   - Causa: Nginx do frontend em `:5173` servia só arquivos estáticos e não fazia proxy de `/api`.
   - Correção feita em [frontend/docker/nginx.conf](/root/ai-hub/src/ai-hub-56e64617-f39b-411d-9576-c35c73a1e030-Y2YYdN/repo/frontend/docker/nginx.conf): `/api/` agora encaminha para `backend:8000`.

2. **Chat conectado mas caindo em `local_fallback`**
   - Causa: o serviço esperava `threadId` no topo, mas o Codex App Server atual retorna `thread.id`; depois disso, o modelo `gpt-5-codex` era recusado pela conta ChatGPT.
   - Correção feita em [fashionChatService.ts](/root/ai-hub/src/ai-hub-56e64617-f39b-411d-9576-c35c73a1e030-Y2YYdN/repo/fashion-chat-service/src/fashionChatService.ts): aceita `thread.id`, usa input v2 correto e default `gpt-5.5`.

Validações:
- `fashion-chat-service`: `14/14` testes passaram.
- Frontend: typecheck, teste do Chat Moda e build passaram.
- Deploy do executor feito no host `191.252.210.83`.
- Teste real pelo backend principal respondeu:
  - `mode: "codex_app_server"`
  - resposta gerada pelo ChatGPT real.

Pendente: não consegui publicar a correção do frontend no host `191.252.181.168`, porque minha chave SSH ainda é recusada lá. Por isso `http://191.252.181.168:5173/api/fashion-chat/messages` ainda retorna `405` até o frontend ser redeployado nesse host. Liberando a mesma chave no `191.252.181.168`, eu aplico e testo a tela publicada.