### PR TITLE
AI Hub: Implementado o suporte para o FEO atuar no fluxo dos experimentos.

O que entrou:
- Backend agora cria fila FEO por experimento.
- Endpoint para iniciar fabricação:
  - `POST /api/experiments/{experimentId}/feo/fabricacao/v1/start`
- Endpoint para…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/FeoFabricacaoV1StageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/FeoFabricacaoV1StageExecution.java
@@ -1,0 +1,116 @@
+package com.marketinghub.feo.fabricacao.v1;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+
+/** Responsabilidade: persistir uma execução auditável de etapa da FEO vinculada a um experimento. */
+@Entity
+@Table(name = "feo_fabricacao_v1_stage_execution")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeoFabricacaoV1StageExecution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Experimento que originou a fabricação dos entregáveis. */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    /** Identificador estável do job de fabricação. */
+    @Column(name = "job_id", nullable = false, length = 64)
+    private String jobId;
+
+    /** Código canônico da etapa consumida pelo worker FEO. */
+    @Column(name = "stage_code", nullable = false, length = 80)
+    private String stageCode;
+
+    /** Status operacional da execução. */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private FeoFabricacaoV1StageStatus status;
+
+    /** Payload de entrada entregue ao worker. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "input_payload", nullable = false, columnDefinition = "LONGTEXT")
+    private String inputPayload;
+
+    /** Payload funcional retornado pelo worker. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "output_payload", columnDefinition = "LONGTEXT")
+    private String outputPayload;
+
+    /** Artefatos auditáveis retornados pelo worker. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "artifacts_payload", columnDefinition = "LONGTEXT")
+    private String artifactsPayload;
+
+    /** Métricas de execução retornadas pelo worker. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "metrics_payload", columnDefinition = "LONGTEXT")
+    private String metricsPayload;
+
+    /** Motivo funcional para bloqueio da etapa. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "block_reason", columnDefinition = "LONGTEXT")
+    private String blockReason;
+
+    /** Próxima etapa solicitada pelo worker quando o contrato permitir avanço automático. */
+    @Column(name = "next_stage_code", length = 80)
+    private String nextStageCode;
+
+    /** Worker que reportou o resultado. */
+    @Column(name = "worker_id", length = 191)
+    private String workerId;
+
+    /** Erro técnico registrado quando a execução falha. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    /** Momento em que o worker assumiu a execução. */
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    /** Momento em que a execução terminou ou foi bloqueada. */
+    @Column(name = "finished_at")
+    private Instant finishedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/FeoFabricacaoV1StageStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/FeoFabricacaoV1StageStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.feo.fabricacao.v1;
+
+/** Responsabilidade: enumerar os estados operacionais de uma execução de etapa da FEO v1. */
+public enum FeoFabricacaoV1StageStatus {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    BLOCKED,
+    FAILED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/controller/FeoFabricacaoV1Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/controller/FeoFabricacaoV1Controller.java
@@ -1,0 +1,70 @@
+package com.marketinghub.feo.fabricacao.v1.controller;
+
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1CompleteRequest;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1ExecutionSummaryResponse;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1FailureRequest;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1PendingResponse;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1StartResponse;
+import com.marketinghub.feo.fabricacao.v1.service.FeoFabricacaoV1Service;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor comandos de experimento e callbacks internos da FEO v1. */
+@RestController
+@RequestMapping("/api")
+public class FeoFabricacaoV1Controller {
+
+    private final FeoFabricacaoV1Service service;
+
+    /** Inicializa o controller com o serviço de fabricação FEO. */
+    public FeoFabricacaoV1Controller(FeoFabricacaoV1Service service) {
+        this.service = service;
+    }
+
+    /** Cria ou reutiliza uma solicitação de fabricação FEO para o experimento. */
+    @PostMapping("/experiments/{experimentId}/feo/fabricacao/v1/start")
+    public ResponseEntity<FeoFabricacaoV1StartResponse> start(@PathVariable Long experimentId) {
+        return ResponseEntity.accepted().body(service.startForExperiment(experimentId));
+    }
+
+    /** Lista execuções FEO vinculadas ao experimento. */
+    @GetMapping("/experiments/{experimentId}/feo/fabricacao/v1/stage-executions")
+    public ResponseEntity<List<FeoFabricacaoV1ExecutionSummaryResponse>> list(@PathVariable Long experimentId) {
+        return ResponseEntity.ok(service.listByExperiment(experimentId));
+    }
+
+    /** Lista pendências canônicas de uma etapa para consumo pelo worker FEO. */
+    @GetMapping("/internal/feo/fabricacao/v1/{stageCode}/stage-executions/pending")
+    public List<FeoFabricacaoV1PendingResponse> pending(
+            @PathVariable String stageCode,
+            @RequestParam(defaultValue = "10") int limit) {
+        return service.listPending(stageCode, limit);
+    }
+
+    /** Recebe conclusão funcional de uma etapa executada pelo worker FEO. */
+    @PostMapping("/internal/feo/fabricacao/v1/{stageCode}/stage-executions/{executionId}/complete")
+    public ResponseEntity<Void> complete(
+            @PathVariable String stageCode,
+            @PathVariable Long executionId,
+            @RequestBody FeoFabricacaoV1CompleteRequest request) {
+        service.complete(stageCode, executionId, request);
+        return ResponseEntity.accepted().build();
+    }
+
+    /** Recebe falha técnica de uma etapa executada pelo worker FEO. */
+    @PostMapping("/internal/feo/fabricacao/v1/{stageCode}/stage-executions/{executionId}/fail")
+    public ResponseEntity<Void> fail(
+            @PathVariable String stageCode,
+            @PathVariable Long executionId,
+            @RequestBody FeoFabricacaoV1FailureRequest request) {
+        service.fail(stageCode, executionId, request);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1CompleteRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1CompleteRequest.java
@@ -1,0 +1,16 @@
+package com.marketinghub.feo.fabricacao.v1.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/** Responsabilidade: receber o resultado funcional publicado pelo worker FEO. */
+public record FeoFabricacaoV1CompleteRequest(
+        String workerId,
+        String jobId,
+        String status,
+        Object output,
+        List<Map<String, Object>> artifacts,
+        Map<String, Object> metrics,
+        String blockReason,
+        String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1ExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1ExecutionSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.feo.fabricacao.v1.dto;
+
+import java.time.Instant;
+
+/** Responsabilidade: resumir uma execução FEO para consulta operacional do experimento. */
+public record FeoFabricacaoV1ExecutionSummaryResponse(
+        Long executionId,
+        String jobId,
+        String stageCode,
+        String status,
+        String blockReason,
+        String errorMessage,
+        Instant createdAt,
+        Instant finishedAt) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1FailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1FailureRequest.java
@@ -1,0 +1,5 @@
+package com.marketinghub.feo.fabricacao.v1.dto;
+
+/** Responsabilidade: receber falha técnica publicada pelo worker FEO. */
+public record FeoFabricacaoV1FailureRequest(String workerId, String jobId, String error) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1PendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1PendingResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.feo.fabricacao.v1.dto;
+
+import java.util.Map;
+
+/** Responsabilidade: expor uma execução pendente no contrato consumido pelo worker FEO. */
+public record FeoFabricacaoV1PendingResponse(
+        String jobId,
+        String executionId,
+        Map<String, Object> input,
+        Map<String, Object> config) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1StartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/dto/FeoFabricacaoV1StartResponse.java
@@ -1,0 +1,5 @@
+package com.marketinghub.feo.fabricacao.v1.dto;
+
+/** Responsabilidade: representar a resposta de criação de uma solicitação FEO para experimento. */
+public record FeoFabricacaoV1StartResponse(Long executionId, String jobId, String stageCode, String status) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/repository/FeoFabricacaoV1StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/repository/FeoFabricacaoV1StageExecutionRepository.java
@@ -1,0 +1,52 @@
+package com.marketinghub.feo.fabricacao.v1.repository;
+
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageExecution;
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageStatus;
+import java.util.List;
+import java.util.Optional;
+import java.time.Instant;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Responsabilidade: consultar e persistir execuções de etapa da FEO v1. */
+public interface FeoFabricacaoV1StageExecutionRepository extends JpaRepository<FeoFabricacaoV1StageExecution, Long> {
+
+    /** Lista pendências da etapa em ordem de criação para consumo pelo worker. */
+    List<FeoFabricacaoV1StageExecution> findByStageCodeAndStatusOrderByCreatedAtAsc(
+            String stageCode,
+            FeoFabricacaoV1StageStatus status,
+            Pageable pageable);
+
+    /** Lista pendências novas ou execuções antigas sem callback para retry operacional. */
+    @Query("""
+            select e
+            from FeoFabricacaoV1StageExecution e
+            where e.stageCode = :stageCode
+              and (
+                e.status = com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageStatus.PENDING
+                or (
+                  e.status = com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageStatus.RUNNING
+                  and e.startedAt < :staleBefore
+                )
+              )
+            order by e.createdAt asc
+            """)
+    List<FeoFabricacaoV1StageExecution> findPendingOrStaleRunning(
+            @Param("stageCode") String stageCode,
+            @Param("staleBefore") Instant staleBefore,
+            Pageable pageable);
+
+    /** Busca execução específica protegendo o callback contra troca de etapa. */
+    Optional<FeoFabricacaoV1StageExecution> findByIdAndStageCode(Long id, String stageCode);
+
+    /** Verifica se já existe etapa inicial ativa para evitar duplicidade por experimento. */
+    boolean existsByExperimentIdAndStageCodeAndStatusIn(
+            Long experimentId,
+            String stageCode,
+            List<FeoFabricacaoV1StageStatus> statuses);
+
+    /** Lista histórico recente da FEO para um experimento. */
+    List<FeoFabricacaoV1StageExecution> findTop20ByExperimentIdOrderByCreatedAtDesc(Long experimentId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/service/FeoFabricacaoV1Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/feo/fabricacao/v1/service/FeoFabricacaoV1Service.java
@@ -1,0 +1,337 @@
+package com.marketinghub.feo.fabricacao.v1.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.deliverable.Deliverable;
+import com.marketinghub.deliverable.DeliverablePackage;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageExecution;
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageStatus;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1CompleteRequest;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1ExecutionSummaryResponse;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1FailureRequest;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1PendingResponse;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1StartResponse;
+import com.marketinghub.feo.fabricacao.v1.repository.FeoFabricacaoV1StageExecutionRepository;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.repository.jpa.deliverable.DeliverablePackageRepository;
+import com.marketinghub.repository.jpa.deliverable.DeliverableRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: orquestrar a fila backend da FEO v1 para fabricação de entregáveis de experimentos. */
+@Service
+public class FeoFabricacaoV1Service {
+
+    private static final Logger log = LoggerFactory.getLogger(FeoFabricacaoV1Service.class);
+    private static final String STAGE_PLANEJAMENTO = "planejamento-entregaveis";
+    private static final String STAGE_MONTAGEM = "montagem-pacote";
+    private static final Duration RUNNING_RETRY_AFTER = Duration.ofMinutes(15);
+    private static final TypeReference<LinkedHashMap<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, Object>>> ARTIFACT_LIST_TYPE = new TypeReference<>() {};
+
+    private final ExperimentRepository experimentRepository;
+    private final DeliverableRepository deliverableRepository;
+    private final DeliverablePackageRepository deliverablePackageRepository;
+    private final FeoFabricacaoV1StageExecutionRepository executionRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o serviço com repositórios canônicos e serializador JSON. */
+    public FeoFabricacaoV1Service(
+            ExperimentRepository experimentRepository,
+            DeliverableRepository deliverableRepository,
+            DeliverablePackageRepository deliverablePackageRepository,
+            FeoFabricacaoV1StageExecutionRepository executionRepository,
+            ObjectMapper objectMapper) {
+        this.experimentRepository = experimentRepository;
+        this.deliverableRepository = deliverableRepository;
+        this.deliverablePackageRepository = deliverablePackageRepository;
+        this.executionRepository = executionRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Cria a etapa inicial de fabricação de entregáveis para um experimento. */
+    @Transactional
+    public FeoFabricacaoV1StartResponse startForExperiment(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        if (hasActiveInitialExecution(experimentId)) {
+            FeoFabricacaoV1StageExecution active = executionRepository
+                    .findTop20ByExperimentIdOrderByCreatedAtDesc(experimentId)
+                    .stream()
+                    .filter(item -> STAGE_PLANEJAMENTO.equals(item.getStageCode()))
+                    .filter(item -> item.getStatus() == FeoFabricacaoV1StageStatus.PENDING
+                            || item.getStatus() == FeoFabricacaoV1StageStatus.RUNNING)
+                    .findFirst()
+                    .orElseThrow();
+            return toStartResponse(active);
+        }
+
+        FeoFabricacaoV1StageExecution execution = FeoFabricacaoV1StageExecution.builder()
+                .experiment(experiment)
+                .jobId("feo-exp-" + experiment.getId() + "-" + UUID.randomUUID())
+                .stageCode(STAGE_PLANEJAMENTO)
+                .status(FeoFabricacaoV1StageStatus.PENDING)
+                .inputPayload(toJson(buildFabricationContext(experiment)))
+                .build();
+        return toStartResponse(executionRepository.save(execution));
+    }
+
+    /** Lista execuções recentes da FEO para o experimento. */
+    @Transactional(readOnly = true)
+    public List<FeoFabricacaoV1ExecutionSummaryResponse> listByExperiment(Long experimentId) {
+        return executionRepository.findTop20ByExperimentIdOrderByCreatedAtDesc(experimentId)
+                .stream()
+                .map(this::toSummary)
+                .toList();
+    }
+
+    /** Lista pendências de uma etapa para consumo pelo worker FEO. */
+    @Transactional
+    public List<FeoFabricacaoV1PendingResponse> listPending(String stageCode, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 50));
+        return executionRepository
+                .findPendingOrStaleRunning(
+                        stageCode,
+                        Instant.now().minus(RUNNING_RETRY_AFTER),
+                        PageRequest.of(0, safeLimit))
+                .stream()
+                .map(this::markRunningAndMap)
+                .toList();
+    }
+
+    /** Registra conclusão, persiste saída e enfileira próxima etapa quando o contrato permitir. */
+    @Transactional
+    public void complete(String stageCode, Long executionId, FeoFabricacaoV1CompleteRequest request) {
+        FeoFabricacaoV1StageExecution execution = findExecution(stageCode, executionId);
+        execution.setWorkerId(request.workerId());
+        execution.setOutputPayload(toJson(request.output()));
+        execution.setArtifactsPayload(toJson(request.artifacts()));
+        execution.setMetricsPayload(toJson(request.metrics()));
+        execution.setBlockReason(trimToNull(request.blockReason()));
+        execution.setNextStageCode(trimToNull(request.nextStageCode()));
+        execution.setFinishedAt(Instant.now());
+        execution.setStatus(resolveCompletedStatus(request));
+        executionRepository.save(execution);
+
+        if (execution.getStatus() == FeoFabricacaoV1StageStatus.COMPLETED) {
+            enqueueNextStageWhenAllowed(execution, request);
+            materializePackageWhenFinal(stageCode, execution, request);
+        }
+    }
+
+    /** Registra falha técnica reportada pelo worker FEO. */
+    @Transactional
+    public void fail(String stageCode, Long executionId, FeoFabricacaoV1FailureRequest request) {
+        FeoFabricacaoV1StageExecution execution = findExecution(stageCode, executionId);
+        execution.setWorkerId(request.workerId());
+        execution.setErrorMessage(trimToNull(request.error()));
+        execution.setFinishedAt(Instant.now());
+        execution.setStatus(FeoFabricacaoV1StageStatus.FAILED);
+        executionRepository.save(execution);
+    }
+
+    /** Marca a execução como assumida e converte para o contrato pending do worker. */
+    private FeoFabricacaoV1PendingResponse markRunningAndMap(FeoFabricacaoV1StageExecution execution) {
+        execution.setStatus(FeoFabricacaoV1StageStatus.RUNNING);
+        execution.setStartedAt(Instant.now());
+        FeoFabricacaoV1StageExecution saved = executionRepository.save(execution);
+        return new FeoFabricacaoV1PendingResponse(
+                saved.getJobId(),
+                String.valueOf(saved.getId()),
+                fromJson(saved.getInputPayload(), MAP_TYPE),
+                Map.of("experimentId", saved.getExperiment().getId()));
+    }
+
+    /** Monta contexto mínimo de fabricação usando experimento, hipótese e pacote de entregáveis existente. */
+    private Map<String, Object> buildFabricationContext(Experiment experiment) {
+        Hypothesis hypothesis = experiment.getHypothesisRef();
+        DeliverablePackage latestPackage = latestPackage(experiment.getId());
+        List<String> deliverables = latestPackage != null
+                ? latestPackage.getDeliverables().stream().map(Deliverable::getTitle).toList()
+                : fallbackDeliverables(hypothesis);
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("requestId", "experiment-" + experiment.getId());
+        context.put("experimentId", String.valueOf(experiment.getId()));
+        context.put("offerName", latestPackage != null ? latestPackage.getName() : experiment.getName());
+        context.put("niche", experiment.getNiche() != null ? experiment.getNiche().getName() : null);
+        context.put("centralPromise", firstText(experiment.getFunnelPromise(), hypothesis != null ? hypothesis.getPromise() : null, experiment.getHypothesis()));
+        context.put("promisedResult", firstText(experiment.getFreeReward(), experiment.getSinglePain(), hypothesis != null ? hypothesis.getEntrega() : null));
+        context.put("coreMechanism", firstText(hypothesis != null ? hypothesis.getUniqueMechanism() : null, hypothesis != null ? hypothesis.getMechanism() : null));
+        context.put("proofSummary", firstText(experiment.getLandingPageQualityReview(), hypothesis != null ? hypothesis.getSuccessRule() : null));
+        context.put("deliverables", deliverables);
+        context.put("validationSignals", List.of(
+                "Gate atual permite definição de oferta e fabricação de entregáveis.",
+                "FEO não libera tráfego nem altera promessa comercial validada."));
+        return context;
+    }
+
+    /** Busca o pacote mais recente vinculado ao experimento. */
+    private DeliverablePackage latestPackage(Long experimentId) {
+        return deliverablePackageRepository.findByExperimentIdOrderByCreatedAtDesc(experimentId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Usa a entrega textual da hipótese como fallback quando ainda não há pacote vinculado. */
+    private List<String> fallbackDeliverables(Hypothesis hypothesis) {
+        if (hypothesis == null || !StringUtils.hasText(hypothesis.getEntrega())) {
+            return List.of();
+        }
+        return List.of(hypothesis.getEntrega().trim());
+    }
+
+    /** Enfileira montagem do pacote após o planejamento retornar um plano aprovado pelo contrato. */
+    private void enqueueNextStageWhenAllowed(FeoFabricacaoV1StageExecution execution, FeoFabricacaoV1CompleteRequest request) {
+        if (!STAGE_PLANEJAMENTO.equals(execution.getStageCode()) || !STAGE_MONTAGEM.equals(request.nextStageCode())) {
+            return;
+        }
+        Map<String, Object> assemblyInput = new LinkedHashMap<>();
+        assemblyInput.put("context", fromJson(execution.getInputPayload(), MAP_TYPE));
+        assemblyInput.put("plan", request.output());
+        FeoFabricacaoV1StageExecution next = FeoFabricacaoV1StageExecution.builder()
+                .experiment(execution.getExperiment())
+                .jobId(execution.getJobId())
+                .stageCode(STAGE_MONTAGEM)
+                .status(FeoFabricacaoV1StageStatus.PENDING)
+                .inputPayload(toJson(assemblyInput))
+                .build();
+        executionRepository.save(next);
+    }
+
+    /** Materializa o pacote final da FEO em entregáveis consumíveis pelo experimento. */
+    private void materializePackageWhenFinal(
+            String stageCode,
+            FeoFabricacaoV1StageExecution execution,
+            FeoFabricacaoV1CompleteRequest request) {
+        if (!STAGE_MONTAGEM.equals(stageCode)) {
+            return;
+        }
+        Map<String, Object> output = objectMapper.convertValue(request.output(), MAP_TYPE);
+        Map<String, Object> manifest = objectMapper.convertValue(output.get("manifest"), MAP_TYPE);
+        String packageTitle = stringValue(manifest.get("packageTitle"), "Pacote FEO - Experimento " + execution.getExperiment().getId())
+                + " - FEO #" + execution.getId();
+        List<Map<String, Object>> items = objectMapper.convertValue(manifest.get("items"), ARTIFACT_LIST_TYPE);
+        LinkedHashSet<Deliverable> deliverables = new LinkedHashSet<>();
+        for (Map<String, Object> item : items) {
+            Deliverable deliverable = deliverableRepository.save(Deliverable.builder()
+                    .niche(execution.getExperiment().getNiche())
+                    .title(stringValue(item.get("fileName"), "Entregável FEO"))
+                    .description(stringValue(item.get("role"), "Entregável final fabricado pela FEO."))
+                    .content(toJson(item))
+                    .model("feo.fabricacao.v1")
+                    .prompt("Fabricado pela FEO a partir do contexto validado do experimento.")
+                    .build());
+            deliverables.add(deliverable);
+        }
+        deliverablePackageRepository.save(DeliverablePackage.builder()
+                .experiment(execution.getExperiment())
+                .name(packageTitle)
+                .description(toJson(output.get("report")))
+                .model("feo.fabricacao.v1")
+                .prompt("Pacote final materializado pela etapa montagem-pacote da FEO.")
+                .deliverables(deliverables)
+                .build());
+    }
+
+    /** Localiza execução pelo id e etapa informada no callback. */
+    private FeoFabricacaoV1StageExecution findExecution(String stageCode, Long executionId) {
+        return executionRepository.findByIdAndStageCode(executionId, stageCode)
+                .orElseThrow(() -> new EntityNotFoundException("FEO execution not found: " + executionId));
+    }
+
+    /** Indica se já existe planejamento pendente ou em execução para o experimento. */
+    private boolean hasActiveInitialExecution(Long experimentId) {
+        return executionRepository.existsByExperimentIdAndStageCodeAndStatusIn(
+                experimentId,
+                STAGE_PLANEJAMENTO,
+                List.of(FeoFabricacaoV1StageStatus.PENDING, FeoFabricacaoV1StageStatus.RUNNING));
+    }
+
+    /** Resolve status final a partir do contrato do worker. */
+    private FeoFabricacaoV1StageStatus resolveCompletedStatus(FeoFabricacaoV1CompleteRequest request) {
+        if ("BLOCKED".equalsIgnoreCase(request.status()) || StringUtils.hasText(request.blockReason())) {
+            return FeoFabricacaoV1StageStatus.BLOCKED;
+        }
+        return FeoFabricacaoV1StageStatus.COMPLETED;
+    }
+
+    /** Converte entidade para resposta de início. */
+    private FeoFabricacaoV1StartResponse toStartResponse(FeoFabricacaoV1StageExecution execution) {
+        return new FeoFabricacaoV1StartResponse(
+                execution.getId(),
+                execution.getJobId(),
+                execution.getStageCode(),
+                execution.getStatus().name());
+    }
+
+    /** Converte entidade para resumo operacional. */
+    private FeoFabricacaoV1ExecutionSummaryResponse toSummary(FeoFabricacaoV1StageExecution execution) {
+        return new FeoFabricacaoV1ExecutionSummaryResponse(
+                execution.getId(),
+                execution.getJobId(),
+                execution.getStageCode(),
+                execution.getStatus().name(),
+                execution.getBlockReason(),
+                execution.getErrorMessage(),
+                execution.getCreatedAt(),
+                execution.getFinishedAt());
+    }
+
+    /** Serializa objeto para JSON preservando falha com stack no chamador transacional. */
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            log.error("Falha ao serializar payload FEO valueType={}", value != null ? value.getClass().getName() : null, ex);
+            throw new IllegalStateException("Falha ao serializar payload FEO", ex);
+        }
+    }
+
+    /** Desserializa JSON para o tipo solicitado. */
+    private <T> T fromJson(String json, TypeReference<T> type) {
+        try {
+            return objectMapper.readValue(json.getBytes(StandardCharsets.UTF_8), type);
+        } catch (Exception ex) {
+            log.error("Falha ao ler payload FEO jsonLength={}", json != null ? json.length() : 0, ex);
+            throw new IllegalStateException("Falha ao ler payload FEO", ex);
+        }
+    }
+
+    /** Retorna o primeiro texto preenchido. */
+    private String firstText(String... values) {
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    /** Normaliza texto vazio como nulo. */
+    private String trimToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    /** Converte valor arbitrário em string com fallback. */
+    private String stringValue(Object value, String fallback) {
+        return value == null || !StringUtils.hasText(String.valueOf(value)) ? fallback : String.valueOf(value);
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-14-feo-fabricacao-v1-stage-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-14-feo-fabricacao-v1-stage-execution.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-14-feo-fabricacao-v1-stage-execution
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: feo_fabricacao_v1_stage_execution
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE feo_fabricacao_v1_stage_execution (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                experiment_id BIGINT NOT NULL,
+                job_id VARCHAR(64) NOT NULL,
+                stage_code VARCHAR(80) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                input_payload LONGTEXT NOT NULL,
+                output_payload LONGTEXT NULL,
+                artifacts_payload LONGTEXT NULL,
+                metrics_payload LONGTEXT NULL,
+                block_reason LONGTEXT NULL,
+                next_stage_code VARCHAR(80) NULL,
+                worker_id VARCHAR(191) NULL,
+                error_message LONGTEXT NULL,
+                started_at DATETIME(6) NULL,
+                finished_at DATETIME(6) NULL,
+                created_at DATETIME(6) NOT NULL,
+                updated_at DATETIME(6) NOT NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_feo_fabricacao_v1_stage_execution_experiment
+                  FOREIGN KEY (experiment_id) REFERENCES experiment(id),
+                KEY idx_feo_fabricacao_v1_stage_status_created (stage_code, status, created_at),
+                KEY idx_feo_fabricacao_v1_experiment_created (experiment_id, created_at),
+                KEY idx_feo_fabricacao_v1_job_stage (job_id, stage_code)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-14-feo-fabricacao-v1-stage-execution.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-14-mds-product-evidence-stage-execution.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/feo/fabricacao/v1/service/FeoFabricacaoV1ServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/feo/fabricacao/v1/service/FeoFabricacaoV1ServiceTest.java
@@ -1,0 +1,203 @@
+package com.marketinghub.feo.fabricacao.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.deliverable.Deliverable;
+import com.marketinghub.deliverable.DeliverablePackage;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageExecution;
+import com.marketinghub.feo.fabricacao.v1.FeoFabricacaoV1StageStatus;
+import com.marketinghub.feo.fabricacao.v1.dto.FeoFabricacaoV1CompleteRequest;
+import com.marketinghub.feo.fabricacao.v1.repository.FeoFabricacaoV1StageExecutionRepository;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.deliverable.DeliverablePackageRepository;
+import com.marketinghub.repository.jpa.deliverable.DeliverableRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Pageable;
+
+/** Responsabilidade: validar o contrato mínimo da fila backend da FEO v1. */
+class FeoFabricacaoV1ServiceTest {
+
+    private final ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+    private final DeliverableRepository deliverableRepository = mock(DeliverableRepository.class);
+    private final DeliverablePackageRepository deliverablePackageRepository = mock(DeliverablePackageRepository.class);
+    private final FeoFabricacaoV1StageExecutionRepository executionRepository =
+            mock(FeoFabricacaoV1StageExecutionRepository.class);
+    private final FeoFabricacaoV1Service service = new FeoFabricacaoV1Service(
+            experimentRepository,
+            deliverableRepository,
+            deliverablePackageRepository,
+            executionRepository,
+            new ObjectMapper());
+
+    /** Deve criar uma pendência FEO com contexto do pacote de entregáveis já vinculado ao experimento. */
+    @Test
+    void shouldStartFabricationFromExperimentPackage() {
+        Experiment experiment = experiment();
+        Deliverable deliverable = Deliverable.builder().title("Checklist elegante").build();
+        DeliverablePackage pack = DeliverablePackage.builder()
+                .name("Método MUSA")
+                .deliverables(new java.util.LinkedHashSet<>(List.of(deliverable)))
+                .build();
+        when(experimentRepository.findById(66L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.existsByExperimentIdAndStageCodeAndStatusIn(eq(66L), eq("planejamento-entregaveis"), any()))
+                .thenReturn(false);
+        when(deliverablePackageRepository.findByExperimentIdOrderByCreatedAtDesc(66L)).thenReturn(List.of(pack));
+        when(executionRepository.save(any())).thenAnswer(invocation -> {
+            FeoFabricacaoV1StageExecution execution = invocation.getArgument(0);
+            execution.setId(10L);
+            return execution;
+        });
+
+        var response = service.startForExperiment(66L);
+
+        assertThat(response.executionId()).isEqualTo(10L);
+        assertThat(response.stageCode()).isEqualTo("planejamento-entregaveis");
+        assertThat(response.status()).isEqualTo("PENDING");
+        ArgumentCaptor<FeoFabricacaoV1StageExecution> captor =
+                ArgumentCaptor.forClass(FeoFabricacaoV1StageExecution.class);
+        verify(executionRepository).save(captor.capture());
+        assertThat(captor.getValue().getInputPayload())
+                .contains("Método MUSA")
+                .contains("Checklist elegante")
+                .contains("Arquitetura de Presença Elegante Acessível");
+    }
+
+    /** Deve marcar pending como running e entregar o contrato esperado pelo worker FEO. */
+    @Test
+    void shouldExposePendingExecutionForWorker() {
+        FeoFabricacaoV1StageExecution execution = FeoFabricacaoV1StageExecution.builder()
+                .id(7L)
+                .jobId("job-1")
+                .experiment(experiment())
+                .stageCode("planejamento-entregaveis")
+                .status(FeoFabricacaoV1StageStatus.PENDING)
+                .inputPayload("{\"requestId\":\"experiment-66\",\"experimentId\":\"66\"}")
+                .build();
+        when(executionRepository.findPendingOrStaleRunning(
+                eq("planejamento-entregaveis"),
+                any(),
+                any(Pageable.class)))
+                .thenReturn(List.of(execution));
+        when(executionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var pending = service.listPending("planejamento-entregaveis", 10);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().executionId()).isEqualTo("7");
+        assertThat(execution.getStatus()).isEqualTo(FeoFabricacaoV1StageStatus.RUNNING);
+    }
+
+    /** Deve enfileirar montagem quando o planejamento conclui com próxima etapa contratada. */
+    @Test
+    void shouldEnqueuePackageAssemblyAfterPlanningCompletion() {
+        FeoFabricacaoV1StageExecution execution = FeoFabricacaoV1StageExecution.builder()
+                .id(7L)
+                .jobId("job-1")
+                .experiment(experiment())
+                .stageCode("planejamento-entregaveis")
+                .status(FeoFabricacaoV1StageStatus.RUNNING)
+                .inputPayload("{\"requestId\":\"experiment-66\",\"experimentId\":\"66\"}")
+                .build();
+        when(executionRepository.findByIdAndStageCode(7L, "planejamento-entregaveis"))
+                .thenReturn(Optional.of(execution));
+        when(executionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.complete(
+                "planejamento-entregaveis",
+                7L,
+                new FeoFabricacaoV1CompleteRequest(
+                        "feo-worker",
+                        "job-1",
+                        "COMPLETED",
+                        Map.of("requestId", "experiment-66", "packageTitle", "Pacote Final"),
+                        List.of(),
+                        Map.of("deliverableCount", 1),
+                        null,
+                        "montagem-pacote"));
+
+        ArgumentCaptor<FeoFabricacaoV1StageExecution> captor =
+                ArgumentCaptor.forClass(FeoFabricacaoV1StageExecution.class);
+        verify(executionRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(1).getStageCode()).isEqualTo("montagem-pacote");
+        assertThat(captor.getAllValues().get(1).getInputPayload()).contains("\"plan\"");
+    }
+
+    /** Deve materializar pacote e entregáveis finais quando a montagem termina. */
+    @Test
+    void shouldMaterializeDeliverablePackageAfterAssemblyCompletion() {
+        FeoFabricacaoV1StageExecution execution = FeoFabricacaoV1StageExecution.builder()
+                .id(8L)
+                .jobId("job-1")
+                .experiment(experiment())
+                .stageCode("montagem-pacote")
+                .status(FeoFabricacaoV1StageStatus.RUNNING)
+                .inputPayload("{\"requestId\":\"experiment-66\",\"experimentId\":\"66\"}")
+                .build();
+        when(executionRepository.findByIdAndStageCode(8L, "montagem-pacote")).thenReturn(Optional.of(execution));
+        when(executionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(deliverableRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(deliverablePackageRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.complete(
+                "montagem-pacote",
+                8L,
+                new FeoFabricacaoV1CompleteRequest(
+                        "feo-worker",
+                        "job-1",
+                        "COMPLETED",
+                        Map.of(
+                                "manifest",
+                                Map.of(
+                                        "packageTitle",
+                                        "Pacote Final MUSA",
+                                        "items",
+                                        List.of(Map.of(
+                                                "fileName",
+                                                "guia.pdf",
+                                                "role",
+                                                "Guia principal",
+                                                "sha256",
+                                                "abc"))),
+                                "report",
+                                Map.of("commercialDecision", "READY_FOR_REVIEW")),
+                        List.of(),
+                        Map.of("generatedFileCount", 1),
+                        null,
+                        null));
+
+        ArgumentCaptor<DeliverablePackage> packageCaptor = ArgumentCaptor.forClass(DeliverablePackage.class);
+        verify(deliverablePackageRepository).save(packageCaptor.capture());
+        assertThat(packageCaptor.getValue().getName()).isEqualTo("Pacote Final MUSA - FEO #8");
+        assertThat(packageCaptor.getValue().getDeliverables()).hasSize(1);
+    }
+
+    /** Monta experimento mínimo com nicho e hipótese comercial. */
+    private Experiment experiment() {
+        MarketNiche niche = MarketNiche.builder().id(3L).name("Moda feminina").build();
+        Hypothesis hypothesis = Hypothesis.builder()
+                .promise("Presença elegante sem gastar com luxo")
+                .entrega("Plano de 7 dias")
+                .uniqueMechanism("Arquitetura de Presença Elegante Acessível")
+                .build();
+        return Experiment.builder()
+                .id(66L)
+                .name("MUSA-H001-E004")
+                .niche(niche)
+                .hypothesisRef(hypothesis)
+                .funnelPromise("Parecer intencional sem parecer rica")
+                .build();
+    }
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: o modulo research precisa atuar nesses experimento.

Modelo: Concordo. Para o experimento **66 / MUSA-H001-E004**, o módulo **Research/MDS** precisa atuar antes da criação da oferta final.

**O que confirmei**
- O experimento está em `PLANNED`, etapa `LANDING`.
- A própria hipótese diz que a oferta MUSA deve nascer **depois da pesquisa de mecanismos de sofisticação acessível**.
- Já existe uma solicitação no MDS:
  - `requestId: 1`
  - status: `PENDING`
  - correlação: `MUSA-H001-E004-research-2026-07-14`
  - contexto inclui `experimentId: 66`
- Ainda não há artefatos publicados: `artifacts: []`.

**Causa-raiz**
O sistema já criou a intenção de pesquisa, mas o Research ainda não virou uma etapa operacional fechada do experimento. Ele está como request pendente, sem entregar o pacote de evidências que deveria destravar a próxima decisão comercial.

**Alternativas**
1. **Pesquisa manual fora do sistema**
   - Rápida para este caso.
   - Ruim para escala e rastreabilidade.

2. **MDS processar o request atual e devolver artefatos**
   - Boa para destravar o experimento 66.
   - Ainda depende de alguém olhar se a oferta só avançou após a pesquisa.

3. **Transformar Research em gate obrigatório do experimento**
   - Melhor opção.
   - O experimento só avança para oferta, FEO, landing e tráfego quando houver pacote de mecanismos/evidências aprovado.

**Recomendação**
Para esse caso, o fluxo correto é:

1. Research/MDS processa o request `1`.
2. Publica artefatos como:
   - mecanismos de elegância acessível;
   - sinais visuais/sensoriais com evidência;
   - riscos de promessa exagerada;
   - ideias de entregáveis reais;
   - ângulos comerciais recomendados.
3. O experimento 66 consome esses artefatos.
4. Só depois nasce a oferta final MUSA.
5. Só depois FEO gera entregáveis e a landing é montada.

Decisão prática: **não criar promessa final, checkout, tráfego ou mockup genérico enquanto o MDS request estiver `PENDING` e sem artefatos aprovados**.

Usuário: executa a recomendação

Modelo: Executado.

**Status**
- MDS request `1` concluído como `COMPLETED`.
- Experimento: `66 / MUSA-H001-E004`.
- Foram publicados 5 artefatos aprovados:
  - `evidencePack` ID `5`
  - `mechanismSpec` ID `6`
  - `practicalKnowledgePack` ID `7`
  - `commercialAnglePack` ID `8`
  - `mechanismDiscoveryReport` ID `9`

**Mecanismo aprovado**
**Arquitetura de Presença Elegante Acessível**

Tese central: a mulher parece mais sofisticada quando reduz ruído visual, cria coerência sensorial e usa sinais contextuais de cuidado, intenção e presença antes de tentar parecer luxuosa.

**Direção comercial recomendada**
Oferta-base:

> **Método MUSA: 7 dias para montar sua assinatura de presença elegante sem gastar com luxo.**

Melhor ângulo:

> Você não precisa parecer rica; precisa parecer intencional.

**Próximo passo**
Agora o fluxo pode avançar para FEO gerar os entregáveis a partir do `practicalKnowledgePack`. Ainda deixei o gate como:

`APPROVED_FOR_OFFER_DEFINITION_NOT_FOR_TRAFFIC`

Ou seja: aprovado para construir oferta e entregáveis, mas ainda não para tráfego/campanha.

**Fontes usadas**
- PubMed odor/autoconfiança: https://pubmed.ncbi.nlm.nih.gov/19134127/
- PubMed fragrância/autoestima: https://pubmed.ncbi.nlm.nih.gov/34780484/
- PubMed cor de roupa/percepção: https://pubmed.ncbi.nlm.nih.gov/34029989/
- Formal clothing/cognição: https://www.columbia.edu/~ms4992/Publications/2015_Slepian-Ferber-Gold-Rutchick_Clothing-Formality_SPPS.pdf
- Attire/percepção ética: https://pmc.ncbi.nlm.nih.gov/articles/PMC9918841/
- Halo de atratividade: https://pmc.ncbi.nlm.nih.gov/articles/PMC11597472/
- Cheiro/nostalgia/autoestima: https://pubmed.ncbi.nlm.nih.gov/24456210/

Não criei PR nem alterei código.

Usuário: executa o próximo passo

Modelo: Executado.

**O que foi criado**
- Pacote de entregáveis do experimento `66 / MUSA-H001-E004`:
  - `deliverable_package` ID `6`
  - Nome: **Método MUSA - Arquitetura de Presença Elegante Acessível**
  - Vinculado ao experimento `66`
  - Total: `7` entregáveis

**Entregáveis criados**
- `22` Diagnóstico de ruído visual e coerência de presença
- `23` Mapa de paleta-base, contraste e ponto de cor
- `24` Guia de assinatura olfativa acessível por ocasião
- `25` Checklist 12 minutos de cabelo, pele, unha, roupa e acessórios
- `26` Matriz ocasião-presença
- `27` Plano 7 dias de microajustes de presença elegante
- `28` Lista de compras anti-impulso e reaproveitamento elegante

**Gate mantido**
- Experimento continua `PLANNED`
- Etapa continua `LANDING`
- Facebook Ads **não foi liberado**
- `facebook_release_requested_at` continua `null`

**Observação importante**
O worker FEO ainda não tem fila produtiva completa no backend. Então executei pelo caminho seguro existente: catálogo oficial de `deliverables` + `deliverable_package` vinculado ao experimento. Isso deixa a oferta pronta para a próxima etapa de landing/oferta, sem pular o gate de tráfego.

Não criei PR nem alterei código.

Última mensagem do usuário:
Ok por ter criado os itens mas precisamos implementar o o FEO para atuar no fluxo dos experimentos.

**Resumo das alterações:**
Implementado o suporte para o FEO atuar no fluxo dos experimentos.

O que entrou:
- Backend agora cria fila FEO por experimento.
- Endpoint para iniciar fabricação:
  - `POST /api/experiments/{experimentId}/feo/fabricacao/v1/start`
- Endpoint para consultar execuções:
  - `GET /api/experiments/{experimentId}/feo/fabricacao/v1/stage-executions`
- Endpoints internos já compatíveis com o worker FEO:
  - `GET /api/internal/feo/fabricacao/v1/{stageCode}/stage-executions/pending`
  - `POST /api/internal/feo/fabricacao/v1/{stageCode}/stage-executions/{executionId}/complete`
  - `POST /api/internal/feo/fabricacao/v1/{stageCode}/stage-executions/{executionId}/fail`
- Persistência auditável em `feo_fabricacao_v1_stage_execution`.
- Ao concluir `planejamento-entregaveis`, o backend enfileira `montagem-pacote`.
- Ao concluir `montagem-pacote`, o backend materializa `deliverable` e `deliverable_package` vinculados ao experimento.
- Adicionei retry para execução travada em `RUNNING` por mais de 15 minutos.

Validações:
- `../mvnw -DskipTests compile` no backend: passou.
- `../mvnw -Dtest=FeoFabricacaoV1ServiceTest test`: passou, 4 testes.
- `mvn -Dtest=FeoFabricacaoV1ContractTest test` no módulo `feo`: passou.
- Changelog validado sem `TIMESTAMP NOT NULL` e com `relativeToChangelogFile: true`.

Não criei PR.