### PR TITLE
AI Hub: Checkout criado no Mercado Pago para o experimento 66.

**Dados principais**
- Produto: `Método MUSA - Presença Elegante em 7 Dias`
- Valor: `R$47`
- Referência: `marketinghub-experiment-66`
- Checkout: https://www.mercadopago.com.br/checkout/v1/r…

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5825,3 +5825,12 @@
 - Validação local: testes do módulo `feo` passaram; testes focados do backend para ZIP/FEO passaram; smoke test local gerou `/tmp/musa-feo-premium.zip` com `01-pacote-final.html`, `02-pacote-final.pdf`, `03-manifesto-entregaveis.csv`, manifesto e relatório.
 - Reforço 2026-07-15: a FEO passa a ter etapa intermediária `redacao-entregaveis`, impedindo montagem final quando só existe plano/manifesto. Cada entregável agora precisa gerar conteúdo aplicável com primeira vitória, seções guiadas, checklist, template, erros a evitar, critério de conclusão e score mínimo antes do pacote final.
 - Reforço 2026-07-15 (Kit de Transformação Aplicável): a etapa de planejamento da FEO passa a gerar obrigatoriamente componentes de produto baseados nos padrões de páginas quentes da biblioteca de vendas: manifesto de uso, plano de 7 dias, checklist, templates prontos, exemplo preenchido, prova tangível, ritual de acompanhamento, bônus anti-objeção e guia de primeiros resultados. A redação bloqueia kit incompleto e exige material pronto, prova, ritual e bônus em cada entregável. A montagem inclui HTML/PDF/CSV consolidados e arquivos HTML individuais no ZIP para cada componente do comprador.
+
+## 2026-07-15 — Checkout Mercado Pago do experimento 66
+
+- Foi criado checkout real no Mercado Pago para o produto `Método MUSA - Presença Elegante em 7 Dias`, valor `R$47`, com referência `marketinghub-experiment-66`.
+- O experimento 66 foi atualizado com a URL de checkout como destino comercial intermediário para desbloquear o GeraSalesPage v1.
+- O draft local da página `sales-page-exp66.html` passou a apontar os CTAs para o checkout real e removeu o texto de "checkout pendente".
+- Validação operacional: o endpoint do ZIP oficial do experimento 66 respondeu `200` com `experimento-66-entregaveis.zip`.
+- Bloqueio restante: o start do GeraSalesPage v1 passou do bloqueio de checkout para o bloqueio de template, retornando ausência de template ativo para `sales-page-offer-brief`; a tabela `ai_prompt_schema_template` não possui linhas para `gera-sales-page-v1` no banco remoto.
+- Próximo passo: restaurar/semear os templates ativos do GeraSalesPage no banco remoto a partir dos changelogs versionados antes de republicar a página auditada e liberar tráfego.

--- a/lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html
+++ b/lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html
@@ -188,7 +188,7 @@
         <h1>Monte em 7 dias uma presença mais elegante sem depender de luxo caro.</h1>
         <p class="lead">Um kit prático para ajustar cabelo, pele, roupa, perfume e acessórios com mais coerência, menos tentativa e uma ordem simples de aplicação.</p>
         <div class="cta-row">
-          <a class="button" href="#checkout-pendente" data-checkout-required="true">Quero meu Kit MUSA por R$47</a>
+          <a class="button" href="https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-58ed9edb-6f21-44f0-a169-b908daa5b4e8">Quero meu Kit MUSA por R$47</a>
           <span class="price">Acesso ao pacote completo</span>
         </div>
         <p class="note">Entrega digital: HTML, PDF e materiais prontos para preencher, revisar e aplicar.</p>
@@ -306,17 +306,17 @@
       </div>
     </section>
 
-    <section class="offer" data-track-section="offer" id="checkout-pendente">
+    <section class="offer" data-track-section="offer" id="checkout">
       <div class="wrap grid-2">
         <div>
           <h2>Comece sua presença elegante em 7 dias.</h2>
           <p class="section-lead">Acesso ao Kit MUSA completo por R$47: plano, checklist, templates, exemplo preenchido, antes/depois, ritual e bônus anti-impulso.</p>
           <div class="cta-row">
