### PR TITLE
AI Hub: Executei o próximo passo até onde o ambiente permite.

Criei um recovery versionado para restaurar os 7 templates ativos do `GeraSalesPage v1`, com foco comercial correto para o experimento 66:

- usa os entregáveis reais do FEO via `experiment.fe…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml
@@ -1,0 +1,68 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml
+  - changeSet:
+      id: 2026-07-15-gera-sales-page-template-recovery-v7-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ai_prompt_schema_template
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ai_prompt_schema_template
+              SET active = false, updated_at = CURRENT_TIMESTAMP
+              WHERE pipeline_code = 'gera-sales-page-v1'
+                AND stage_code IN (
+                  'sales-page-offer-brief',
+                  'sales-page-wireframe',
+                  'sales-page-copy',
+                  'sales-page-visual-plan',
+                  'sales-page-html',
+                  'sales-page-checkout-quality-review',
+                  'sales-page-publication-package'
+                );
+
+              INSERT INTO ai_prompt_schema_template
+                (template_key, pipeline_code, stage_code, version, openai_model, schema_name, prompt_markdown_content, schema_json, active, created_at, updated_at)
+              VALUES
+                ('gera-sales-page-v1:sales-page-offer-brief:v7', 'gera-sales-page-v1', 'sales-page-offer-brief', 'v7', 'gpt-5.5', 'gera_sales_page_v1_offer_brief',
+                 'Você é estrategista de vendas diretas para produto digital low-ticket. Gere a etapa sales-page-offer-brief do GeraSalesPage v1 em português brasileiro. Use experiment.feoDeliverablePackage como fonte soberana dos entregáveis reais: não invente módulos, bônus ou arquivos fora do pacote. Para DIRECT_CHECKOUT, venda o kit pago com checkout real, preço, promessa, mecanismo, prova visual e redução clara de esforço. Para LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, diferencie amostra gratuita e produto pago. Explique o que a cliente recebe de forma concreta, usando títulos e descrições dos entregáveis reais. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["summary","promise","checkoutUrl","offerStack","risks"],"properties":{"summary":{"type":"string"},"promise":{"type":"string"},"checkoutUrl":{"type":"string"},"offerStack":{"type":"array","items":{"type":"string"}},"risks":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-wireframe:v7', 'gera-sales-page-v1', 'sales-page-wireframe', 'v7', 'gpt-5.5', 'gera_sales_page_v1_wireframe',
+                 'Você é arquiteto de página de vendas para tráfego pago. Gere a etapa sales-page-wireframe do GeraSalesPage v1 com seções que tornem a oferta fácil de comprar: hero com promessa e mockup, dor atual, mecanismo, prova visual, entregáveis reais, bônus, oferta, FAQ e CTA final. Use experiment.feoDeliverablePackage para nomear claramente o que a cliente recebe. Para DIRECT_CHECKOUT, todos os CTAs devem apontar ao checkout real. Para LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, CTAs devem ir ao formulário gerenciado e nunca a iframe. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["sections","primaryCta","checkoutUrl"],"properties":{"sections":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["id","goal","content"],"properties":{"id":{"type":"string"},"goal":{"type":"string"},"content":{"type":"string"}}}},"primaryCta":{"type":"string"},"checkoutUrl":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-copy:v7', 'gera-sales-page-v1', 'sales-page-copy', 'v7', 'gpt-5.5', 'gera_sales_page_v1_copy',
+                 'Você é copywriter de resposta direta. Gere a etapa sales-page-copy do GeraSalesPage v1 com comunicação sedutora, concreta e honesta. A copy deve vender transformação rápida, redução de esforço e clareza de aplicação. Use os entregáveis reais de experiment.feoDeliverablePackage como prova de valor: plano, checklist, templates, exemplo preenchido, previews, ritual e bônus somente quando existirem no pacote. Evite linguagem interna de pesquisa, pipeline, mecanismo em validação ou produto futuro. Para DIRECT_CHECKOUT, CTA aponta para compra. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["headline","subheadline","sections","cta"],"properties":{"headline":{"type":"string"},"subheadline":{"type":"string"},"sections":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["id","title","body"],"properties":{"id":{"type":"string"},"title":{"type":"string"},"body":{"type":"string"}}}},"cta":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-visual-plan:v7', 'gera-sales-page-v1', 'sales-page-visual-plan', 'v7', 'gpt-5.5', 'gera_sales_page_v1_visual_plan',
+                 'Você é diretor de arte de venda direta. Gere a etapa sales-page-visual-plan do GeraSalesPage v1 com foco em prova visual concreta da transformação. Planeje obrigatoriamente 3 a 5 cenas visuais: depois desejado, dor atual, preview/mockup do kit, contexto real de uso e reforço de confiança. Cada imageBrief deve indicar sectionId, purpose e prompt com imagem realista ou mockup tangível dos entregáveis reais de experiment.feoDeliverablePackage. Não use ícones, cards genéricos, gradientes ou decoração abstrata como prova. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["visualDirection","imageBriefs","trustElements"],"properties":{"visualDirection":{"type":"string"},"imageBriefs":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["sectionId","purpose","prompt"],"properties":{"sectionId":{"type":"string"},"purpose":{"type":"string"},"prompt":{"type":"string"}}}},"trustElements":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-html:v7', 'gera-sales-page-v1', 'sales-page-html', 'v7', 'gpt-5.5', 'gera_sales_page_v1_html',
+                 'Você é desenvolvedor front-end de página de vendas. Gere a etapa sales-page-html do GeraSalesPage v1 em HTML responsivo, português brasileiro profissional e texto público com acentuação correta. A página deve deixar claro o que são os entregáveis reais do pacote usando experiment.feoDeliverablePackage; não invente entregáveis. Inclua pelo menos 3 blocos HTML com prova visual concreta marcados com data-transform-visual. Use valores sem acento: after, pain e preview. Cada bloco marcado deve conter img, picture, video, canvas, svg ou background-image real; cards de texto, ícones soltos e gradientes não contam. Para DIRECT_CHECKOUT, use a URL de checkout real nos CTAs e não crie formulário obrigatório. Para LEAD_PORTAL_PERSONALIZED_SAMPLE_FUNNEL, use formulário gerenciado e nunca iframe. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["html","checkoutUrl","notes"],"properties":{"html":{"type":"string"},"checkoutUrl":{"type":"string"},"notes":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-checkout-quality-review:v7', 'gera-sales-page-v1', 'sales-page-checkout-quality-review', 'v7', 'gpt-5.5', 'gera_sales_page_v1_checkout_quality_review',
+                 'Você é auditor comercial. Revise a página do GeraSalesPage v1 como material que receberá tráfego pago. Aprove somente se a página explicar claramente preço, promessa, checkout, entrega e lista concreta dos entregáveis reais de experiment.feoDeliverablePackage. Bloqueie página que venda itens inventados, use linguagem interna de pesquisa, não mostre o que a cliente recebe, não tenha CTA de checkout real em DIRECT_CHECKOUT ou tenha formulário obrigatório antes da compra. Bloqueie se o HTML não tiver pelo menos 3 cenas visuais concretas marcadas com data-transform-visual contendo img, picture, video, canvas, svg ou background-image real. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["approved","blockers","recommendation"],"properties":{"approved":{"type":"boolean"},"blockers":{"type":"array","items":{"type":"string"}},"recommendation":{"type":"string"}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                ('gera-sales-page-v1:sales-page-publication-package:v7', 'gera-sales-page-v1', 'sales-page-publication-package', 'v7', 'gpt-5.5', 'gera_sales_page_v1_publication_package',
+                 'Você é responsável por empacotar a página para publicação. Retorne readyForTraffic=true somente se o HTML final estiver pronto para tráfego pago, com checkout real em DIRECT_CHECKOUT, preço claro, promessa clara, entregáveis reais descritos, ausência de linguagem interna, português brasileiro correto e pelo menos 3 cenas visuais concretas com data-transform-visual contendo img, picture, video, canvas, svg ou background-image real. O checklist deve confirmar checkout, oferta, entregáveis reais, prova visual, acentuação, ausência de iframe indevido e ausência de itens inventados. Responda apenas JSON válido aderente ao schema. Experimento: {{experiment}} Saídas anteriores: {{previousStageOutputs}}',
+                 '{"type":"object","additionalProperties":false,"required":["readyForTraffic","html","checkoutUrl","releaseChecklist"],"properties":{"readyForTraffic":{"type":"boolean"},"html":{"type":"string"},"checkoutUrl":{"type":"string"},"releaseChecklist":{"type":"array","items":{"type":"string"}}}}',
+                 true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+              ON DUPLICATE KEY UPDATE
+                openai_model = VALUES(openai_model),
+                schema_name = VALUES(schema_name),
+                prompt_markdown_content = VALUES(prompt_markdown_content),
+                schema_json = VALUES(schema_json),
+                active = true,
+                updated_at = CURRENT_TIMESTAMP;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -18,6 +18,9 @@ databaseChangeLog:
       file: changesets/2026-07-09-gera-sales-page-visual-transform-v6.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-07-commercial-plan-week-objectives.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateChangelogTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateChangelogTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 class AiPromptSchemaTemplateChangelogTest {
     private static final Path PROMPT_SCHEMA_CHANGELOG = Path.of(
             "src/main/resources/db/changelog/changesets/2026-07-02-experiment-ai-prompt-schema-usage.yaml");
+    private static final Path GERA_SALES_PAGE_RECOVERY_CHANGELOG = Path.of(
+            "src/main/resources/db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml");
 
     /** Garante que a etapa Prova use o mesmo campo de evidencias aceito pelo AI Worker. */
     @Test
@@ -24,5 +26,24 @@ class AiPromptSchemaTemplateChangelogTest {
                 .contains(changeSetId)
                 .contains("\"evidenceSignals\"")
                 .doesNotContain("\"proofSignals\"");
+    }
+
+    /** Garante que o recovery do GeraSalesPage recrie todas as etapas comerciais com pacote FEO real. */
+    @Test
+    void geraSalesPageRecoveryShouldSeedAllCommercialTemplates() throws IOException {
+        String changelog = Files.readString(GERA_SALES_PAGE_RECOVERY_CHANGELOG, StandardCharsets.UTF_8);
+
+        assertThat(changelog)
+                .contains("gera-sales-page-v1:sales-page-offer-brief:v7")
+                .contains("gera-sales-page-v1:sales-page-wireframe:v7")
+                .contains("gera-sales-page-v1:sales-page-copy:v7")
+                .contains("gera-sales-page-v1:sales-page-visual-plan:v7")
+                .contains("gera-sales-page-v1:sales-page-html:v7")
+                .contains("gera-sales-page-v1:sales-page-checkout-quality-review:v7")
+                .contains("gera-sales-page-v1:sales-page-publication-package:v7")
+                .contains("experiment.feoDeliverablePackage")
+                .contains("DIRECT_CHECKOUT")
+                .contains("data-transform-visual")
+                .contains("ON DUPLICATE KEY UPDATE");
     }
 }

--- a/docs/registros/experimento-66.md
+++ b/docs/registros/experimento-66.md
@@ -1,0 +1,222 @@
+# Experimento 66 - MUSA-H001-E004
+
+## Diretriz operacional
+
+- Objetivo comercial: transformar o experimento 66 em uma oferta low-ticket validável, com foco em vendas.
+- Produto: `Método MUSA - Presença Elegante em 7 Dias`.
+- Preço definido: `R$47`.
+- Regra de execução: priorizar ações pelo sistema, endpoints e APIs oficiais.
+- Uso de banco de dados: apenas leitura/diagnóstico, salvo decisão explícita em contrário.
+- Tráfego pago: não liberar enquanto a página de venda não estiver publicada/auditada e o fluxo de checkout/entrega não estiver validado.
+
+## Resposta sobre alteração direta no banco
+
+Até este registro, a orientação operacional é:
+
+- Checkout: criado via API oficial do Mercado Pago.
+- Página de venda draft: criada como arquivo local de publicação estática.
+- Atualizações do experimento: devem ser feitas pelo backend/sistema quando existir endpoint adequado.
+- Banco remoto: usado apenas para validação/leitura, como confirmar bloqueios e ausência de templates ativos.
+- Não executar alteração direta manual no banco sem registrar antes neste documento o motivo, a tabela, a mudança e a alternativa pelo sistema que foi tentada.
+
+## Decisão comercial
+
+O experimento 66 não deve ser tratado como pesquisa de mecanismos nem como PDF isolado.
+
+A direção escolhida é vender um kit aplicável:
+
+**Método MUSA - Presença Elegante em 7 Dias**
+
+Promessa:
+
+> Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.
+
+CTA principal:
+
+> Quero meu Kit MUSA por R$47
+
+## Entregáveis reais do pacote
+
+O pacote FEO foi tratado como um Kit de Transformação Aplicável, com:
+
+- manifesto e ordem de uso;
+- plano rápido de 7 dias;
+- checklist de aplicação;
+- templates prontos;
+- exemplo preenchido;
+- preview antes/depois;
+- ritual de acompanhamento;
+- bônus anti-objeção;
+- guia de primeiros resultados;
+- anexos práticos.
+
+## Página de venda
+
+Foi criada uma página de venda draft usando os entregáveis reais como base:
+
+- Arquivo: `lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html`
+- Oferta: kit digital por `R$47`.
+- Checkout conectado: Mercado Pago.
+- Status: draft comercial, ainda não liberado para tráfego.
+
+Pontos que a página precisa comunicar claramente:
+
+- o que a cliente recebe;
+- como usar o kit;
+- por que o método reduz esforço;
+- por que não depende de luxo caro;
+- quais entregáveis são práticos e aplicáveis;
+- qual resultado inicial a cliente deve buscar em 7 dias.
+
+## Checkout Mercado Pago
+
+Checkout criado para o produto:
+
+- Produto: `Método MUSA - Presença Elegante em 7 Dias`
+- Valor: `R$47`
+- Referência: `marketinghub-experiment-66`
+- URL: `https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-58ed9edb-6f21-44f0-a169-b908daa5b4e8`
+
+Observação: o checkout existe, mas o destino oficial de campanha não deve ser o checkout direto. Para tráfego pago, o destino correto deve ser uma página de venda auditada pelo GeraSalesPage.
+
+## Criativos aprovados para teste inicial
+
+Foram definidos 5 criativos/ângulos:
+
+1. `Presença elegante em 7 dias`
+2. `Elegância não começa no preço`
+3. `Checklist de presença em 12 minutos`
+4. `Pare de comprar no impulso`
+5. `Quando o visual parece quase certo`
+
+## Público inicial
+
+Segmentação inicial proposta:
+
+- mulheres urbanas;
+- moda feminina;
+- beleza e autocuidado;
+- maquiagem;
+- perfumes;
+- cabelo;
+- skincare;
+- imagem pessoal;
+- consultoria de estilo;
+- compras online;
+- consumo consciente;
+- lojas de departamento/moda acessível.
+
+IDs/segmentos Meta citados no andamento:
+
+- `Beauty`;
+- `Fragrances (cosmetics)`;
+- comportamento de consumo qualificado/intermediário-alto no Brasil;
+- cargo `Cabeleireira e Maquiadora`.
+
+## Bloqueio atual
+
+O bloqueio principal para liberar tráfego é:
+
+- GeraSalesPage ainda não consegue concluir a página oficial porque falta template ativo de prompt/schema para `sales-page-offer-brief`.
+
+Mensagem registrada no andamento:
+
+> Template ativo de prompt/schema não encontrado para sales-page-offer-brief.
+
+Diagnóstico informado:
+
+- A tabela remota `ai_prompt_schema_template` estava sem templates ativos para `gera-sales-page-v1`.
+- Esse diagnóstico deve ser tratado como leitura/validação.
+- A correção preferencial é semear/restaurar os templates pelo fluxo controlado do sistema, changelog, seed oficial ou endpoint administrativo adequado, não por edição manual direta sem registro.
+
+## Investigação do próximo passo
+
+Foi verificado no repositório que já existe um recovery versionado para os templates do GeraSalesPage:
+
+- Changeset: `backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml`
+- Include no mestre: `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- Include possui `relativeToChangelogFile: true`.
+- O changeset insere/reativa os templates `v7` para todas as etapas:
+  - `sales-page-offer-brief`;
+  - `sales-page-wireframe`;
+  - `sales-page-copy`;
+  - `sales-page-visual-plan`;
+  - `sales-page-html`;
+  - `sales-page-checkout-quality-review`;
+  - `sales-page-publication-package`.
+
+Conclusão operacional:
+
+- O caminho correto não é inserir manualmente templates no banco.
+- A causa provável é que o Liquibase do ambiente remoto ainda não aplicou esse changeset, aplicou com `MARK_RAN` por precondição, ou o backend remoto em uso não está com esse código/changelog carregado.
+- Próximo passo seguro: validar execução do Liquibase/histórico do changeset no ambiente remoto e reaplicar pelo fluxo de deploy/migração do sistema, sem `UPDATE`/`INSERT` manual direto.
+
+## Validação remota via MCP
+
+Consulta somente leitura feita pelo MCP em `DATABASECHANGELOG`:
+
+- Changeset pesquisado: `2026-07-15-gera-sales-page-template-recovery-v7-001`
+- Resultado: `0` linhas.
+
+Consulta somente leitura feita pelo MCP em `ai_prompt_schema_template`:
+
+- Filtro: `pipeline_code = 'gera-sales-page-v1'`
+- Resultado: `0` linhas.
+
+Conclusão confirmada:
+
+- O ambiente remoto não aplicou o recovery `v7`.
+- O bloqueio do GeraSalesPage não é ausência de definição no repositório; é ausência da migração aplicada no ambiente remoto.
+- Próxima ação correta: executar o fluxo oficial de migração/deploy do backend para aplicar o Liquibase, depois reiniciar o GeraSalesPage do experimento 66.
+
+## Validação local
+
+Teste executado:
+
+```bash
+mvn -f backend/ads-service/pom.xml -Dtest=AiPromptSchemaTemplateChangelogTest test
+```
+
+Resultado:
+
+- `Tests run: 2`
+- `Failures: 0`
+- `Errors: 0`
+- `BUILD SUCCESS`
+
+Conclusão:
+
+- O repositório local possui o recovery `v7` protegido por teste.
+- A pendência está no ambiente remoto, não na falta de changelog local.
+
+## Próxima ação segura
+
+Antes de mexer em qualquer dado remoto, comparar 3 caminhos:
+
+1. **Inserir templates direto no banco**
+   - Benefício: rápido.
+   - Risco: contorna rastreabilidade, pode criar divergência entre ambientes.
+   - Aderência: baixa, só usar como exceção registrada.
+
+2. **Criar/usar seed versionado do sistema**
+   - Benefício: rastreável, repetível e alinhado ao produto.
+   - Risco: exige mais cuidado técnico.
+   - Aderência: alta.
+
+3. **Acionar endpoint administrativo/carga já existente**
+   - Benefício: usa sistema e reduz intervenção manual.
+   - Risco: depende de existir endpoint/rotina funcional.
+   - Aderência: alta se já existir.
+
+Escolha recomendada:
+
+**Primeiro procurar endpoint/rotina existente; se não existir, criar seed versionado ou changelog rastreável. Não alterar direto no banco como primeira opção.**
+
+## Pendências para ficar pronto para tráfego
+
+- Restaurar/semear templates ativos do GeraSalesPage v1.
+- Rodar novamente o GeraSalesPage para gerar a página oficial.
+- Auditar a página publicada.
+- Confirmar que o destino da campanha aponta para a página auditada, não para o checkout direto.
+- Validar fluxo de compra e entrega do produto digital.
+- Só depois liberar Facebook Ads.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5834,3 +5834,10 @@
 - Validação operacional: o endpoint do ZIP oficial do experimento 66 respondeu `200` com `experimento-66-entregaveis.zip`.
 - Bloqueio restante: o start do GeraSalesPage v1 passou do bloqueio de checkout para o bloqueio de template, retornando ausência de template ativo para `sales-page-offer-brief`; a tabela `ai_prompt_schema_template` não possui linhas para `gera-sales-page-v1` no banco remoto.
 - Próximo passo: restaurar/semear os templates ativos do GeraSalesPage no banco remoto a partir dos changelogs versionados antes de republicar a página auditada e liberar tráfego.
