### PR TITLE
AI Hub: {"titulo":"CTA do Dia 1 corrigido","comentario":"Correção executada.\n\n**O que mudou:**\n- O CTA principal agora diz: `Começar missão do Dia 1`.\n- O card de `Próxima missão` não mostra mais um segundo botão concorrente quando a próxima ação aind…

### DIFF
--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -606,6 +606,7 @@ function App() {
   const completedMissionIds = new Set(workspace?.completedMissionIds ?? []);
   const firstMission = currentProduct.missions[0];
   const nextMission = currentProduct.missions.find((mission) => !completedMissionIds.has(mission.id)) ?? currentProduct.missions[0];
+  const nextMissionIsFirstMission = Boolean(firstMission && nextMission?.id === firstMission.id);
   const hasActiveSubscription = workspace?.subscriptionStatus === 'ACTIVE';
 
   if (!workspace) {
@@ -773,9 +774,13 @@ function App() {
           <h1>Sua presença elegante começa hoje.</h1>
           <p className="promise">{currentProduct.promise}</p>
           <div className="musa-hero-actions">
-            <button className="primary-button" onClick={() => openMission(firstMission?.id ?? '', 'primary_start')}>
+            <button
+              className="primary-button"
+              onClick={() => openMission(firstMission?.id ?? '', 'primary_start')}
+              disabled={!firstMission}
+            >
               <Sparkles size={18} />
-              Começar Dia 1
+              Começar missão do Dia 1
             </button>
             <span>Uma missão curta por dia, com evidências simples de progresso.</span>
           </div>
@@ -791,13 +796,20 @@ function App() {
               ? 'Escolha uma combinação real, identifique o detalhe que apaga sua presença e registre a frase que vai guiar seu primeiro ajuste.'
               : currentProduct.completionOffer}
           </p>
-          <button
-            className="secondary-button next-mission-button"
-            onClick={() => openMission(nextMission?.id ?? firstMission?.id ?? '', 'next_mission_open')}
-          >
-            Abrir orientação
-            <ChevronRight size={18} />
-          </button>
+          {nextMission && !nextMissionIsFirstMission ? (
+            <button
+              className="secondary-button next-mission-button"
+              onClick={() => openMission(nextMission.id, 'next_mission_open')}
+            >
+              Abrir próxima missão
+              <ChevronRight size={18} />
+            </button>
+          ) : (
+            <div className="next-mission-guidance">
+              <Sparkles size={18} />
+              <span>Toque no botão acima para iniciar sua primeira missão.</span>
+            </div>
+          )}
         </article>
         <aside className="progress-hero-card" aria-label="Progresso da jornada MUSA">
           <Gauge size={24} />

--- a/pde-platform/frontend/src/styles.css
+++ b/pde-platform/frontend/src/styles.css
@@ -181,6 +181,22 @@ input {
   width: fit-content;
 }
 
+.next-mission-guidance {
+  align-items: center;
+  background: rgba(255, 248, 243, 0.12);
+  color: #fff8f3;
+  display: inline-flex;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 12px 14px;
+  width: fit-content;
+}
+
+.next-mission-guidance span {
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
 .progress-hero-card {
   align-content: center;
   background: rgba(255, 248, 243, 0.95);
@@ -1201,7 +1217,8 @@ h3 {
   }
 
   .musa-hero-actions .primary-button,
-  .next-mission-button {
+  .next-mission-button,
+  .next-mission-guidance {
     width: 100%;
   }
 


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: Fiquei confuso nessa tela primeiro achei que tinha que clicar em 'Começar dia 1' depois achei que tinha que clicar em 'Abrir Orientação'

Modelo: {"titulo":"CTA confuso no Dia 1","comentario":"Você está certo: a tela gera dúvida.\n\n**Diagnóstico:** existem dois botões com cara de ação principal no mesmo primeiro bloco: `Começar Dia 1` e `Abrir orientação`. Na prática, eles parecem levar para o mesmo começo da missão, mas comunicam intenções diferentes. Para uma usuária nova, isso quebra a promessa central do PDE: reduzir esforço e conduzir com clareza.\n\n**Causa-raiz:** a tela mistura dois conceitos no mesmo momento: início da jornada e abertura da missão. O botão `Começar Dia 1` parece ser o próximo passo obrigatório; o card abaixo diz `Próxima missão` e também oferece `Abrir orientação`, criando competição de decisão.\n\n**Melhor correção recomendada:** manter apenas um CTA principal acima da dobra, com texto único e direto: `Começar missão do Dia 1`. O card de missão pode continuar existindo, mas sem outro botão concorrente, ou com ação secundária mais clara como `Ver detalhes da missão`.\n\n**Alternativas avaliadas:**\n\n1. **Manter os dois botões e explicar melhor**  \nBenefício: exige pouca mudança.  \nRisco: continua pedindo raciocínio da usuária.  \nAderência comercial: baixa, porque aumenta fricção.\n\n2. **Remover o botão superior e deixar só `Abrir orientação` no card**  \nBenefício: simplifica a tela.  \nRisco: o primeiro CTA fica mais baixo e menos óbvio.  \nAderência comercial: média.\n\n3. **Unificar a ação em um CTA dominante: `Começar missão do Dia 1`**  \nBenefício: transforma a dúvida em comando claro, preserva o foco na primeira microação e reduz abandono.  \nRisco: baixo.  \nAderência comercial: alta.\n\n**Orientação final:** eu trataria isso como ajuste prioritário de conversão/ativação. A usuária não deve pensar qual botão clicar; ela deve sentir que só existe um próximo passo natural.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
execute a correção sugerida

**Resumo das alterações:**
{"titulo":"CTA do Dia 1 corrigido","comentario":"Correção executada.\n\n**O que mudou:**\n- O CTA principal agora diz: `Começar missão do Dia 1`.\n- O card de `Próxima missão` não mostra mais um segundo botão concorrente quando a próxima ação ainda é o Dia 1.\n- No lugar de `Abrir orientação`, ele mostra uma instrução clara: `Toque no botão acima para iniciar sua primeira missão.`\n- Quando a usuária avançar para os próximos dias, o card volta a ter ação própria com texto mais claro: `Abrir próxima missão`.\n\n**Arquivos alterados:**\n- `pde-platform/frontend/src/App.tsx`\n- `pde-platform/frontend/src/styles.css`\n\n**Validação:**\n- `npm run build` executado com sucesso.\n- Servidor local ativo em `http://localhost:5176/`.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":""}