### PR TITLE
AI Hub: Verifiquei o GitHub Actions. Não foi erro de arquitetura.

A falha real foi no backend, em `FacebookAdsCampaignControllerTest`: os testes ainda mockavam a regra antiga de criativo `READY`, mas a aplicação agora usa a fonte correta de prontidão: cr…

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -243,7 +243,7 @@ class FacebookAdsCampaignControllerTest {
                 .instagramAccount(instagramAccount)
                 .leadPortalFlow(leadPortalFlow)
                 .build();
-        when(creativeRepository.existsByExperimentIdAndStatus(1L, CreativeStatus.READY)).thenReturn(true);
+        when(creativeRepository.existsByExperimentIdAndStatusAndUsableImage(1L, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(1L)).thenReturn(List.of(
                 ExperimentTargetingSelection.builder()
                         .candidateType(TargetingCandidateType.INTEREST)
@@ -347,7 +347,7 @@ class FacebookAdsCampaignControllerTest {
         when(experimentService.listByStatusAndPlatform(ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK))
                 .thenReturn(List.of(experiment));
         when(campaignRepository.existsByExperimentId(53L)).thenReturn(false);
-        when(creativeRepository.existsByExperimentIdAndStatus(53L, CreativeStatus.READY)).thenReturn(true);
+        when(creativeRepository.existsByExperimentIdAndStatusAndUsableImage(53L, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(53L)).thenReturn(List.of(
                 ExperimentTargetingSelection.builder()
                         .candidateType(TargetingCandidateType.INTEREST)


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Última mensagem do usuário:
veja o que aconteceu no github action. Se foi um erro de arquitetura temos que ajustar a aplicaçaõ para atender a arquitetura. Se for outro tipo de erro ajuste da forma correta.

**Resumo das alterações:**
Verifiquei o GitHub Actions. Não foi erro de arquitetura.

A falha real foi no backend, em `FacebookAdsCampaignControllerTest`: os testes ainda mockavam a regra antiga de criativo `READY`, mas a aplicação agora usa a fonte correta de prontidão: criativo `READY` com imagem publicável.

Corrigi somente os testes em:

[FacebookAdsCampaignControllerTest.java](/root/ai-hub/src/ai-hub-4dc40c4f-f816-4c0c-8be7-64c82be872d3-0QCKqe/repo/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java)

Validações locais concluídas:

- `FacebookAdsCampaignControllerTest#listExperimentsByStatus,experimentsReadyIncludesExperimentTypeForLowTicketSalesCampaigns`: passou
- `FacebookAdsCampaignControllerTest`: passou
- `mvn -q test` em `backend/ads-service`: passou

O deploy falhou só como consequência, porque o build/teste do backend não gerou o artefato da imagem. Não criei PR.