+# 2026-07-15 — Recovery dos templates GeraSalesPage v1 para experimento 66
+
+- Contexto: ao iniciar o próximo passo do experimento 66, o backend remoto bloqueou o GeraSalesPage com `Template ativo de prompt/schema não encontrado para sales-page-offer-brief`.
+- Confirmação via MCP: `ai_prompt_schema_template` tinha `0` registros para `pipeline_code='gera-sales-page-v1'`.
+- Decisão: criar recovery seed idempotente `v7` para as 7 etapas do GeraSalesPage, preservando venda direta low-ticket, checkout real, entregáveis reais do FEO via `experiment.feoDeliverablePackage` e prova visual obrigatória com `data-transform-visual`.
+- Objetivo comercial: impedir página genérica e garantir que a página de venda explique claramente o que a cliente recebe antes de liberar tráfego.
+- Limitação operacional: o `liquibase:update` executado com `DB_URL/DB_USER/DB_PASS` do sandbox concluiu 1 changeset, mas MCP e backend remoto continuaram retornando `0` templates e `409` no start do experimento 66; portanto essas variáveis não apontam para o mesmo schema operacional do backend. O changeset precisa ser aplicado pelo deploy/Liquibase do ambiente remoto correto antes de iniciar o GeraSalesPage.


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Histórico da conversa:
Usuário: Vamos criar mais 2 ou 3 objetivos baseado nas definições que fizemos do uso do FEO:

