### PR TITLE
AI Hub: Executei a opção 2 no workflow de deploy.

Alterei [.github/workflows/deploy-containers.yml](/root/ai-hub/src/ai-hub-456a3871-6529-4c82-a7ab-26cf16f18d40-zd6Uxe/repo/.github/workflows/deploy-containers.yml:25) para:

- adicionar um job `detect-cha…

### DIFF
--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -22,9 +22,77 @@ permissions:
   packages: read
 
 jobs:
+  detect-changes:
+    name: Detect changed modules
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      video: ${{ steps.filter.outputs.video }}
+      app_deploy: ${{ steps.filter.outputs.app_deploy }}
+      video_deploy: ${{ steps.filter.outputs.video_deploy }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        name: Detect affected deployment targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          before="${{ github.event.before }}"
+          if [[ -z "${before}" || "${before}" =~ ^0+$ ]]; then
+            base="$(git rev-list --max-parents=0 HEAD)"
+          else
+            base="${before}"
+          fi
+
+          changed_files="$(git diff --name-only "${base}" "${GITHUB_SHA}")"
+          printf 'Changed files:\n%s\n' "${changed_files}"
+
+          backend=false
+          frontend=false
+          video=false
+          deploy=false
+
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            case "${file}" in
+              .dockerignore) backend=true; frontend=true; video=true ;;
+              backend/settings.xml) backend=true ;;
+              backend/ads-service/*) backend=true ;;
+              frontend/*) frontend=true ;;
+              video-management-service/*) video=true ;;
+              deploy/*) deploy=true ;;
+            esac
+          done <<< "${changed_files}"
+
+          app_deploy=false
+          video_deploy=false
+
+          if [[ "${backend}" == "true" || "${frontend}" == "true" || "${deploy}" == "true" ]]; then
+            app_deploy=true
+          fi
+
+          if [[ "${video}" == "true" || "${deploy}" == "true" ]]; then
+            video_deploy=true
+          fi
+
+          {
+            echo "backend=${backend}"
+            echo "frontend=${frontend}"
+            echo "video=${video}"
+            echo "app_deploy=${app_deploy}"
+            echo "video_deploy=${video_deploy}"
+          } >> "${GITHUB_OUTPUT}"
+
   backend-image:
     name: Backend – build image
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
     services:
       mysql:
         image: mysql:5.7
@@ -94,6 +162,8 @@ jobs:
   frontend-image:
     name: Frontend – build image
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -127,6 +197,8 @@ jobs:
   video-management-image:
     name: Video management – build image
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.video == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -156,17 +228,20 @@ jobs:
   deploy-app:
     name: Deploy backend + frontend
     runs-on: ubuntu-latest
-    needs: [backend-image, frontend-image]
+    needs: [detect-changes, backend-image, frontend-image]
+    if: always() && needs.detect-changes.outputs.app_deploy == 'true'
     steps:
       - uses: actions/checkout@v4
 
       - name: Download backend image artifact
+        if: needs.detect-changes.outputs.backend == 'true'
         uses: actions/download-artifact@v4
         with:
           name: backend-image
           path: artifacts
 
       - name: Download frontend image artifact
+        if: needs.detect-changes.outputs.frontend == 'true'
         uses: actions/download-artifact@v4
         with:
           name: frontend-image
@@ -199,6 +274,7 @@ jobs:
           retry rsync -az --delete -e "ssh ${SSH_OPTS}" deploy/ ${VPS_USER}@${APP_VPS_IP}:${DEPLOY_DIR}/
 
       - name: Upload images to APP VPS
+        if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.frontend == 'true'
         env:
           SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
         run: |
@@ -213,8 +289,33 @@ jobs:
             done
           }
 
-          retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/backend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/backend-image.tar
-          retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/frontend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/frontend-image.tar
+          if [[ -f artifacts/backend-image.tar ]]; then
+            retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/backend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/backend-image.tar
+          fi
+
+          if [[ -f artifacts/frontend-image.tar ]]; then
+            retry rsync -az --partial --append-verify -e "ssh ${SSH_OPTS}" artifacts/frontend-image.tar ${VPS_USER}@${APP_VPS_IP}:/tmp/frontend-image.tar
+          fi
+
+      - name: Remove unchanged APP image artifacts
+        env:
+          BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+          FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+          SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
+        run: |
+          files_to_remove=()
+
+          if [[ "${BACKEND_CHANGED}" != "true" ]]; then
+            files_to_remove+=(/tmp/backend-image.tar)
+          fi
+
+          if [[ "${FRONTEND_CHANGED}" != "true" ]]; then
+            files_to_remove+=(/tmp/frontend-image.tar)
+          fi
+
+          if [[ "${#files_to_remove[@]}" -gt 0 ]]; then
+            ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} "rm -f ${files_to_remove[*]}"
+          fi
 
       - name: Apply backend/frontend stack
         env:
@@ -228,11 +329,13 @@ jobs:
   deploy-video-management:
     name: Deploy video management
     runs-on: ubuntu-latest
-    needs: [video-management-image]
+    needs: [detect-changes, video-management-image]
+    if: always() && needs.detect-changes.outputs.video_deploy == 'true'
     steps:
       - uses: actions/checkout@v4
 
       - name: Download video-management image artifact
+        if: needs.detect-changes.outputs.video == 'true'
         uses: actions/download-artifact@v4
         with:
           name: video-management-image
@@ -265,6 +368,7 @@ jobs:
           retry rsync -az --delete -e "ssh ${SSH_OPTS}" deploy/ ${VPS_USER}@${VIDEO_VPS_IP}:${DEPLOY_DIR}/
 
       - name: Upload image to VIDEO VPS
+        if: needs.detect-changes.outputs.video == 'true'
         env:
           SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
         run: |
@@ -280,6 +384,12 @@ jobs:
           }
 
           retry scp ${SSH_OPTS} artifacts/video-management-image.tar ${VPS_USER}@${VIDEO_VPS_IP}:/tmp/video-management-image.tar
+
+      - name: Remove unchanged VIDEO image artifact
+        if: needs.detect-changes.outputs.video != 'true'
+        env:
+          SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
+        run: ssh ${SSH_OPTS} ${VPS_USER}@${VIDEO_VPS_IP} "rm -f /tmp/video-management-image.tar"
 
       - name: Apply video-management stack
         env:


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: faz uma revisão nos workflows do projeto. Se realmente eles só estão sendo executados quando ocorre mudança no modulo e se eles não esta executando de forma desnecessária.

Modelo: **Conclusão**

Não. A maioria dos workflows está segmentada por módulo, mas existem execuções desnecessárias e um risco alto de deploy/build em produção sem mudança relevante.

**Achados principais**

1. **Dois workflows rodam em todo push na `main`, sem filtro por módulo**
   - [ci-cd.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/ci-cd.yml:4) roda em qualquer push na `main`.
   - [deploy-containers.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/deploy-containers.yml:3) também roda em qualquer push na `main`.

   Impacto: alteração em docs, worker isolado ou workflow não relacionado pode disparar build/teste/deploy de backend, frontend e video-management.

2. **`deploy-containers.yml` é o mais problemático**
   Ele sempre monta:
   - backend em [deploy-containers.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/deploy-containers.yml:25)
   - frontend em [deploy-containers.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/deploy-containers.yml:94)
   - video-management em [deploy-containers.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/deploy-containers.yml:127)
   - deploy backend/frontend em [deploy-containers.yml](/root/ai-hub/src/ai-hub-cdba32a8-8d2a-4663-a746-b10e645b24db-dJtIFu/repo/.github/workflows/deploy-containers.yml:156)

   Isso é execução desnecessária e risco operacional.

3. **Vários workflows de módulo têm `paths`, mas fazem Docker push também em PR**
   Exemplos: `ai-worker`, `facebook-ads-worker`, `lead-portal`, `oprm`, `mds`, `email-service`, `image-zipper`, `image-watermark`, `product-ai-worker`.

   Eles filtram por pasta, mas o job Docker não tem trava tipo:
   `if: github.event_name != 'pull_request'`

   Resultado: em PR, o correto seria testar/buildar; publicar imagem é custo e risco desnecessário.

4. **Alguns workflows estão corretos nesse ponto**
   Já têm bloqueio de Docker em PR:
   - `mois`
   - `feo`
   - `fashion-chat-service`
   - `scientific-research-worker`
   - `mois-hotmart-collector`
   - `mois-clickbank-collector`
   - `mois-sales-library-worker`
   - `ops-monitor-worker`

**Melhor caminho**

Avaliei 3 alternativas:

1. **Correção mínima**
   Adicionar `paths` nos dois workflows globais e `if` nos jobs Docker em PR.  
   Baixo custo, resolve a maior parte.

2. **Correção por módulo com `paths-filter` interno**
   O workflow global até pode disparar, mas cada job só roda se sua pasta mudou.  
   Melhor controle, evita build de frontend quando só backend mudou.

3. **Reestruturar tudo em um dispatcher monorepo**
   Mais limpo no longo prazo, mas esforço maior e risco de mexer demais agora.

Minha recomendação: **alternativa 2 para `deploy-containers.yml` e alternativa 1 para os demais**.

**Ação recomendada**

Quando você pedir a alteração, eu ajustaria assim:

- `ci-cd.yml`: rodar só com mudanças em `backend/ads-service/**`, `ai-worker/**` quando realmente necessário, e no próprio workflow.
- `deploy-containers.yml`: separar detecção de mudança por `backend`, `frontend`, `video-management` e `deploy`; cada imagem/deploy roda só quando afetado.
- Jobs Docker de PR: adicionar `if: github.event_name != 'pull_request'` nos workflows que ainda publicam imagem em PR.

Não fiz alterações nem preparei PR.

Última mensagem do usuário:
pode executar opção 2

**Resumo das alterações:**
Executei a opção 2 no workflow de deploy.

Alterei [.github/workflows/deploy-containers.yml](/root/ai-hub/src/ai-hub-456a3871-6529-4c82-a7ab-26cf16f18d40-zd6Uxe/repo/.github/workflows/deploy-containers.yml:25) para:

- adicionar um job `detect-changes`;
- rodar build de `backend`, `frontend` e `video-management` apenas quando o respectivo módulo mudou;
- reaplicar deploy de `backend/frontend` só quando mudou `backend`, `frontend` ou `deploy/`;
- reaplicar deploy de vídeo só quando mudou `video-management-service` ou `deploy/`;
- evitar uso de `.tar` antigo no VPS quando só parte da stack mudou;
- considerar dependências reais dos builds: `backend/settings.xml` e `.dockerignore`.

Validei com:

- `git diff --check`: passou.
- simulação local dos filtros: docs não disparam build/deploy; cada módulo dispara só o alvo correto; `deploy/` reaplica descritores; `.dockerignore` aciona todos por afetar o contexto Docker.

Limitação: o ambiente não tinha `ruby`, `PyYAML` nem `actionlint`, então não consegui rodar um linter específico de GitHub Actions localmente. Não criei PR.