### PR TITLE
AI Hub: {"comentario":"## Ajuste realizado\n\nAjustei o workflow `.github/workflows/pde-platform-metodo-musa-ci.yml` para remover a dependência do `docker/metadata-action@v5`, que era o ponto que falhava com erro interno do GitHub.\n\nAgora o próprio work…

### DIFF
--- a/.github/workflows/pde-platform-metodo-musa-ci.yml
+++ b/.github/workflows/pde-platform-metodo-musa-ci.yml
@@ -79,40 +79,41 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Backend image metadata
-        id: meta_backend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ github.sha }}
+      - name: Define Docker image metadata
+        id: image_metadata
+        run: |
+          {
+            echo "backend_tags<<EOF"
+            echo "${IMAGE_NAMESPACE}/${BACKEND_IMAGE_NAME}:latest"
+            echo "${IMAGE_NAMESPACE}/${BACKEND_IMAGE_NAME}:${GITHUB_SHA}"
+            echo "EOF"
+            echo "frontend_tags<<EOF"
+            echo "${IMAGE_NAMESPACE}/${FRONTEND_IMAGE_NAME}:latest"
+            echo "${IMAGE_NAMESPACE}/${FRONTEND_IMAGE_NAME}:${GITHUB_SHA}"
+            echo "EOF"
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Build and push backend image
         uses: docker/build-push-action@v6
         with:
           context: pde-platform/backend
           file: pde-platform/backend/Dockerfile
           push: true
-          tags: ${{ steps.meta_backend.outputs.tags }}
-          labels: ${{ steps.meta_backend.outputs.labels }}
+          tags: ${{ steps.image_metadata.outputs.backend_tags }}
+          labels: ${{ steps.image_metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}:buildcache,mode=max
-      - name: Frontend image metadata
-        id: meta_frontend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ github.sha }}
       - name: Build and push frontend image
         uses: docker/build-push-action@v6
         with:
           context: pde-platform/frontend
           file: pde-platform/frontend/Dockerfile
           push: true
-          tags: ${{ steps.meta_frontend.outputs.tags }}
-          labels: ${{ steps.meta_frontend.outputs.labels }}
+          tags: ${{ steps.image_metadata.outputs.frontend_tags }}
+          labels: ${{ steps.image_metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}:buildcache,mode=max
       - name: Expose image tag


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"comentario":"<resposta principal em Markdown>","orientacaoProximaAcao":"<orientação objetiva para a próxima ação baseada na alternativa escolhida, ou string vazia se não houver orientação aplicável>"}. Use comentario para a resposta normal e orientacaoProximaAcao apenas quando existir uma decisão entre alternativas ou próxima ação clara.

Histórico da conversa:
Usuário: Vamos pensar o seguinte. Agora com o produto MUSA e o PED Area Musa precisamos para esse tipo de produto um funil de vendas diferente, com as seguintes etapas na minha opinião:
- ver o anuncio
- clicar no anuncio
- entrara na tela inicial do PED
- fazer o login/criar conta
- fazer a assinatura para ter acesso a todos os recursos e todas as áreas ( podendo aqui ter niveis e preços diferentes )

O que acha ?
Vamos implementar esse filtro novo ?