-            <a class="button" href="#checkout-pendente" data-checkout-required="true">Checkout pendente de conexão</a>
+            <a class="button" href="https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-58ed9edb-6f21-44f0-a169-b908daa5b4e8">Comprar com Mercado Pago</a>
             <span class="price">R$47</span>
           </div>
           <div class="checkout-warning">
-            Status operacional: página preparada como draft comercial. Antes de tráfego pago, conectar URL real de checkout digital para o pacote FEO do experimento 66 e republicar pelo GeraSalesPage v1.
+            Checkout real criado no Mercado Pago. Antes de tráfego pago, republicar e auditar a página pelo GeraSalesPage v1 para ativar os coletores e transformar esta página em destino oficial da campanha.
           </div>
         </div>
         <div class="item">
@@ -331,7 +331,7 @@
 
   <footer>
     <div class="wrap">
-      Draft comercial do experimento 66 - Método MUSA. Usar somente após checkout real, auditoria GeraSalesPage e coletores de analytics ativos.
+      Draft comercial do experimento 66 - Método MUSA. Checkout Mercado Pago conectado; usar em tráfego pago somente após auditoria GeraSalesPage e coletores de analytics ativos.
     </div>
   </footer>
 </body>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: Vamos criar mais 2 ou 3 objetivos baseado nas definições que fizemos do uso do FEO:

Pesquisei a biblioteca operacional de páginas de venda do MOIS.

Usei como evidência:
- [uso-paginas-vendas-sucesso-pequenos-passos.md](/root/ai-hub/src/ai-hub-40c24d8a-0e8f-4984-b393-d54ae21d5b49-u7izsd/repo/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md)
- Endpoint real: `/api/mois/sales-library/hot-products/salespagepatterns/v1/candidates?workspaceId=workspace-001`
- Detalhes das análises de páginas com score alto.

**Conclusão principal**

O FEO não deve gerar “um PDF bonito”. Isso é pouco valor.

As páginas quentes vendem produtos que parecem completos porque entregam:

- método prático;
- plano de execução;
- materiais prontos;
- suporte/ritual/acompanhamento;
- bônus aplicáveis;
- prova visual do que a pessoa vai receber;
- redução clara de esforço.

Na biblioteca, encontrei 100 candidatos com temperatura Hotmart `>= 80`; dentro deles, 16 também tinham `scoreTotal >= 80`, que são os melhores exemplos para copiar o padrão estrutural.

Exemplos fortes:
- `BLACK MAGRA` — temperatura `127.07`, score `86`
- `Hotmart Pages e Send` — temperatura `150`, score `84`
- `Resina LAB` — temperatura `150`, score `82`
- `Leadlovers` — temperatura `150`, score `82`
- `Plataforma Assaad / Hotmart` — temperatura `150`, score `82`
- `Formação em Terapia Cognitiva Sexual 2.0` — temperatura `103.63`, score `86`
- `Face Academy Community` — temperatura `97.6`, score `86`
- `Assinatura Asimov Academy` — temperatura `95.5`, score `84`

**Padrão dos entregáveis vencedores**

O FEO precisa gerar pacotes com esta lógica:

1. **Entregável central de execução**
   - plano de 7, 14 ou 30 dias;
   - roteiro passo a passo;
   - checklist de aplicação;
   - trilha “comece por aqui”.

2. **Materiais prontos para usar**
   - templates;
   - planilhas;
   - scripts;
   - mensagens prontas;
   - fichas, modelos, calendários, cardápios, roteiros ou prompts.

3. **Prova/tangibilização**
   - mockup do pacote;
   - amostra real;
   - antes/depois quando aplicável;
   - exemplo preenchido;
   - miniresultado demonstrável.

4. **Acompanhamento ou ritual**
   - áudios diários;
   - lives;
   - comunidade;
   - suporte;
   - rotina de aplicação;
   - lembretes ou checkpoints.

5. **Bônus que remove objeção**
   - planilha de precificação;
   - lista de fornecedores;
   - modelo de cobrança;
   - FAQ operacional;
   - guia de erros comuns;
   - versão para perfil específico do público.

**3 alternativas para o FEO**

1. **Gerar apenas PDFs individuais**
   - Benefício: simples.
   - Risco: baixo valor percebido.
   - Aderência a vendas: fraca.