Pesquisei a biblioteca operacional de páginas de venda do MOIS.

Usei como evidência:
- [uso-paginas-vendas-sucesso-pequenos-passos.md](/root/ai-hub/src/ai-hub-40c24d8a-0e8f-4984-b393-d54ae21d5b49-u7izsd/repo/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md)
- Endpoint real: `/api/mois/sales-library/hot-products/salespagepatterns/v1/candidates?workspaceId=workspace-001`
- Detalhes das análises de páginas com score alto.

**Conclusão principal**

O FEO não deve gerar “um PDF bonito”. Isso é pouco valor.

As páginas quentes vendem produtos que parecem completos porque entregam:

- método prático;
- plano de execução;
- materiais prontos;
- suporte/ritual/acompanhamento;
- bônus aplicáveis;
- prova visual do que a pessoa vai receber;
- redução clara de esforço.

Na biblioteca, encontrei 100 candidatos com temperatura Hotmart `>= 80`; dentro deles, 16 também tinham `scoreTotal >= 80`, que são os melhores exemplos para copiar o padrão estrutural.

Exemplos fortes:
- `BLACK MAGRA` — temperatura `127.07`, score `86`
- `Hotmart Pages e Send` — temperatura `150`, score `84`
- `Resina LAB` — temperatura `150`, score `82`
- `Leadlovers` — temperatura `150`, score `82`
- `Plataforma Assaad / Hotmart` — temperatura `150`, score `82`
- `Formação em Terapia Cognitiva Sexual 2.0` — temperatura `103.63`, score `86`
- `Face Academy Community` — temperatura `97.6`, score `86`
- `Assinatura Asimov Academy` — temperatura `95.5`, score `84`

