### PR TITLE
AI Hub: {"titulo":"Playwright aplicado no MUSA","comentario":"Implementado no PDE do MUSA.\n\n- Instalei `@playwright/test` no frontend do `pde-platform`.\n- Adicionei o script `npm run test:visual`.\n- Criei configuração Playwright com validação desktop …

### DIFF
--- a/pde-platform/.gitignore
+++ b/pde-platform/.gitignore
@@ -1,4 +1,5 @@
 backend/target/
 frontend/node_modules/
 frontend/dist/
+frontend/test-results/
 *.tsbuildinfo

--- a/pde-platform/README.md
+++ b/pde-platform/README.md
@@ -19,12 +19,16 @@ Frontend:
 cd pde-platform/frontend
 npm install
 npm run build
+npm run test:visual
 npm run dev
 ```
 
 O frontend carrega `.npmrc` com `include=dev` e o script `npm run dev`
 define `NODE_ENV=development`, para evitar que um ambiente shell em producao
 omita dependencias do Vite/TypeScript ou desative recursos de desenvolvimento.
+
+Playwright fica instalado no frontend do PDE para repetir validacoes visuais da
+entrada MUSA sem depender de instalacao temporaria.
 
 Docker:
 

--- a/pde-platform/frontend/package-lock.json
+++ b/pde-platform/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "vite": "^8.1.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "typescript": "^5.9.3"
@@ -76,6 +77,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -746,6 +763,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/pde-platform/frontend/package.json
+++ b/pde-platform/frontend/package.json
@@ -6,6 +6,7 @@
     "check:api-boundary": "bash scripts/validate-api-boundary.sh",
     "dev": "NODE_ENV=development vite --host 0.0.0.0",
     "build": "tsc --noEmit && vite build",
+    "test:visual": "playwright test",
     "preview": "vite preview --host 0.0.0.0"
   },
   "dependencies": {
@@ -16,6 +17,7 @@
     "vite": "^8.1.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "typescript": "^5.9.3"

--- a/pde-platform/frontend/playwright.config.ts
+++ b/pde-platform/frontend/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:57180',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 57180 --strictPort',
+    url: 'http://127.0.0.1:57180',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+});

--- a/pde-platform/frontend/tests/musa-entry.visual.spec.ts
+++ b/pde-platform/frontend/tests/musa-entry.visual.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test('carrega a entrada visual do Clube MUSA', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByText('Clube MUSA')).toBeVisible();
+  await expect(page.getByRole('heading', { name: /descubra o detalhe/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Entrar' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Primeiro acesso', exact: true })).toBeVisible();
+  await expect(page.getByLabel(/Prévia da experiência Método MUSA/i)).toBeVisible();
+
+  await page.screenshot({
+    path: test.info().outputPath('musa-entry.png'),
+    fullPage: true,
+  });
+});


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Última mensagem do usuário:
Execute:
"Ter Playwright já instalado no projeto facilitaria repetir validações visuais sem instalação temporária." no PDE do MUSA

**Resumo das alterações:**
{"titulo":"Playwright aplicado no MUSA","comentario":"Implementado no PDE do MUSA.\n\n- Instalei `@playwright/test` no frontend do `pde-platform`.\n- Adicionei o script `npm run test:visual`.\n- Criei configuração Playwright com validação desktop e mobile.\n- Criei teste visual da entrada do Clube MUSA, cobrindo headline, botões principais e prévia visual.\n- Documentei o comando no `pde-platform/README.md`.\n- Adicionei `frontend/test-results/` ao `.gitignore`.\n\nValidações executadas:\n\n- `npm run build` passou.\n- `npm run test:visual` passou com 2 testes: desktop e mobile.\n\nTambém instalei o Chromium do Playwright no ambiente local para permitir a execução real da validação visual. Não criei PR.","sugestaoMelhoriaAmbiente":""}