2. **Gerar curso/material completo com muitos módulos**
   - Benefício: alto valor percebido.
   - Risco: demora, excesso de teoria, produto pesado.
   - Aderência a vendas: média/alta.

3. **Gerar pacote operacional de transformação rápida**
   - Benefício: parece produto de verdade, reduz esforço, vende melhor.
   - Risco: exige pipeline mais cuidadoso.
   - Aderência a vendas: melhor.

Minha escolha: **alternativa 3**.

**Direção para o FEO**

O FEO deve fabricar sempre um **Kit de Transformação Aplicável**, não apenas arquivos soltos.

Formato recomendado para cada produto:

- `Plano rápido de execução`
- `Checklist de aplicação`
- `Templates prontos`
- `Exemplo preenchido`
- `Material de apoio`
- `Bônus anti-objeção`
- `Guia de primeiros resultados`
- `Manifesto do pacote com ordem de uso`

Resumo: o FEO precisa transformar a promessa em um **sistema utilizável**, com sensação de acompanhamento, clareza de aplicação e prova tangível. É isso que as páginas com temperatura alta estão vendendo.


Modelo: Sugestão de mais **3 objetivos para a próxima semana**, alinhados ao novo papel do FEO:

1. **Transformar o FEO em fabricante de Kit de Transformação Aplicável:** definir o pacote mínimo obrigatório por produto com plano rápido, checklist, templates, exemplo preenchido, material de apoio, bônus anti-objeção e ordem de uso.

2. **Tangibilizar valor antes da venda:** para cada oferta FEO, gerar prova visual do pacote, amostra real ou exemplo preenchido que mostre claramente “o que a pessoa recebe” e reduza a sensação de esforço.

3. **Validar o padrão vencedor com MUSA-H001-E004:** evoluir a oferta final para não vender apenas PDF, mas um sistema aplicável com promessa, execução guiada, materiais prontos e bônus que removem objeções de compra.

Minha recomendação: usar os 3. Eles completam bem os objetivos atuais porque conectam produto, percepção de valor e validação comercial.

Usuário: verifque se o experimento 66 esta de acordo com os objetivos. O me diga o que falta para ele ficar pronto

Modelo: **Conclusão curta**

O experimento 66 está **bem alinhado aos novos objetivos do FEO no produto/entregável**, mas **ainda não está pronto para rodar campanha nem vender**.

Ele já tem um Kit de Transformação Aplicável materializado, mas falta transformar isso em funil comercial publicável.

**O que já está de acordo**

- Experimento: `MUSA-H001-E004`
- Status: `PLANNED`
- FEO final criado: `Pacote Final - Método MUSA - Arquitetura de Presença Elegante Acessível - FEO #3`
- Decisão do pacote: `READY_FOR_PREMIUM_REVIEW`
- ZIP oficial existe: `experimento-66-entregaveis.zip`
- Pacote tem HTML, PDF, CSV e 19 entregáveis.
- Inclui os componentes certos:
  - manifesto / ordem de uso;
  - plano de 7 dias;
  - checklist;
  - templates;
  - exemplo preenchido;
  - preview antes/depois;
  - ritual de acompanhamento;
  - bônus anti-objeção;
  - guia de primeiros resultados.

Ou seja: ele deixou de ser “PDF bonito” e virou um pacote operacional. Isso está certo.

**O que falta para ficar pronto**

1. **Definir se o experimento ainda é pesquisa ou já é oferta**
   Hoje o experimento nasceu com a lógica: “não gerar campanha ainda; pesquisar mecanismos antes da oferta”.  
   Mas o FEO já criou um produto vendável. Falta decidir se vamos usar isso como:
   - pesquisa/validação de interesse;
   - lead magnet;
   - oferta low-ticket de R$47.

2. **Ajustar a promessa comercial**
   A promessa atual ainda está muito interna: “descobrir mecanismos antes da oferta final”.  
   Para vender, precisa virar promessa de comprador, por exemplo:  
   “Monte em 7 dias uma assinatura de presença elegante sem depender de luxo caro.”