**Padrão dos entregáveis vencedores**

O FEO precisa gerar pacotes com esta lógica:

1. **Entregável central de execução**
   - plano de 7, 14 ou 30 dias;
   - roteiro passo a passo;
   - checklist de aplicação;
   - trilha “comece por aqui”.

2. **Materiais prontos para usar**
   - templates;
   - planilhas;
   - scripts;
   - mensagens prontas;
   - fichas, modelos, calendários, cardápios, roteiros ou prompts.

3. **Prova/tangibilização**
   - mockup do pacote;
   - amostra real;
   - antes/depois quando aplicável;
   - exemplo preenchido;
   - miniresultado demonstrável.

4. **Acompanhamento ou ritual**
   - áudios diários;
   - lives;
   - comunidade;
   - suporte;
   - rotina de aplicação;
   - lembretes ou checkpoints.

5. **Bônus que remove objeção**
   - planilha de precificação;
   - lista de fornecedores;
   - modelo de cobrança;
   - FAQ operacional;
   - guia de erros comuns;
   - versão para perfil específico do público.

**3 alternativas para o FEO**

1. **Gerar apenas PDFs individuais**
   - Benefício: simples.
   - Risco: baixo valor percebido.
   - Aderência a vendas: fraca.

2. **Gerar curso/material completo com muitos módulos**
   - Benefício: alto valor percebido.
   - Risco: demora, excesso de teoria, produto pesado.
   - Aderência a vendas: média/alta.