Modelo: {"comentario":"## Minha avaliação\n\nSim, faz sentido implementar um funil novo para MUSA/PED. Esse produto não é igual ao funil antigo de formulário/amostra/checkout. Pela documentação, o MUSA é um **Produto Digital Experiencial** com área guiada, login, progresso, materiais e potencial de assinatura.\n\nEvidências analisadas:\n\n- `pde-platform/README.md`: produto inicial `metodo-musa-7-dias`, formato experiência guiada + e-book + checklists + templates.\n- `docs/canonical/pde-platform-canon.v1.md`: PDE deve ter tela inicial/login, acesso, progresso, materiais e preparação para assinatura.\n- `docs/canonical/product-types-canon.v1.md`: área de membros exige métricas como compra aprovada, liberação de acesso, primeiro acesso, consumo, renovação, cancelamento e chargeback.\n- `docs/manual-usuario/aihub/funil-vendas-experimento.md`: funil atual é mais voltado a anúncio → formulário → amostra/e-mail → checkout → entrega, não assinatura/área de membros.\n\n## Funil recomendado para MUSA/PED\n\nEu ajustaria sua proposta para este modelo:\n\n1. **Visualização do anúncio**\n2. **Clique no anúncio**\n3. **Acesso à tela inicial do PED/MUSA**\n4. **Criação de conta / login**\n5. **Visualização da oferta de assinatura**\n6. **Clique no plano/checkout**\n7. **Assinatura iniciada ou compra aprovada**\n8. **Liberação de acesso**\n9. **Primeiro uso real da área**\n10. **Consumo/ativação: diagnóstico, missão ou material acessado**\n11. **Renovação, upgrade, cancelamento ou inadimplência**\n\nO ponto mais importante: **assinatura aprovada não pode ser o fim do funil**. Para produto recorrente, precisamos medir se a pessoa entrou, usou e percebeu valor. Sem ativação, a venda vira churn futuro.\n\n## Alternativas comparadas\n\n**Alternativa 1 — Adaptar o funil atual**  \nBenefício: menor esforço.  \nRisco: mistura formulário/amostra com assinatura e gera leitura ruim.  \nAderência: baixa para MUSA/PED.\n\n**Alternativa 2 — Criar funil específico de Área de Membros/PDE**  \nBenefício: mede exatamente os gargalos desse produto: anúncio, entrada, login, checkout, acesso e ativação.  \nRisco: exige novo tipo de funil e novos eventos.  \nAderência: alta.\n\n**Alternativa 3 — Criar funil genérico de assinatura para qualquer produto recorrente**  \nBenefício: mais escalável no futuro.  \nRisco: pode ficar abstrato demais agora e atrasar o MUSA.  \nAderência: média/alta, mas melhor como evolução depois.\n\n## Decisão\n\nEu recomendo implementar agora a **Alternativa 2: funil específico para Área de Membros/PDE**, com nome operacional como:\n\n`PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL`\n\nEsse funil deve ser separado do funil antigo de Lead Portal. Assim o sistema passa a comparar corretamente produtos de naturezas diferentes:\n\n- produto de formulário/amostra;\n- produto low-ticket direto;\n- produto IA personalizado;\n- área de membros/assinatura PDE.\n\n## Minha sugestão prática\n\nSim, vamos implementar, mas eu mudaria o nome de “filtro” para **tipo de funil** ou **modelo de funil**. O filtro na tela seria consequência: o usuário escolhe ou visualiza o experimento pelo tipo `Área de membros / Assinatura PDE`.\n\nA primeira versão deve medir no mínimo:\n\n- anúncio visto;\n- clique;\n- acesso ao PED;\n- login/criação de conta;\n- checkout iniciado;\n- assinatura aprovada;\n- acesso liberado;\n- primeiro uso;\n- missão/material consumido;\n- cancelamento/renovação quando existir assinatura real.","orientacaoProximaAcao":"Implementar o novo tipo de funil `PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL` para MUSA/PED, separado do funil antigo do Lead Portal, priorizando métricas de assinatura e ativação pós-compra."}

Usuário: vamos colocar no PED do MUSA opção de login com google e com Instagram ? O que acha ?