3. **Revisão premium do pacote**
   O próprio pacote indica como próxima ação: revisar capa, promessa e primeiro exercício antes de publicar.  
   Minha leitura: o conteúdo está estruturado, mas ainda precisa de polimento para não parecer gerado/templated em algumas partes.

4. **Criar os ativos de venda**
   O experimento ainda não tem:
   - criativos aprovados;
   - copy de anúncio;
   - briefing de imagem;
   - landing page;
   - GeraLanding completo;
   - fluxo do portal do lead;
   - e-mails/amostra;
   - página de venda ou checkout conectado.

5. **Selecionar público**
   O readiness acusa ausência de segmentação:
   - interesses;
   - cargos;
   - comportamentos;
   - públicos Meta.

6. **Gerar prova visual pública**
   O pacote tem “preview tangível”, mas falta usar isso na venda:
   - mockup do kit;
   - imagem do PDF/planilha;
   - amostra visual do antes/depois;
   - print do plano de 7 dias;
   - visual do checklist/templates.

**Minha recomendação**

Seguir com a alternativa 3: transformar o 66 em **oferta low-ticket validável**, não apenas pesquisa.

Antes de publicar, eu faria nesta ordem:

1. Reescrever promessa, nome e headline para venda.
2. Revisar o FEO premium como produto de comprador.
3. Criar mockup/prova visual do kit.
4. Gerar landing + criativos.
5. Configurar público e fluxo de captura/checkout.
6. Só então liberar tráfego.

Resumo: **o produto FEO está no caminho certo; o funil comercial ainda não está pronto.**

Usuário: alternativa 3, com certeza ! Pode seguir.

Modelo: Segui pela **alternativa 3: oferta low-ticket validável**.

**Decisão operacional**

O experimento 66 deve deixar de ser tratado como “pesquisa de mecanismos” e virar uma oferta de entrada de **R$47**:

**Método MUSA — Arquitetura de Presença Elegante Acessível**  
Promessa comercial sugerida:  
**“Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.”**

**Evidências validadas**

- Backend do experimento 66 ainda está em lógica de pesquisa:
  - CTA atual: `Pesquisar mecanismos antes da oferta`
  - promessa atual: descobrir mecanismos antes da oferta final
  - status: `PLANNED`
  - etapa: `LANDING`
- Readiness confirma que ainda falta:
  - criativos aprovados;
  - fluxo do Lead Portal;
  - público/segmentação;
  - GeraLanding completo.
- ZIP do experimento existe e tem base forte:
  - pacote FEO premium;
  - plano de 7 dias;
  - checklist;
  - templates;
  - exemplo preenchido;
  - antes/depois;
  - ritual;
  - bônus anti-objeção;
  - guia de primeiros resultados.

**O que falta para ficar pronto para venda**

1. **Reposicionar a oferta**
   Trocar a promessa interna de pesquisa por promessa de compradora: elegância acessível, presença marcante, clareza de aplicação em 7 dias.

2. **Revisar o pacote FEO premium**
   O kit está estruturalmente certo, mas ainda precisa polimento comercial. Algumas partes ainda carregam linguagem de “pesquisa/oferta futura”, quando deveriam falar diretamente com quem vai comprar e aplicar.

3. **Criar a página de venda**
   A landing precisa vender o kit como produto aplicável, com:
   - promessa clara;
   - dor atual;
   - mecanismo MUSA;
   - prova visual do pacote;
   - lista de entregáveis;
   - bônus;
   - garantia/remoção de risco;
   - CTA para compra ou captura.

4. **Gerar prova visual pública**
   Usar mockup do kit, preview do checklist, trecho do plano de 7 dias e antes/depois visual. Isso é essencial porque a biblioteca de páginas quentes mostra que produto tangível vende melhor.

5. **Criar criativos**
   Ângulos recomendados:
   - “parecer elegante sem gastar com luxo”;
   - “12 detalhes que deixam sua presença mais sofisticada”;
   - “o erro visual que faz uma mulher parecer menos refinada”;
   - “plano de 7 dias para presença elegante acessível”.

6. **Selecionar público**
   Foco inicial:
   - mulheres urbanas;
   - beleza/autocuidado;
   - moda acessível;
   - perfumes;
   - imagem pessoal;
   - maquiagem;
   - cabelo;
   - consumo consciente;
   - lifestyle feminino.