3. **Gerar pacote operacional de transformação rápida**
   - Benefício: parece produto de verdade, reduz esforço, vende melhor.
   - Risco: exige pipeline mais cuidadoso.
   - Aderência a vendas: melhor.

Minha escolha: **alternativa 3**.

**Direção para o FEO**

O FEO deve fabricar sempre um **Kit de Transformação Aplicável**, não apenas arquivos soltos.

Formato recomendado para cada produto:

- `Plano rápido de execução`
- `Checklist de aplicação`
- `Templates prontos`
- `Exemplo preenchido`
- `Material de apoio`
- `Bônus anti-objeção`
- `Guia de primeiros resultados`
- `Manifesto do pacote com ordem de uso`

Resumo: o FEO precisa transformar a promessa em um **sistema utilizável**, com sensação de acompanhamento, clareza de aplicação e prova tangível. É isso que as páginas com temperatura alta estão vendendo.


Modelo: Sugestão de mais **3 objetivos para a próxima semana**, alinhados ao novo papel do FEO:

1. **Transformar o FEO em fabricante de Kit de Transformação Aplicável:** definir o pacote mínimo obrigatório por produto com plano rápido, checklist, templates, exemplo preenchido, material de apoio, bônus anti-objeção e ordem de uso.

2. **Tangibilizar valor antes da venda:** para cada oferta FEO, gerar prova visual do pacote, amostra real ou exemplo preenchido que mostre claramente “o que a pessoa recebe” e reduza a sensação de esforço.

3. **Validar o padrão vencedor com MUSA-H001-E004:** evoluir a oferta final para não vender apenas PDF, mas um sistema aplicável com promessa, execução guiada, materiais prontos e bônus que removem objeções de compra.

Minha recomendação: usar os 3. Eles completam bem os objetivos atuais porque conectam produto, percepção de valor e validação comercial.

Usuário: verifque se o experimento 66 esta de acordo com os objetivos. O me diga o que falta para ele ficar pronto

Modelo: **Conclusão curta**

O experimento 66 está **bem alinhado aos novos objetivos do FEO no produto/entregável**, mas **ainda não está pronto para rodar campanha nem vender**.

Ele já tem um Kit de Transformação Aplicável materializado, mas falta transformar isso em funil comercial publicável.

**O que já está de acordo**

- Experimento: `MUSA-H001-E004`
- Status: `PLANNED`
- FEO final criado: `Pacote Final - Método MUSA - Arquitetura de Presença Elegante Acessível - FEO #3`
- Decisão do pacote: `READY_FOR_PREMIUM_REVIEW`
- ZIP oficial existe: `experimento-66-entregaveis.zip`
- Pacote tem HTML, PDF, CSV e 19 entregáveis.
- Inclui os componentes certos:
  - manifesto / ordem de uso;
  - plano de 7 dias;
  - checklist;
  - templates;
  - exemplo preenchido;
  - preview antes/depois;
  - ritual de acompanhamento;
  - bônus anti-objeção;
  - guia de primeiros resultados.

Ou seja: ele deixou de ser “PDF bonito” e virou um pacote operacional. Isso está certo.

**O que falta para ficar pronto**

1. **Definir se o experimento ainda é pesquisa ou já é oferta**
   Hoje o experimento nasceu com a lógica: “não gerar campanha ainda; pesquisar mecanismos antes da oferta”.  
   Mas o FEO já criou um produto vendável. Falta decidir se vamos usar isso como:
   - pesquisa/validação de interesse;
   - lead magnet;
   - oferta low-ticket de R$47.

2. **Ajustar a promessa comercial**
   A promessa atual ainda está muito interna: “descobrir mecanismos antes da oferta final”.  
   Para vender, precisa virar promessa de comprador, por exemplo:  
   “Monte em 7 dias uma assinatura de presença elegante sem depender de luxo caro.”

3. **Revisão premium do pacote**
   O próprio pacote indica como próxima ação: revisar capa, promessa e primeiro exercício antes de publicar.  
   Minha leitura: o conteúdo está estruturado, mas ainda precisa de polimento para não parecer gerado/templated em algumas partes.

4. **Criar os ativos de venda**
   O experimento ainda não tem:
   - criativos aprovados;
   - copy de anúncio;
   - briefing de imagem;
   - landing page;
   - GeraLanding completo;
   - fluxo do portal do lead;
   - e-mails/amostra;
   - página de venda ou checkout conectado.

5. **Selecionar público**
   O readiness acusa ausência de segmentação:
   - interesses;
   - cargos;
   - comportamentos;
   - públicos Meta.

6. **Gerar prova visual pública**
   O pacote tem “preview tangível”, mas falta usar isso na venda:
   - mockup do kit;
   - imagem do PDF/planilha;
   - amostra visual do antes/depois;
   - print do plano de 7 dias;
   - visual do checklist/templates.

**Minha recomendação**

Seguir com a alternativa 3: transformar o 66 em **oferta low-ticket validável**, não apenas pesquisa.