Modelo: {"comentario":"**Minha opinião: sim para Google agora; Instagram depois, com cuidado.**\n\nPara o PED do MUSA, login social faz sentido porque reduz atrito antes da assinatura. Mas eu não colocaria Google e Instagram com o mesmo peso no MVP.\n\n**Evidência do repositório:** nos testes anteriores, o problema forte apareceu depois do clique. O plano de funil registra 575 visualizações de formulário e 0 envios em experimentos com bom CTR; no experimento 40 houve 2.757 impressões, 113 cliques, 104 visualizações e 0 envios. Ou seja: cada etapa extra mata conversão.\n\n**Alternativas:**\n\n1. **Google + e-mail/magic link**  \nMelhor equilíbrio. Google é familiar, rápido e confiável. Mantém uma rota alternativa para quem não quer conta Google.\n\n2. **Google + Instagram**  \nSedutor para um produto vindo de anúncio no Instagram, mas mais arriscado. A documentação da Meta posiciona Instagram Login principalmente para contas profissionais/creator/business, não como login universal simples para consumidor. Fonte: [Meta Instagram Platform](https://developers.facebook.com/documentation/instagram-platform) e [Business Login](https://developers.facebook.com/documentation/instagram-platform/instagram-api-with-instagram-login/business-login).\n\n3. **Entrar sem conta até bater no paywall**  \nMenor atrito inicial, mas pior para assinatura, recuperação de carrinho e continuidade do uso.\n\n**Escolha recomendada:** começar com **Google como login principal + e-mail/magic link como backup**. O botão de Instagram pode entrar em uma segunda fase, só se o objetivo for conectar perfil profissional, puxar dados do Instagram ou reforçar identidade social dentro do MUSA.\n\n**Funil ideal para o PED MUSA:**\n\n- ver anúncio;\n- clicar no anúncio;\n- entrar no PED;\n- experimentar uma prévia curta sem cadastro ou com cadastro mínimo;\n- login com Google/e-mail;\n- ver paywall com benefício claro;\n- assinar;\n- liberar áreas e recursos.\n\n**Ponto importante:** o login não deve aparecer como barreira seca. Ele deve aparecer como continuação natural: “Salve seu diagnóstico e libere seu plano personalizado”. Isso transforma cadastro em benefício, não em obstáculo.\n\nFontes externas usadas: [Google Identity Services](https://developers.google.com/identity/gsi/web/guides/overview), [Google Sign-In Web](https://developers.google.com/identity/sign-in/web/sign-in), [Meta Instagram Platform](https://developers.facebook.com/documentation/instagram-platform).","orientacaoProximaAcao":"Implementar primeiro Google + e-mail/magic link no PED do MUSA e medir: entrada no PED, início de login, login concluído, paywall visto, clique em assinatura e assinatura aprovada. Deixar Instagram para fase 2, como teste separado."}

Usuário: essa é uma tela do registro.br procurei metodomusa.com.br mas já foi registrado, estou pensando no metodomusa.ia.br. O que acha ?

Modelo: {"comentario":"Minha opinião: **vale registrar `metodomusa.ia.br` agora**, mas eu não trataria como domínio final definitivo sem testar a percepção do público.\n\nPelo print, `metodomusa.ia.br` aparece disponível no Registro.br. E, pela informação pública do NIC.br/Registro.br, a categoria `.ia.br` foi criada para iniciativas ligadas a inteligência artificial e pode ser registrada por pessoa física ou jurídica sem restrições especiais. Fonte: [NIC.br](https://nic.br/noticia/na-midia/brasil-inaugura-ia-br-e-mais-tres-categorias-de-dominio/) e [Registro.br](https://registro.br/dominio/categorias/).\n\n**Análise de marketing:**\n\n1. **`metodomusa.ia.br`**\n   - Benefício: conecta bem com o Marketing Hub, IA, personalização e produto digital moderno.\n   - Risco: para o público feminino de presença/elegância, `.ia.br` pode parecer mais tecnológico do que emocional/premium.\n   - Custo/esforço: baixo.\n   - Aderência: boa para validação e para reforçar que a experiência é guiada por inteligência.\n\n2. **Buscar outro `.com.br` mais simples** como `musa7.com.br`, `areamusa.com.br`, `clubemusa.com.br`, `metodomusa7.com.br` ou `metodomusaoficial.com.br`\n   - Benefício: tende a passar mais confiança para compra, checkout, login e assinatura.\n   - Risco: pode estar indisponível ou menos alinhado com IA.\n   - Custo/esforço: baixo, mas exige pesquisa.\n   - Aderência: melhor para escala em tráfego pago se encontrarmos um nome forte.\n\n3. **Continuar com domínio técnico atual / subpasta existente**\n   - Benefício: mais rápido.\n   - Risco: reduz confiança, parece improvisado e atrapalha uma oferta premium.\n   - Aderência: aceitável só como teste interno, ruim para escalar.\n\n**Escolha recomendada:** registrar `metodomusa.ia.br` imediatamente como ativo defensivo e usar como domínio de validação do PED/Área MUSA, principalmente se vamos posicionar o produto como uma experiência guiada e personalizada por IA.\n\nMas eu ainda procuraria em paralelo um domínio `.com.br` mais emocional e confiável para ser o domínio principal de escala. O `.ia.br` pode funcionar muito bem como tecnologia/produto: `area.metodomusa.ia.br`, `app.metodomusa.ia.br` ou `ped.metodomusa.ia.br`.\n\nSobre login com Google/Instagram: o domínio final importa porque ele será usado nos callbacks de autenticação. Então eu escolheria/registraria o domínio antes de implementar login social. Google eu vejo como prioridade. Instagram eu deixaria para depois, porque pode gerar mais fricção operacional com Meta/app review.","orientacaoProximaAcao":"Registre `metodomusa.ia.br` agora para não perder o ativo, mas antes de escalar anúncios pesquise também 5 opções `.com.br` mais comerciais para decidir se o domínio principal será emocional (`.com.br`) ou tecnológico (`.ia.br`)."}

