### PR TITLE
AI Hub: {"comentario":"**Ajuste realizado.**\n\nA Área MUSA agora mostra claramente o início da transformação:\n\n- Adicionei um bloco destacado **“Comece aqui”** antes das missões.\n- O bloco mostra **“Dia 1: Sair do quase bom”** como primeira ação da cl…

### DIFF
--- a/lead-portal-payments-service/docker/proxy/html/obrigado-exp66-metodo-musa.html
+++ b/lead-portal-payments-service/docker/proxy/html/obrigado-exp66-metodo-musa.html
@@ -27,8 +27,8 @@
         <h2 id="statusTitle">Verificando pedido</h2>
         <p id="statusText">Se o pagamento foi aprovado, o acesso ao kit aparece nesta página. Se ficar pendente, acompanhe a confirmação do Mercado Pago.</p>
         <div class="cta-row hidden" id="downloadActions">
-          <a class="btn" id="downloadButton" href="https://pagamentopalf.site/downloads/experimento-66-entregaveis.zip" download>Baixar Kit MUSA agora</a>
-          <a class="btn secondary" id="pdeButton" href="http://191.252.102.54:5176/" target="_blank" rel="noreferrer">Entrar na Área MUSA</a>
+          <a class="btn" id="pdeButton" href="http://191.252.102.54:5176/" target="_blank" rel="noreferrer">Começar Dia 1 na Área MUSA</a>
+          <a class="btn secondary" id="downloadButton" href="https://pagamentopalf.site/downloads/experimento-66-entregaveis.zip" download>Baixar materiais de apoio</a>
           <a class="btn secondary" href="https://pagamentopalf.site/sales-page-exp66.html">Voltar para a página de venda</a>
         </div>
       </div>
@@ -49,7 +49,7 @@
         <div class="detail"><span>Preço</span><b>R$ 47</b></div>
         <div class="detail"><span>Entrega imediata</span><b>ZIP + Área MUSA</b></div>
       </div>
-      <p class="micro">O ZIP é a entrega imediata da compra. A Área MUSA é a experiência guiada para acompanhar os 7 dias e consultar os materiais da biblioteca.</p>
+      <p class="micro">Comece pela Área MUSA: ela mostra a missão do Dia 1 e guia os 7 dias. O ZIP fica como biblioteca complementar para consulta e download.</p>
     </section>
   </main>
 
@@ -88,7 +88,7 @@
     document.getElementById('contentsCard').classList.toggle('hidden', !allowDownload);
   }
   if (isApproved()) {
-    setState('success','✓','Pagamento aprovado. Seu Método MUSA está liberado.','Compra confirmada','Baixe o ZIP para ter a entrega imediata e entre na Área MUSA para seguir a experiência guiada de 7 dias.','Obrigado pela compra. Comece pelo ZIP e use a Área MUSA para acompanhar as missões.',true);
+    setState('success','✓','Pagamento aprovado. Seu Método MUSA está liberado.','Compra confirmada','Comece pelo Dia 1 na Área MUSA. Depois, use o ZIP apenas como biblioteca de apoio para consultar os materiais quando precisar.','Obrigado pela compra. Sua primeira ação é abrir a Área MUSA e seguir a missão do Dia 1.',true);
   } else if (isPending()) {
     setState('pending','!','Pagamento em processamento','Ainda estamos aguardando confirmação','O Mercado Pago ainda não confirmou a aprovação. Assim que aprovar, volte por este link ou pela confirmação da compra.','Seu pedido foi recebido, mas a entrega só deve ser acessada após a aprovação.',false);
   } else if (status === 'failure' || status === 'rejected' || status === 'cancelled' || status === 'canceled') {

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
@@ -48,7 +48,7 @@ public class ProductCatalogService {
                                 1,
                                 "Sair do quase bom",
                                 "A presenca cresce quando voce identifica o detalhe que mais apaga o conjunto.",
-                                "Escolha uma combinacao real e marque o que hoje gera ruido: excesso, falta de acabamento, cor solta, peca sem intencao ou acessorio perdido.",
+                                "Hoje voce nao vai tentar mudar tudo. Vista ou separe uma combinacao real, olhe cabelo, pele, roupa, perfume e acessorios, escolha o detalhe que mais apaga sua presenca e ajuste apenas esse ponto.",
                                 "Frase preenchida: eu me sinto arrumada, mas pouco marcante quando...",
                                 "Compare a sensacao antes/depois de remover ou ajustar um detalhe."),
                         new MissionDto(

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -82,7 +82,7 @@ const fallbackProduct: ProductExperience = {
       day: 1,
       title: 'Sair do quase bom',
       principle: 'A presenca cresce quando voce identifica o detalhe que mais apaga o conjunto.',
-      action: 'Escolha uma combinacao real e marque o que hoje gera ruido: excesso, falta de acabamento, cor solta, peca sem intencao ou acessorio perdido.',
+      action: 'Hoje voce nao vai tentar mudar tudo. Vista ou separe uma combinacao real, olhe cabelo, pele, roupa, perfume e acessorios, escolha o detalhe que mais apaga sua presenca e ajuste apenas esse ponto.',
       evidence: 'Frase preenchida: eu me sinto arrumada, mas pouco marcante quando...',
       visualCue: 'Compare a sensacao antes/depois de remover ou ajustar um detalhe.',
     },
@@ -198,6 +198,7 @@ function App() {
 
   const currentProduct = workspace?.product ?? product;
   const completedMissionIds = new Set(workspace?.completedMissionIds ?? []);
+  const firstMission = currentProduct.missions[0];
 
   return (
     <main className="app-shell">
@@ -264,6 +265,21 @@ function App() {
         </aside>
 
         <section className="mission-panel">
+          {firstMission && (
+            <article className="start-here-panel">
+              <p className="section-kicker">Comece aqui</p>
+              <h2>Dia 1: {firstMission.title}</h2>
+              <p>
+                A primeira missao e escolher uma combinacao real, identificar o detalhe que mais
+                apaga sua presenca e escrever a frase de diagnostico. Voce termina o dia sabendo
+                exatamente o que ajustar antes de pensar em comprar algo novo.
+              </p>
+              <button className="inline-action" onClick={() => setActiveMissionId(firstMission.id)}>
+                Abrir orientacao do Dia 1
+                <ChevronRight size={17} />
+              </button>
+            </article>
+          )}
           <div className="mission-tabs">
             {currentProduct.missions.map((mission) => (
               <button

--- a/pde-platform/frontend/src/styles.css
+++ b/pde-platform/frontend/src/styles.css
@@ -251,6 +251,35 @@ h3 {
   padding: 26px;
 }
 
+.start-here-panel {
+  background: #fff8f3;
+  border: 1px solid rgba(214, 167, 92, 0.5);
+  margin-bottom: 22px;
+  padding: 20px;
+}
+
+.start-here-panel h2 {
+  font-size: 1.65rem;
+  margin-bottom: 10px;
+}
+
+.start-here-panel p {
+  color: #5a4a42;
+  margin-bottom: 16px;
+}
+
+.inline-action {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: #7a2444;
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 850;
+  gap: 6px;
+  padding: 0;
+}
+
 .diagnostic-panel svg,
 .section-heading svg,
 .completion-band svg {


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"comentario":"<resposta principal em Markdown>","orientacaoProximaAcao":"<orientação objetiva para a próxima ação baseada na alternativa escolhida, ou string vazia se não houver orientação aplicável>"}. Use comentario para a resposta normal e orientacaoProximaAcao apenas quando existir uma decisão entre alternativas ou próxima ação clara.

Histórico da conversa:
Usuário: vamos falar do Kit Musa do experimento 66.
É um processo de transformaçaõ em 7 dias.
Imaginando que eu sou uma cliente, onde eu encontro a orientaçaõ do que fazer no primeiro dia ?

Modelo: {"comentario":"**Resposta curta:** hoje a orientação do primeiro dia aparece em dois lugares:\n\n1. **Área MUSA**: entrar na Área MUSA e abrir a missão **Dia 1**. Lá aparece a orientação mais clara: **“Sair do quase bom”**, com ação de hoje e evidência de progresso.\n2. **ZIP do produto experiencial**: abrir `01-experiencia-guiada/index.html`. Dentro dele, ir em **Jornada guiada de 7 dias > Dia 1**. A missão é: **“Escolher o foco de presença”**.\n\n**Como cliente, eu esperaria este caminho:**\n\nApós a compra, na página de obrigado, clicar em **Entrar na Área MUSA** e ver imediatamente o **Dia 1** destacado como próxima ação. A orientação do Dia 1 deveria dizer algo como:\n\n> Hoje você não vai tentar mudar tudo. Você vai escolher uma combinação real, identificar o detalhe que mais apaga sua presença e escrever uma frase simples: “Eu me sinto arrumada, mas pouco marcante quando...”.\n\n**Ponto crítico encontrado:** existe orientação, mas a experiência ainda não está perfeita. A página de obrigado também oferece um botão para baixar ZIP, e o ZIP público de entrega pode confundir porque há mais de uma versão/material. Para venda, isso é perigoso: cliente recém-compradora não pode ter que procurar onde começa.\n\n**Minha avaliação:** o melhor caminho comercial é fazer a Área MUSA ser a entrada principal pós-compra, já abrindo no **Dia 1**, e deixar o ZIP/e-book como apoio secundário. Isso aumenta ativação, reduz arrependimento e reforça a promessa de transformação guiada em 7 dias.","orientacaoProximaAcao":"A próxima melhoria recomendada é ajustar a entrega pós-compra para que o botão principal seja “Começar Dia 1 na Área MUSA”, levando direto para a missão do primeiro dia; o ZIP deve ficar como material complementar, não como início da experiência."}

Última mensagem do usuário:
Faça o ajuste para que a Área MUSA mostre claramente como é o primeiro dia, conforme sua sugestão.

**Resumo das alterações:**
{"comentario":"**Ajuste realizado.**\n\nA Área MUSA agora mostra claramente o início da transformação:\n\n- Adicionei um bloco destacado **“Comece aqui”** antes das missões.\n- O bloco mostra **“Dia 1: Sair do quase bom”** como primeira ação da cliente.\n- A orientação do Dia 1 ficou mais concreta: escolher uma combinação real, observar cabelo, pele, roupa, perfume e acessórios, identificar o detalhe que mais apaga a presença e ajustar só esse ponto.\n- A página de obrigado agora prioriza o botão **“Começar Dia 1 na Área MUSA”**.\n- O ZIP passou a ser tratado como **material de apoio**, não como início da experiência.\n\n**Validação feita:**\n\n- Testes do backend PDE passaram: `3 tests`, `0 failures`.\n- Build do frontend passou.\n- Servidor local da Área MUSA está respondendo em `http://localhost:5177/`.\n\nNão criei PR.","orientacaoProximaAcao":"Próxima ação recomendada: validar visualmente a página em `http://localhost:5177/` como se fosse uma cliente recém-compradora e confirmar se o caminho “começar Dia 1” está óbvio o suficiente para reduzir dúvida pós-compra."}