Antes de publicar, eu faria nesta ordem:

1. Reescrever promessa, nome e headline para venda.
2. Revisar o FEO premium como produto de comprador.
3. Criar mockup/prova visual do kit.
4. Gerar landing + criativos.
5. Configurar público e fluxo de captura/checkout.
6. Só então liberar tráfego.

Resumo: **o produto FEO está no caminho certo; o funil comercial ainda não está pronto.**

Usuário: alternativa 3, com certeza ! Pode seguir.

Modelo: Segui pela **alternativa 3: oferta low-ticket validável**.

**Decisão operacional**

O experimento 66 deve deixar de ser tratado como “pesquisa de mecanismos” e virar uma oferta de entrada de **R$47**:

**Método MUSA — Arquitetura de Presença Elegante Acessível**  
Promessa comercial sugerida:  
**“Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.”**

**Evidências validadas**

- Backend do experimento 66 ainda está em lógica de pesquisa:
  - CTA atual: `Pesquisar mecanismos antes da oferta`
  - promessa atual: descobrir mecanismos antes da oferta final
  - status: `PLANNED`
  - etapa: `LANDING`
- Readiness confirma que ainda falta:
  - criativos aprovados;
  - fluxo do Lead Portal;
  - público/segmentação;
  - GeraLanding completo.
- ZIP do experimento existe e tem base forte:
  - pacote FEO premium;
  - plano de 7 dias;
  - checklist;
  - templates;
  - exemplo preenchido;
  - antes/depois;
  - ritual;
  - bônus anti-objeção;
  - guia de primeiros resultados.

**O que falta para ficar pronto para venda**

1. **Reposicionar a oferta**
   Trocar a promessa interna de pesquisa por promessa de compradora: elegância acessível, presença marcante, clareza de aplicação em 7 dias.

2. **Revisar o pacote FEO premium**
   O kit está estruturalmente certo, mas ainda precisa polimento comercial. Algumas partes ainda carregam linguagem de “pesquisa/oferta futura”, quando deveriam falar diretamente com quem vai comprar e aplicar.

3. **Criar a página de venda**
   A landing precisa vender o kit como produto aplicável, com:
   - promessa clara;
   - dor atual;
   - mecanismo MUSA;
   - prova visual do pacote;
   - lista de entregáveis;
   - bônus;
   - garantia/remoção de risco;
   - CTA para compra ou captura.

4. **Gerar prova visual pública**
   Usar mockup do kit, preview do checklist, trecho do plano de 7 dias e antes/depois visual. Isso é essencial porque a biblioteca de páginas quentes mostra que produto tangível vende melhor.

5. **Criar criativos**
   Ângulos recomendados:
   - “parecer elegante sem gastar com luxo”;
   - “12 detalhes que deixam sua presença mais sofisticada”;
   - “o erro visual que faz uma mulher parecer menos refinada”;
   - “plano de 7 dias para presença elegante acessível”.

6. **Selecionar público**
   Foco inicial:
   - mulheres urbanas;
   - beleza/autocuidado;
   - moda acessível;
   - perfumes;
   - imagem pessoal;
   - maquiagem;
   - cabelo;
   - consumo consciente;
   - lifestyle feminino.

**Minha recomendação final**

Não publicar ainda.

A próxima ação correta é transformar o experimento 66 em um **funil de venda low-ticket completo**, nesta ordem:

1. Reescrever promessa, nome comercial e headline.
2. Revisar o FEO como produto de compradora.
3. Criar mockup/prova visual.
4. Gerar landing/página de venda.
5. Gerar 3 a 5 criativos.
6. Configurar público.
7. Só então liberar tráfego.

Resumo: o **produto está praticamente pronto**, mas o **funil de venda ainda não está pronto**. O gargalo agora não é mais FEO; é embalagem comercial, prova visual e distribuição.

Usuário: Pode executar:

A próxima ação correta é transformar o experimento 66 em um funil de venda low-ticket completo, nesta ordem:

1. Reescrever promessa, nome comercial e headline.
2. Revisar o FEO como produto de compradora.
3. Criar mockup/prova visual.
4. Gerar landing/página de venda.
5. Gerar 3 a 5 criativos.
6. Configurar público.
7. Só então liberar tráfego

Modelo: Executei a preparação comercial do funil low-ticket do experimento 66 sem publicar tráfego e sem alterar PR.

**Conclusão**

O experimento 66 pode virar oferta de R$47, mas ainda precisa trocar a lógica interna de “pesquisa de mecanismos” por uma promessa direta para compradora.

Evidências validadas:
- Backend: `MUSA-H001-E004`, ID `66`, status `PLANNED`, objetivo atual `LEADS`.
- Readiness: faltam criativos, Lead Portal, segmentação e GeraLanding.
- ZIP oficial existe: `experimento-66-entregaveis.zip`.
- FEO interno está `COMPLETED`, decisão `READY_FOR_PREMIUM_REVIEW`.
- O pacote tem 19 arquivos, incluindo plano de 7 dias, checklist, templates, exemplo preenchido, antes/depois, ritual, bônus e anexos.

**Decisão de posicionamento**

Comparei 3 caminhos:

| Alternativa | Benefício | Risco | Escolha |
|---|---|---|---|
| Vender como “pesquisa de mecanismos” | fiel ao experimento original | pouco desejo de compra | não |
| Vender como curso de imagem pessoal | valor percebido alto | promete mais do que o pacote entrega | não |
| Vender como kit prático de presença elegante em 7 dias | alinha entrega, dor e compra impulsiva de R$47 | exige boa prova visual | sim |

**Oferta escolhida**

Nome comercial:
**Método MUSA — Presença Elegante em 7 Dias**

Promessa:
**Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.**

Headline:
**Pare de sentir que “falta algo” no visual e organize sua presença elegante em 7 dias com um kit prático de beleza, roupa, perfume e autocuidado acessível.**

CTA principal:
**Quero meu Kit MUSA por R$47**

Subheadline:
Um plano guiado com checklist, templates, exemplo preenchido, antes/depois e lista anti-impulso para você ajustar cabelo, pele, roupa, perfume e acessórios com mais intenção e menos tentativa.