Usuário: Pode executar sua sugestão:

Implementar o novo tipo de funil `PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL` para MUSA/PED, separado do funil antigo do Lead Portal, priorizando métricas de assinatura e ativação pós-compra.

Modelo: {"comentario":"## Implementado\n\nImplementei o novo tipo de funil `PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL` para MUSA/PED, separado do funil antigo do Lead Portal.\n\nO que mudou:\n\n- Novo tipo comercial no backend: `PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL`.\n- Funil MUSA/PDE com etapas próprias:\n  - visualização do anúncio;\n  - clique para o PED/MUSA;\n  - entrada na tela inicial;\n  - login/criação de conta;\n  - visualização da oferta de assinatura;\n  - clique no plano/checkout;\n  - assinatura aprovada;\n  - acesso liberado;\n  - primeiro uso/ativação.\n- Diagnóstico estatístico específico para assinatura PDE, incluindo ativação pós-compra.\n- Tracking de `checkout_click` agora funciona também para PDE/MUSA, não só low-ticket.\n- Frontend permite escolher `PDE / assinatura MUSA` como tipo de experimento.\n- Tela de funil mostra o modelo correto para MUSA/PDE mesmo antes de existirem eventos.\n- Campanhas desse tipo passam a nascer com objetivo comercial de vendas, não leads.\n- Changelog Liquibase criado para ampliar `experiment_type` para `VARCHAR(48)`, necessário porque o novo código passa de 32 caracteres.\n- Documento canônico `docs/canonical/product-types-canon.v1.md` atualizado com o funil PDE/MUSA.\n\n## Validação\n\nValidei com sucesso:\n\n- Backend: `mvn -Dtest=ExperimentFunnelDiagnosticServiceTest,ExperimentFunnelServiceRenderCompleteTest test`\n- Frontend typecheck: `npm run typecheck`\n- Frontend teste da aba de funil: `NODE_ENV=test npm test -- --run src/pages/experiment/ExperimentFunnelTab.test.tsx`\n- `git diff --check`\n- Changelog mestre validado com `relativeToChangelogFile: true`.\n\nNão criei PR, conforme sua instrução.","orientacaoProximaAcao":"Próximo passo recomendado: instrumentar o backend/frontend do PDE para registrar eventos reais de login, oferta de assinatura, acesso liberado e primeiro uso, porque agora o funil já existe, mas parte das métricas pós-login ainda dependerá desses eventos operacionais."}

Usuário: implemente sua sugestão:

Implementar primeiro Google + e-mail/magic link no PED do MUSA e medir: entrada no PED, início de login, login concluído, paywall visto, clique em assinatura e assinatura aprovada. Deixar Instagram para fase 2, como teste separado.