**Minha recomendação final**

Não publicar ainda.

A próxima ação correta é transformar o experimento 66 em um **funil de venda low-ticket completo**, nesta ordem:

1. Reescrever promessa, nome comercial e headline.
2. Revisar o FEO como produto de compradora.
3. Criar mockup/prova visual.
4. Gerar landing/página de venda.
5. Gerar 3 a 5 criativos.
6. Configurar público.
7. Só então liberar tráfego.

Resumo: o **produto está praticamente pronto**, mas o **funil de venda ainda não está pronto**. O gargalo agora não é mais FEO; é embalagem comercial, prova visual e distribuição.

Usuário: Pode executar:

A próxima ação correta é transformar o experimento 66 em um funil de venda low-ticket completo, nesta ordem:

1. Reescrever promessa, nome comercial e headline.
2. Revisar o FEO como produto de compradora.
3. Criar mockup/prova visual.
4. Gerar landing/página de venda.
5. Gerar 3 a 5 criativos.
6. Configurar público.
7. Só então liberar tráfego

Modelo: Executei a preparação comercial do funil low-ticket do experimento 66 sem publicar tráfego e sem alterar PR.

**Conclusão**

O experimento 66 pode virar oferta de R$47, mas ainda precisa trocar a lógica interna de “pesquisa de mecanismos” por uma promessa direta para compradora.

Evidências validadas:
- Backend: `MUSA-H001-E004`, ID `66`, status `PLANNED`, objetivo atual `LEADS`.
- Readiness: faltam criativos, Lead Portal, segmentação e GeraLanding.
- ZIP oficial existe: `experimento-66-entregaveis.zip`.
- FEO interno está `COMPLETED`, decisão `READY_FOR_PREMIUM_REVIEW`.
- O pacote tem 19 arquivos, incluindo plano de 7 dias, checklist, templates, exemplo preenchido, antes/depois, ritual, bônus e anexos.

**Decisão de posicionamento**

Comparei 3 caminhos:

| Alternativa | Benefício | Risco | Escolha |
|---|---|---|---|
| Vender como “pesquisa de mecanismos” | fiel ao experimento original | pouco desejo de compra | não |
| Vender como curso de imagem pessoal | valor percebido alto | promete mais do que o pacote entrega | não |
| Vender como kit prático de presença elegante em 7 dias | alinha entrega, dor e compra impulsiva de R$47 | exige boa prova visual | sim |

**Oferta escolhida**

Nome comercial:
**Método MUSA — Presença Elegante em 7 Dias**

Promessa:
**Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.**

Headline:
**Pare de sentir que “falta algo” no visual e organize sua presença elegante em 7 dias com um kit prático de beleza, roupa, perfume e autocuidado acessível.**

CTA principal:
**Quero meu Kit MUSA por R$47**

Subheadline:
Um plano guiado com checklist, templates, exemplo preenchido, antes/depois e lista anti-impulso para você ajustar cabelo, pele, roupa, perfume e acessórios com mais intenção e menos tentativa.

**Página de venda recomendada**

1. Hero com promessa + mockup do kit.
2. Dor: “você se arruma, mas sente que o resultado não transmite presença”.
3. Mecanismo: checklist de 12 sinais visuais e sensoriais + rotina enxuta + curadoria por orçamento.
4. Prova visual: preview do plano de 7 dias, checklist e quadro antes/depois.
5. Entregáveis:
   - plano rápido de 7 dias;
   - checklist de aplicação;
   - templates preenchíveis;
   - exemplo preenchido;
   - diagnóstico de ruído visual;
   - guia de assinatura olfativa;
   - mapa de paleta/contraste;
   - checklist de 12 minutos;
   - lista de compras anti-impulso.
6. Bônus: ritual de checkpoints + guia de primeiros resultados.
7. Oferta: acesso ao kit por R$47.
8. FAQ: tempo, orçamento, experiência prévia, se serve para quem não entende moda, como recebe o material.
9. CTA final: **Começar minha presença elegante em 7 dias**.

**Criativos iniciais**

1. **Ângulo dor visual**
   “Você compra roupa, perfume e maquiagem, mas ainda sente que o visual não fica sofisticado?”