**Página de venda recomendada**

1. Hero com promessa + mockup do kit.
2. Dor: “você se arruma, mas sente que o resultado não transmite presença”.
3. Mecanismo: checklist de 12 sinais visuais e sensoriais + rotina enxuta + curadoria por orçamento.
4. Prova visual: preview do plano de 7 dias, checklist e quadro antes/depois.
5. Entregáveis:
   - plano rápido de 7 dias;
   - checklist de aplicação;
   - templates preenchíveis;
   - exemplo preenchido;
   - diagnóstico de ruído visual;
   - guia de assinatura olfativa;
   - mapa de paleta/contraste;
   - checklist de 12 minutos;
   - lista de compras anti-impulso.
6. Bônus: ritual de checkpoints + guia de primeiros resultados.
7. Oferta: acesso ao kit por R$47.
8. FAQ: tempo, orçamento, experiência prévia, se serve para quem não entende moda, como recebe o material.
9. CTA final: **Começar minha presença elegante em 7 dias**.

**Criativos iniciais**

1. **Ângulo dor visual**
   “Você compra roupa, perfume e maquiagem, mas ainda sente que o visual não fica sofisticado?”

2. **Ângulo baixo esforço**
   “Um checklist de 12 minutos para ajustar cabelo, pele, roupa e acessórios antes de sair.”

3. **Ângulo luxo acessível**
   “Elegância não começa no preço da peça. Começa na coerência dos detalhes.”

4. **Ângulo anti-impulso**
   “Antes de comprar mais uma peça, descubra o que reaproveitar para parecer mais alinhada.”

5. **Ângulo 7 dias**
   “7 dias de microajustes para uma presença mais elegante sem transformação radical.”

**Segmentação inicial**

Prioridade:
- mulheres urbanas;
- moda feminina;
- beleza e autocuidado;
- maquiagem;
- perfumes;
- cabelo;
- skincare;
- imagem pessoal;
- consultoria de estilo;
- compras online;
- consumo consciente;
- lojas de departamento/moda acessível.

Teste recomendado:
- 3 conjuntos de anúncio.
- R$25/dia inicial.
- Criativos 1, 2 e 3 primeiro.
- Métrica de corte: CPL até R$8, lead rate acima de 20%, clique de intenção de compra acima de 5%.

**O que falta para ficar pronto**

1. Revisar o FEO para remover linguagem interna de “pesquisa de mecanismos”.
2. Criar mockup visual do kit.
3. Gerar a landing/GeraLanding com a promessa nova.
4. Criar fluxo Lead Portal ou checkout/captura.
5. Salvar segmentação oficial com IDs da Meta.
6. Aprovar 3 a 5 criativos.
7. Só depois liberar tráfego.

Resumo: o produto existe e está forte como kit. O gargalo agora é embalagem comercial e publicação do funil.

Usuário: Siga para :

1. Revisar o FEO para remover linguagem interna de “pesquisa de mecanismos”.
2. Criar mockup visual do kit.
3. Gerar a landing/GeraLanding com a promessa nova.
4. Criar fluxo Lead Portal ou checkout/captura.
5. Salvar segmentação oficial com IDs da Meta.
6. Aprovar 3 a 5 criativos.
7. Só depois liberar tráfego.

Modelo: Executei a preparação do experimento 66 até o ponto seguro, sem PR e sem liberar tráfego.

**O que ficou pronto**

- Reposicionei o experimento para oferta low-ticket:
  - Tipo: `LOW_TICKET_PRODUCT`
  - Objetivo: `SALES`
  - Preço: `R$47`
  - CTA: **Quero meu Kit MUSA por R$47**
  - Promessa: **Monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro, compras impulsivas ou transformação radical.**

- Removi a lógica comercial de “pesquisa de mecanismos” da fonte principal do experimento.

- Criei e aprovei 5 criativos:
  - `Presença elegante em 7 dias`
  - `Elegância não começa no preço`
  - `Checklist de presença em 12 minutos`
  - `Pare de comprar no impulso`
  - `Quando o visual parece quase certo`

- Configurei público com IDs oficiais da Meta:
  - Interesse: `Beauty`
  - Interesse: `Fragrances (cosmetics)`
  - Comportamento: consumo qualificado/intermediário-alto no Brasil
  - Cargo: `Cabeleireira e Maquiadora`

**Status atual**

O readiness agora mostra:

- Criativos: pronto, `5`
- Público: pronto
- Tráfego: não liberado
- Bloqueio restante: **GeraSalesPage / página de venda**

**O que falta para ficar pronto para tráfego**

Falta criar ou vincular uma **URL real de checkout**.

Tentei iniciar o GeraSalesPage, mas o backend bloqueou corretamente:

> `GeraSalesPage v1 exige URL real de checkout antes de iniciar.`

Isso é correto para venda low-ticket. O sistema não deve publicar anúncio sem página de venda auditada e sem checkout real.

**Conclusão**

O experimento 66 agora está comercialmente preparado como oferta de venda.  
O único gargalo restante é operacional: **checkout real → GeraSalesPage → página publicada → liberação de tráfego**.

Não liberei Facebook Ads.

Usuário: coloca uma marquinha de tick validado nas etapas dessa tela para o usuario saber o que já foi feito 

Modelo: Feito. Coloquei a marca **Validado** com ícone de check nas etapas da aba **Construção**.

O ponto importante: o tick não é inferido no frontend. Agora o backend envia `flowSteps` com `validated=true/false`, e a tela só apresenta essa verdade.

Alterações principais:
- Backend expõe status validado por etapa no endpoint `/api/experiments/{id}/construction`.
- Frontend removeu a lista fixa local e usa as etapas vindas do backend.
- Etapas validadas aparecem com selo verde **Validado**.
- Etapas ainda incompletas ficam sem tick, para o usuário enxergar o que falta.

Validei com:
- `npm run typecheck` no frontend: passou.
- `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentControllerTest#constructionEndpointExplainsManualExperimentBuild test`: passou.