Modelo: {"comentario":"## Implementado\n\nFoi implementado no PED/MUSA o fluxo recomendado para reduzir atrito e medir venda de assinatura:\n\n- Login com Google via ID token validado no backend.\n- Magic link por e-mail sem senha.\n- Instagram mantido fora da fase 1.\n- Área MUSA agora diferencia `TRIAL` de `ACTIVE`.\n- Paywall dentro da área para liberar todos os recursos somente após assinatura.\n- Eventos do funil gravados em `pde_funnel_event`: `PED_ENTRY`, `LOGIN_STARTED`, `LOGIN_COMPLETED`, `PAYWALL_VIEWED`, `SUBSCRIPTION_CLICKED`, `SUBSCRIPTION_APPROVED`.\n- Checkout/Pepper promove o mesmo acesso de `TRIAL` para `ACTIVE` sem criar outro token.\n- Retry de checkout não deve inflar assinatura aprovada.\n\n## Validações\n\n- Backend PDE: `8` testes passaram.\n- Frontend PDE: build Vite/TypeScript passou.\n- Teste local HTTP validou produto, evento, magic link e promoção para assinatura ativa.\n- SMTP descartável validado em `sandbox-mail:1025`; e-mail chegou na API do sandbox.\n- Liquibase revisado com include relativo e sem `TIMESTAMP NOT NULL` sem default.\n\n## Observação operacional\n\nPara produção, faltam configurar os valores reais:\n\n- `PDE_GOOGLE_CLIENT_ID`\n- `VITE_GOOGLE_CLIENT_ID`\n- `VITE_MUSA_CHECKOUT_URL`\n- SMTP transacional real ou sandbox conforme ambiente\n\nNão criei PR, conforme instrução.","orientacaoProximaAcao":"Configurar o OAuth Client do Google para o domínio final do MUSA e definir a URL real de checkout da assinatura antes de publicar tráfego pago para esse novo funil."}

Usuário: Quais opções outras vc me sugere ?

Registre `metodomusa.ia.br` agora para não perder o ativo, mas antes de escalar anúncios pesquise também 5 opções `.com.br` mais comerciais para decidir se o domínio principal será emocional (`.com.br`) ou tecnológico (`.ia.br`).

Modelo: Solicitação #1885 apagada antes do envio ao modelo. Nenhuma resposta será gerada para esta mensagem.

Usuário: comprei clubemusa.com.br
Vamos configurar tudo para já acessar por esse dominio e usando https. 
Crie uma chave para acessar por ssh/scp me manda a chave publica para voce acessar o servidor e fazer as configurações necessárias.

Modelo: {"comentario":"Chave SSH pública gerada para configurar o `clubemusa.com.br`:\n\n```text\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFzoQIssL4T6LLEuz6s2gPXTXm1hu19mdW/IpD3N0PGz codex-clubemusa-20260716\n```\n\nPara eu conseguir acessar o servidor, instale essa chave no usuário SSH que devo usar, no arquivo:\n\n```text\n~/.ssh/authorized_keys\n```\n\nTambém preciso que o DNS do domínio aponte para o servidor:\n\n- `clubemusa.com.br` → registro `A` para o IP do servidor\n- `www.clubemusa.com.br` → registro `A` ou `CNAME` para o domínio principal\n\nMinha recomendação operacional é configurar:\n\n1. domínio principal: `https://clubemusa.com.br`;\n2. redirecionamento de `http` para `https`;\n3. redirecionamento de `www.clubemusa.com.br` para `clubemusa.com.br`;\n4. certificado Let's Encrypt/Certbot;\n5. ajuste do Nginx/Proxy para apontar para o PED do MUSA;\n6. depois validar login, checkout, tracking e eventos do funil.\n\nNão vou criar PR nem alterar código agora. Assim que a chave estiver instalada e você me passar o usuário/host de SSH, eu entro e faço a configuração no servidor.","orientacaoProximaAcao":"Instale a chave pública no servidor e me envie o usuário e host/IP de SSH. Em paralelo, aponte o DNS de `clubemusa.com.br` e `www.clubemusa.com.br` para o IP correto do servidor."}

Usuário: execute essa orientação:

Próximo passo recomendado: instrumentar o backend/frontend do PDE para registrar eventos reais de login, oferta de assinatura, acesso liberado e primeiro uso, porque agora o funil já existe, mas parte das métricas pós-login ainda dependerá desses eventos operacionais.

