### PR TITLE
AI Hub: Corrigi a causa do GitHub Action.

A falha não era arquitetura: backend, testes, Liquibase e build passaram. O erro estava no deploy: o VPS já tinha um container `marketinghub-backend` ocupando o nome, e o `docker compose up` falhava ao tentar rec…

### DIFF
--- a/deploy/bin/apply.sh
+++ b/deploy/bin/apply.sh
@@ -90,11 +90,40 @@ cleanup_previous_tags() {
     | xargs -r docker image rm >/dev/null 2>&1 || true
 }
 
+remove_conflicting_container() {
+  local service_name="$1"
+  local container_name="$2"
+  local container_id
+  local compose_project
+  local compose_service
+  local expected_project
+
+  container_id="$(docker ps -aq --filter "name=^/${container_name}$" | head -n 1)"
+  if [[ -z "${container_id}" ]]; then
+    return 0
+  fi
+
+  compose_project="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "${container_id}" 2>/dev/null || true)"
+  compose_service="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.service" }}' "${container_id}" 2>/dev/null || true)"
+  expected_project="$(basename "${DEPLOY_DIR}")"
+
+  if [[ "${compose_project}" == "${expected_project}" && "${compose_service}" == "${service_name}" ]]; then
+    log "Container ${container_name} pertence ao compose atual; docker compose fará a recriação quando necessário."
+    return 0
+  fi
+
+  log "Removendo container conflitante ${container_name} antes do compose up (id=${container_id}, composeProject=${compose_project:-none}, composeService=${compose_service:-none})"
+  docker rm -f "${container_id}" >/dev/null
+}
+
 if [[ "${IMAGE_TAG}" != "latest" ]]; then
   tag_image_if_exists "${BACKEND_IMAGE}:${IMAGE_TAG}" "${BACKEND_IMAGE}:latest"
   tag_image_if_exists "${FRONTEND_IMAGE}:${IMAGE_TAG}" "${FRONTEND_IMAGE}:latest"
   tag_image_if_exists "${VIDEO_IMAGE}:${IMAGE_TAG}" "${VIDEO_IMAGE}:latest"
 fi
+
+remove_conflicting_container "backend" "marketinghub-backend"
+remove_conflicting_container "frontend" "marketinghub-frontend"
 
 run_with_heartbeat \
   "recriar somente backend/frontend" \


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Última mensagem do usuário:
estamos com problema no github action. Se for problema de arquitetura ajuste a aplicaçaõ para atender as definições de arquitetura, senão faça o ajuste que achar mais adequado.

**Resumo das alterações:**
Corrigi a causa do GitHub Action.

A falha não era arquitetura: backend, testes, Liquibase e build passaram. O erro estava no deploy: o VPS já tinha um container `marketinghub-backend` ocupando o nome, e o `docker compose up` falhava ao tentar recriar.

Ajuste feito em [deploy/bin/apply.sh](/root/ai-hub/src/ai-hub-80670f9f-5046-4a70-80b7-9612d8a9c9ea-dF0JED/repo/deploy/bin/apply.sh:93): antes do `docker compose up`, o script agora detecta containers conflitantes (`marketinghub-backend` e `marketinghub-frontend`) que não pertencem ao Compose atual e remove apenas esses legados. Se o container já pertence ao Compose correto, ele deixa o Compose recriar normalmente.

Validações:
- `mvn -B -q test` em `backend/ads-service`: passou.
- `mvn -B -q -Dtest=ArquiteturaTest test`: passou.
- `bash -n deploy/bin/apply.sh`: passou.
- Simulação com Docker mockado confirmou remoção do container legado e conclusão do deploy.

Não criei PR.