Não criei PR.

Usuário: Vamos produzir a pagina de vendas. Use os entregaveis reais se for gerar mocks. Coloca claramente o que são os entregaveis o cliente precisa entender bem. Se precisar alterar os prompts para a pagina de vendas ficar melhor.

Modelo: Produzi a página de venda draft do experimento 66 usando os entregáveis reais do FEO.

Arquivo criado:
[lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html](/root/ai-hub/src/ai-hub-1a536a19-a757-47ea-a007-8d7b156e7cd2-JfNQO3/repo/lead-portal-payments-service/docker/proxy/html/sales-page-exp66.html)

Também ajustei o backend local do `GeraSalesPage` para enviar o pacote FEO real no contexto dos prompts, evitando página genérica:
[GerSalesPageStageService.java](/root/ai-hub/src/ai-hub-1a536a19-a757-47ea-a007-8d7b156e7cd2-JfNQO3/repo/backend/ads-service/src/main/java/com/marketinghub/gerasalespage/v1/service/GeraSalesPageStageService.java)

Validação executada:
`mvn -Dtest=GeraSalesPageStageServiceTest test` passou com sucesso.

**Status comercial**

A página já comunica claramente:

- promessa de 7 dias;
- kit por R$47;
- mockup visual;
- dor principal;
- mecanismo MUSA;
- prova visual;
- lista concreta dos entregáveis reais;
- bônus;
- alerta de que o checkout ainda precisa ser conectado.

**Bloqueios reais antes de liberar tráfego**

1. O experimento 66 ainda está sem `followUpActionUrl`.
2. O serviço de pagamento não consegue vender o pacote FEO `id=7`; ele trata esse ID como pacote de imagem do Lead Portal e retorna status `FAILED`.
3. A tabela remota `ai_prompt_schema_template` está vazia; mesmo com checkout, o GeraSalesPage remoto não teria prompts/schemas ativos para rodar.

**Conclusão**

A página de venda foi produzida como draft, mas ainda não está pronta para tráfego.  
O próximo passo correto é conectar checkout digital para pacote FEO/low-ticket e restaurar/semear os templates ativos do GeraSalesPage no banco remoto. Não criei PR e não liberei Facebook Ads.

Usuário: precisamos criar checkout do produto no mercado pago. Pode criar

Modelo: Checkout criado no Mercado Pago para o experimento 66.

**Dados principais**
- Produto: `Método MUSA - Presença Elegante em 7 Dias`
- Valor: `R$47`
- Referência: `marketinghub-experiment-66`
- Checkout: https://www.mercadopago.com.br/checkout/v1/redirect?pref_id=133771061-58ed9edb-6f21-44f0-a169-b908daa5b4e8

**Também feito**
- Atualizei o experimento 66 no backend com esse checkout como URL comercial intermediária.
- Atualizei o draft local da página `sales-page-exp66.html` para os botões apontarem para o Mercado Pago.
- Registrei a ação em `docs/registros/experimentos.md`.
- Confirmei que o ZIP oficial do produto responde corretamente: `experimento-66-entregaveis.zip`.

**Bloqueio restante**

Tentei iniciar o GeraSalesPage, mas agora o bloqueio não é mais checkout. O backend retornou:

`Template ativo de prompt/schema não encontrado para sales-page-offer-brief`

Confirmei no banco remoto que a tabela `ai_prompt_schema_template` tem `0` templates para `gera-sales-page-v1`.

**Conclusão**

O checkout está criado e vinculado.  
Ainda **não liberei tráfego**.

Próximo passo: restaurar/semear os templates ativos do GeraSalesPage no banco remoto, depois republicar/auditar a página de venda para ela virar o destino oficial da campanha.

Referência usada: documentação oficial Mercado Pago para criação de preferência/checkout: https://www.mercadopago.com.br/developers/pt/reference/online-payments/checkout-pro/preferences/create-preference/post

Última mensagem do usuário:
faça o proximo passo

**Resumo das alterações:**
Executei o próximo passo até onde o ambiente permite.

Criei um recovery versionado para restaurar os 7 templates ativos do `GeraSalesPage v1`, com foco comercial correto para o experimento 66:

- usa os entregáveis reais do FEO via `experiment.feoDeliverablePackage`;
- força venda direta low-ticket com checkout real;
- exige clareza do que a cliente recebe;
- bloqueia página genérica sem prova visual;
- exige blocos `data-transform-visual`.

Arquivos alterados:
- [2026-07-15-gera-sales-page-template-recovery-v7.yaml](/root/ai-hub/src/ai-hub-adc5b2de-84e1-4fc6-8bb2-26293178d30d-tBO9yy/repo/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-15-gera-sales-page-template-recovery-v7.yaml)
- [db.changelog-master.yaml](/root/ai-hub/src/ai-hub-adc5b2de-84e1-4fc6-8bb2-26293178d30d-tBO9yy/repo/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml)
- [AiPromptSchemaTemplateChangelogTest.java](/root/ai-hub/src/ai-hub-adc5b2de-84e1-4fc6-8bb2-26293178d30d-tBO9yy/repo/backend/ads-service/src/test/java/com/marketinghub/aiprompt/AiPromptSchemaTemplateChangelogTest.java)
- [experimentos.md](/root/ai-hub/src/ai-hub-adc5b2de-84e1-4fc6-8bb2-26293178d30d-tBO9yy/repo/docs/registros/experimentos.md)

Validações:
- `AiPromptSchemaTemplateChangelogTest`: passou.
- `liquibase:validate` offline MySQL: passou.
- Include relativo no master: validado.

Limitação real: tentei aplicar via `DB_URL/DB_USER/DB_PASS` do sandbox, mas esse banco não é o mesmo usado pelo backend/MCP. O backend remoto continua com `0` templates e o start do experimento 66 ainda retorna `409`.

Próximo passo operacional: aplicar esse changeset no banco remoto correto pelo deploy/Liquibase do backend. Depois disso, o GeraSalesPage do experimento 66 pode ser iniciado/rebuildado. Não criei PR e não liberei tráfego.