Modelo: {"comentario":"## Implementado\n\nInstrumentei o PED/MUSA para medir a parte crítica do funil pós-login e pós-compra.\n\nO que mudou:\n\n- Backend PDE agora aceita os eventos `ACCESS_RELEASED` e `FIRST_USE`.\n- Quando uma assinatura/compra `CHECKOUT` ou `PEPPER` libera acesso ativo, o backend registra `ACCESS_RELEASED`.\n- Quando a primeira missão é concluída, o backend registra `FIRST_USE` como fallback confiável.\n- Frontend registra `FIRST_USE` quando a cliente com assinatura ativa abre uma missão ou material.\n- Cânone do funil PDE/MUSA atualizado com a lista operacional de eventos.\n- Registro da tarefa adicionado em `docs/registros/experimentos.md`.\n\n## Validação\n\n- Backend PDE: `mvn -f pde-platform/backend/pom.xml test` passou.\n- Frontend PDE: `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR.","orientacaoProximaAcao":"Próximo passo recomendado: depois do deploy, validar no banco se eventos reais estão entrando em `pde_funnel_event` para `PED_ENTRY`, `LOGIN_STARTED`, `LOGIN_COMPLETED`, `PAYWALL_VIEWED`, `SUBSCRIPTION_CLICKED`, `SUBSCRIPTION_APPROVED`, `ACCESS_RELEASED` e `FIRST_USE`."}

Usuário: Voce acha melhor eu registrar o dominio no nome da minha empresa ou do meu cpf ?



Modelo: {"comentario":"Eu recomendo registrar o domínio **no CNPJ da empresa**, não no CPF.\n\n**Por quê:**\n\n- O domínio será um ativo comercial do Marketing Hub/MUSA.\n- Facilita venda, parceria, contabilidade, marca, anúncios e meios de pagamento.\n- Evita confusão futura se o produto crescer, receber sócios, afiliados ou investimento.\n- Passa mais profissionalismo em disputas, contratos, checkout e operação.\n- Se amanhã você vender o produto ou criar uma estrutura separada para ele, o domínio já está no lugar certo.\n\nEu só registraria no CPF se fosse um teste pessoal, sem intenção comercial séria. Mas `clubemusa.com.br` já nasce como marca/produto com potencial de assinatura, tráfego pago e venda recorrente. Então faz mais sentido estar no CNPJ.\n\n**Minha orientação:** registre ou mantenha `clubemusa.com.br` no CNPJ da empresa que vai operar o produto, receber pagamentos e responder comercialmente pelo MUSA. Se o domínio já foi comprado no CPF, depois avalie transferir para o CNPJ antes de escalar anúncios e checkout.","orientacaoProximaAcao":"Use o CNPJ da empresa como titular do domínio `clubemusa.com.br`, alinhando domínio, checkout, política de privacidade, suporte e operação comercial do MUSA."}

Usuário: verifica o github action, falhou

Modelo: {"comentario":"## Verificação do GitHub Action\n\nA falha foi no workflow **CI - PDE Platform Metodo MUSA**, no push para `main` do commit `69e802a`.\n\nResultado dos jobs:\n\n- **Backend**: passou.\n- **Frontend**: passou.\n- **Build and Push Images**: falhou.\n- **Deploy to Metodo MUSA host**: foi pulado porque o build de imagens falhou.\n\nA falha aconteceu especificamente no passo:\n\n`Frontend image metadata`\n\nO erro mostrado pelo GitHub foi uma página interna do próprio GitHub com título **“Unicorn!”**, dentro do `docker/metadata-action@v5`. Isso indica falha/transiente do GitHub ou da Action ao gerar metadata da imagem Docker, não erro de código do MUSA.\n\n## Causa mais provável\n\nNão parece ser problema no backend, frontend, testes ou build TypeScript. O PR anterior do mesmo workflow passou, e no push para `main` só quebrou a etapa de imagem/deploy.\n\nA causa mais provável é instabilidade/transiente no GitHub Actions/GitHub API durante o passo de metadata da imagem frontend.\n\n## Alternativas\n\n1. **Reexecutar apenas os jobs falhos**  \nMelhor opção agora. Baixo risco, rápido, e deve resolver se foi instabilidade do GitHub.\n\n2. **Alterar o workflow Docker agora**  \nNão recomendo como primeira ação, porque não há evidência de erro estrutural no YAML.\n\n3. **Investigar secrets/deploy/servidor**  \nAinda não é o ponto principal, porque o deploy nem chegou a rodar. Só faz sentido se o build de imagens passar e o deploy falhar depois.\n\n## Decisão recomendada\n\nReexecutar o job falho do workflow **CI - PDE Platform Metodo MUSA**. Se falhar de novo no mesmo ponto, aí sim vale ajustar o workflow para reduzir dependência do `docker/metadata-action` ou simplificar a geração de tags da imagem frontend.","orientacaoProximaAcao":"Reexecute os jobs falhos do workflow `CI - PDE Platform Metodo MUSA`. Se quiser, posso tentar reexecutar por aqui o run `29539241799`."}

