### PR TITLE
AI Hub: Removi o timeout de leitura da ponte backend → Fashion Chat.

Alterado:
- `integrations.fashion-chat.read-timeout`: `PT45S` → `PT0S`
- fallback Java do `FashionChatMessageService`: `PT180S` → `PT0S`

Validação:
- `mvn -q -Dtest=FashionChatMessageS…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatMessageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/fashionchat/service/FashionChatMessageService.java
@@ -40,7 +40,7 @@ public class FashionChatMessageService {
             RestTemplateBuilder restTemplateBuilder,
             @Value("${integrations.fashion-chat.base-url:http://191.252.210.83:8094}") String serviceBaseUrl,
             @Value("${integrations.fashion-chat.connect-timeout:PT2S}") Duration connectTimeout,
-            @Value("${integrations.fashion-chat.read-timeout:PT180S}") Duration readTimeout) {
+            @Value("${integrations.fashion-chat.read-timeout:PT0S}") Duration readTimeout) {
         this(restTemplateBuilder
                 .setConnectTimeout(connectTimeout)
                 .setReadTimeout(readTimeout)

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -101,7 +101,7 @@ integrations.lead-portal-payments.read-timeout=${LEAD_PORTAL_PAYMENTS_READ_TIMEO
 
 integrations.fashion-chat.base-url=${FASHION_CHAT_SERVICE_BASE_URL:http://191.252.210.83:8094}
 integrations.fashion-chat.connect-timeout=${FASHION_CHAT_CONNECT_TIMEOUT:PT2S}
-integrations.fashion-chat.read-timeout=${FASHION_CHAT_READ_TIMEOUT:PT45S}
+integrations.fashion-chat.read-timeout=${FASHION_CHAT_READ_TIMEOUT:PT0S}
 
 # Lead portal asset storage (Cloudflare R2)
 lead-portal.storage.bucket=${LEAD_PORTAL_STORAGE_BUCKET:leadportal}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: o que aconteceu ? 

Modelo: O que aconteceu: a tela não quebrou por causa da pergunta. Ela enviou corretamente a mensagem para `/api/fashion-chat/messages`, mas a rota do backend principal não devolveu resposta a tempo e o navegador recebeu `HTTP 504`.

Eu validei 3 hipóteses:

1. **Serviço de moda fora do ar**: descartada. O healthcheck respondeu `200`, autenticado e executável.
2. **Erro na pergunta ou no frontend**: descartada. A tela chama o endpoint correto e o payload está simples.
3. **Falha/timeout na ponte backend principal → executor Fashion Chat**: hipótese mais forte. Chamei o executor diretamente e ele respondeu com uma recomendação válida em cerca de 20s. Já pela rota real do backend principal, a chamada ficou presa por mais de 60s e estourou timeout.

Resumo prático: o módulo de moda consegue responder, mas o caminho usado pela tela está falhando no backend/proxy antes de entregar a resposta ao usuário.

Resultado direto do executor para a sua pergunta seria algo como: vestido midi escuro ou grafite, blazer/casaco de alfaiataria, bota ou scarpin fechado e ponto de cor sofisticado nos acessórios.

Também apareceu um problema secundário: a geração de imagem falhou com `CODEX_IMAGE_EMPTY_PAYLOAD`, mas isso não deveria impedir a resposta textual.

Não fiz alteração nem preparei PR. Próximo passo técnico recomendado: corrigir a rota do backend para não travar na chamada de mensagem e melhorar a observabilidade/logs desse fluxo, porque hoje o endpoint de validação diz “tudo ok”, mas o endpoint real de conversa ainda pode falhar.

Última mensagem do usuário:
retira esse timeout

**Resumo das alterações:**
Removi o timeout de leitura da ponte backend → Fashion Chat.

Alterado:
- `integrations.fashion-chat.read-timeout`: `PT45S` → `PT0S`
- fallback Java do `FashionChatMessageService`: `PT180S` → `PT0S`

Validação:
- `mvn -q -Dtest=FashionChatMessageServiceTest test` passou.

Não criei PR. A mudança está pronta no workspace; para fazer efeito em produção, precisa publicar/reiniciar o backend com essa configuração.