2. **Ângulo baixo esforço**
   “Um checklist de 12 minutos para ajustar cabelo, pele, roupa e acessórios antes de sair.”

3. **Ângulo luxo acessível**
   “Elegância não começa no preço da peça. Começa na coerência dos detalhes.”

4. **Ângulo anti-impulso**
   “Antes de comprar mais uma peça, descubra o que reaproveitar para parecer mais alinhada.”

5. **Ângulo 7 dias**
   “7 dias de microajustes para uma presença mais elegante sem transformação radical.”

**Segmentação inicial**

Prioridade:
- mulheres urbanas;
- moda feminina;
- beleza e autocuidado;
- maquiagem;
- perfumes;
- cabelo;
- skincare;
- imagem pessoal;
- consultoria de estilo;
- compras online;
- consumo consciente;
- lojas de departamento/moda acessível.

Teste recomendado:
- 3 conjuntos de anúncio.
- R$25/dia inicial.
- Criativos 1, 2 e 3 primeiro.
- Métrica de corte: CPL até R$8, lead rate acima de 20%, clique de intenção de compra acima de 5%.

**O que falta para ficar pronto**

1. Revisar o FEO para remover linguagem interna de “pesquisa de mecanismos”.
2. Criar mockup visual do kit.
3. Gerar a landing/GeraLanding com a promessa nova.
4. Criar fluxo Lead Portal ou checkout/captura.
5. Salvar segmentação oficial com IDs da Meta.
6. Aprovar 3 a 5 criativos.
7. Só depois liberar tráfego.

Resumo: o produto existe e está forte como kit. O gargalo agora é embalagem comercial e publicação do funil.

Usuário: Siga para :

1. Revisar o FEO para remover linguagem interna de “pesquisa de mecanismos”.
2. Criar mockup visual do kit.
3. Gerar a landing/GeraLanding com a promessa nova.
4. Criar fluxo Lead Portal ou checkout/captura.
5. Salvar segmentação oficial com IDs da Meta.
6. Aprovar 3 a 5 criativos.
7. Só depois liberar tráfego.

Modelo: Executei a preparação do experimento 66 até o ponto seguro, sem PR e sem liberar tráfego.

**O que ficou pronto**

- Reposicionei o experimento para oferta low-ticket:
  - Tipo: `LOW_TICKET_PRODUCT`
  - Objetivo: `SALES`
  - Preço: `R$47`
  - CTA: **Quero meu Kit MUSA por R$47**
  - Promessa: **Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.**

- Removi a lógica comercial de “pesquisa de mecanismos” da fonte principal do experimento.

- Criei e aprovei 5 criativos:
  - `Presença elegante em 7 dias`
  - `Elegância não começa no preço`
  - `Checklist de presença em 12 minutos`
  - `Pare de comprar no impulso`
  - `Quando o visual parece quase certo`

- Configurei público com IDs oficiais da Meta:
  - Interesse: `Beauty`
  - Interesse: `Fragrances (cosmetics)`
  - Comportamento: consumo qualificado/intermediário-alto no Brasil
  - Cargo: `Cabeleireira e Maquiadora`

**Status atual**

O readiness agora mostra:

- Criativos: pronto, `5`
- Público: pronto
- Tráfego: não liberado
- Bloqueio restante: **GeraSalesPage / página de venda**

**O que falta para ficar pronto para tráfego**

Falta criar ou vincular uma **URL real de checkout**.

Tentei iniciar o GeraSalesPage, mas o backend bloqueou corretamente:

> `GeraSalesPage v1 exige URL real de checkout antes de iniciar.`

Isso é correto para venda low-ticket. O sistema não deve publicar anúncio sem página de venda auditada e sem checkout real.

**Conclusão**

O experimento 66 agora está comercialmente preparado como oferta de venda.  
O único gargalo restante é operacional: **checkout real → GeraSalesPage → página publicada → liberação de tráfego**.

Não liberei Facebook Ads.

Usuário: coloca uma marquinha de tick validado nas etapas dessa tela para o usuario saber o que já foi feito 

Modelo: Feito. Coloquei a marca **Validado** com ícone de check nas etapas da aba **Construção**.

O ponto importante: o tick não é inferido no frontend. Agora o backend envia `flowSteps` com `validated=true/false`, e a tela só apresenta essa verdade.