Usuário: tenta executar

Modelo: {"comentario":"## Resultado da tentativa\n\nConsegui reexecutar os jobs falhos do GitHub Action.\n\nO workflow rodou de novo como **tentativa 2**, mas falhou novamente.\n\n**Status atual:**\n\n- Backend: passou.\n- Frontend: passou.\n- Build and Push Images: falhou.\n- Deploy to Metodo MUSA host: pulado.\n\nA falha agora ficou mais clara: aconteceu no step **Backend image metadata**, dentro do `docker/metadata-action@v5`.\n\nO log retornou novamente a página interna **“Unicorn! · GitHub”**, ou seja, o step recebeu HTML de erro do GitHub em vez da resposta esperada da API. Isso reforça que o problema não está no código do MUSA, nem no build backend/frontend. Está na etapa de metadata da imagem Docker usando Action externa/GitHub API.\n\n## Alternativas\n\n1. **Reexecutar novamente**  \nBaixo esforço, mas como já falhou duas vezes no mesmo tipo de ponto, a chance de resolver só com retry caiu.\n\n2. **Trocar/simplificar o uso do `docker/metadata-action`**  \nMelhor opção. Gerar as tags manualmente no workflow evita essa dependência que está quebrando antes mesmo do build da imagem.\n\n3. **Investigar registry/deploy/servidor**  \nAinda não é prioridade, porque o login no GHCR passou e o deploy nem chegou a iniciar.\n\n## Minha recomendação\n\nA melhor decisão agora é ajustar o workflow para remover ou reduzir a dependência do `docker/metadata-action@v5` nessa pipeline do MUSA. Isso ataca a causa-raiz provável e libera o build/push das imagens para o deploy HTTPS do `clubemusa.com.br` seguir depois.","orientacaoProximaAcao":"Autorize eu ajustar o workflow `.github/workflows/pde-platform-metodo-musa-ci.yml` para gerar tags Docker manualmente, sem depender do `docker/metadata-action@v5`, e depois reexecutar o CI."}

Última mensagem do usuário:
ajuste o workflow

**Resumo das alterações:**
{"comentario":"## Ajuste realizado\n\nAjustei o workflow `.github/workflows/pde-platform-metodo-musa-ci.yml` para remover a dependência do `docker/metadata-action@v5`, que era o ponto que falhava com erro interno do GitHub.\n\nAgora o próprio workflow gera diretamente:\n\n- imagem backend com tags `latest` e `${GITHUB_SHA}`;\n- imagem frontend com tags `latest` e `${GITHUB_SHA}`;\n- labels OCI básicas com repositório e revisão.\n\n## Decisão tomada\n\nComparei 3 caminhos:\n\n1. **Reexecutar novamente**: baixo esforço, mas já falhou duas vezes.\n2. **Atualizar versão da action**: simples, mas continuaria dependente do mesmo ponto frágil.\n3. **Remover `docker/metadata-action` nesse workflow**: menor dependência e resolve a causa provável.\n\nEscolhi a opção 3.\n\n## Validação\n\n- `git diff --check` passou.\n- Simulei o script novo de geração de tags/labels e o formato do `$GITHUB_OUTPUT` ficou correto.\n- Não rodei `actionlint` porque ele não está instalado no ambiente.\n- Não criei PR.","orientacaoProximaAcao":"Commitar e enviar essa alteração para o GitHub; depois reexecutar o workflow `CI - PDE Platform Metodo MUSA` para validar build, push das imagens e deploy."}