### PR TITLE
AI Hub: Corrigi as falhas identificadas no GitHub Actions, sem alterar testes de arquitetura.

O que foi ajustado:
- Backend: removi a dependência direta de `HypothesisPainStageService` para `ProductEvidenceWorkflowService`, que quebrava o `ArquiteturaTes…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/ProductEvidenceWorkflowGateAdapter.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/ProductEvidenceWorkflowGateAdapter.java
@@ -1,0 +1,34 @@
+package com.marketinghub.hypothesis.pain;
+
+import com.marketinghub.hypothesis.pain.service.HypothesisProductEvidenceGate;
+import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: adaptar o gate científico de hipótese ao workflow de evidências do MDS. */
+@Component
+public class ProductEvidenceWorkflowGateAdapter implements HypothesisProductEvidenceGate {
+    private final ProductEvidenceWorkflowService workflowService;
+
+    /** Inicializa o adaptador com o workflow canônico de evidências de produto. */
+    public ProductEvidenceWorkflowGateAdapter(ProductEvidenceWorkflowService workflowService) {
+        this.workflowService = workflowService;
+    }
+
+    /** Garante que existe uma pesquisa científica iniciada para o nicho informado. */
+    @Override
+    public void ensureProductEvidenceStarted(Long marketNicheId) {
+        workflowService.ensureProductEvidenceStarted(marketNicheId);
+    }
+
+    /** Bloqueia o avanço comercial quando o pacote científico ainda não foi aprovado. */
+    @Override
+    public void requireApprovedEvidencePack(Long marketNicheId) {
+        workflowService.requireApprovedEvidencePack(marketNicheId);
+    }
+
+    /** Informa se o nicho já possui pacote científico final concluído. */
+    @Override
+    public boolean hasApprovedEvidencePack(Long marketNicheId) {
+        return workflowService.hasApprovedEvidencePack(marketNicheId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -17,7 +17,6 @@ import com.marketinghub.aiprompt.AiPromptSchemaTemplate;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
-import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
@@ -77,7 +76,7 @@ public class HypothesisPainStageService {
     private final AiPromptSchemaTemplateRepository templateRepository;
     private final HypothesisPainCostCalculator costCalculator;
     private final HypothesisPipelineContentGuard contentGuard;
-    private final ProductEvidenceWorkflowService productEvidenceWorkflowService;
+    private final HypothesisProductEvidenceGate productEvidenceGate;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
@@ -87,14 +86,14 @@ public class HypothesisPainStageService {
             AiPromptSchemaTemplateRepository templateRepository,
             HypothesisPainCostCalculator costCalculator,
             HypothesisPipelineContentGuard contentGuard,
-            ProductEvidenceWorkflowService productEvidenceWorkflowService) {
+            HypothesisProductEvidenceGate productEvidenceGate) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
         this.templateRepository = templateRepository;
         this.costCalculator = costCalculator;
         this.contentGuard = contentGuard;
-        this.productEvidenceWorkflowService = productEvidenceWorkflowService;
+        this.productEvidenceGate = productEvidenceGate;
     }
 
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
@@ -302,8 +301,8 @@ public class HypothesisPainStageService {
         if (!StringUtils.hasText(latestOpenCompletedProofResponse(marketNicheId))) {
             return PROOF_STAGE_CODE;
         }
-        if (!productEvidenceWorkflowService.hasApprovedEvidencePack(marketNicheId)) {
-            productEvidenceWorkflowService.ensureProductEvidenceStarted(marketNicheId);
+        if (!productEvidenceGate.hasApprovedEvidencePack(marketNicheId)) {
+            productEvidenceGate.ensureProductEvidenceStarted(marketNicheId);
             throw new IllegalStateException(
                     "A base científica foi iniciada e precisa concluir antes da etapa Oferta para o nicho: " + marketNicheId);
         }
@@ -593,7 +592,7 @@ public class HypothesisPainStageService {
             requireCompletedResult(marketNicheId);
             requireCompletedMechanism(marketNicheId);
             requireCompletedProof(marketNicheId);
-            productEvidenceWorkflowService.requireApprovedEvidencePack(marketNicheId);
+            productEvidenceGate.requireApprovedEvidencePack(marketNicheId);
         }
     }
 
@@ -843,8 +842,8 @@ public class HypothesisPainStageService {
         MarketNiche niche = marketNicheRepository.findById(execution.getMarketNicheId())
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + execution.getMarketNicheId()));
         if (PROOF_STAGE_CODE.equals(execution.getStageCode())
-                && !productEvidenceWorkflowService.hasApprovedEvidencePack(execution.getMarketNicheId())) {
-            productEvidenceWorkflowService.ensureProductEvidenceStarted(execution.getMarketNicheId());
+                && !productEvidenceGate.hasApprovedEvidencePack(execution.getMarketNicheId())) {
+            productEvidenceGate.ensureProductEvidenceStarted(execution.getMarketNicheId());
             log.info(
                     "[HypothesisPipeline] Fluxo automático aguardando base científica antes da Oferta marketNicheId={} idJob={}",
                     execution.getMarketNicheId(),

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisProductEvidenceGate.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisProductEvidenceGate.java
@@ -1,0 +1,14 @@
+package com.marketinghub.hypothesis.pain.service;
+
+/** Responsabilidade: expor para o pipeline de hipótese o gate científico exigido antes da oferta. */
+public interface HypothesisProductEvidenceGate {
+
+    /** Garante que existe uma pesquisa científica iniciada para o nicho informado. */
+    void ensureProductEvidenceStarted(Long marketNicheId);
+
+    /** Bloqueia o avanço comercial quando o pacote científico ainda não foi aprovado. */
+    void requireApprovedEvidencePack(Long marketNicheId);
+
+    /** Informa se o nicho já possui pacote científico final concluído. */
+    boolean hasApprovedEvidencePack(Long marketNicheId);
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -21,7 +21,6 @@ import com.marketinghub.repository.jpa.aiprompt.AiPromptSchemaTemplateRepository
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.hypothesis.service.HypothesisPipelineContentGuard;
-import com.marketinghub.mds.productevidence.v1.service.ProductEvidenceWorkflowService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +54,7 @@ class HypothesisPainStageServiceTest {
     private HypothesisPainCostCalculator costCalculator;
 
     @Mock
-    private ProductEvidenceWorkflowService productEvidenceWorkflowService;
+    private HypothesisProductEvidenceGate productEvidenceGate;
 
     private HypothesisPainStageService service;
 
@@ -69,8 +68,8 @@ class HypothesisPainStageServiceTest {
                 templateRepository,
                 costCalculator,
                 new HypothesisPipelineContentGuard(new ObjectMapper()),
-                productEvidenceWorkflowService);
-        lenient().when(productEvidenceWorkflowService.hasApprovedEvidencePack(anyLong())).thenReturn(true);
+                productEvidenceGate);
+        lenient().when(productEvidenceGate.hasApprovedEvidencePack(anyLong())).thenReturn(true);
         mockActiveTemplate("hypothesis-pain");
         mockActiveTemplate("hypothesis-result");
         mockActiveTemplate("hypothesis-mechanism");

--- a/scientific-research-worker/docker-compose.deploy.yml
+++ b/scientific-research-worker/docker-compose.deploy.yml
@@ -1,7 +1,6 @@
 services:
   scientific-research-worker:
     image: ${SCIENTIFIC_RESEARCH_WORKER_IMAGE:-ghcr.io/marketing-hub-org/marketing-hub/scientific-research-worker:latest}
-    build: null
     environment:
       SCIENTIFIC_RESEARCH_BACKEND_BASE_URL: ${SCIENTIFIC_RESEARCH_BACKEND_BASE_URL:-http://191.252.181.168}
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-/run/secrets/openai_api_key}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
deu erro no github action, verifique e ajuste mas não altere testes de arquitetura sem antes me avisar

**Resumo das alterações:**
Corrigi as falhas identificadas no GitHub Actions, sem alterar testes de arquitetura.

O que foi ajustado:
- Backend: removi a dependência direta de `HypothesisPainStageService` para `ProductEvidenceWorkflowService`, que quebrava o `ArquiteturaTest`. Criei uma porta local de hipótese e um adaptador para o MDS.
  - [HypothesisPainStageService.java](/root/ai-hub/src/ai-hub-f7573949-7a84-4ebc-9ba3-942318486c45-jCAjWw/repo/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java)
  - [HypothesisProductEvidenceGate.java](/root/ai-hub/src/ai-hub-f7573949-7a84-4ebc-9ba3-942318486c45-jCAjWw/repo/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisProductEvidenceGate.java)
  - [ProductEvidenceWorkflowGateAdapter.java](/root/ai-hub/src/ai-hub-f7573949-7a84-4ebc-9ba3-942318486c45-jCAjWw/repo/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/ProductEvidenceWorkflowGateAdapter.java)
- Scientific Research Worker: corrigi o deploy removendo `build: null`, que o `docker compose` rejeitava.
  - [docker-compose.deploy.yml](/root/ai-hub/src/ai-hub-f7573949-7a84-4ebc-9ba3-942318486c45-jCAjWw/repo/scientific-research-worker/docker-compose.deploy.yml)

Validações feitas:
- `mvn -q -Dtest=HypothesisPainStageServiceTest,ArquiteturaTest test` passou.
- `mvn -q test` no backend passou.
- `mvn -q package -DskipTests` no backend passou.
- `docker compose -f docker-compose.yml -f docker-compose.deploy.yml config` no `scientific-research-worker` passou.

Observação: o Docker daemon local não está ativo, então validei a configuração Compose, mas não subi container local. Também não criei PR.