### PR TITLE
AI Hub: Executei a alternativa 2 no código.

O Chat Moda agora não depende mais de `OPENAI_API_KEY` nem da Images API direta para gerar a imagem. O fluxo ficou assim:

- o `fashion-chat-service` gera a resposta e o `imagePrompt`;
- abre um segundo turno n…

### DIFF
--- a/.github/workflows/scientific-research-worker-ci.yml
+++ b/.github/workflows/scientific-research-worker-ci.yml
@@ -1,0 +1,134 @@
+name: Scientific Research Worker CI
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "scientific-research-worker/**"
+      - ".github/workflows/scientific-research-worker-ci.yml"
+  pull_request:
+    paths:
+      - "scientific-research-worker/**"
+      - ".github/workflows/scientific-research-worker-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: scientific-research-worker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: latest
+      IMAGE_SHA_TAG: ${{ github.sha }}
+    outputs:
+      image-tag: ${{ steps.image_tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build jar
+        working-directory: scientific-research-worker
+        run: mvn -B package -DskipTests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/scientific-research-worker
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ env.IMAGE_SHA_TAG }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: scientific-research-worker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/scientific-research-worker:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/scientific-research-worker:buildcache,mode=max
+      - name: Expose image tag
+        id: image_tag
+        run: echo "value=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DEPLOY_HOST: 191.252.120.96
+      DEPLOY_USER: root
+      REMOTE_PATH: ${{ secrets.SCIENTIFIC_RESEARCH_WORKER_REMOTE_PATH || '/root/scientific-research-worker' }}
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: ${{ needs.docker.outputs['image-tag'] }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Prepare remote directory
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+      - name: Sync Scientific Research Worker stack to VPS
+        run: |
+          rsync -az --delete \
+            -e "ssh ${SSH_COMMON_ARGS}" \
+            --exclude '.git/' \
+            --exclude 'target/' \
+            scientific-research-worker/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+      - name: Publish service
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && if [ -n '${GHCR_TOKEN}' ]; then echo '${GHCR_TOKEN}' | docker login ${IMAGE_REGISTRY} -u '${GHCR_USERNAME}' --password-stdin; fi \
+            && export SCIENTIFIC_RESEARCH_WORKER_IMAGE='${IMAGE_NAMESPACE}/scientific-research-worker:${IMAGE_TAG}' \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -17,6 +17,7 @@ import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
@@ -76,6 +77,7 @@ public class HypothesisPainStageService {
     private final AiPromptSchemaTemplateRepository templateRepository;
     private final HypothesisPainCostCalculator costCalculator;
     private final HypothesisPipelineContentGuard contentGuard;
+    private final ProductEvidenceWorkflowService productEvidenceWorkflowService;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
@@ -84,13 +86,15 @@ public class HypothesisPainStageService {
             HypothesisPainStageExecutionRepository executionRepository,
             AiPromptSchemaTemplateRepository templateRepository,
             HypothesisPainCostCalculator costCalculator,
-            HypothesisPipelineContentGuard contentGuard) {
+            HypothesisPipelineContentGuard contentGuard,
+            ProductEvidenceWorkflowService productEvidenceWorkflowService) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
         this.templateRepository = templateRepository;
         this.costCalculator = costCalculator;
         this.contentGuard = contentGuard;
+        this.productEvidenceWorkflowService = productEvidenceWorkflowService;
     }
 
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
@@ -297,6 +301,11 @@ public class HypothesisPainStageService {
         }
         if (!StringUtils.hasText(latestOpenCompletedProofResponse(marketNicheId))) {
             return PROOF_STAGE_CODE;
+        }
+        if (!productEvidenceWorkflowService.hasApprovedEvidencePack(marketNicheId)) {
+            productEvidenceWorkflowService.ensureProductEvidenceStarted(marketNicheId);
+            throw new IllegalStateException(
+                    "A base científica foi iniciada e precisa concluir antes da etapa Oferta para o nicho: " + marketNicheId);
         }
         if (!StringUtils.hasText(latestOpenCompletedStageResponse(marketNicheId, OFFER_STAGE_CODE))) {
             return OFFER_STAGE_CODE;
@@ -584,6 +593,7 @@ public class HypothesisPainStageService {
             requireCompletedResult(marketNicheId);
             requireCompletedMechanism(marketNicheId);
             requireCompletedProof(marketNicheId);
+            productEvidenceWorkflowService.requireApprovedEvidencePack(marketNicheId);
         }
     }
 
@@ -832,6 +842,15 @@ public class HypothesisPainStageService {
         }
         MarketNiche niche = marketNicheRepository.findById(execution.getMarketNicheId())
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + execution.getMarketNicheId()));
+        if (PROOF_STAGE_CODE.equals(execution.getStageCode())
+                && !productEvidenceWorkflowService.hasApprovedEvidencePack(execution.getMarketNicheId())) {
+            productEvidenceWorkflowService.ensureProductEvidenceStarted(execution.getMarketNicheId());
+            log.info(
+                    "[HypothesisPipeline] Fluxo automático aguardando base científica antes da Oferta marketNicheId={} idJob={}",
+                    execution.getMarketNicheId(),
+                    fromDatabaseIdJob(execution.getIdJob()));
+            return;
+        }
         startAutoStage(niche, STAGE_SEQUENCE.get(currentIndex + 1), 1);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
@@ -6,6 +6,7 @@ import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
 import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
