### PR TITLE
AI Hub: {"comentario":"**Implementado**\n\nCriei a URL pública para gerar a definição de mercado do produto em Markdown:\n\n`GET /api/products/public/{codigoDoProduto}/marketing-definition.md`\n\nO `{codigoDoProduto}` usa preferencialmente o `slug` do pro…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -1,20 +1,28 @@
 package com.marketinghub.product.service;
 
+import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.product.Product;
 import com.marketinghub.product.dto.CreateProductRequest;
-import com.marketinghub.repository.jpa.product.ProductRepository;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
-import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import com.marketinghub.repository.jpa.product.ProductRepository;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Responsabilidade: gerenciar o cadastro comercial de produtos digitais.
  */
 @Service
 public class ProductService {
+    private static final Locale BRAZIL = Locale.forLanguageTag("pt-BR");
+
     private final ProductRepository repository;
     private final InstagramAccountRepository accountRepository;
     private final MarketNicheRepository marketNicheRepository;
@@ -102,5 +110,119 @@ public class ProductService {
     /** Lista todos os produtos cadastrados para uso operacional no Marketing Hub. */
     public Iterable<Product> listProducts() {
         return repository.findAll();
+    }
+
+    /** Monta a definição pública de mercado do produto em Markdown. */
+    @Transactional(readOnly = true)
+    public String buildPublicMarketingDefinitionMarkdown(String productCode) {
+        Product product = findProductByCode(productCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Produto não encontrado"));
+
+        StringBuilder markdown = new StringBuilder();
+        appendTitle(markdown, product);
+        appendSection(markdown, "1. Identidade do produto",
+                line("Nome comercial", product.getName()),
+                line("Código do produto", product.getSlug()),
+                line("Tipo de produto", product.getProductType()),
+                line("Status comercial", product.getCommercialStatus()),
+                line("Preço atual", formatPrice(product.getCurrentPriceBrl())),
+                line("URL pública", product.getPublicUrl()));
+        appendSection(markdown, "2. Mercado e nicho",
+                line("Nicho", resolveNiche(product)),
+                line("Público alvo", product.getTargetAudience()),
+                line("Avatar", product.getAvatar()));
+        appendSection(markdown, "3. Hipótese comercial",
+                paragraph(product.getPrimaryHypothesis()));
+        appendSection(markdown, "4. Dor, promessa e transformação",
+                line("Dor principal", product.getExplicitPain()),
+                line("Promessa", product.getPromise()),
+                line("Mecanismo único", product.getUniqueMechanism()));
+        appendSection(markdown, "5. Estilo de comunicação",
+                line("Linguagem", product.getLanguageStyle()),
+                line("Storytelling", product.getStorytelling()),
+                line("Paleta visual", product.getColorPalette()));
+        appendSection(markdown, "6. Oferta e monetização",
+                line("Oferta de entrada", product.getTripwire()),
+                line("Reversão de risco", product.getRiskReversal()),
+                line("Prova social", product.getSocialProof()),
+                line("Checkout e monetização", product.getCheckoutMonetization()));
+        appendSection(markdown, "7. Funil de aquisição e venda",
+                paragraph(product.getFunnel()));
+        appendSection(markdown, "8. Criativos e escala",
+                line("Volume criativo esperado", product.getCreativeVolume()),
+                line("Experimentos associados", product.getAssociatedExperiments()));
+        appendSection(markdown, "9. Aprendizados e próximos ajustes de marketing",
+                paragraph(product.getCommercialNotes()));
+        return markdown.toString();
+    }
+
+    /** Busca o produto por slug público ou por identificador interno numérico. */
+    private Optional<Product> findProductByCode(String productCode) {
+        if (productCode == null || productCode.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedCode = productCode.trim();
+        Optional<Product> bySlug = repository.findBySlug(normalizedCode);
+        if (bySlug.isPresent()) {
+            return bySlug;
+        }
+        if (!normalizedCode.matches("\\d+")) {
+            return Optional.empty();
+        }
+        return repository.findById(Long.valueOf(normalizedCode));
+    }
+
+    /** Adiciona o título principal do documento. */
+    private void appendTitle(StringBuilder markdown, Product product) {
+        markdown.append("# Definição de Produto para Mercado — ")
+                .append(valueOrFallback(product.getName()))
+                .append("\n\n");
+        markdown.append("> Documento público de posicionamento comercial do produto. Não inclui detalhes técnicos de implementação.\n\n");
+    }
+
+    /** Adiciona uma seção com linhas ou parágrafos já formatados. */
+    private void appendSection(StringBuilder markdown, String title, String... entries) {
+        markdown.append("## ").append(title).append("\n\n");
+        for (String entry : entries) {
+            markdown.append(entry);
+            if (!entry.endsWith("\n")) {
+                markdown.append("\n");
+            }
+        }
+        markdown.append("\n");
+    }
+
+    /** Formata uma linha de definição de negócio. */
+    private String line(String label, String value) {
+        return "- **" + label + ":** " + valueOrFallback(value) + "\n";
+    }
+
+    /** Formata um parágrafo livre preservando um fallback quando não houver dado cadastrado. */
+    private String paragraph(String value) {
+        return valueOrFallback(value) + "\n";
+    }
+
+    /** Resolve o nicho priorizando o relacionamento canônico e usando o campo legado como fallback. */
+    private String resolveNiche(Product product) {
+        if (product.getMarketNiche() != null && product.getMarketNiche().getName() != null) {
+            return product.getMarketNiche().getName();
+        }
+        return product.getNiche();
+    }
+
+    /** Formata o preço comercial em reais quando ele estiver cadastrado. */
+    private String formatPrice(BigDecimal price) {
+        if (price == null) {
+            return null;
+        }
+        return NumberFormat.getCurrencyInstance(BRAZIL).format(price);
+    }
+
+    /** Retorna um texto padrão para campos comerciais ainda não definidos. */
+    private String valueOrFallback(String value) {
+        if (value == null || value.isBlank()) {
+            return "Não definido";
+        }
+        return value.trim();
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
@@ -4,10 +4,12 @@ import com.marketinghub.product.dto.CreateProductRequest;
 import com.marketinghub.product.dto.ProductDto;
 import com.marketinghub.product.mapper.ProductMapper;
 import com.marketinghub.product.service.ProductService;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 import java.util.stream.StreamSupport;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * Responsabilidade: expor endpoints REST do cadastro comercial de produtos.
@@ -48,5 +50,17 @@ public class ProductController {
         return StreamSupport.stream(service.listProducts().spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
+    }
+
+    /** Retorna a definição pública de mercado do produto em Markdown. */
+    @GetMapping(
+            value = "/public/{productCode}/marketing-definition.md",
+            produces = "text/markdown;charset=UTF-8")
+    public ResponseEntity<String> getPublicMarketingDefinitionMarkdown(@PathVariable String productCode) {
+        String filename = "produto-" + productCode + "-definicao-mercado.md";
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/markdown;charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"")
+                .body(service.buildPublicMarketingDefinitionMarkdown(productCode));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/product/ProductRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/product/ProductRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Repositório JPA responsável pela persistência de produtos digitais.
  */
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    /** Busca um produto pelo slug comercial público. */
+    Optional<Product> findBySlug(String slug);
+
     /** Busca o produto operacional mais recente vinculado ao nicho informado. */
     Optional<Product> findFirstByMarketNiche_IdOrderByCreatedAtDesc(Long marketNicheId);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -7,11 +7,13 @@ import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.repository.jpa.product.ProductRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,5 +47,76 @@ class ProductServiceTest {
         assertThat(updated.getCurrentPriceBrl()).isEqualByComparingTo("47.00");
         assertThat(updated.getTargetAudience()).isEqualTo(request.getTargetAudience());
         assertThat(updated.getMarketNiche()).isSameAs(niche);
+    }
+
+    /** Deve montar uma definição pública em Markdown com foco comercial e sem detalhes técnicos. */
+    @Test
+    void buildPublicMarketingDefinitionMarkdown() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        MarketNiche niche = MarketNiche.builder().name("Elegância feminina prática").build();
+        Product product = Product.builder()
+                .id(1L)
+                .slug("metodo-musa-7-dias")
+                .name("Método MUSA - Presença Elegante em 7 Dias")
+                .productType("PDE")
+                .commercialStatus("validação comercial")
+                .currentPriceBrl(new BigDecimal("47.00"))
+                .marketNiche(niche)
+                .targetAudience("Mulheres que querem parecer elegantes sem trocar o guarda-roupa inteiro")
+                .primaryHypothesis("Mulheres desejam presença elegante com baixo esforço e baixo gasto.")
+                .explicitPain("Sente que a aparência não comunica o valor pessoal.")
+                .promise("Parecer mais elegante em 7 dias.")
+                .uniqueMechanism("Curadoria guiada de presença visual.")
+                .languageStyle("Sofisticada, prática e acolhedora.")
+                .funnel("Anúncio → login → experiência gratuita → paywall → compra.")
+                .codeModules("pde-platform, backend")
+                .aiCost(new BigDecimal("1.20"))
+                .build();
+
+        when(productRepository.findBySlug("metodo-musa-7-dias")).thenReturn(Optional.of(product));
+
+        String markdown = service.buildPublicMarketingDefinitionMarkdown("metodo-musa-7-dias");
+
+        assertThat(markdown).contains("# Definição de Produto para Mercado — Método MUSA - Presença Elegante em 7 Dias");
+        assertThat(markdown).contains("## 2. Mercado e nicho");
+        assertThat(markdown).contains("Elegância feminina prática");
+        assertThat(markdown).contains("Parecer mais elegante em 7 dias.");
+        assertThat(markdown).doesNotContain("pde-platform");
+        assertThat(markdown).doesNotContain("1.20");
+    }
+
+    /** Deve aceitar o identificador interno como fallback quando o código for numérico. */
+    @Test
+    void buildPublicMarketingDefinitionMarkdownByNumericCode() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        Product product = Product.builder().id(7L).name("Produto 7").build();
+
+        when(productRepository.findBySlug("7")).thenReturn(Optional.empty());
+        when(productRepository.findById(7L)).thenReturn(Optional.of(product));
+
+        String markdown = service.buildPublicMarketingDefinitionMarkdown("7");
+
+        assertThat(markdown).contains("Produto 7");
+    }
+
+    /** Deve retornar erro controlado quando o produto não existir. */
+    @Test
+    void buildPublicMarketingDefinitionMarkdownNotFound() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+
+        when(productRepository.findBySlug("inexistente")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buildPublicMarketingDefinitionMarkdown("inexistente"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Produto não encontrado");
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
@@ -20,7 +20,10 @@ import java.math.BigDecimal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,5 +70,20 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.name").value(request.getName()))
                 .andExpect(jsonPath("$.currentPriceBrl").value(47.00));
+    }
+
+    /** Deve expor a definição pública de mercado do produto como Markdown. */
+    @Test
+    void getPublicMarketingDefinitionMarkdown() throws Exception {
+        String markdown = "# Definição de Produto para Mercado — Método MUSA\n\n## 1. Identidade do produto\n";
+
+        when(service.buildPublicMarketingDefinitionMarkdown("metodo-musa-7-dias")).thenReturn(markdown);
+
+        mockMvc.perform(get("/api/products/public/{productCode}/marketing-definition.md", "metodo-musa-7-dias"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/markdown;charset=UTF-8"))
+                .andExpect(header().string("Content-Disposition",
+                        "inline; filename=\"produto-metodo-musa-7-dias-definicao-mercado.md\""))
+                .andExpect(content().string(markdown));
     }
 }

--- a/docs/canonical/product-catalog-canon.v1.md
+++ b/docs/canonical/product-catalog-canon.v1.md
@@ -68,3 +68,15 @@ Regras comerciais:
 ## Regra de evolução
 
 Novos atributos devem ser adicionados ao cadastro de produto quando ajudarem a aumentar vendas, reduzir retrabalho operacional ou preservar aprendizado comercial. Exemplos: checkout, domínio HTTPS, avatar detalhado, objeções, promessa principal, mecanismo único, upsells, canais ativos, criativos vencedores, métricas de conversão, taxa de ativação e aprendizados por experimento.
+
+## Documento público de definição de mercado
+
+Todo produto cadastrado pode expor uma definição pública em Markdown pela URL:
+
+```text
+/api/products/public/{codigoDoProduto}/marketing-definition.md
+```
+
+O parâmetro `{codigoDoProduto}` deve usar preferencialmente o slug estável do produto. O identificador interno numérico pode ser aceito como fallback operacional.
+
+Esse documento deve ser uma ferramenta de Marketing, não um relatório técnico. Deve organizar os pontos comerciais mais importantes do produto: identidade, nicho, público, avatar, hipótese, dor, promessa, mecanismo, estilo de linguagem, oferta, funil, criativos, experimentos associados, aprendizados e próximos ajustes. Detalhes internos como módulos de código, custos técnicos, prompts, banco de dados, workers ou implementação não devem aparecer no documento público.


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"comentario":"<resposta principal em Markdown>","orientacaoProximaAcao":"<orientação objetiva para a próxima ação baseada na alternativa escolhida, ou string vazia se não houver orientação aplicável>"}. Use comentario para a resposta normal e orientacaoProximaAcao apenas quando existir uma decisão entre alternativas ou próxima ação clara.

Última mensagem do usuário:
eu quero criar uma url publica em que eu passe como parametro o codigo do produto e essa url gere para mim um documento em formato markdown tudo de mais importante sobre o produto: nicho, hipotese, estilo, linguagem, objetivo, etc. De forma bem organzada.
Mas não precisa colocar detalhes técnicos precisa ser uma ferramante de Marketing uma definição do produto para o mercado.

**Resumo das alterações:**
{"comentario":"**Implementado**\n\nCriei a URL pública para gerar a definição de mercado do produto em Markdown:\n\n`GET /api/products/public/{codigoDoProduto}/marketing-definition.md`\n\nO `{codigoDoProduto}` usa preferencialmente o `slug` do produto, mas também aceita ID numérico como fallback.\n\n**O documento gerado inclui:**\n- identidade do produto;\n- nicho e público;\n- avatar;\n- hipótese comercial;\n- dor, promessa e mecanismo único;\n- estilo de linguagem;\n- oferta e monetização;\n- funil de aquisição e venda;\n- criativos, experimentos associados e aprendizados.\n\n**O documento não inclui detalhes técnicos**, como módulos de código, custos internos, banco, prompts ou workers.\n\n**Alternativas avaliadas**\n1. Criar um endpoint simples no backend usando o cadastro atual do produto. Melhor custo-benefício, rápido, consistente e suficiente para marketing.\n2. Gerar o documento com IA em tempo real. Mais flexível, mas adicionaria custo, latência e risco de variação no conteúdo.\n3. Criar uma tabela nova para versões do documento. Mais robusto para histórico, mas excessivo para a necessidade atual.\n\nEscolhi a alternativa 1 porque entrega a ferramenta agora, usa a fonte canônica do produto e mantém o documento estável.\n\n**Validação**\n\nExecutei:\n\n`mvn -Dtest=ProductServiceTest,ProductControllerTest test`\n\nResultado: `BUILD SUCCESS`, 6 testes passaram.\n\nTambém atualizei o cânone em `docs/canonical/product-catalog-canon.v1.md` registrando o novo endpoint e a regra de que o documento é uma ferramenta de Marketing, não um relatório técnico.\n\nNão criei Pull Request.","orientacaoProximaAcao":"Preencher ou revisar no cadastro do produto os campos comerciais principais: slug, nicho, público alvo, avatar, hipótese, dor, promessa, mecanismo único, linguagem, funil, oferta e aprendizados. Depois testar a URL com o slug do produto, por exemplo `/api/products/public/metodo-musa-7-dias/marketing-definition.md`."}