Alterações principais:
- Backend expõe status validado por etapa no endpoint `/api/experiments/{id}/construction`.
- Frontend removeu a lista fixa local e usa as etapas vindas do backend.
- Etapas validadas aparecem com selo verde **Validado**.
- Etapas ainda incompletas ficam sem tick, para o usuário enxergar o que falta.

Validei com:
- `npm run typecheck` no frontend: passou.
- `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentControllerTest#constructionEndpointExplainsManualExperimentBuild test`: passou.

Não criei PR.

Usuário: Vamos produzir a pagina de vendas. Use os entregaveis reais se for gerar mocks. Coloca claramente o que são os entregaveis o cliente precisa entender bem. Se precisar alterar os prompts para a pagina de vendas ficar melhor.

Modelo: Produzi a página de venda draft do experimento 66 usando os entregáveis reais do FEO.

Arquivo criado:
[lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html](/root/ai-hub/src/ai-hub-1a536a19-a757-47ea-a007-8d7b156e7cd2-JfNQO3/repo/lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html)

Também ajustei o backend local do `GeraSalesPage` para enviar o pacote FEO real no contexto dos prompts, evitando página genérica:
[GerSalesPageStageService.java](/root/ai-hub/src/ai-hub-1a536a19-a757-47ea-a007-8d7b156e7cd2-JfNQO3/repo/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java)

Validação executada:
`mvn -Dtest=GeraSalesPageStageServiceTest test` passou com sucesso.

**Status comercial**

A página já comunica claramente:

- promessa de 7 dias;
- kit por R$47;
- mockup visual;
- dor principal;
- mecanismo MUSA;
- prova visual;
- lista concreta dos entregáveis reais;
- bônus;
- alerta de que o checkout ainda precisa ser conectado.

**Bloqueios reais antes de liberar tráfego**

1. O experimento 66 ainda está sem `followUpActionUrl`.
2. O serviço de pagamento não consegue vender o pacote FEO `id=7`; ele trata esse ID como pacote de imagem do Lead Portal e retorna status `FAILED`.
3. A tabela remota `ai_prompt_schema_template` está vazia; mesmo com checkout, o GeraSalesPage remoto não teria prompts/schemas ativos para rodar.

**Conclusão**

A página de venda foi produzida como draft, mas ainda não está pronta para tráfego.  
O próximo passo correto é conectar checkout digital para pacote FEO/low-ticket e restaurar/semear os templates ativos do GeraSalesPage no banco remoto. Não criei PR e não liberei Facebook Ads.

Última mensagem do usuário:
precisamos criar checkout do produto no mercado pago. Pode criar

**Resumo das alterações:**
Checkout criado no Mercado Pago para o experimento 66.

**Dados principais**
- Produto: `Método MUSA - Presença Elegante em 7 Dias`
- Valor: `R$47`
- Referência: `marketinghub-experiment-66`
- Checkout: https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-58ed9edb-6f21-44f0-a169-b908daa5b4e8

**Também feito**
- Atualizei o experimento 66 no backend com esse checkout como URL comercial intermediária.
- Atualizei o draft local da página `sales-page-exp66.html` para os botões apontarem para o Mercado Pago.
- Registrei a ação em `docs/registros/experimentos.md`.
- Confirmei que o ZIP oficial do produto responde corretamente: `experimento-66-entregaveis.zip`.

**Bloqueio restante**

Tentei iniciar o GeraSalesPage, mas agora o bloqueio não é mais checkout. O backend retornou:

`Template ativo de prompt/schema não encontrado para sales-page-offer-brief`

Confirmei no banco remoto que a tabela `ai_prompt_schema_template` tem `0` templates para `gera-sales-page-v1`.

**Conclusão**

O checkout está criado e vinculado.  
Ainda **não liberei tráfego**.

Próximo passo: restaurar/semear os templates ativos do GeraSalesPage no banco remoto, depois republicar/auditar a página de venda para ela virar o destino oficial da campanha.

Referência usada: documentação oficial Mercado Pago para criação de preferência/checkout: https://www.mercadopago.com.br/developers/pt/reference/online-payments/checkout-pro/preferences/create-preference/post