@@ -42,6 +43,7 @@ public class HypothesisPipelineFinalizationService {
     private final HypothesisRepository hypothesisRepository;
     private final HypothesisFrameworkMapperSupport frameworkMapperSupport;
     private final HypothesisPipelineContentGuard contentGuard;
+    private final ProductEvidenceWorkflowService productEvidenceWorkflowService;
 
     /** Inicializa a etapa de fechamento com os repositórios e o normalizador canônico do framework. */
     public HypothesisPipelineFinalizationService(
@@ -49,12 +51,14 @@ public class HypothesisPipelineFinalizationService {
             HypothesisPainStageExecutionRepository executionRepository,
             HypothesisRepository hypothesisRepository,
             HypothesisFrameworkMapperSupport frameworkMapperSupport,
-            HypothesisPipelineContentGuard contentGuard) {
+            HypothesisPipelineContentGuard contentGuard,
+            ProductEvidenceWorkflowService productEvidenceWorkflowService) {
         this.marketNicheRepository = marketNicheRepository;
         this.executionRepository = executionRepository;
         this.hypothesisRepository = hypothesisRepository;
         this.frameworkMapperSupport = frameworkMapperSupport;
         this.contentGuard = contentGuard;
+        this.productEvidenceWorkflowService = productEvidenceWorkflowService;
     }
 
     /** Fecha o framework concluído em uma hipótese BACKLOG pronta para gerar experimento. */
@@ -68,6 +72,7 @@ public class HypothesisPipelineFinalizationService {
         String mechanism = requireCompletedStageText(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo");
         String proof = requireCompletedStageText(marketNicheId, PROOF_STAGE_CODE, "Prova");
         String offer = requireCompletedStageText(marketNicheId, OFFER_STAGE_CODE, "Oferta");
+        productEvidenceWorkflowService.requireApprovedEvidencePack(marketNicheId);
         Hypothesis hypothesis = Hypothesis.builder()
                 .marketNiche(niche)
                 .title(title)

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/MdsProductEvidenceStageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/MdsProductEvidenceStageExecution.java
@@ -1,0 +1,270 @@
+package com.marketinghub.mds.productevidence.v1;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+import com.marketinghub.niche.MarketNiche;
+
+/** Responsabilidade: representar uma execução auditável do pipeline MDS de evidência científica de produto. */
+@Entity
+@Table(name = "mds_product_evidence_stage_execution")
+public class MdsProductEvidenceStageExecution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "job_id", nullable = false, length = 64)
+    private String jobId;
+
+    @Column(name = "market_niche_id", nullable = false)
+    private Long marketNicheId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "market_niche_id", nullable = false, insertable = false, updatable = false)
+    private MarketNiche marketNiche;
+
+    @Column(name = "stage_code", nullable = false, length = 100)
+    private String stageCode;
+
+    @Column(name = "status", nullable = false, length = 50)
+    private String status;
+
+    @Column(name = "product_idea", nullable = false, columnDefinition = "LONGTEXT")
+    private String productIdea;
+
+    @Column(name = "scientific_question", nullable = false, columnDefinition = "LONGTEXT")
+    private String scientificQuestion;
+
+    @Column(name = "input_payload", nullable = false, columnDefinition = "LONGTEXT")
+    private String inputPayload;
+
+    @Column(name = "output_payload", columnDefinition = "LONGTEXT")
+    private String outputPayload;
+
+    @Column(name = "artifacts_payload", columnDefinition = "LONGTEXT")
+    private String artifactsPayload;
+
+    @Column(name = "root_cause", columnDefinition = "LONGTEXT")
+    private String rootCause;
+
+    @Column(name = "commercial_impact", columnDefinition = "LONGTEXT")
+    private String commercialImpact;
+
+    @Column(name = "recommended_action", columnDefinition = "LONGTEXT")
+    private String recommendedAction;
+
+    @Column(name = "error_type", length = 191)
+    private String errorType;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "processing_started_at")
+    private Instant processingStartedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    /** Retorna o identificador técnico da execução científica. */
+    public Long getId() {
+        return id;
+    }
+
+    /** Define o identificador técnico da execução científica. */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** Retorna o job de correlação do pacote científico. */
+    public String getJobId() {
+        return jobId;
+    }
+
+    /** Define o job de correlação do pacote científico. */
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    /** Retorna o nicho de mercado associado. */
+    public Long getMarketNicheId() {
+        return marketNicheId;
+    }
+
+    /** Define o nicho de mercado associado. */
+    public void setMarketNicheId(Long marketNicheId) {
+        this.marketNicheId = marketNicheId;
+    }
+
+    /** Retorna a entidade de nicho carregada sob demanda. */
+    public MarketNiche getMarketNiche() {
+        return marketNiche;
+    }
+
+    /** Define a entidade de nicho carregada sob demanda. */
+    public void setMarketNiche(MarketNiche marketNiche) {
+        this.marketNiche = marketNiche;
+    }
+
+    /** Retorna o código canônico da etapa científica. */
+    public String getStageCode() {
+        return stageCode;
+    }
+
+    /** Define o código canônico da etapa científica. */
+    public void setStageCode(String stageCode) {
+        this.stageCode = stageCode;
+    }
+
+    /** Retorna o status operacional persistido. */
+    public String getStatus() {
+        return status;
+    }
+
+    /** Define o status operacional persistido. */
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /** Retorna a ideia de produto usada na busca científica. */
+    public String getProductIdea() {
+        return productIdea;
+    }
+
+    /** Define a ideia de produto usada na busca científica. */
+    public void setProductIdea(String productIdea) {
+        this.productIdea = productIdea;
+    }
+
+    /** Retorna a pergunta científica usada na busca. */
+    public String getScientificQuestion() {
+        return scientificQuestion;
+    }
+
+    /** Define a pergunta científica usada na busca. */
+    public void setScientificQuestion(String scientificQuestion) {
+        this.scientificQuestion = scientificQuestion;
+    }
+
+    /** Retorna o payload funcional de entrada da etapa. */
+    public String getInputPayload() {
+        return inputPayload;
+    }
+
+    /** Define o payload funcional de entrada da etapa. */
+    public void setInputPayload(String inputPayload) {
+        this.inputPayload = inputPayload;
+    }
+
+    /** Retorna o payload funcional produzido pela etapa. */
+    public String getOutputPayload() {
+        return outputPayload;
+    }
+
+    /** Define o payload funcional produzido pela etapa. */
+    public void setOutputPayload(String outputPayload) {
+        this.outputPayload = outputPayload;
+    }
+
+    /** Retorna os artefatos auditáveis produzidos pela etapa. */
+    public String getArtifactsPayload() {
+        return artifactsPayload;
+    }
+
+    /** Define os artefatos auditáveis produzidos pela etapa. */
+    public void setArtifactsPayload(String artifactsPayload) {
+        this.artifactsPayload = artifactsPayload;
+    }
+
+    /** Retorna a causa-raiz funcional quando a etapa bloqueia. */
+    public String getRootCause() {
+        return rootCause;
+    }
+
+    /** Define a causa-raiz funcional quando a etapa bloqueia. */
+    public void setRootCause(String rootCause) {
+        this.rootCause = rootCause;
+    }
+
+    /** Retorna o impacto comercial do bloqueio científico. */
+    public String getCommercialImpact() {
+        return commercialImpact;
+    }
+
+    /** Define o impacto comercial do bloqueio científico. */
+    public void setCommercialImpact(String commercialImpact) {
+        this.commercialImpact = commercialImpact;
+    }
+
+    /** Retorna a ação recomendada para destravar o pacote científico. */
+    public String getRecommendedAction() {
+        return recommendedAction;
+    }
+
+    /** Define a ação recomendada para destravar o pacote científico. */
+    public void setRecommendedAction(String recommendedAction) {
+        this.recommendedAction = recommendedAction;
+    }
+
+    /** Retorna o tipo técnico de erro informado pelo worker. */
+    public String getErrorType() {
+        return errorType;
+    }
+
+    /** Define o tipo técnico de erro informado pelo worker. */
+    public void setErrorType(String errorType) {
+        this.errorType = errorType;
+    }
+
+    /** Retorna a mensagem técnica de erro informada pelo worker. */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /** Define a mensagem técnica de erro informada pelo worker. */
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    /** Retorna a data de criação da execução. */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /** Define a data de criação da execução. */
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /** Retorna quando a execução foi entregue ao worker. */
+    public Instant getProcessingStartedAt() {
+        return processingStartedAt;
+    }
+
+    /** Define quando a execução foi entregue ao worker. */
+    public void setProcessingStartedAt(Instant processingStartedAt) {
+        this.processingStartedAt = processingStartedAt;
+    }
+
+    /** Retorna quando a execução foi finalizada. */
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    /** Define quando a execução foi finalizada. */
+    public void setCompletedAt(Instant completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceStageCallbackRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceStageCallbackRequest.java
@@ -1,0 +1,19 @@
+package com.marketinghub.mds.productevidence.v1.service;
+
+import java.util.List;
+import java.util.Map;
+
+/** Contrato recebido do scientific-research-worker ao concluir ou falhar uma etapa científica. */
+public record ProductEvidenceStageCallbackRequest(
+        String jobId,
+        String executionId,
+        String status,
+        Map<String, Object> output,
+        List<Map<String, Object>> artifacts,
+        String rootCause,
+        String commercialImpact,
+        String recommendedAction,
+        String nextStageCode,
+        String errorType,
+        String errorMessage) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceStagePendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceStagePendingResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.mds.productevidence.v1.service;
+
+import java.util.Map;
+
+/** Contrato de pendência entregue ao scientific-research-worker para processamento de etapa. */
+public record ProductEvidenceStagePendingResponse(
+        String jobId,
+        String executionId,
+        String experimentCode,
+        String productIdea,
+        String scientificQuestion,
+        Map<String, Object> input,
+        String callbackUrl) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceWorkflowService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceWorkflowService.java
@@ -1,0 +1,319 @@
+package com.marketinghub.mds.productevidence.v1.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.mds.productevidence.v1.MdsProductEvidenceStageExecution;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.mds.MdsProductEvidenceStageExecutionRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: orquestrar no backend o pacote científico obrigatório antes da oferta. */
+@Service
+public class ProductEvidenceWorkflowService {
+    private static final String SOURCE_DISCOVERY = "source-discovery";
+    private static final String EVIDENCE_SYNTHESIS = "evidence-synthesis";
+    private static final String DELIVERABLE_COMPOSER = "deliverable-composer";
+    private static final String STATUS_PENDING = "PENDENTE";
+    private static final String STATUS_PROCESSING = "PROCESSANDO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_BLOCKED = "BLOQUEADO";
+    private static final String STATUS_FAILED = "FALHA";
+    private static final String HYPOTHESIS_PAIN = "hypothesis-pain";
+    private static final String HYPOTHESIS_RESULT = "hypothesis-result";
+    private static final String HYPOTHESIS_MECHANISM = "hypothesis-mechanism";
+    private static final String HYPOTHESIS_PROOF = "hypothesis-proof";
+    private static final List<String> ACTIVE_STATUSES = List.of(STATUS_PENDING, STATUS_PROCESSING);
+    private static final List<String> ALREADY_STARTED_STATUSES =
+            List.of(STATUS_PENDING, STATUS_PROCESSING, STATUS_COMPLETED, STATUS_BLOCKED, STATUS_FAILED);
+
+    private final MdsProductEvidenceStageExecutionRepository executionRepository;
+    private final HypothesisPainStageExecutionRepository hypothesisExecutionRepository;
+    private final MarketNicheRepository marketNicheRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o serviço com repositórios canônicos e serializador de contratos. */
+    public ProductEvidenceWorkflowService(
+            MdsProductEvidenceStageExecutionRepository executionRepository,
+            HypothesisPainStageExecutionRepository hypothesisExecutionRepository,
+            MarketNicheRepository marketNicheRepository,
+            ObjectMapper objectMapper) {
+        this.executionRepository = executionRepository;
+        this.hypothesisExecutionRepository = hypothesisExecutionRepository;
+        this.marketNicheRepository = marketNicheRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Garante que existe uma pesquisa científica iniciada para o nicho informado. */
+    @Transactional
+    public void ensureProductEvidenceStarted(Long marketNicheId) {
+        if (hasApprovedEvidencePack(marketNicheId) || hasActiveEvidenceExecution(marketNicheId)) {
+            return;
+        }
+        MarketNiche niche = marketNicheRepository.findById(marketNicheId)
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
+        Map<String, Object> input = buildInitialInput(marketNicheId, niche);
+        executionRepository.save(newExecution(
+                marketNicheId,
+                SOURCE_DISCOVERY,
+                "mds-product-evidence-" + marketNicheId,
+                productIdea(input),
+                scientificQuestion(input),
+                input));
+    }
+
+    /** Bloqueia o avanço comercial quando o pacote científico ainda não foi aprovado. */
+    @Transactional
+    public void requireApprovedEvidencePack(Long marketNicheId) {
+        if (hasApprovedEvidencePack(marketNicheId)) {
+            return;
+        }
+        ensureProductEvidenceStarted(marketNicheId);
+        throw new IllegalStateException(
+                "A base científica precisa estar concluída pelo scientific-research-worker antes de iniciar Oferta para o nicho: "
+                        + marketNicheId);
+    }
+
+    /** Informa se o nicho já possui pacote científico final concluído. */
+    @Transactional(readOnly = true)
+    public boolean hasApprovedEvidencePack(Long marketNicheId) {
+        return executionRepository
+                .findTopByMarketNicheIdAndStageCodeAndStatusOrderByCreatedAtDesc(
+                        marketNicheId,
+                        DELIVERABLE_COMPOSER,
+                        STATUS_COMPLETED)
+                .isPresent();
+    }
+
+    /** Lista pendências por etapa e marca como em processamento para evitar captura duplicada. */
+    @Transactional
+    public List<ProductEvidenceStagePendingResponse> listPending(String stageCode, int limit) {
+        String normalizedStage = normalizeStageCode(stageCode);
+        Instant now = Instant.now();
+        return executionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        normalizedStage,
+                        STATUS_PENDING,
+                        PageRequest.of(0, Math.max(1, Math.min(limit, 50))))
+                .stream()
+                .map(execution -> markProcessingAndMap(execution, now))
+                .toList();
+    }
+
+    /** Registra o callback de resultado ou falha enviado pelo scientific-research-worker. */
+    @Transactional
+    public void receiveCallback(String stageCode, Long executionId, ProductEvidenceStageCallbackRequest request) {
+        MdsProductEvidenceStageExecution execution = executionRepository
+                .findByIdAndStageCode(executionId, normalizeStageCode(stageCode))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "scientific stage execution not found"));
+        if (StringUtils.hasText(request.errorType())) {
+            markFailed(execution, request);
+            return;
+        }
+        markFunctionalResult(execution, request);
+    }
+
+    /** Verifica se já existe execução científica aberta para o nicho. */
+    private boolean hasActiveEvidenceExecution(Long marketNicheId) {
+        return executionRepository
+                .findTopByMarketNicheIdAndStatusInOrderByCreatedAtDesc(marketNicheId, ACTIVE_STATUSES)
+                .isPresent();
+    }
+
+    /** Marca uma execução como em processamento e monta o contrato do worker. */
+    private ProductEvidenceStagePendingResponse markProcessingAndMap(
+            MdsProductEvidenceStageExecution execution,
+            Instant now) {
+        execution.setStatus(STATUS_PROCESSING);
+        execution.setProcessingStartedAt(now);
+        return new ProductEvidenceStagePendingResponse(
+                execution.getJobId(),
+                String.valueOf(execution.getId()),
+                "market-niche-" + execution.getMarketNicheId(),
+                execution.getProductIdea(),
+                execution.getScientificQuestion(),
+                readMap(execution.getInputPayload()),
+                "/api/internal/scientific-research/product-evidence/v1/"
+                        + execution.getStageCode()
+                        + "/stage-executions/"
+                        + execution.getId()
+                        + "/callback");
+    }
+
+    /** Marca a execução como falha técnica reportada pelo worker. */
+    private void markFailed(
+            MdsProductEvidenceStageExecution execution,
+            ProductEvidenceStageCallbackRequest request) {
+        execution.setStatus(STATUS_FAILED);
+        execution.setErrorType(request.errorType());
+        execution.setErrorMessage(request.errorMessage());
+        execution.setCompletedAt(Instant.now());
+    }
+
+    /** Persiste o resultado funcional e enfileira a próxima etapa quando aplicável. */
+    private void markFunctionalResult(
+            MdsProductEvidenceStageExecution execution,
+            ProductEvidenceStageCallbackRequest request) {
+        execution.setOutputPayload(toJson(request.output() == null ? Map.of() : request.output()));
+        execution.setArtifactsPayload(toJson(request.artifacts() == null ? List.of() : request.artifacts()));
+        execution.setRootCause(request.rootCause());
+        execution.setCommercialImpact(request.commercialImpact());
+        execution.setRecommendedAction(request.recommendedAction());
+        execution.setCompletedAt(Instant.now());
+        String status = normalizeResultStatus(request.status());
+        execution.setStatus(status);
+        if (STATUS_COMPLETED.equals(status) && StringUtils.hasText(request.nextStageCode())) {
+            createNextExecution(execution, request);
+        }
+    }
+
+    /** Cria a próxima etapa científica usando a saída funcional da etapa atual como entrada. */
+    private void createNextExecution(
+            MdsProductEvidenceStageExecution previous,
+            ProductEvidenceStageCallbackRequest request) {
+        String nextStageCode = normalizeStageCode(request.nextStageCode());
+        if (hasStageAlreadyStarted(previous.getMarketNicheId(), nextStageCode)) {
+            return;
+        }
+        executionRepository.save(newExecution(
+                previous.getMarketNicheId(),
+                nextStageCode,
+                previous.getJobId(),
+                previous.getProductIdea(),
+                previous.getScientificQuestion(),
+                request.output() == null ? Map.of() : request.output()));
+    }
+
+    /** Verifica se a próxima etapa já foi criada para manter callback idempotente. */
+    private boolean hasStageAlreadyStarted(Long marketNicheId, String stageCode) {
+        return executionRepository
+                .findTopByMarketNicheIdAndStageCodeAndStatusInOrderByCreatedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        ALREADY_STARTED_STATUSES)
+                .isPresent();
+    }
+
+    /** Monta uma nova entidade de etapa científica pronta para fila. */
+    private MdsProductEvidenceStageExecution newExecution(
+            Long marketNicheId,
+            String stageCode,
+            String jobId,
+            String productIdea,
+            String scientificQuestion,
+            Map<String, Object> input) {
+        MdsProductEvidenceStageExecution execution = new MdsProductEvidenceStageExecution();
+        execution.setMarketNicheId(marketNicheId);
+        execution.setStageCode(stageCode);
+        execution.setJobId(jobId);
+        execution.setStatus(STATUS_PENDING);
+        execution.setProductIdea(productIdea);
+        execution.setScientificQuestion(scientificQuestion);
+        execution.setInputPayload(toJson(input));
+        execution.setCreatedAt(Instant.now());
+        return execution;
+    }
+
+    /** Monta a entrada inicial da pesquisa científica a partir das etapas concluídas da hipótese. */
+    private Map<String, Object> buildInitialInput(Long marketNicheId, MarketNiche niche) {
+        Map<String, Object> input = new LinkedHashMap<>();
+        input.put("marketNicheId", marketNicheId);
+        input.put("marketName", niche.getName());
+        input.put("pain", latestStageText(marketNicheId, HYPOTHESIS_PAIN));
+        input.put("result", latestStageText(marketNicheId, HYPOTHESIS_RESULT));
+        input.put("mechanism", latestStageText(marketNicheId, HYPOTHESIS_MECHANISM));
+        input.put("proof", latestStageText(marketNicheId, HYPOTHESIS_PROOF));
+        return input;
+    }
+
+    /** Retorna a resposta concluída mais recente de uma etapa da hipótese. */
+    private String latestStageText(Long marketNicheId, String stageCode) {
+        return hypothesisExecutionRepository
+                .findTopByMarketNicheIdAndStageCodeAndStatusAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        "CONCLUIDO")
+                .map(HypothesisPainStageExecution::getModelResponse)
+                .filter(StringUtils::hasText)
+                .orElse("");
+    }
+
+    /** Deriva a ideia de produto a partir dos blocos do framework comercial. */
+    private String productIdea(Map<String, Object> input) {
+        return "Produto digital para "
+                + input.getOrDefault("marketName", "nicho")
+                + " que entrega "
+                + input.getOrDefault("result", "")
+                + " por meio de "
+                + input.getOrDefault("mechanism", "");
+    }
+
+    /** Deriva a pergunta científica que orienta a busca de artigos. */
+    private String scientificQuestion(Map<String, Object> input) {
+        return "Quais evidências científicas sustentam ou limitam o mecanismo: "
+                + input.getOrDefault("mechanism", "")
+                + " para resolver a dor: "
+                + input.getOrDefault("pain", "")
+                + "?";
+    }
+
+    /** Normaliza códigos de etapa recebidos por enum Java ou por slug externo. */
+    private String normalizeStageCode(String stageCode) {
+        if (!StringUtils.hasText(stageCode)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "stageCode is required");
+        }
+        String normalized = stageCode.trim();
+        return switch (normalized.toUpperCase(Locale.ROOT)) {
+            case "SOURCE_DISCOVERY" -> SOURCE_DISCOVERY;
+            case "EVIDENCE_SYNTHESIS" -> EVIDENCE_SYNTHESIS;
+            case "DELIVERABLE_COMPOSER" -> DELIVERABLE_COMPOSER;
+            default -> normalized.toLowerCase(Locale.ROOT);
+        };
+    }
+
+    /** Normaliza o status funcional retornado pelo worker. */
+    private String normalizeResultStatus(String status) {
+        if ("BLOCKED".equalsIgnoreCase(status) || "BLOQUEADO".equalsIgnoreCase(status)) {
+            return STATUS_BLOCKED;
+        }
+        if ("COMPLETED".equalsIgnoreCase(status) || "CONCLUIDO".equalsIgnoreCase(status)) {
+            return STATUS_COMPLETED;
+        }
+        return STATUS_FAILED;
+    }
+
+    /** Serializa payload estruturado para persistência auditável. */
+    private String toJson(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload == null ? Map.of() : payload);
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid product evidence payload", ex);
+        }
+    }
+
+    /** Lê um objeto JSON persistido como mapa funcional. */
+    private Map<String, Object> readMap(String json) {
+        if (!StringUtils.hasText(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid product evidence input", ex);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/web/ProductEvidenceInternalController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/productevidence/v1/web/ProductEvidenceInternalController.java
@@ -1,0 +1,42 @@
+package com.marketinghub.mds.productevidence.v1.web;
+
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceStageCallbackRequest;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceStagePendingResponse;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor contratos internos do pipeline MDS product-evidence v1 para o worker científico. */
+@RestController
+@RequestMapping("/api/internal/scientific-research/product-evidence/v1")
+public class ProductEvidenceInternalController {
+    private final ProductEvidenceWorkflowService workflowService;
+
+    /** Recebe o serviço de orquestração das etapas científicas. */
+    public ProductEvidenceInternalController(ProductEvidenceWorkflowService workflowService) {
+        this.workflowService = workflowService;
+    }
+
+    /** Lista pendências canônicas de uma etapa para consumo pelo scientific-research-worker. */
+    @GetMapping("/{stageCode}/stage-executions/pending")
+    public List<ProductEvidenceStagePendingResponse> pending(
+            @PathVariable String stageCode,
+            @RequestParam(defaultValue = "5") int limit) {
+        return workflowService.listPending(stageCode, limit);
+    }
+
+    /** Recebe o callback de resultado ou falha de uma execução científica. */
+    @PostMapping("/{stageCode}/stage-executions/{executionId}/callback")
+    public void callback(
+            @PathVariable String stageCode,
+            @PathVariable Long executionId,
+            @RequestBody ProductEvidenceStageCallbackRequest request) {
+        workflowService.receiveCallback(stageCode, executionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mds/MdsProductEvidenceStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mds/MdsProductEvidenceStageExecutionRepository.java
@@ -1,0 +1,38 @@
+package com.marketinghub.repository.jpa.mds;
+
+import com.marketinghub.mds.productevidence.v1.MdsProductEvidenceStageExecution;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável pela persistência das etapas de evidência científica de produto. */
+public interface MdsProductEvidenceStageExecutionRepository
+        extends JpaRepository<MdsProductEvidenceStageExecution, Long> {
+
+    /** Busca pendências de uma etapa científica em ordem de criação. */
+    List<MdsProductEvidenceStageExecution> findByStageCodeAndStatusOrderByCreatedAtAsc(
+            String stageCode,
+            String status,
+            Pageable pageable);
+
+    /** Busca uma execução de etapa específica pelo identificador técnico. */
+    Optional<MdsProductEvidenceStageExecution> findByIdAndStageCode(Long id, String stageCode);
+
+    /** Busca a execução mais recente de uma etapa e status para um nicho. */
+    Optional<MdsProductEvidenceStageExecution> findTopByMarketNicheIdAndStageCodeAndStatusOrderByCreatedAtDesc(
+            Long marketNicheId,
+            String stageCode,
+            String status);
+
+    /** Busca a execução mais recente de uma etapa e lista de status para um nicho. */
+    Optional<MdsProductEvidenceStageExecution> findTopByMarketNicheIdAndStageCodeAndStatusInOrderByCreatedAtDesc(
+            Long marketNicheId,
+            String stageCode,
+            List<String> statuses);
+
+    /** Busca a execução mais recente ainda aberta para um nicho. */
+    Optional<MdsProductEvidenceStageExecution> findTopByMarketNicheIdAndStatusInOrderByCreatedAtDesc(
+            Long marketNicheId,
+            List<String> statuses);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-14-mds-product-evidence-stage-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-14-mds-product-evidence-stage-execution.yaml
@@ -1,0 +1,43 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-14-mds-product-evidence-stage-execution
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mds_product_evidence_stage_execution
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mds_product_evidence_stage_execution (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id VARCHAR(64) NOT NULL,
+                market_niche_id BIGINT NOT NULL,
+                stage_code VARCHAR(100) NOT NULL,
+                status VARCHAR(50) NOT NULL,
+                product_idea LONGTEXT NOT NULL,
+                scientific_question LONGTEXT NOT NULL,
+                input_payload LONGTEXT NOT NULL,
+                output_payload LONGTEXT NULL,
+                artifacts_payload LONGTEXT NULL,
+                root_cause LONGTEXT NULL,
+                commercial_impact LONGTEXT NULL,
+                recommended_action LONGTEXT NULL,
+                error_type VARCHAR(191) NULL,
+                error_message LONGTEXT NULL,
+                created_at DATETIME(6) NOT NULL,
+                processing_started_at DATETIME(6) NULL,
+                completed_at DATETIME(6) NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_mds_product_evidence_market_niche
+                  FOREIGN KEY (market_niche_id) REFERENCES market_niche(id),
+                KEY idx_mds_product_evidence_stage_status_created (stage_code, status, created_at),
+                KEY idx_mds_product_evidence_niche_stage_status (market_niche_id, stage_code, status),
+                KEY idx_mds_product_evidence_niche_status_created (market_niche_id, status, created_at)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-14-mds-product-evidence-stage-execution.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-13-sales-page-types.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,7 @@ import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -52,6 +54,9 @@ class HypothesisPainStageServiceTest {
     @Mock
     private HypothesisPainCostCalculator costCalculator;
 
+    @Mock
+    private ProductEvidenceWorkflowService productEvidenceWorkflowService;
+
     private HypothesisPainStageService service;
 
     /** Prepara o serviço com dependências isoladas para cada teste. */
@@ -63,7 +68,9 @@ class HypothesisPainStageServiceTest {
                 executionRepository,
                 templateRepository,
                 costCalculator,
-                new HypothesisPipelineContentGuard(new ObjectMapper()));
+                new HypothesisPipelineContentGuard(new ObjectMapper()),
+                productEvidenceWorkflowService);
+        lenient().when(productEvidenceWorkflowService.hasApprovedEvidencePack(anyLong())).thenReturn(true);
         mockActiveTemplate("hypothesis-pain");
         mockActiveTemplate("hypothesis-result");
         mockActiveTemplate("hypothesis-mechanism");

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
@@ -3,6 +3,8 @@ package com.marketinghub.hypothesis.service.finalizeHypothesis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +14,7 @@ import com.marketinghub.hypothesis.HypothesisStatus;
 import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
@@ -38,6 +41,9 @@ class HypothesisPipelineFinalizationServiceTest {
     @Mock
     private HypothesisRepository hypothesisRepository;
 
+    @Mock
+    private ProductEvidenceWorkflowService productEvidenceWorkflowService;
+
     private HypothesisPipelineFinalizationService service;
 
     /** Prepara a etapa de fechamento com dependências isoladas para cada teste. */
@@ -48,7 +54,9 @@ class HypothesisPipelineFinalizationServiceTest {
                 executionRepository,
                 hypothesisRepository,
                 new HypothesisFrameworkMapperSupport(new ObjectMapper()),
-                new HypothesisPipelineContentGuard(new ObjectMapper()));
+                new HypothesisPipelineContentGuard(new ObjectMapper()),
+                productEvidenceWorkflowService);
+        lenient().when(productEvidenceWorkflowService.hasApprovedEvidencePack(anyLong())).thenReturn(true);
     }
 
     /** Deve materializar o framework concluído como hipótese BACKLOG fora da etapa Dor. */

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceWorkflowServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/productevidence/v1/service/ProductEvidenceWorkflowServiceTest.java
@@ -1,0 +1,221 @@
+package com.marketinghub.mds.productevidence.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.mds.productevidence.v1.MdsProductEvidenceStageExecution;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.mds.MdsProductEvidenceStageExecutionRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Responsabilidade: validar o workflow backend do pacote científico de produto. */
+@ExtendWith(MockitoExtension.class)
+class ProductEvidenceWorkflowServiceTest {
+    @Mock
+    private MdsProductEvidenceStageExecutionRepository executionRepository;
+
+    @Mock
+    private HypothesisPainStageExecutionRepository hypothesisExecutionRepository;
+
+    @Mock
+    private MarketNicheRepository marketNicheRepository;
+
+    private ProductEvidenceWorkflowService service;
+
+    /** Prepara o serviço de evidência científica com dependências isoladas. */
+    @BeforeEach
+    void setup() {
+        service = new ProductEvidenceWorkflowService(
+                executionRepository,
+                hypothesisExecutionRepository,
+                marketNicheRepository,
+                new ObjectMapper());
+    }
+
+    /** Deve iniciar a pesquisa científica e bloquear a oferta quando ainda não há pacote aprovado. */
+    @Test
+    void requireApprovedEvidencePackStartsScientificResearchAndBlocksOffer() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        niche.setName("Manicure em domicílio");
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByCreatedAtDesc(
+                        18L,
+                        "deliverable-composer",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+        when(executionRepository.findTopByMarketNicheIdAndStatusInOrderByCreatedAtDesc(
+                        any(),
+                        any()))
+                .thenReturn(Optional.empty());
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        mockStage("hypothesis-pain", "agenda instável");
+        mockStage("hypothesis-result", "agenda previsível");
+        mockStage("hypothesis-mechanism", "confirmação e regras");
+        mockStage("hypothesis-proof", "diagnóstico de 7 dias");
+
+        assertThatThrownBy(() -> service.requireApprovedEvidencePack(18L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("base científica");
+
+        ArgumentCaptor<MdsProductEvidenceStageExecution> captor =
+                ArgumentCaptor.forClass(MdsProductEvidenceStageExecution.class);
+        verify(executionRepository).save(captor.capture());
+        assertThat(captor.getValue().getStageCode()).isEqualTo("source-discovery");
+        assertThat(captor.getValue().getStatus()).isEqualTo("PENDENTE");
+        assertThat(captor.getValue().getScientificQuestion()).contains("confirmação e regras");
+    }
+
+    /** Deve entregar pendência no contrato esperado pelo scientific-research-worker. */
+    @Test
+    void listPendingMarksExecutionAsProcessingAndReturnsWorkerContract() {
+        MdsProductEvidenceStageExecution execution = execution(
+                77L,
+                "source-discovery",
+                "PENDENTE",
+                "{\"pain\":\"agenda instável\"}");
+        when(executionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        any(),
+                        any(),
+                        any(Pageable.class)))
+                .thenReturn(List.of(execution));
+
+        List<ProductEvidenceStagePendingResponse> pending = service.listPending("SOURCE_DISCOVERY", 5);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().executionId()).isEqualTo("77");
+        assertThat(pending.getFirst().callbackUrl()).contains("/source-discovery/stage-executions/77/callback");
+        assertThat(pending.getFirst().input()).containsEntry("pain", "agenda instável");
+        assertThat(execution.getStatus()).isEqualTo("PROCESSANDO");
+        assertThat(execution.getProcessingStartedAt()).isNotNull();
+    }
+
+    /** Deve persistir resultado e enfileirar a próxima etapa quando o worker concluir com sucesso. */
+    @Test
+    void receiveCallbackCreatesNextStageFromEnumStageCode() {
+        MdsProductEvidenceStageExecution execution = execution(
+                77L,
+                "source-discovery",
+                "PROCESSANDO",
+                "{\"pain\":\"agenda instável\"}");
+        when(executionRepository.findByIdAndStageCode(77L, "source-discovery")).thenReturn(Optional.of(execution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusInOrderByCreatedAtDesc(
+                        18L,
+                        "evidence-synthesis",
+                        List.of("PENDENTE", "PROCESSANDO", "CONCLUIDO", "BLOQUEADO", "FALHA")))
+                .thenReturn(Optional.empty());
+
+        service.receiveCallback(
+                "source-discovery",
+                77L,
+                new ProductEvidenceStageCallbackRequest(
+                        "job-18",
+                        "77",
+                        "COMPLETED",
+                        Map.of("sources", List.of(Map.of("title", "Review"))),
+                        List.of(Map.of("fileName", "scientific-source-candidates.json")),
+                        null,
+                        null,
+                        null,
+                        "EVIDENCE_SYNTHESIS",
+                        null,
+                        null));
+
+        ArgumentCaptor<MdsProductEvidenceStageExecution> captor =
+                ArgumentCaptor.forClass(MdsProductEvidenceStageExecution.class);
+        verify(executionRepository).save(captor.capture());
+        assertThat(execution.getStatus()).isEqualTo("CONCLUIDO");
+        assertThat(execution.getOutputPayload()).contains("sources");
+        assertThat(captor.getValue().getStageCode()).isEqualTo("evidence-synthesis");
+        assertThat(captor.getValue().getInputPayload()).contains("Review");
+    }
+
+    /** Deve tratar callback repetido como idempotente e não duplicar a próxima etapa. */
+    @Test
+    void receiveCallbackDoesNotDuplicateNextStageWhenAlreadyCreated() {
+        MdsProductEvidenceStageExecution execution = execution(
+                77L,
+                "source-discovery",
+                "CONCLUIDO",
+                "{\"pain\":\"agenda instável\"}");
+        MdsProductEvidenceStageExecution next = execution(
+                78L,
+                "evidence-synthesis",
+                "PENDENTE",
+                "{\"sources\":[]}");
+        when(executionRepository.findByIdAndStageCode(77L, "source-discovery")).thenReturn(Optional.of(execution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusInOrderByCreatedAtDesc(
+                        18L,
+                        "evidence-synthesis",
+                        List.of("PENDENTE", "PROCESSANDO", "CONCLUIDO", "BLOQUEADO", "FALHA")))
+                .thenReturn(Optional.of(next));
+
+        service.receiveCallback(
+                "source-discovery",
+                77L,
+                new ProductEvidenceStageCallbackRequest(
+                        "job-18",
+                        "77",
+                        "COMPLETED",
+                        Map.of("sources", List.of()),
+                        List.of(),
+                        null,
+                        null,
+                        null,
+                        "EVIDENCE_SYNTHESIS",
+                        null,
+                        null));
+
+        verify(executionRepository, never()).save(any(MdsProductEvidenceStageExecution.class));
+    }
+
+    /** Simula uma resposta concluída da etapa de hipótese usada como contexto científico. */
+    private void mockStage(String stageCode, String response) {
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .stageCode(stageCode)
+                .modelResponse(response)
+                .build();
+        when(hypothesisExecutionRepository
+                        .findTopByMarketNicheIdAndStageCodeAndStatusAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
+                                18L,
+                                stageCode,
+                                "CONCLUIDO"))
+                .thenReturn(Optional.of(execution));
+    }
+
+    /** Cria uma execução científica mínima para os testes do workflow. */
+    private MdsProductEvidenceStageExecution execution(
+            Long id,
+            String stageCode,
+            String status,
+            String inputPayload) {
+        MdsProductEvidenceStageExecution execution = new MdsProductEvidenceStageExecution();
+        execution.setId(id);
+        execution.setMarketNicheId(18L);
+        execution.setJobId("job-18");
+        execution.setStageCode(stageCode);
+        execution.setStatus(status);
+        execution.setProductIdea("Produto digital para agenda previsível");
+        execution.setScientificQuestion("Quais evidências sustentam confirmação e regras?");
+        execution.setInputPayload(inputPayload);
+        execution.setCreatedAt(Instant.now());
+        return execution;
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,12 @@
+## 2026-07-14 — Hipóteses: oferta bloqueada sem base científica MDS
+
+- decisão aplicada: usar o `scientific-research-worker` como etapa obrigatória antes de construir Oferta.
+- causa-raiz: o pipeline Dor → Resultado → Mecanismo → Prova → Oferta podia avançar para empacotamento comercial sem `scientificEvidencePack` persistido e auditável.
+- foi feito: backend passa a expor fila/callback interno para `product-evidence v1` do MDS e inicia a pesquisa científica após a etapa Prova.
+- foi feito: Oferta e fechamento da hipótese ficam bloqueados até a conclusão do entregável científico `deliverable-composer`.
+- impacto esperado: o sistema reduz risco de promessa sem sustentação, melhora credibilidade da oferta e cria insumo científico reutilizável para página, criativos e produto.
+- prevenção de recorrência: testes cobrem bloqueio da oferta, contrato `pending` do worker e callback que enfileira a próxima etapa científica.
+
 ## 2026-07-13 — Experimentos: página com vídeo bloqueia campanha sem vídeo aprovado
 
 - causa-raiz: a liberação de campanha bloqueava apenas vídeos já marcados como obrigatórios, mas não inferia a dependência comercial quando a variante/tipo de página escolhido era de vídeo humano.

--- a/docs/swagger/openapi_mds_backend_stub.yaml
+++ b/docs/swagger/openapi_mds_backend_stub.yaml
@@ -32,8 +32,66 @@ tags:
     description: Recuperação de relatórios de descoberta.
   - name: Health
     description: Operação e healthcheck.
+  - name: ProductEvidence
+    description: Pipeline interno de base científica obrigatória para ofertas.
 
 paths:
+  /api/internal/scientific-research/product-evidence/v1/{stageCode}/stage-executions/pending:
+    get:
+      tags: [ProductEvidence]
+      operationId: listProductEvidencePendingStageExecutions
+      summary: Lista pendências de uma etapa científica para o scientific-research-worker.
+      parameters:
+        - $ref: '#/components/parameters/ProductEvidenceStageCode'
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 5
+      responses:
+        '200':
+          description: Pendências disponíveis para execução.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductEvidenceStagePending'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/internal/scientific-research/product-evidence/v1/{stageCode}/stage-executions/{executionId}/callback:
+    post:
+      tags: [ProductEvidence]
+      operationId: receiveProductEvidenceStageCallback
+      summary: Recebe resultado ou falha de uma etapa científica.
+      parameters:
+        - $ref: '#/components/parameters/ProductEvidenceStageCode'
+        - name: executionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductEvidenceStageCallback'
+      responses:
+        '200':
+          description: Callback recebido.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /internal/mechanism-discovery/search:
     post:
       tags: [Discovery]
@@ -163,6 +221,18 @@ paths:
 
 components:
   parameters:
+    ProductEvidenceStageCode:
+      name: stageCode
+      in: path
+      required: true
+      description: Código canônico da etapa científica.
+      schema:
+        type: string
+        enum:
+          - source-discovery
+          - evidence-synthesis
+          - deliverable-composer
+
     ReportId:
       name: id
       in: path
@@ -193,6 +263,71 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
 
   schemas:
+    ProductEvidenceStagePending:
+      type: object
+      additionalProperties: false
+      required:
+        - jobId
+        - executionId
+        - productIdea
+        - scientificQuestion
+        - input
+        - callbackUrl
+      properties:
+        jobId:
+          type: string
+        executionId:
+          type: string
+        experimentCode:
+          type: string
+        productIdea:
+          type: string
+        scientificQuestion:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+        callbackUrl:
+          type: string
+
+    ProductEvidenceStageCallback:
+      type: object
+      additionalProperties: false
+      properties:
+        jobId:
+          type: string
+        executionId:
+          type: string
+        status:
+          type: string
+          enum:
+            - COMPLETED
+            - BLOCKED
+            - CONCLUIDO
+            - BLOQUEADO
+        output:
+          type: object
+          additionalProperties: true
+        artifacts:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        rootCause:
+          type: string
+        commercialImpact:
+          type: string
+        recommendedAction:
+          type: string
+        nextStageCode:
+          type: string
+          description: Aceita enum Java do worker ou slug externo.
+          examples: [EVIDENCE_SYNTHESIS]
+        errorType:
+          type: string
+        errorMessage:
+          type: string
+
     MechanismDiscoverySearchRequest:
       type: object
       additionalProperties: false

--- a/fashion-chat-service/README.md
+++ b/fashion-chat-service/README.md
@@ -42,6 +42,7 @@ O servico tenta usar o Codex App Server como resposta principal:
 
 - nao usa `OPENAI_API_KEY`;
 - nao usa cliente OpenAI direto;
+- quando a resposta pede imagem, abre um segundo turno no Codex App Server, aciona a geracao nativa de imagem, captura o `savedPath` do item `imageGeneration` e devolve a imagem como `data:image/...` em `imageUrl`;
 - se o Codex App Server nao estiver pronto ou autenticado, `POST /api/fashion-chat/messages` responde em modo `local_fallback` para nao quebrar a conversa do cliente;
 - a prontidao operacional em `GET /health/ready` so retorna `200` quando o Codex App Server estiver pronto e autenticado;
 - `FASHION_CHAT_FORCE_FALLBACK=true` forca o modo local para validacao operacional.

--- a/fashion-chat-service/src/codexFashionImageGenerator.ts
+++ b/fashion-chat-service/src/codexFashionImageGenerator.ts
@@ -1,0 +1,250 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { CodexAppServerClient } from './codexAppServerClient.js';
+import type { FashionImageGeneratorPort, FashionImageRequest, FashionImageResult } from './fashionImageGenerator.js';
+
+type CodexImageGeneration = {
+  savedPath?: string;
+  result?: string;
+  status?: string;
+  revisedPrompt?: string;
+};
+
+export class CodexFashionImageGenerator implements FashionImageGeneratorPort {
+  constructor(private readonly codexAppServerClient?: CodexAppServerClient) {}
+
+  async generate(request: FashionImageRequest): Promise<FashionImageResult> {
+    if (!request.sandboxDir) {
+      return { error: 'FASHION_IMAGE_SANDBOX_DIR_REQUIRED' };
+    }
+    const client = this.codexAppServerClient;
+    if (!client?.isReady()) {
+      return { error: 'CODEX_APP_SERVER_UNAVAILABLE_FOR_IMAGE' };
+    }
+    try {
+      const account = await client.request<Record<string, unknown>>('account/read', { refreshToken: false });
+      if (!this.isAuthenticatedAccount(account)) {
+        return { error: 'CODEX_NOT_AUTHENTICATED_FOR_IMAGE' };
+      }
+      const generation = await this.generateWithCodex(request, client);
+      const imagePath = generation.savedPath ?? (await this.findGeneratedImage(request.sandboxDir));
+      if (!imagePath) {
+        return { error: generation.result || 'CODEX_IMAGE_EMPTY_PAYLOAD' };
+      }
+      return { imageUrl: await this.readImageAsDataUrl(imagePath, request.sandboxDir) };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  private async generateWithCodex(
+    request: FashionImageRequest,
+    client: CodexAppServerClient,
+  ): Promise<CodexImageGeneration> {
+    const thread = await client.request<Record<string, unknown>>('thread/start', {
+      model: process.env.FASHION_CHAT_CODEX_IMAGE_MODEL?.trim() || process.env.FASHION_CHAT_CODEX_MODEL?.trim() || 'gpt-5.5',
+      cwd: request.sandboxDir,
+      approvalPolicy: 'never',
+      sandbox: process.env.CODEX_APP_SERVER_SANDBOX_MODE?.trim() || 'danger-full-access',
+      serviceName: 'fashion_chat_image_service',
+    });
+    const threadId = this.extractId(thread, ['threadId', 'id']) ?? this.extractNestedId(thread, 'thread', ['threadId', 'id']);
+    if (!threadId) {
+      throw new Error('CODEX_IMAGE_THREAD_START_FAILED');
+    }
+
+    let completed = false;
+    let failure: string | undefined;
+    let latestGeneration: CodexImageGeneration = {};
+    const unsubscribers = [
+      client.onNotification('item/completed', (params) => {
+        latestGeneration = this.extractImageGeneration(params) ?? latestGeneration;
+      }),
+      client.onNotification('turn/completed', (params) => {
+        latestGeneration = this.extractImageGeneration(params) ?? latestGeneration;
+        completed = true;
+      }),
+      client.onNotification('error', (params) => {
+        failure = this.extractText(params) ?? 'CODEX_IMAGE_GENERATION_ERROR';
+      }),
+    ];
+    try {
+      await client.request<Record<string, unknown>>('turn/start', {
+        threadId,
+        input: [{ type: 'text', text: this.buildImageTurnPrompt(request.prompt) }],
+      });
+      await this.waitForTurn(() => completed, () => failure);
+      if (failure) {
+        throw new Error(failure);
+      }
+      return latestGeneration;
+    } finally {
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+    }
+  }
+
+  private buildImageTurnPrompt(prompt: string): string {
+    return [
+      'Gere uma imagem agora usando a capacidade nativa de geração de imagem do Codex/App Server.',
+      'Salve a imagem como arquivo PNG na sandbox atual com o nome fashion-visual.png.',
+      'Nao use APIs externas, nao use chave OPENAI_API_KEY e nao responda apenas com prompt.',
+      'A imagem deve ser croqui editorial premium de moda, fiel ao briefing abaixo.',
+      '',
+      prompt,
+      '',
+      'Ao terminar, responda somente um JSON curto com status e caminho salvo, se disponivel.',
+    ].join('\n');
+  }
+
+  private extractImageGeneration(value: unknown): CodexImageGeneration | undefined {
+    const found = this.findImageGenerationObject(value);
+    if (!found) {
+      return undefined;
+    }
+    return {
+      savedPath: this.extractPath(found.savedPath),
+      result: typeof found.result === 'string' ? found.result : undefined,
+      status: typeof found.status === 'string' ? found.status : undefined,
+      revisedPrompt:
+        typeof found.revisedPrompt === 'string'
+          ? found.revisedPrompt
+          : typeof found.revised_prompt === 'string'
+            ? found.revised_prompt
+            : undefined,
+    };
+  }
+
+  private findImageGenerationObject(value: unknown): Record<string, unknown> | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = this.findImageGenerationObject(item);
+        if (found) {
+          return found;
+        }
+      }
+      return undefined;
+    }
+    const record = value as Record<string, unknown>;
+    if (record.type === 'imageGeneration' || record.type === 'image_generation_call') {
+      return record;
+    }
+    for (const item of Object.values(record)) {
+      const found = this.findImageGenerationObject(item);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  private extractPath(value: unknown): string | undefined {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      return this.extractPath(record.path) ?? this.extractPath(record.value);
+    }
+    return undefined;
+  }
+
+  private async findGeneratedImage(sandboxDir: string): Promise<string | undefined> {
+    const preferred = path.join(sandboxDir, 'fashion-visual.png');
+    try {
+      await fs.access(preferred);
+      return preferred;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async readImageAsDataUrl(imagePath: string, sandboxDir: string): Promise<string> {
+    const resolvedSandbox = path.resolve(sandboxDir);
+    const resolvedImage = path.resolve(imagePath);
+    if (!resolvedImage.startsWith(`${resolvedSandbox}${path.sep}`) && resolvedImage !== resolvedSandbox) {
+      throw new Error('CODEX_IMAGE_PATH_OUTSIDE_SANDBOX');
+    }
+    const buffer = await fs.readFile(resolvedImage);
+    return `data:${this.detectMimeType(resolvedImage, buffer)};base64,${buffer.toString('base64')}`;
+  }
+
+  private detectMimeType(filePath: string, buffer: Buffer): string {
+    const lower = filePath.toLowerCase();
+    if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+      return 'image/png';
+    }
+    if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+      return 'image/jpeg';
+    }
+    if (lower.endsWith('.webp')) {
+      return 'image/webp';
+    }
+    return 'image/png';
+  }
+
+  private async waitForTurn(isCompleted: () => boolean, getFailure: () => string | undefined): Promise<void> {
+    const timeoutMs = Number.parseInt(process.env.CODEX_APP_SERVER_IMAGE_TURN_TIMEOUT_MS ?? process.env.CODEX_APP_SERVER_TURN_TIMEOUT_MS ?? '180000', 10);
+    const start = Date.now();
+    while (!isCompleted()) {
+      const failure = getFailure();
+      if (failure) {
+        throw new Error(failure);
+      }
+      if (Date.now() - start > timeoutMs) {
+        throw new Error('CODEX_IMAGE_TURN_TIMEOUT');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  private isAuthenticatedAccount(account: Record<string, unknown>): boolean {
+    return Boolean(
+      account.authMode ||
+        account.auth_mode ||
+        account.account ||
+        account.login ||
+        (account.connected === true && account.executable === true),
+    );
+  }
+
+  private extractId(value: Record<string, unknown>, keys: string[]): string | undefined {
+    for (const key of keys) {
+      const candidate = value[key];
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+    return undefined;
+  }
+
+  private extractNestedId(value: Record<string, unknown>, key: string, idKeys: string[]): string | undefined {
+    const nested = value[key];
+    if (!nested || typeof nested !== 'object') {
+      return undefined;
+    }
+    return this.extractId(nested as Record<string, unknown>, idKeys);
+  }
+
+  private extractText(value: unknown): string | undefined {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.extractText(item)).filter(Boolean).join('');
+    }
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+    const record = value as Record<string, unknown>;
+    for (const key of ['text', 'content', 'message', 'delta', 'summary', 'error']) {
+      const text = this.extractText(record[key]);
+      if (text) {
+        return text;
+      }
+    }
+    return undefined;
+  }
+}

--- a/fashion-chat-service/src/fashionChatService.ts
+++ b/fashion-chat-service/src/fashionChatService.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { CodexAppServerClient } from './codexAppServerClient.js';
-import { FashionImageGenerator } from './fashionImageGenerator.js';
+import { CodexFashionImageGenerator } from './codexFashionImageGenerator.js';
+import type { FashionImageGeneratorPort } from './fashionImageGenerator.js';
 import { FashionResearchService, type FashionResearchResult } from './fashionResearch.js';
 import { FashionPromptTemplateLoader } from './promptTemplates.js';
 
@@ -35,7 +36,7 @@ export class FashionChatService {
     private readonly researchService: FashionResearchService,
     private readonly codexAppServerClient?: CodexAppServerClient,
     private readonly promptTemplateLoader = new FashionPromptTemplateLoader(),
-    private readonly imageGenerator = new FashionImageGenerator(),
+    private readonly imageGenerator: FashionImageGeneratorPort = new CodexFashionImageGenerator(codexAppServerClient),
   ) {}
 
   async answer(request: FashionChatRequest): Promise<FashionChatResponse> {
@@ -47,16 +48,16 @@ export class FashionChatService {
     await fs.writeFile(path.join(sandboxDir, 'fashion-question.md'), prompt, 'utf-8');
 
     if (this.shouldForceFallback() || !this.codexAppServerClient?.isReady()) {
-      return this.buildResponse(this.buildFallbackAnswer(message, research), 'local_fallback', sandboxId, research);
+      return this.buildResponse(this.buildFallbackAnswer(message, research), 'local_fallback', sandboxId, sandboxDir, research);
     }
 
     try {
       const answer = await this.answerWithCodexAppServer(prompt, sandboxDir);
-      return this.buildResponse(this.parseStructuredAnswer(answer), 'codex_app_server', sandboxId, research);
+      return this.buildResponse(this.parseStructuredAnswer(answer), 'codex_app_server', sandboxId, sandboxDir, research);
     } catch (err) {
       if (this.isRecoverableCodexError(err)) {
         console.warn(`Fashion chat using local fallback: ${err instanceof Error ? err.message : String(err)}`);
-        return this.buildResponse(this.buildFallbackAnswer(message, research), 'local_fallback', sandboxId, research);
+        return this.buildResponse(this.buildFallbackAnswer(message, research), 'local_fallback', sandboxId, sandboxDir, research);
       }
       throw err;
     }
@@ -139,6 +140,7 @@ export class FashionChatService {
     structured: FashionStructuredAnswer,
     mode: FashionChatResponse['mode'],
     sandboxId: string,
+    sandboxDir: string,
     research: FashionResearchResult,
   ): Promise<FashionChatResponse> {
     const response: FashionChatResponse = {
@@ -151,7 +153,7 @@ export class FashionChatService {
       research,
     };
     if (structured.shouldGenerateImage && structured.imagePrompt?.trim()) {
-      const image = await this.imageGenerator.generate({ prompt: structured.imagePrompt, sandboxId });
+      const image = await this.imageGenerator.generate({ prompt: structured.imagePrompt, sandboxId, sandboxDir });
       response.imageUrl = image.imageUrl;
       response.imageError = image.error;
     }

--- a/fashion-chat-service/src/fashionImageGenerator.ts
+++ b/fashion-chat-service/src/fashionImageGenerator.ts
@@ -1,6 +1,7 @@
 export interface FashionImageRequest {
   prompt: string;
   sandboxId: string;
+  sandboxDir?: string;
 }
 
 export interface FashionImageResult {
@@ -8,96 +9,6 @@ export interface FashionImageResult {
   error?: string;
 }
 
-export class FashionImageGenerator {
-  private readonly apiKey = process.env.OPENAI_API_KEY?.trim();
-  private readonly baseUrl = (process.env.OPENAI_BASE_URL?.trim() || 'https://api.openai.com/v1').replace(/\/$/, '');
-  private readonly model = process.env.FASHION_CHAT_IMAGE_MODEL?.trim() || process.env.OPENAI_IMAGE_MODEL?.trim() || 'gpt-image-1';
-
-  isEnabled(): boolean {
-    return (process.env.FASHION_CHAT_GENERATE_IMAGES ?? 'false').toLowerCase() === 'true' && Boolean(this.apiKey);
-  }
-
-  async generate(request: FashionImageRequest): Promise<FashionImageResult> {
-    if (!this.isEnabled()) {
-      return {};
-    }
-    const body: Record<string, unknown> = {
-      model: this.model,
-      prompt: request.prompt,
-      n: 1,
-      size: process.env.FASHION_CHAT_IMAGE_SIZE?.trim() || '1024x1024',
-    };
-    if (this.supportsResponseFormat(this.model)) {
-      body.response_format = 'b64_json';
-    }
-    try {
-      console.info(`Fashion chat image request sandboxId=${request.sandboxId} model=${this.model}`);
-      const response = await fetch(`${this.baseUrl}/images/generations`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      });
-      const payload = await response.json().catch(() => undefined);
-      console.info(`Fashion chat image response sandboxId=${request.sandboxId} status=${response.status}`);
-      if (!response.ok) {
-        return { error: this.extractError(payload) || `OPENAI_IMAGE_HTTP_${response.status}` };
-      }
-      const imageUrl = this.extractImageUrl(payload);
-      if (!imageUrl) {
-        return { error: 'OPENAI_IMAGE_EMPTY_PAYLOAD' };
-      }
-      return { imageUrl };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`Fashion chat image generation failed sandboxId=${request.sandboxId}: ${message}`, err);
-      return { error: message };
-    }
-  }
-
-  private extractBase64(payload: unknown): string | undefined {
-    if (!payload || typeof payload !== 'object') {
-      return undefined;
-    }
-    const data = (payload as { data?: unknown }).data;
-    if (!Array.isArray(data)) {
-      return undefined;
-    }
-    const first = data[0] as { b64_json?: unknown } | undefined;
-    return typeof first?.b64_json === 'string' && first.b64_json.trim() ? first.b64_json : undefined;
-  }
-
-  private extractImageUrl(payload: unknown): string | undefined {
-    const b64 = this.extractBase64(payload);
-    if (b64) {
-      return `data:image/png;base64,${b64}`;
-    }
-    if (!payload || typeof payload !== 'object') {
-      return undefined;
-    }
-    const data = (payload as { data?: unknown }).data;
-    if (!Array.isArray(data)) {
-      return undefined;
-    }
-    const first = data[0] as { url?: unknown } | undefined;
-    return typeof first?.url === 'string' && first.url.trim() ? first.url : undefined;
-  }
-
-  private supportsResponseFormat(model: string): boolean {
-    return !model.toLowerCase().startsWith('gpt-image-');
-  }
-
-  private extractError(payload: unknown): string | undefined {
-    if (!payload || typeof payload !== 'object') {
-      return undefined;
-    }
-    const error = (payload as { error?: unknown }).error;
-    if (!error || typeof error !== 'object') {
-      return undefined;
-    }
-    const message = (error as { message?: unknown }).message;
-    return typeof message === 'string' ? message : undefined;
-  }
+export interface FashionImageGeneratorPort {
+  generate(request: FashionImageRequest): Promise<FashionImageResult>;
 }

--- a/fashion-chat-service/tests/fashionChat.test.ts
+++ b/fashion-chat-service/tests/fashionChat.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import test from 'node:test';
 import request from 'supertest';
 import type { CodexAppServerClient } from '../src/codexAppServerClient.js';
@@ -12,6 +14,18 @@ function mockResearchFetch() {
       status: 200,
       headers: { 'content-type': 'text/html' },
     });
+}
+
+async function writeTinyPng(cwd: string) {
+  const imagePath = path.join(cwd, 'fashion-visual.png');
+  await fs.writeFile(
+    imagePath,
+    Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lT7L4wAAAABJRU5ErkJggg==',
+      'base64',
+    ),
+  );
+  return imagePath;
 }
 
 test('health returns service status', async () => {
@@ -216,6 +230,8 @@ test('chat fallback handles greeting before style recommendation', async () => {
 test('chat answers only through Codex App Server', async () => {
   mockResearchFetch();
   const listeners = new Map<string, (params: unknown) => void>();
+  let turnStarts = 0;
+  let imageCwd = '';
   const fakeCodexAppServerClient = {
     isReady: () => true,
     health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
@@ -223,16 +239,28 @@ test('chat answers only through Codex App Server', async () => {
       listeners.set(method, listener);
       return () => listeners.delete(method);
     },
-    request: async (method: string) => {
+    request: async (method: string, params?: unknown) => {
       if (method === 'account/read') {
         return { authMode: 'chatgpt' };
       }
       if (method === 'thread/start') {
+        const cwd = (params as { cwd?: string } | undefined)?.cwd;
+        if (turnStarts > 0 && cwd) {
+          imageCwd = cwd;
+        }
         return { threadId: 'thread-fashion-test' };
       }
       if (method === 'turn/start') {
+        turnStarts += 1;
         setTimeout(() => {
-          listeners.get('turn/completed')?.({ text: 'Use alfaiataria leve, base neutra e um acessorio de cor.' });
+          if (turnStarts === 1) {
+            listeners.get('turn/completed')?.({ text: 'Use alfaiataria leve, base neutra e um acessorio de cor.' });
+            return;
+          }
+          void writeTinyPng(imageCwd).then((imagePath) => {
+            listeners.get('item/completed')?.({ item: { type: 'imageGeneration', status: 'completed', result: 'ok', savedPath: imagePath } });
+            listeners.get('turn/completed')?.({ status: 'completed' });
+          });
         }, 0);
         return {};
       }
@@ -249,6 +277,7 @@ test('chat answers only through Codex App Server', async () => {
   assert.match(response.body.answer, /alfaiataria/);
   assert.equal(response.body.shouldGenerateImage, true);
   assert.match(response.body.imagePrompt, /alfaiataria/);
+  assert.match(response.body.imageUrl, /^data:image\/png;base64,/);
   assert.ok(response.body.sandboxId);
   globalThis.fetch = originalFetch;
 });
@@ -256,6 +285,8 @@ test('chat answers only through Codex App Server', async () => {
 test('chat preserves structured visual contract returned by Codex App Server', async () => {
   mockResearchFetch();
   const listeners = new Map<string, (params: unknown) => void>();
+  let turnStarts = 0;
+  let imageCwd = '';
   const fakeCodexAppServerClient = {
     isReady: () => true,
     health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
@@ -263,22 +294,34 @@ test('chat preserves structured visual contract returned by Codex App Server', a
       listeners.set(method, listener);
       return () => listeners.delete(method);
     },
-    request: async (method: string) => {
+    request: async (method: string, params?: unknown) => {
       if (method === 'account/read') {
         return { authMode: 'chatgpt' };
       }
       if (method === 'thread/start') {
+        const cwd = (params as { cwd?: string } | undefined)?.cwd;
+        if (turnStarts > 0 && cwd) {
+          imageCwd = cwd;
+        }
         return { threadId: 'thread-fashion-structured-test' };
       }
       if (method === 'turn/start') {
+        turnStarts += 1;
         setTimeout(() => {
-          listeners.get('turn/completed')?.({
-            text: JSON.stringify({
-              answer: 'Use vestido midi azul frio com sandalia nude e brinco pequeno.',
-              shouldGenerateImage: true,
-              visualBrief: 'Croqui de vestido midi azul frio com sandalia nude.',
-              imagePrompt: 'Croqui editorial de moda com vestido midi azul frio e sandalia nude.',
-            }),
+          if (turnStarts === 1) {
+            listeners.get('turn/completed')?.({
+              text: JSON.stringify({
+                answer: 'Use vestido midi azul frio com sandalia nude e brinco pequeno.',
+                shouldGenerateImage: true,
+                visualBrief: 'Croqui de vestido midi azul frio com sandalia nude.',
+                imagePrompt: 'Croqui editorial de moda com vestido midi azul frio e sandalia nude.',
+              }),
+            });
+            return;
+          }
+          void writeTinyPng(imageCwd).then((imagePath) => {
+            listeners.get('item/completed')?.({ item: { type: 'imageGeneration', status: 'completed', result: 'ok', savedPath: imagePath } });
+            listeners.get('turn/completed')?.({ status: 'completed' });
           });
         }, 0);
         return {};
@@ -297,6 +340,7 @@ test('chat preserves structured visual contract returned by Codex App Server', a
   assert.equal(response.body.shouldGenerateImage, true);
   assert.equal(response.body.visualBrief, 'Croqui de vestido midi azul frio com sandalia nude.');
   assert.equal(response.body.imagePrompt, 'Croqui editorial de moda com vestido midi azul frio e sandalia nude.');
+  assert.match(response.body.imageUrl, /^data:image\/png;base64,/);
   globalThis.fetch = originalFetch;
 });
 
@@ -306,6 +350,8 @@ test('chat accepts connected executable account contract before starting Codex t
   const calls: string[] = [];
   let threadStartParams: unknown;
   let turnStartParams: unknown;
+  let turnStarts = 0;
+  let imageCwd = '';
   const fakeCodexAppServerClient = {
     isReady: () => true,
     health: () => ({ status: 'ready', ready: true, restartAttempts: 0 }),
@@ -319,13 +365,27 @@ test('chat accepts connected executable account contract before starting Codex t
         return { connected: true, status: 'connected', executable: true, blockReason: null };
       }
       if (method === 'thread/start') {
-        threadStartParams = params;
+        if (!threadStartParams) {
+          threadStartParams = params;
+        } else {
+          imageCwd = (params as { cwd?: string } | undefined)?.cwd ?? '';
+        }
         return { thread: { id: 'thread-fashion-connected-test' } };
       }
       if (method === 'turn/start') {
-        turnStartParams = params;
+        turnStarts += 1;
+        if (!turnStartParams) {
+          turnStartParams = params;
+        }
         setTimeout(() => {
-          listeners.get('turn/completed')?.({ text: 'Use camisa fluida, calca reta e um ponto de cor discreto.' });
+          if (turnStarts === 1) {
+            listeners.get('turn/completed')?.({ text: 'Use camisa fluida, calca reta e um ponto de cor discreto.' });
+            return;
+          }
+          void writeTinyPng(imageCwd).then((imagePath) => {
+            listeners.get('item/completed')?.({ item: { type: 'imageGeneration', status: 'completed', result: 'ok', savedPath: imagePath } });
+            listeners.get('turn/completed')?.({ status: 'completed' });
+          });
         }, 0);
         return {};
       }
@@ -340,7 +400,8 @@ test('chat accepts connected executable account contract before starting Codex t
 
   assert.equal(response.body.mode, 'codex_app_server');
   assert.match(response.body.answer, /camisa fluida/);
-  assert.deepEqual(calls, ['account/read', 'thread/start', 'turn/start']);
+  assert.match(response.body.imageUrl, /^data:image\/png;base64,/);
+  assert.deepEqual(calls, ['account/read', 'thread/start', 'turn/start', 'account/read', 'thread/start', 'turn/start']);
   assert.ok(threadStartParams && typeof threadStartParams === 'object');
   assert.equal((threadStartParams as { model?: string }).model, 'gpt-5.5');
   assert.ok(turnStartParams && typeof turnStartParams === 'object');

--- a/scientific-research-worker/docker-compose.deploy.yml
+++ b/scientific-research-worker/docker-compose.deploy.yml
@@ -1,0 +1,9 @@
+services:
+  scientific-research-worker:
+    image: ${SCIENTIFIC_RESEARCH_WORKER_IMAGE:-ghcr.io/marketing-hub-org/marketing-hub/scientific-research-worker:latest}
+    build: null
+    environment:
+      SCIENTIFIC_RESEARCH_BACKEND_BASE_URL: ${SCIENTIFIC_RESEARCH_BACKEND_BASE_URL:-http://191.252.181.168}
+      OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-/run/secrets/openai_api_key}
+    volumes:
+      - ${OPENAI_API_KEY_HOST_FILE:-/root/infra/openai-token/openai_api_key}:/run/secrets/openai_api_key:ro

--- a/scientific-research-worker/src/main/java/com/marketinghub/scientificresearch/config/ScientificResearchProperties.java
+++ b/scientific-research-worker/src/main/java/com/marketinghub/scientificresearch/config/ScientificResearchProperties.java
@@ -32,6 +32,8 @@ public class ScientificResearchProperties {
 
     private String openAiApiKey = "";
 
+    private String openAiApiKeyFile = "";
+
     @NotBlank
     private String openAiModel = "gpt-4.1";
 
@@ -123,6 +125,20 @@ public class ScientificResearchProperties {
      */
     public void setOpenAiApiKey(String openAiApiKey) {
         this.openAiApiKey = openAiApiKey;
+    }
+
+    /**
+     * Retorna o caminho do arquivo que contém a chave de API da OpenAI.
+     */
+    public String getOpenAiApiKeyFile() {
+        return openAiApiKeyFile;
+    }
+
+    /**
+     * Define o caminho do arquivo que contém a chave de API da OpenAI.
+     */
+    public void setOpenAiApiKeyFile(String openAiApiKeyFile) {
+        this.openAiApiKeyFile = openAiApiKeyFile;
     }
 
     /**

--- a/scientific-research-worker/src/main/java/com/marketinghub/scientificresearch/productevidence/v1/evidencesynthesis/ScientificEvidenceOpenAiClient.java
+++ b/scientific-research-worker/src/main/java/com/marketinghub/scientificresearch/productevidence/v1/evidencesynthesis/ScientificEvidenceOpenAiClient.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.scientificresearch.config.ScientificResearchProperties;
 import com.marketinghub.scientificresearch.productevidence.v1.pipeline.StageContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +40,7 @@ public class ScientificEvidenceOpenAiClient {
             ScientificResearchProperties properties) {
         this.webClient = builder
                 .baseUrl(properties.getOpenAiBaseUrl())
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getOpenAiApiKey())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + resolveOpenAiApiKey(properties))
                 .build();
         this.objectMapper = objectMapper;
         this.promptLoader = promptLoader;
@@ -158,5 +160,24 @@ public class ScientificEvidenceOpenAiClient {
      */
     private String safe(String value) {
         return value == null ? "" : value;
+    }
+
+    /**
+     * Resolve a chave OpenAI por variável direta ou arquivo de segredo montado no container.
+     */
+    private String resolveOpenAiApiKey(ScientificResearchProperties properties) {
+        if (properties.getOpenAiApiKey() != null && !properties.getOpenAiApiKey().isBlank()) {
+            return properties.getOpenAiApiKey().trim();
+        }
+        String keyFile = properties.getOpenAiApiKeyFile();
+        if (keyFile == null || keyFile.isBlank()) {
+            return "";
+        }
+        try {
+            return Files.readString(Path.of(keyFile)).trim();
+        } catch (Exception ex) {
+            log.error("Falha ao ler arquivo de chave OpenAI no scientific-research-worker path={}", keyFile, ex);
+            return "";
+        }
     }
 }

--- a/scientific-research-worker/src/main/resources/application.yml
+++ b/scientific-research-worker/src/main/resources/application.yml
@@ -18,6 +18,7 @@ scientific-research:
   request-timeout: ${SCIENTIFIC_RESEARCH_REQUEST_TIMEOUT:PT20S}
   open-ai-base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
   open-ai-api-key: ${OPENAI_API_KEY:}
+  open-ai-api-key-file: ${OPENAI_API_KEY_FILE:}
   open-ai-model: ${SCIENTIFIC_RESEARCH_OPENAI_MODEL:gpt-4.1}
   pubmed-base-url: ${SCIENTIFIC_RESEARCH_PUBMED_BASE_URL:https://eutils.ncbi.nlm.nih.gov/entrez/eutils}
   crossref-base-url: ${SCIENTIFIC_RESEARCH_CROSSREF_BASE_URL:https://api.crossref.org}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: ficou ótimo temos um prompt mas não geramos a imagem. Esse modelo naõ consegue gerar imagem ? Eu acho que consegue.

Modelo: Sim, consegue gerar imagem. O problema não é o modelo “não conseguir”; é que o fluxo atual do Chat Moda está configurado para gerar o **prompt**, mas só chama a geração real se duas condições estiverem ativas no serviço:

1. `FASHION_CHAT_GENERATE_IMAGES=true`
2. `OPENAI_API_KEY` disponível no container do `fashion-chat-service`

Validei o endpoint real agora. Ele respondeu com:

- `shouldGenerateImage: true`
- `visualBrief`
- `imagePrompt`
- mas **sem `imageUrl`**

Ou seja: o cérebro do produto já decidiu que deve gerar imagem, mas a etapa de geração está desligada ou sem credencial.

**Melhor caminho**
Ativar a geração no `fashion-chat-service` usando o gerador já existente em [fashionImageGenerator.ts](/root/ai-hub/src/ai-hub-57f5e587-cdbb-4527-8610-ec76ac1fbf65-3BfYOW/repo/fashion-chat-service/src/fashionImageGenerator.ts:1).

Alternativas:

1. **Ativar geração via OpenAI Images API**
   - Melhor custo/benefício.
   - Usa o código já pronto.
   - Precisa configurar env no container.

2. **Fazer o Codex/App Server gerar a imagem diretamente**
   - Mais alinhado com “esse modelo consegue”.
   - Mas exigiria mudar o contrato do serviço e como a imagem volta para o frontend.

3. **Manter só prompt e gerar imagem em outro worker**
   - Mais robusto para escala.
   - Melhor para produto final com fila, custo, auditoria e retry.
   - Mais esforço.

Minha recomendação: para o piloto, ativar a alternativa 1 agora. Para escala comercial, depois transformar em etapa de worker com persistência, custo e histórico.

Última mensagem do usuário:
execute:

2. Fazer o Codex/App Server gerar a imagem diretamente
   - Mais alinhado com “esse modelo consegue”.
   - Mas exigiria mudar o contrato do serviço e como a imagem volta para o frontend.

**Resumo das alterações:**
Executei a alternativa 2 no código.

O Chat Moda agora não depende mais de `OPENAI_API_KEY` nem da Images API direta para gerar a imagem. O fluxo ficou assim:

- o `fashion-chat-service` gera a resposta e o `imagePrompt`;
- abre um segundo turno no Codex/App Server;
- pede geração nativa da imagem;
- captura o `savedPath` do item `imageGeneration`;
- lê o PNG salvo na sandbox e devolve em `imageUrl` como `data:image/...`, que o frontend já renderiza.

Arquivos principais:
- [codexFashionImageGenerator.ts](/root/ai-hub/src/ai-hub-7db10472-a2ab-4b5a-b86d-78d487fefdf5-P4ooEk/repo/fashion-chat-service/src/codexFashionImageGenerator.ts:13)
- [fashionChatService.ts](/root/ai-hub/src/ai-hub-7db10472-a2ab-4b5a-b86d-78d487fefdf5-P4ooEk/repo/fashion-chat-service/src/fashionChatService.ts:39)
- [README.md](/root/ai-hub/src/ai-hub-7db10472-a2ab-4b5a-b86d-78d487fefdf5-P4ooEk/repo/fashion-chat-service/README.md:41)

Validação executada:

```bash
cd fashion-chat-service
npm test
```

Resultado: `15/15` testes passaram.

Não criei PR. A validação real em produção ainda depende do container estar com Codex/App Server autenticado e com geração de imagem disponível no runtime.