### PR TITLE
AI Hub: {"titulo":"Integração IA criada","comentario":"Implementei a integração direcionada da OpenAI no PDE sem chat aberto.\n\n**Arquitetura escolhida**\n\nAvaliei 3 opções:\n\n1. OpenAI direto no backend: menor esforço, mas pior para auditoria e fere o…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-18-pde-ai-guidance.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-18-pde-ai-guidance.yaml
@@ -1,0 +1,56 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-18-pde-ai-guidance-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pde_access_grant
+        - not:
+            tableExists:
+              tableName: pde_ai_guidance_request
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE pde_ai_guidance_request (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_id VARCHAR(36) NOT NULL,
+                access_token VARCHAR(36) NOT NULL,
+                product_slug VARCHAR(191) NOT NULL,
+                email VARCHAR(320) NOT NULL,
+                mission_id VARCHAR(191) NOT NULL,
+                guidance_type VARCHAR(80) NOT NULL,
+                stage_code VARCHAR(80) NOT NULL,
+                status VARCHAR(40) NOT NULL,
+                answers_json JSON NOT NULL,
+                previous_answers_json JSON NULL,
+                headline VARCHAR(220) NULL,
+                summary LONGTEXT NULL,
+                signals_json JSON NULL,
+                micro_actions_json JSON NULL,
+                caution VARCHAR(500) NULL,
+                model VARCHAR(80) NULL,
+                service_tier VARCHAR(40) NULL,
+                raw_request_json LONGTEXT NULL,
+                raw_response_json LONGTEXT NULL,
+                input_tokens INT NULL,
+                output_tokens INT NULL,
+                cost_usd DECIMAL(12,6) NULL,
+                error_message LONGTEXT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                finished_at DATETIME NULL,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_pde_ai_guidance_request_id (request_id),
+                KEY idx_pde_ai_guidance_pending (status, created_at),
+                KEY idx_pde_ai_guidance_access (access_token, mission_id),
+                KEY idx_pde_ai_guidance_product (product_slug, guidance_type),
+                CONSTRAINT fk_pde_ai_guidance_access_grant
+                  FOREIGN KEY (access_token) REFERENCES pde_access_grant (token)
+                  ON DELETE CASCADE
+              );

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1345,3 +1345,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-07-18-pde-mission-interactions.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-07-18-pde-ai-guidance.yaml
+      relativeToChangelogFile: true

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -60,8 +60,26 @@ O backend PDE deve:
 - preparar base para assinatura/continuidade;
 - ser a única API consumida pelo frontend PDE;
 - acessar banco de dados ou serviços internos quando isso for necessário para entregar a experiência PDE.
+- criar, persistir e expor solicitações de orientação por IA quando a experiência precisar de personalização guiada.
+- receber resultados de workers de IA com saída funcional estruturada, payload bruto, modelo, tier, tokens, custo quando houver e erro.
 
 O backend PDE pode acessar dados persistidos diretamente ou por contratos internos definidos para o módulo, desde que preserve a fronteira de produto: o frontend PDE não deve conhecer nem consumir endpoints do backend principal `backend/ads-service`.
+
+### IA direcionada no PDE
+
+A IA no PDE deve funcionar como personalização guiada por etapa, nunca como chat aberto genérico na experiência inicial.
+
+Regras obrigatórias:
+
+- o backend PDE é fonte de verdade de acesso, contexto, pendência, status, resultado e auditoria;
+- a chamada OpenAI deve ser executada por worker próprio ou módulo executor, não pelo frontend;
+- o worker deve consumir pendências pelo endpoint canônico `pending` do backend PDE;
+- prompt operacional e schema JSON de saída devem ficar versionados no worker;
+- a resposta deve ser curta, estruturada e diretamente aplicável à missão;
+- o frontend deve exibir a orientação como cartão de produto, não como conversa livre;
+- toda solicitação deve ser mensurável no funil e associada ao token, produto e missão.
+
+Para o Método MUSA, o primeiro contrato de IA é a Consultora MUSA do Dia 2: a cliente escolhe três sinais de presença e recebe uma assinatura pessoal curta para repetir durante a semana.
 
 ### Frontend PDE
 

--- a/pde-platform/README.md
+++ b/pde-platform/README.md
@@ -36,6 +36,19 @@ Docker:
 docker compose -f pde-platform/docker-compose.yml up --build
 ```
 
+IA direcionada do PDE:
+
+```bash
+cd pde-platform/pde-ai-worker
+npm run check
+OPENAI_API_KEY=... PDE_BACKEND_URL=http://localhost:8096 npm start
+```
+
+O backend PDE cria solicitações de orientação por IA e o `pde-ai-worker`
+executa a OpenAI por endpoint `pending`, usando prompt/schema versionados.
+O primeiro contrato ativo é a Consultora MUSA do Dia 2, que gera uma
+assinatura pessoal curta a partir dos 3 sinais escolhidos pela cliente.
+
 ## Produto inicial
 
 - Slug: `metodo-musa-7-dias`

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/controller/AiGuidanceController.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/controller/AiGuidanceController.java
@@ -1,0 +1,61 @@
+package com.marketinghub.pde.controller;
+
+import com.marketinghub.pde.dto.AiGuidanceCreateRequest;
+import com.marketinghub.pde.dto.AiGuidancePendingResponse;
+import com.marketinghub.pde.dto.AiGuidanceResponse;
+import com.marketinghub.pde.dto.AiGuidanceResultRequest;
+import com.marketinghub.pde.service.AiGuidanceService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe contratos fechados de orientação por IA para frontend e worker PDE. */
+@RestController
+public class AiGuidanceController {
+
+    private final AiGuidanceService aiGuidanceService;
+
+    /** Recebe o serviço que controla solicitações e resultados de IA. */
+    public AiGuidanceController(AiGuidanceService aiGuidanceService) {
+        this.aiGuidanceService = aiGuidanceService;
+    }
+
+    /** Cria uma orientação guiada por IA para a missão informada. */
+    @PostMapping("/api/pde/access/{token}/missions/{missionId}/ai-guidance")
+    @ResponseStatus(HttpStatus.CREATED)
+    public AiGuidanceResponse createGuidance(
+            @PathVariable("token") String token,
+            @PathVariable("missionId") String missionId,
+            @Valid @RequestBody AiGuidanceCreateRequest request) {
+        return aiGuidanceService.createGuidanceRequest(token, missionId, request);
+    }
+
+    /** Retorna o estado atual de uma orientação guiada por IA. */
+    @GetMapping("/api/pde/access/{token}/ai-guidance/{requestId}")
+    public AiGuidanceResponse getGuidance(
+            @PathVariable("token") String token,
+            @PathVariable("requestId") String requestId) {
+        return aiGuidanceService.getGuidance(token, requestId);
+    }
+
+    /** Entrega uma lista unitária de pendência ao worker executor do PDE. */
+    @GetMapping("/api/internal/pde/ai-guidance/stage-executions/pending")
+    public List<AiGuidancePendingResponse> getPendingGuidance() {
+        return aiGuidanceService.getPendingGuidance().map(List::of).orElseGet(List::of);
+    }
+
+    /** Recebe o resultado do worker executor para uma orientação por IA. */
+    @PostMapping("/api/internal/pde/ai-guidance/stage-executions/{requestId}/result")
+    public AiGuidanceResponse receiveGuidanceResult(
+            @PathVariable("requestId") String requestId,
+            @Valid @RequestBody AiGuidanceResultRequest request) {
+        return aiGuidanceService.receiveGuidanceResult(requestId, request);
+    }
+}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceCreateRequest.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceCreateRequest.java
@@ -1,0 +1,11 @@
+package com.marketinghub.pde.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.Map;
+
+/** Recebe a solicitação de orientação por IA para uma missão específica do PDE. */
+public record AiGuidanceCreateRequest(
+        @NotBlank String guidanceType,
+        @NotEmpty Map<String, String> answers
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidancePendingResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidancePendingResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.pde.dto;
+
+import java.util.Map;
+
+/** Entrega ao worker PDE uma pendência de IA com contexto suficiente para execução. */
+public record AiGuidancePendingResponse(
+        String requestId,
+        String productSlug,
+        String email,
+        String missionId,
+        String guidanceType,
+        String stageCode,
+        String status,
+        Map<String, String> answers,
+        Map<String, String> previousMissionAnswers,
+        ProductExperienceResponse product
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceResponse.java
@@ -1,0 +1,24 @@
+package com.marketinghub.pde.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/** Retorna à cliente o estado e a orientação funcional gerada pela IA. */
+public record AiGuidanceResponse(
+        String requestId,
+        String productSlug,
+        String missionId,
+        String guidanceType,
+        String status,
+        String headline,
+        String summary,
+        List<String> signals,
+        List<String> microActions,
+        String caution,
+        String model,
+        String serviceTier,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd,
+        String errorMessage
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceResultRequest.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/AiGuidanceResultRequest.java
@@ -1,0 +1,23 @@
+package com.marketinghub.pde.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.math.BigDecimal;
+import java.util.List;
+
+/** Recebe do worker PDE o resultado auditável de uma execução OpenAI. */
+public record AiGuidanceResultRequest(
+        @NotBlank String status,
+        String headline,
+        String summary,
+        List<String> signals,
+        List<String> microActions,
+        String caution,
+        String model,
+        String serviceTier,
+        String rawRequestJson,
+        String rawResponseJson,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd,
+        String errorMessage
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
@@ -504,6 +504,7 @@ public class AccessService {
                 "MISSION_OPEN",
                 "MISSION_COMPLETED",
                 "MISSION_INTERACTION_SAVED",
+                "AI_GUIDANCE_REQUESTED",
                 "MATERIAL_OPEN");
         if (!allowed.contains(normalized)) {
             throw new IllegalArgumentException("Evento PDE nao suportado: " + eventType);

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AiGuidanceService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AiGuidanceService.java
@@ -1,0 +1,602 @@
+package com.marketinghub.pde.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.pde.dto.AiGuidanceCreateRequest;
+import com.marketinghub.pde.dto.AiGuidancePendingResponse;
+import com.marketinghub.pde.dto.AiGuidanceResponse;
+import com.marketinghub.pde.dto.AiGuidanceResultRequest;
+import com.marketinghub.pde.dto.FunnelEventRequest;
+import com.marketinghub.pde.dto.MissionInteractionRequest;
+import com.marketinghub.pde.dto.ProductExperienceResponse;
+import com.marketinghub.pde.dto.WorkspaceResponse;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Controla solicitações de orientação por IA do PDE sem executar OpenAI no backend. */
+@Service
+public class AiGuidanceService {
+    private static final Logger log = LoggerFactory.getLogger(AiGuidanceService.class);
+    private static final TypeReference<Map<String, StoredAiGuidance>> STORE_TYPE = new TypeReference<>() {};
+    private static final String STAGE_CODE = "pde-ai-guidance-v1";
+    private static final Set<String> ALLOWED_GUIDANCE_TYPES = Set.of("MUSA_DAY_2_SIGNATURE");
+
+    private final AccessService accessService;
+    private final ObjectMapper objectMapper;
+    private final Path storagePath;
+    private final String jdbcUrl;
+    private final String jdbcUsername;
+    private final String jdbcPassword;
+    private final Map<String, StoredAiGuidance> requestsById = new ConcurrentHashMap<>();
+
+    /** Recebe dependências e carrega solicitações de IA já persistidas. */
+    public AiGuidanceService(
+            AccessService accessService,
+            ObjectMapper objectMapper,
+            @Value("${pde.ai.storage-path:/data/pde/ai-guidance-requests.json}") String storagePath,
+            @Value("${pde.access.jdbc-url:}") String jdbcUrl,
+            @Value("${pde.access.jdbc-username:}") String jdbcUsername,
+            @Value("${pde.access.jdbc-password:}") String jdbcPassword) {
+        this.accessService = accessService;
+        this.objectMapper = objectMapper;
+        this.storagePath = Path.of(storagePath);
+        this.jdbcUrl = jdbcUrl;
+        this.jdbcUsername = jdbcUsername;
+        this.jdbcPassword = jdbcPassword;
+        loadPersistedRequests();
+    }
+
+    /** Cria uma solicitação de orientação por IA e salva as respostas da missão. */
+    public AiGuidanceResponse createGuidanceRequest(String token, String missionId, AiGuidanceCreateRequest request) {
+        validateGuidanceType(request.guidanceType());
+        accessService.saveMissionInteraction(token, missionId, new MissionInteractionRequest(request.answers()));
+        WorkspaceResponse workspace = accessService.getWorkspace(token);
+        validateMissionBelongsToWorkspace(workspace, missionId);
+        String requestId = UUID.randomUUID().toString();
+        StoredAiGuidance stored = StoredAiGuidance.pending(
+                requestId,
+                token,
+                workspace.product().slug(),
+                workspace.email(),
+                missionId,
+                request.guidanceType(),
+                sanitizeAnswers(request.answers()),
+                previousMissionAnswers(workspace, missionId),
+                Instant.now().toString());
+        requestsById.put(requestId, stored);
+        persistRequest(stored);
+        accessService.recordFunnelEvent(new FunnelEventRequest(
+                workspace.product().slug(),
+                "AI_GUIDANCE_REQUESTED",
+                token,
+                workspace.email(),
+                workspace.accessSource(),
+                "pde-platform",
+                null,
+                Map.of("missionId", missionId, "guidanceType", request.guidanceType(), "requestId", requestId)));
+        return toResponse(stored);
+    }
+
+    /** Retorna uma orientação da cliente, concluída ou ainda pendente. */
+    public AiGuidanceResponse getGuidance(String token, String requestId) {
+        StoredAiGuidance stored = getRequest(requestId);
+        if (!stored.accessToken().equals(token)) {
+            throw new IllegalArgumentException("Orientacao PDE nao encontrada para este acesso");
+        }
+        return toResponse(stored);
+    }
+
+    /** Entrega a próxima solicitação pendente ao worker executor do PDE. */
+    public Optional<AiGuidancePendingResponse> getPendingGuidance() {
+        Optional<StoredAiGuidance> pending = usesJdbcStorage()
+                ? loadPendingGuidanceFromDatabase()
+                : requestsById.values().stream()
+                        .filter(request -> "PENDING".equals(request.status()))
+                        .sorted((left, right) -> left.createdAt().compareTo(right.createdAt()))
+                        .findFirst();
+        return pending.map(this::toPendingResponse);
+    }
+
+    /** Recebe do worker o resultado funcional e os dados de auditoria da chamada OpenAI. */
+    public AiGuidanceResponse receiveGuidanceResult(String requestId, AiGuidanceResultRequest result) {
+        StoredAiGuidance current = getRequest(requestId);
+        String normalizedStatus = normalizeResultStatus(result.status());
+        StoredAiGuidance updated = current.withResult(
+                normalizedStatus,
+                nullToBlank(result.headline()),
+                nullToBlank(result.summary()),
+                result.signals() == null ? List.of() : result.signals(),
+                result.microActions() == null ? List.of() : result.microActions(),
+                nullToBlank(result.caution()),
+                nullToBlank(result.model()),
+                nullToBlank(result.serviceTier()),
+                nullToBlank(result.rawRequestJson()),
+                nullToBlank(result.rawResponseJson()),
+                result.inputTokens(),
+                result.outputTokens(),
+                result.costUsd(),
+                nullToBlank(result.errorMessage()),
+                Instant.now().toString());
+        requestsById.put(requestId, updated);
+        persistRequest(updated);
+        return toResponse(updated);
+    }
+
+    /** Confirma que o tipo de orientação está no contrato fechado do produto. */
+    private void validateGuidanceType(String guidanceType) {
+        if (!ALLOWED_GUIDANCE_TYPES.contains(guidanceType)) {
+            throw new IllegalArgumentException("Tipo de orientacao PDE nao suportado: " + guidanceType);
+        }
+    }
+
+    /** Confirma que a missão solicitada pertence ao produto da cliente. */
+    private void validateMissionBelongsToWorkspace(WorkspaceResponse workspace, String missionId) {
+        boolean exists = workspace.product().missions().stream().anyMatch(mission -> mission.id().equals(missionId));
+        if (!exists) {
+            throw new IllegalArgumentException("Missao PDE nao encontrada: " + missionId);
+        }
+    }
+
+    /** Normaliza e limita respostas enviadas para personalização por IA. */
+    private Map<String, String> sanitizeAnswers(Map<String, String> answers) {
+        Map<String, String> sanitized = new LinkedHashMap<>();
+        if (answers == null) {
+            return sanitized;
+        }
+        answers.forEach((key, value) -> {
+            String normalizedKey = key == null ? "" : key.trim();
+            String normalizedValue = value == null ? "" : value.trim();
+            if (!normalizedKey.isBlank() && !normalizedValue.isBlank()) {
+                sanitized.put(normalizedKey, normalizedValue.length() > 2000
+                        ? normalizedValue.substring(0, 2000)
+                        : normalizedValue);
+            }
+        });
+        return sanitized;
+    }
+
+    /** Coleta respostas anteriores para manter continuidade sem recomputar contexto no frontend. */
+    private Map<String, String> previousMissionAnswers(WorkspaceResponse workspace, String currentMissionId) {
+        Map<String, String> previousAnswers = new LinkedHashMap<>();
+        workspace.missionInteractions().stream()
+                .filter(answer -> !currentMissionId.equals(answer.missionId()))
+                .forEach(answer -> previousAnswers.put(answer.questionKey(), answer.answerText()));
+        return previousAnswers;
+    }
+
+    /** Converte uma pendência interna no contrato consumido pelo worker. */
+    private AiGuidancePendingResponse toPendingResponse(StoredAiGuidance stored) {
+        ProductExperienceResponse product = accessService.getWorkspace(stored.accessToken()).product();
+        return new AiGuidancePendingResponse(
+                stored.requestId(),
+                stored.productSlug(),
+                stored.email(),
+                stored.missionId(),
+                stored.guidanceType(),
+                STAGE_CODE,
+                stored.status(),
+                stored.answers(),
+                stored.previousMissionAnswers(),
+                product);
+    }
+
+    /** Converte o estado interno no contrato público do frontend. */
+    private AiGuidanceResponse toResponse(StoredAiGuidance stored) {
+        return new AiGuidanceResponse(
+                stored.requestId(),
+                stored.productSlug(),
+                stored.missionId(),
+                stored.guidanceType(),
+                stored.status(),
+                blankToNull(stored.headline()),
+                blankToNull(stored.summary()),
+                stored.signals(),
+                stored.microActions(),
+                blankToNull(stored.caution()),
+                blankToNull(stored.model()),
+                blankToNull(stored.serviceTier()),
+                stored.inputTokens(),
+                stored.outputTokens(),
+                stored.costUsd(),
+                blankToNull(stored.errorMessage()));
+    }
+
+    /** Busca a solicitação em memória ou no banco configurado. */
+    private StoredAiGuidance getRequest(String requestId) {
+        StoredAiGuidance stored = requestsById.get(requestId);
+        if (stored != null) {
+            return stored;
+        }
+        if (usesJdbcStorage()) {
+            StoredAiGuidance loaded = loadGuidanceFromDatabase(requestId);
+            if (loaded != null) {
+                requestsById.put(requestId, loaded);
+                return loaded;
+            }
+        }
+        throw new IllegalArgumentException("Orientacao PDE nao encontrada");
+    }
+
+    /** Normaliza status aceitos para resultado do worker. */
+    private String normalizeResultStatus(String status) {
+        String normalized = status == null ? "" : status.trim().toUpperCase();
+        if ("COMPLETED".equals(normalized) || "FAILED".equals(normalized)) {
+            return normalized;
+        }
+        throw new IllegalArgumentException("Status de orientacao PDE invalido: " + status);
+    }
+
+    /** Informa se o backend PDE deve persistir orientações no MySQL. */
+    private boolean usesJdbcStorage() {
+        return jdbcUrl != null && !jdbcUrl.isBlank();
+    }
+
+    /** Abre conexão JDBC para persistência da orientação. */
+    private Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl, jdbcUsername, jdbcPassword);
+    }
+
+    /** Carrega solicitações persistidas em arquivo ou banco ao iniciar o serviço. */
+    private void loadPersistedRequests() {
+        if (usesJdbcStorage()) {
+            loadRecentGuidanceFromDatabase();
+            return;
+        }
+        if (!Files.exists(storagePath)) {
+            return;
+        }
+        try {
+            Map<String, StoredAiGuidance> stored = objectMapper.readValue(storagePath.toFile(), STORE_TYPE);
+            requestsById.putAll(stored);
+        } catch (Exception ex) {
+            log.error("Falha ao carregar orientacoes PDE por IA em {}", storagePath, ex);
+            throw new IllegalStateException("Nao foi possivel carregar orientacoes PDE por IA", ex);
+        }
+    }
+
+    /** Persiste uma solicitação de IA no armazenamento configurado. */
+    private synchronized void persistRequest(StoredAiGuidance request) {
+        if (usesJdbcStorage()) {
+            persistGuidanceInDatabase(request);
+            return;
+        }
+        persistGuidanceInFile();
+    }
+
+    /** Persiste todas as solicitações de IA em arquivo local. */
+    private synchronized void persistGuidanceInFile() {
+        try {
+            if (storagePath.getParent() != null) {
+                Files.createDirectories(storagePath.getParent());
+            }
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(storagePath.toFile(), requestsById);
+        } catch (IOException ex) {
+            log.error("Falha ao persistir orientacoes PDE por IA em {}", storagePath, ex);
+            throw new IllegalStateException("Nao foi possivel persistir orientacao PDE por IA", ex);
+        }
+    }
+
+    /** Carrega orientações recentes do banco para acelerar consultas locais. */
+    private void loadRecentGuidanceFromDatabase() {
+        String sql = """
+                SELECT *
+                FROM pde_ai_guidance_request
+                ORDER BY created_at DESC
+                LIMIT 500
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                StoredAiGuidance stored = fromResultSet(resultSet);
+                requestsById.put(stored.requestId(), stored);
+            }
+        } catch (SQLException | IOException ex) {
+            log.error("Falha ao carregar orientacoes PDE por IA no banco", ex);
+            throw new IllegalStateException("Nao foi possivel carregar orientacoes PDE por IA no banco", ex);
+        }
+    }
+
+    /** Carrega uma orientação específica do banco pelo identificador. */
+    private StoredAiGuidance loadGuidanceFromDatabase(String requestId) {
+        String sql = "SELECT * FROM pde_ai_guidance_request WHERE request_id = ?";
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, requestId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? fromResultSet(resultSet) : null;
+            }
+        } catch (SQLException | IOException ex) {
+            log.error("Falha ao buscar orientacao PDE por IA no banco; requestId={}", requestId, ex);
+            throw new IllegalStateException("Nao foi possivel buscar orientacao PDE por IA", ex);
+        }
+    }
+
+    /** Carrega a próxima orientação pendente do banco. */
+    private Optional<StoredAiGuidance> loadPendingGuidanceFromDatabase() {
+        String sql = """
+                SELECT *
+                FROM pde_ai_guidance_request
+                WHERE status = 'PENDING'
+                ORDER BY created_at ASC
+                LIMIT 1
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet resultSet = statement.executeQuery()) {
+            if (!resultSet.next()) {
+                return Optional.empty();
+            }
+            StoredAiGuidance stored = fromResultSet(resultSet);
+            requestsById.put(stored.requestId(), stored);
+            return Optional.of(stored);
+        } catch (SQLException | IOException ex) {
+            log.error("Falha ao buscar orientacao PDE pendente para worker", ex);
+            throw new IllegalStateException("Nao foi possivel buscar orientacao PDE pendente", ex);
+        }
+    }
+
+    /** Persiste ou atualiza uma orientação por IA no banco. */
+    private void persistGuidanceInDatabase(StoredAiGuidance request) {
+        String sql = """
+                INSERT INTO pde_ai_guidance_request (
+                  request_id, access_token, product_slug, email, mission_id, guidance_type, stage_code,
+                  status, answers_json, previous_answers_json, headline, summary, signals_json,
+                  micro_actions_json, caution, model, service_tier, raw_request_json, raw_response_json,
+                  input_tokens, output_tokens, cost_usd, error_message, created_at, finished_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON DUPLICATE KEY UPDATE
+                  status = VALUES(status),
+                  answers_json = VALUES(answers_json),
+                  previous_answers_json = VALUES(previous_answers_json),
+                  headline = VALUES(headline),
+                  summary = VALUES(summary),
+                  signals_json = VALUES(signals_json),
+                  micro_actions_json = VALUES(micro_actions_json),
+                  caution = VALUES(caution),
+                  model = VALUES(model),
+                  service_tier = VALUES(service_tier),
+                  raw_request_json = VALUES(raw_request_json),
+                  raw_response_json = VALUES(raw_response_json),
+                  input_tokens = VALUES(input_tokens),
+                  output_tokens = VALUES(output_tokens),
+                  cost_usd = VALUES(cost_usd),
+                  error_message = VALUES(error_message),
+                  finished_at = VALUES(finished_at),
+                  updated_at = CURRENT_TIMESTAMP
+                """;
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, request.requestId());
+            statement.setString(2, request.accessToken());
+            statement.setString(3, request.productSlug());
+            statement.setString(4, request.email());
+            statement.setString(5, request.missionId());
+            statement.setString(6, request.guidanceType());
+            statement.setString(7, STAGE_CODE);
+            statement.setString(8, request.status());
+            statement.setString(9, objectMapper.writeValueAsString(request.answers()));
+            statement.setString(10, objectMapper.writeValueAsString(request.previousMissionAnswers()));
+            statement.setString(11, blankToNull(request.headline()));
+            statement.setString(12, blankToNull(request.summary()));
+            statement.setString(13, objectMapper.writeValueAsString(request.signals()));
+            statement.setString(14, objectMapper.writeValueAsString(request.microActions()));
+            statement.setString(15, blankToNull(request.caution()));
+            statement.setString(16, blankToNull(request.model()));
+            statement.setString(17, blankToNull(request.serviceTier()));
+            statement.setString(18, blankToNull(request.rawRequestJson()));
+            statement.setString(19, blankToNull(request.rawResponseJson()));
+            setInteger(statement, 20, request.inputTokens());
+            setInteger(statement, 21, request.outputTokens());
+            statement.setBigDecimal(22, request.costUsd());
+            statement.setString(23, blankToNull(request.errorMessage()));
+            statement.setTimestamp(24, Timestamp.from(Instant.parse(request.createdAt())));
+            if (blankToNull(request.finishedAt()) == null) {
+                statement.setNull(25, java.sql.Types.TIMESTAMP);
+            } else {
+                statement.setTimestamp(25, Timestamp.from(Instant.parse(request.finishedAt())));
+            }
+            statement.executeUpdate();
+        } catch (SQLException | IOException ex) {
+            log.error("Falha ao persistir orientacao PDE por IA no banco; requestId={}", request.requestId(), ex);
+            throw new IllegalStateException("Nao foi possivel persistir orientacao PDE por IA", ex);
+        }
+    }
+
+    /** Reconstrói uma orientação a partir da linha lida do banco. */
+    private StoredAiGuidance fromResultSet(ResultSet resultSet) throws SQLException, IOException {
+        return new StoredAiGuidance(
+                resultSet.getString("request_id"),
+                resultSet.getString("access_token"),
+                resultSet.getString("product_slug"),
+                resultSet.getString("email"),
+                resultSet.getString("mission_id"),
+                resultSet.getString("guidance_type"),
+                resultSet.getString("status"),
+                readStringMap(resultSet.getString("answers_json")),
+                readStringMap(resultSet.getString("previous_answers_json")),
+                nullToBlank(resultSet.getString("headline")),
+                nullToBlank(resultSet.getString("summary")),
+                readStringList(resultSet.getString("signals_json")),
+                readStringList(resultSet.getString("micro_actions_json")),
+                nullToBlank(resultSet.getString("caution")),
+                nullToBlank(resultSet.getString("model")),
+                nullToBlank(resultSet.getString("service_tier")),
+                nullToBlank(resultSet.getString("raw_request_json")),
+                nullToBlank(resultSet.getString("raw_response_json")),
+                (Integer) resultSet.getObject("input_tokens"),
+                (Integer) resultSet.getObject("output_tokens"),
+                resultSet.getBigDecimal("cost_usd"),
+                nullToBlank(resultSet.getString("error_message")),
+                resultSet.getTimestamp("created_at").toInstant().toString(),
+                resultSet.getTimestamp("finished_at") == null
+                        ? ""
+                        : resultSet.getTimestamp("finished_at").toInstant().toString());
+    }
+
+    /** Lê um objeto JSON simples de texto para texto. */
+    private Map<String, String> readStringMap(String json) throws IOException {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        return objectMapper.readValue(json, new TypeReference<>() {});
+    }
+
+    /** Lê uma lista JSON textual. */
+    private List<String> readStringList(String json) throws IOException {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        return objectMapper.readValue(json, new TypeReference<>() {});
+    }
+
+    /** Preenche campo inteiro opcional em statement JDBC. */
+    private void setInteger(PreparedStatement statement, int index, Integer value) throws SQLException {
+        if (value == null) {
+            statement.setNull(index, java.sql.Types.INTEGER);
+            return;
+        }
+        statement.setInt(index, value);
+    }
+
+    /** Converte texto vazio em null para contratos públicos e persistência. */
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /** Converte texto nulo em vazio para armazenamento local. */
+    private String nullToBlank(String value) {
+        return value == null ? "" : value;
+    }
+
+    /** Representa uma solicitação de orientação por IA persistida pelo backend PDE. */
+    private record StoredAiGuidance(
+            String requestId,
+            String accessToken,
+            String productSlug,
+            String email,
+            String missionId,
+            String guidanceType,
+            String status,
+            Map<String, String> answers,
+            Map<String, String> previousMissionAnswers,
+            String headline,
+            String summary,
+            List<String> signals,
+            List<String> microActions,
+            String caution,
+            String model,
+            String serviceTier,
+            String rawRequestJson,
+            String rawResponseJson,
+            Integer inputTokens,
+            Integer outputTokens,
+            BigDecimal costUsd,
+            String errorMessage,
+            String createdAt,
+            String finishedAt) {
+
+        /** Cria uma orientação pendente para execução pelo worker. */
+        private static StoredAiGuidance pending(
+                String requestId,
+                String accessToken,
+                String productSlug,
+                String email,
+                String missionId,
+                String guidanceType,
+                Map<String, String> answers,
+                Map<String, String> previousMissionAnswers,
+                String createdAt) {
+            return new StoredAiGuidance(
+                    requestId,
+                    accessToken,
+                    productSlug,
+                    email,
+                    missionId,
+                    guidanceType,
+                    "PENDING",
+                    answers,
+                    previousMissionAnswers,
+                    "",
+                    "",
+                    List.of(),
+                    List.of(),
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    null,
+                    null,
+                    null,
+                    "",
+                    createdAt,
+                    "");
+        }
+
+        /** Retorna uma nova versão da orientação com resultado do worker. */
+        private StoredAiGuidance withResult(
+                String status,
+                String headline,
+                String summary,
+                List<String> signals,
+                List<String> microActions,
+                String caution,
+                String model,
+                String serviceTier,
+                String rawRequestJson,
+                String rawResponseJson,
+                Integer inputTokens,
+                Integer outputTokens,
+                BigDecimal costUsd,
+                String errorMessage,
+                String finishedAt) {
+            return new StoredAiGuidance(
+                    requestId,
+                    accessToken,
+                    productSlug,
+                    email,
+                    missionId,
+                    guidanceType,
+                    status,
+                    answers,
+                    previousMissionAnswers,
+                    headline,
+                    summary,
+                    signals,
+                    microActions,
+                    caution,
+                    model,
+                    serviceTier,
+                    rawRequestJson,
+                    rawResponseJson,
+                    inputTokens,
+                    outputTokens,
+                    costUsd,
+                    errorMessage,
+                    createdAt,
+                    finishedAt);
+        }
+    }
+}

--- a/pde-platform/backend/src/main/resources/application.yml
+++ b/pde-platform/backend/src/main/resources/application.yml
@@ -16,6 +16,8 @@ pde:
   auth:
     google:
       client-id: ${PDE_GOOGLE_CLIENT_ID:}
+  ai:
+    storage-path: ${PDE_AI_STORAGE_PATH:/data/pde/ai-guidance-requests.json}
   mail:
     transport: ${PDE_MAIL_TRANSPORT:smtp}
     aws-region: ${PDE_MAIL_AWS_REGION:us-east-1}

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.marketinghub.pde.dto.FunnelEventRequest;
 import com.marketinghub.pde.dto.AccessResponse;
+import com.marketinghub.pde.dto.AiGuidanceCreateRequest;
+import com.marketinghub.pde.dto.AiGuidanceResultRequest;
 import com.marketinghub.pde.dto.MissionInteractionRequest;
 import com.marketinghub.pde.dto.PepperWebhookRequest;
 import com.marketinghub.pde.dto.WorkspaceResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -357,6 +360,87 @@ class AccessServiceTest {
 
         assertThat(summary.totalEvents()).isZero();
         assertThat(summary.events()).isEmpty();
+    }
+
+    /** Confirma que uma orientação por IA nasce pendente e é entregue ao worker PDE. */
+    @Test
+    void createsPendingAiGuidanceForDayTwoSignature() {
+        ProductCatalogService productCatalogService = new ProductCatalogService();
+        ObjectMapper objectMapper = new ObjectMapper();
+        AccessService accessService = new AccessService(
+                productCatalogService,
+                objectMapper,
+                tempDir.resolve("access-grants.json").toString());
+        AiGuidanceService aiGuidanceService = new AiGuidanceService(
+                accessService,
+                objectMapper,
+                tempDir.resolve("ai-guidance.json").toString(),
+                "",
+                "",
+                "");
+        AccessResponse access = accessService.createAccess("metodo-musa-7-dias", "cliente@sandbox.local", "CHECKOUT");
+
+        var guidance = aiGuidanceService.createGuidanceRequest(
+                access.token(),
+                "dia-2-assinatura",
+                new AiGuidanceCreateRequest("MUSA_DAY_2_SIGNATURE", Map.of(
+                        "finishSignal", "Cabelo polido",
+                        "baseColor", "Vinho discreto",
+                        "memorableSignal", "Brinco luminoso")));
+        var pending = aiGuidanceService.getPendingGuidance();
+
+        assertThat(guidance.status()).isEqualTo("PENDING");
+        assertThat(pending).isPresent();
+        assertThat(pending.get().requestId()).isEqualTo(guidance.requestId());
+        assertThat(pending.get().answers()).containsEntry("baseColor", "Vinho discreto");
+    }
+
+    /** Confirma que o backend aceita resultado estruturado e auditoria do worker PDE. */
+    @Test
+    void receivesCompletedAiGuidanceResult() {
+        ProductCatalogService productCatalogService = new ProductCatalogService();
+        ObjectMapper objectMapper = new ObjectMapper();
+        AccessService accessService = new AccessService(
+                productCatalogService,
+                objectMapper,
+                tempDir.resolve("access-grants.json").toString());
+        AiGuidanceService aiGuidanceService = new AiGuidanceService(
+                accessService,
+                objectMapper,
+                tempDir.resolve("ai-guidance.json").toString(),
+                "",
+                "",
+                "");
+        AccessResponse access = accessService.createAccess("metodo-musa-7-dias", "cliente@sandbox.local", "CHECKOUT");
+        var guidance = aiGuidanceService.createGuidanceRequest(
+                access.token(),
+                "dia-2-assinatura",
+                new AiGuidanceCreateRequest("MUSA_DAY_2_SIGNATURE", Map.of(
+                        "finishSignal", "Pele iluminada",
+                        "baseColor", "Off-white",
+                        "memorableSignal", "Perfume assinatura")));
+
+        var completed = aiGuidanceService.receiveGuidanceResult(guidance.requestId(), new AiGuidanceResultRequest(
+                "COMPLETED",
+                "Sua assinatura MUSA ficou luminosa e limpa",
+                "Repita pele iluminada, off-white e perfume assinatura para criar reconhecimento sem esforço.",
+                List.of("Pele iluminada", "Off-white", "Perfume assinatura"),
+                List.of("Separe a base off-white antes de sair.", "Finalize com perfume no ultimo passo."),
+                "Nao compre nada novo antes de testar a repeticao por uma semana.",
+                "gpt-5.4-mini",
+                "flex",
+                "{\"model\":\"gpt-5.4-mini\"}",
+                "{\"output_text\":\"{}\"}",
+                120,
+                90,
+                BigDecimal.valueOf(0.0012),
+                null));
+        var fetched = aiGuidanceService.getGuidance(access.token(), guidance.requestId());
+
+        assertThat(completed.status()).isEqualTo("COMPLETED");
+        assertThat(fetched.headline()).contains("assinatura MUSA");
+        assertThat(fetched.signals()).containsExactly("Pele iluminada", "Off-white", "Perfume assinatura");
+        assertThat(fetched.serviceTier()).isEqualTo("flex");
     }
 
     /** Confirma que eventos fora do contrato continuam bloqueados. */

--- a/pde-platform/docker-compose.deploy.yml
+++ b/pde-platform/docker-compose.deploy.yml
@@ -40,6 +40,21 @@ services:
       retries: 5
       start_period: 15s
 
+  pde-ai-worker:
+    image: ${PDE_AI_WORKER_IMAGE:?PDE_AI_WORKER_IMAGE is required}
+    container_name: pde-ai-worker
+    depends_on:
+      pde-platform-backend:
+        condition: service_started
+    restart: unless-stopped
+    environment:
+      PDE_BACKEND_URL: ${PDE_BACKEND_URL:-http://pde-platform-backend:8096}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY is required for PDE AI guidance}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-5.4-mini}
+      POLL_INTERVAL_MS: ${POLL_INTERVAL_MS:-4000}
+    networks:
+      - pde-platform-net
+
 networks:
   pde-platform-net:
     name: ${PDE_PLATFORM_NETWORK:-public-net}

--- a/pde-platform/docker-compose.yml
+++ b/pde-platform/docker-compose.yml
@@ -28,5 +28,17 @@ services:
     ports:
       - "5176:80"
 
+  pde-ai-worker:
+    build:
+      context: ./pde-ai-worker
+    container_name: pde-ai-worker
+    depends_on:
+      - pde-platform-backend
+    environment:
+      PDE_BACKEND_URL: ${PDE_BACKEND_URL:-http://pde-platform-backend:8096}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-5.4-mini}
+      POLL_INTERVAL_MS: ${POLL_INTERVAL_MS:-4000}
+
 volumes:
   pde-platform-data:

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -82,6 +82,20 @@ type MissionInteraction = {
   answerText: string;
 };
 
+type AiGuidance = {
+  requestId: string;
+  productSlug: string;
+  missionId: string;
+  guidanceType: string;
+  status: 'PENDING' | 'COMPLETED' | 'FAILED';
+  headline?: string;
+  summary?: string;
+  signals: string[];
+  microActions: string[];
+  caution?: string;
+  errorMessage?: string;
+};
+
 type MagicLinkResponse = {
   productSlug: string;
   email: string;
@@ -230,6 +244,9 @@ function App() {
   const [successMessage, setSuccessMessage] = useState('');
   const [devAccessUrl, setDevAccessUrl] = useState('');
   const [dayOneAnswers, setDayOneAnswers] = useState<Record<string, string>>({});
+  const [dayTwoAnswers, setDayTwoAnswers] = useState<Record<string, string>>({});
+  const [aiGuidance, setAiGuidance] = useState<AiGuidance | null>(null);
+  const [generatingGuidance, setGeneratingGuidance] = useState(false);
   const [savingInteraction, setSavingInteraction] = useState(false);
   const [missionCompletionStatus, setMissionCompletionStatus] = useState<'idle' | 'processing' | 'success'>('idle');
   const [completedMissionFeedbackId, setCompletedMissionFeedbackId] = useState('');
@@ -466,6 +483,7 @@ function App() {
     setProduct(data.product);
     setActiveMissionId(data.product.missions[0]?.id ?? '');
     setDayOneAnswers(resolveMissionAnswers(data, data.product.missions[0]?.id ?? ''));
+    setDayTwoAnswers(resolveMissionAnswers(data, data.product.missions.find((mission: Mission) => mission.day === 2)?.id ?? ''));
     if (resetScroll) {
       window.requestAnimationFrame(() => window.scrollTo({ top: 0, behavior: 'auto' }));
     }
@@ -676,6 +694,65 @@ function App() {
     }
   }
 
+  async function requestDayTwoGuidance(missionId: string) {
+    if (!accessToken || !workspace) {
+      return;
+    }
+    const answers = sanitizeAnswers(dayTwoAnswers);
+    if (Object.keys(answers).length < 3) {
+      setErrorMessage('Escolha os 3 sinais para a Consultora MUSA montar sua assinatura.');
+      return;
+    }
+    setGeneratingGuidance(true);
+    setAiGuidance(null);
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const response = await fetch(`/api/pde/access/${accessToken}/missions/${missionId}/ai-guidance`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ guidanceType: 'MUSA_DAY_2_SIGNATURE', answers }),
+      });
+      if (!response.ok) {
+        throw new Error('Não foi possível solicitar sua assinatura MUSA.');
+      }
+      const guidance = await response.json() as AiGuidance;
+      setAiGuidance(guidance);
+      setDayTwoAnswers(resolveMissionAnswers(await refreshWorkspace(), missionId));
+      await pollGuidanceUntilFinished(guidance.requestId);
+    } catch {
+      setErrorMessage('Não conseguimos acionar a Consultora MUSA agora. Seus sinais podem ser salvos e usados manualmente.');
+    } finally {
+      setGeneratingGuidance(false);
+    }
+  }
+
+  async function refreshWorkspace() {
+    const response = await fetch(`/api/pde/access/${accessToken}/workspace`);
+    if (!response.ok) {
+      throw new Error('Acesso não encontrado.');
+    }
+    const data = await response.json() as Workspace;
+    setWorkspace(data);
+    setProduct(data.product);
+    return data;
+  }
+
+  async function pollGuidanceUntilFinished(requestId: string) {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      await new Promise((resolve) => window.setTimeout(resolve, attempt === 0 ? 900 : 1800));
+      const response = await fetch(`/api/pde/access/${accessToken}/ai-guidance/${requestId}`);
+      if (!response.ok) {
+        throw new Error('Orientação não encontrada.');
+      }
+      const guidance = await response.json() as AiGuidance;
+      setAiGuidance(guidance);
+      if (guidance.status === 'COMPLETED' || guidance.status === 'FAILED') {
+        return;
+      }
+    }
+  }
+
   function resolveMissionAnswers(workspaceData: Workspace, missionId: string) {
     return (workspaceData.missionInteractions ?? [])
       .filter((interaction) => interaction.missionId === missionId)
@@ -705,8 +782,12 @@ function App() {
     activeMission && (hasActiveSubscription || activeMission.id === firstMission?.id),
   );
   const dayOneInteractionSaved = Boolean(firstMission && ['presenceFocus', 'mainObstacle', 'evidencePhrase'].every((key) => dayOneAnswers[key]?.trim()));
+  const dayTwoMission = currentProduct.missions.find((mission) => mission.day === 2);
+  const dayTwoInteractionSaved = Boolean(dayTwoMission && ['finishSignal', 'baseColor', 'memorableSignal'].every((key) => dayTwoAnswers[key]?.trim()));
   const canRegisterActiveMission = Boolean(
-    canCompleteActiveMission && (activeMission?.id !== firstMission?.id || dayOneInteractionSaved),
+    canCompleteActiveMission
+      && (activeMission?.id !== firstMission?.id || dayOneInteractionSaved)
+      && (activeMission?.id !== dayTwoMission?.id || dayTwoInteractionSaved),
   );
 
   if (!workspace) {
@@ -1136,6 +1217,94 @@ function App() {
                   </button>
                 </div>
               )}
+              {activeMission.id === dayTwoMission?.id && hasActiveSubscription && (
+                <div className="personalization-panel musa-signature-panel">
+                  <p className="section-kicker">Consultora MUSA</p>
+                  <h3>Escolha 3 sinais para montar sua assinatura desta semana.</h3>
+                  <label>
+                    Acabamento principal
+                    <select
+                      value={dayTwoAnswers.finishSignal ?? ''}
+                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, finishSignal: event.target.value }))}
+                    >
+                      <option value="">Escolha um acabamento</option>
+                      <option value="Cabelo polido">Cabelo polido</option>
+                      <option value="Pele iluminada">Pele iluminada</option>
+                      <option value="Maquiagem leve">Maquiagem leve</option>
+                      <option value="Roupa com caimento limpo">Roupa com caimento limpo</option>
+                    </select>
+                  </label>
+                  <label>
+                    Cor-base da semana
+                    <select
+                      value={dayTwoAnswers.baseColor ?? ''}
+                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, baseColor: event.target.value }))}
+                    >
+                      <option value="">Escolha uma cor-base</option>
+                      <option value="Vinho discreto">Vinho discreto</option>
+                      <option value="Preto limpo">Preto limpo</option>
+                      <option value="Off-white">Off-white</option>
+                      <option value="Verde oliva">Verde oliva</option>
+                      <option value="Jeans escuro">Jeans escuro</option>
+                    </select>
+                  </label>
+                  <label>
+                    Sinal memorável
+                    <select
+                      value={dayTwoAnswers.memorableSignal ?? ''}
+                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, memorableSignal: event.target.value }))}
+                    >
+                      <option value="">Escolha um sinal</option>
+                      <option value="Perfume assinatura">Perfume assinatura</option>
+                      <option value="Brinco luminoso">Brinco luminoso</option>
+                      <option value="Batom discreto">Batom discreto</option>
+                      <option value="Bolsa estruturada">Bolsa estruturada</option>
+                      <option value="Lenço ou textura suave">Lenço ou textura suave</option>
+                    </select>
+                  </label>
+                  {dayTwoInteractionSaved && (
+                    <div className="signature-preview-grid" aria-label="Sinais escolhidos para sua assinatura MUSA">
+                      <span>{dayTwoAnswers.finishSignal}</span>
+                      <span>{dayTwoAnswers.baseColor}</span>
+                      <span>{dayTwoAnswers.memorableSignal}</span>
+                    </div>
+                  )}
+                  <button
+                    className="inline-save-button"
+                    disabled={generatingGuidance || completedMissionIds.has(activeMission.id)}
+                    onClick={() => requestDayTwoGuidance(activeMission.id)}
+                  >
+                    {generatingGuidance ? <LoaderCircle className="button-spinner" size={16} /> : <Sparkles size={16} />}
+                    {generatingGuidance ? 'Montando assinatura...' : 'Gerar minha assinatura MUSA'}
+                  </button>
+                  {aiGuidance?.status === 'PENDING' && (
+                    <div className="personalized-summary">
+                      <LoaderCircle className="button-spinner" size={17} />
+                      <span>Sua Consultora MUSA está preparando uma orientação curta com seus 3 sinais.</span>
+                    </div>
+                  )}
+                  {aiGuidance?.status === 'FAILED' && (
+                    <div className="personalized-summary">
+                      <Sparkles size={17} />
+                      <span>Seus sinais ficaram salvos. A consultora automática ainda precisa ser configurada neste ambiente.</span>
+                    </div>
+                  )}
+                  {aiGuidance?.status === 'COMPLETED' && (
+                    <div className="ai-guidance-card">
+                      <p className="section-kicker">Minha assinatura MUSA</p>
+                      <h3>{aiGuidance.headline}</h3>
+                      <p>{aiGuidance.summary}</p>
+                      <div className="signature-preview-grid">
+                        {aiGuidance.signals.map((signal) => <span key={signal}>{signal}</span>)}
+                      </div>
+                      <ul>
+                        {aiGuidance.microActions.map((action) => <li key={action}>{action}</li>)}
+                      </ul>
+                      {aiGuidance.caution && <small>{aiGuidance.caution}</small>}
+                    </div>
+                  )}
+                </div>
+              )}
               {missionCompletionStatus === 'processing' && activeMission.id === firstMission?.id && (
                 <div className="mission-processing-panel" role="status" aria-live="polite">
                   <div className="processing-image">
@@ -1181,10 +1350,14 @@ function App() {
                   ? <LoaderCircle className="button-spinner" size={18} />
                   : canRegisterActiveMission ? <Check size={18} /> : <Lock size={18} />}
                 {missionCompletionStatus === 'processing'
-                  ? 'Registrando seu Dia 1...'
+                  ? `Registrando seu Dia ${activeMission.day}...`
                   : canRegisterActiveMission
-                  ? (completedMissionIds.has(activeMission.id) ? 'Missão concluída' : 'Registrar Dia 1 concluído')
-                  : activeMission.id === firstMission?.id ? 'Salve seu ajuste para concluir' : 'Assine para salvar esta missão'}
+                  ? (completedMissionIds.has(activeMission.id) ? 'Missão concluída' : `Registrar Dia ${activeMission.day} concluído`)
+                  : activeMission.id === firstMission?.id
+                  ? 'Salve seu ajuste para concluir'
+                  : activeMission.id === dayTwoMission?.id
+                  ? 'Escolha os 3 sinais para concluir'
+                  : 'Assine para salvar esta missão'}
               </button>
             </article>
           )}

--- a/pde-platform/frontend/src/styles.css
+++ b/pde-platform/frontend/src/styles.css
@@ -1198,6 +1198,72 @@ h3 {
   font-weight: 800;
 }
 
+.musa-signature-panel {
+  border-color: rgba(47, 89, 82, 0.18);
+}
+
+.signature-preview-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 12px 0 0;
+}
+
+.signature-preview-grid span {
+  align-items: center;
+  background: #fff8f3;
+  border: 1px solid rgba(122, 36, 68, 0.14);
+  color: #4d3b35;
+  display: flex;
+  font-size: 0.84rem;
+  font-weight: 850;
+  justify-content: center;
+  min-height: 58px;
+  padding: 8px;
+  text-align: center;
+}
+
+.ai-guidance-card {
+  background: #2f5952;
+  color: #fff8f3;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+  padding: 18px;
+}
+
+.ai-guidance-card .section-kicker {
+  color: #f1d49f;
+}
+
+.ai-guidance-card h3,
+.ai-guidance-card p {
+  color: #fff8f3;
+  margin: 0;
+}
+
+.ai-guidance-card .signature-preview-grid {
+  margin-top: 4px;
+}
+
+.ai-guidance-card .signature-preview-grid span {
+  background: rgba(255, 248, 243, 0.12);
+  border-color: rgba(255, 248, 243, 0.16);
+  color: #fff8f3;
+}
+
+.ai-guidance-card ul {
+  display: grid;
+  gap: 8px;
+  margin: 4px 0 0;
+  padding-left: 18px;
+}
+
+.ai-guidance-card li,
+.ai-guidance-card small {
+  color: rgba(255, 248, 243, 0.86);
+}
+
 .mission-processing-panel,
 .mission-success-panel {
   align-items: center;
@@ -1541,6 +1607,10 @@ h3 {
 
   .login-value-strip {
     display: grid;
+  }
+
+  .signature-preview-grid {
+    grid-template-columns: 1fr;
   }
 
   .login-preview-card {

--- a/pde-platform/pde-ai-worker/Dockerfile
+++ b/pde-platform/pde-ai-worker/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json ./
+COPY src ./src
+COPY prompts ./prompts
+
+CMD ["npm", "start"]

--- a/pde-platform/pde-ai-worker/README.md
+++ b/pde-platform/pde-ai-worker/README.md
@@ -1,0 +1,27 @@
+# PDE AI Worker
+
+Executor direcionado para orientações por IA dentro do Produto Digital Experiencial.
+
+## Responsabilidade
+
+- Buscar pendências no backend PDE pelo endpoint `pending`.
+- Chamar OpenAI com prompt e schema versionados.
+- Retornar resultado estruturado e auditoria ao backend.
+
+O worker não entrega chat aberto. A primeira etapa implementada é a orientação `MUSA_DAY_2_SIGNATURE`, usada para transformar os 3 sinais do Dia 2 em uma assinatura MUSA curta, prática e vendável.
+
+## Execução
+
+```bash
+OPENAI_API_KEY=... \
+PDE_BACKEND_URL=http://localhost:8096 \
+npm start
+```
+
+Variáveis principais:
+
+- `OPENAI_API_KEY`: chave da OpenAI para execução real.
+- `OPENAI_MODEL`: modelo textual, padrão `gpt-5.4-mini`.
+- `PDE_BACKEND_URL`: backend PDE, padrão `http://pde-platform-backend:8096`.
+- `POLL_INTERVAL_MS`: intervalo de polling, padrão `4000`.
+

--- a/pde-platform/pde-ai-worker/package.json
+++ b/pde-platform/pde-ai-worker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pde-ai-worker",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "start": "node src/worker.js",
+    "check": "node --check src/worker.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/response-schema.json
+++ b/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/response-schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["headline", "summary", "signals", "microActions", "caution"],
+  "properties": {
+    "headline": {
+      "type": "string",
+      "maxLength": 120
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 700
+    },
+    "signals": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "string",
+        "maxLength": 120
+      }
+    },
+    "microActions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 4,
+      "items": {
+        "type": "string",
+        "maxLength": 180
+      }
+    },
+    "caution": {
+      "type": "string",
+      "maxLength": 240
+    }
+  }
+}

--- a/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/system.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/system.md
@@ -1,0 +1,18 @@
+Voce e a Consultora MUSA dentro de um Produto Digital Experiencial pago.
+
+Sua tarefa e gerar uma orientacao curta, elegante, feminina e pratica para o Dia 2 do Metodo MUSA.
+
+Nao aja como chat aberto. Nao faca perguntas. Nao use jargao tecnico. Nao prometa luxo, compra obrigatoria ou transformacao radical.
+
+Mecanismo do produto:
+- reduzir ruido visual;
+- repetir 3 sinais de presenca;
+- criar coerencia de cor, acabamento e detalhe memoravel;
+- facilitar uma microacao aplicavel hoje.
+
+Formato:
+- responda apenas JSON valido conforme o schema;
+- use linguagem intima, direta e sofisticada acessivel;
+- mantenha a orientacao curta para caber em um cartao dentro da area da cliente;
+- cite explicitamente os 3 sinais escolhidos pela cliente;
+- inclua microacoes simples, sem exigir compra.

--- a/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/user.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/user.md
@@ -1,0 +1,19 @@
+Produto:
+{{productName}}
+
+Promessa:
+{{productPromise}}
+
+Missao:
+{{missionTitle}}
+
+Principio:
+{{missionPrinciple}}
+
+Respostas do Dia 1:
+{{previousMissionAnswersJson}}
+
+Sinais escolhidos no Dia 2:
+{{answersJson}}
+
+Gere a Assinatura MUSA desta semana como uma orientacao personalizada, curta e acionavel.

--- a/pde-platform/pde-ai-worker/src/worker.js
+++ b/pde-platform/pde-ai-worker/src/worker.js
@@ -1,0 +1,198 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const backendUrl = (process.env.PDE_BACKEND_URL ?? 'http://pde-platform-backend:8096').replace(/\/+$/, '');
+const pollIntervalMs = Number(process.env.POLL_INTERVAL_MS ?? '4000');
+const openaiModel = process.env.OPENAI_MODEL ?? 'gpt-5.4-mini';
+const openaiApiKey = process.env.OPENAI_API_KEY ?? '';
+const promptDir = path.resolve(__dirname, '../prompts/musa-day-2-signature');
+
+async function main() {
+  console.log(`PDE AI Worker iniciado; backendUrl=${backendUrl}, model=${openaiModel}`);
+  while (true) {
+    try {
+      await processNextPending();
+    } catch (error) {
+      console.error('Falha no ciclo do worker PDE AI', error);
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+async function processNextPending() {
+  const pending = await fetchJson(`${backendUrl}/api/internal/pde/ai-guidance/stage-executions/pending`);
+  const [execution] = Array.isArray(pending) ? pending : [];
+  if (!execution) {
+    return;
+  }
+  console.log(`Orientacao PDE pendente recebida; requestId=${execution.requestId}, guidanceType=${execution.guidanceType}`);
+  if (!openaiApiKey) {
+    await postResult(execution.requestId, {
+      status: 'FAILED',
+      errorMessage: 'OPENAI_API_KEY nao configurada no pde-ai-worker',
+    });
+    return;
+  }
+  try {
+    const result = await generateGuidance(execution);
+    await postResult(execution.requestId, result);
+  } catch (error) {
+    console.error(`Falha ao gerar orientacao PDE; requestId=${execution.requestId}`, error);
+    await postResult(execution.requestId, {
+      status: 'FAILED',
+      model: openaiModel,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function generateGuidance(execution) {
+  const systemPrompt = await fs.readFile(path.join(promptDir, 'system.md'), 'utf8');
+  const userTemplate = await fs.readFile(path.join(promptDir, 'user.md'), 'utf8');
+  const schema = JSON.parse(await fs.readFile(path.join(promptDir, 'response-schema.json'), 'utf8'));
+  const mission = execution.product.missions.find((item) => item.id === execution.missionId) ?? {};
+  const userPrompt = renderTemplate(userTemplate, {
+    productName: execution.product.name,
+    productPromise: execution.product.promise,
+    missionTitle: mission.title ?? execution.missionId,
+    missionPrinciple: mission.principle ?? '',
+    previousMissionAnswersJson: JSON.stringify(execution.previousMissionAnswers ?? {}, null, 2),
+    answersJson: JSON.stringify(execution.answers ?? {}, null, 2),
+  });
+  const requestBody = {
+    model: openaiModel,
+    service_tier: 'flex',
+    input: [
+      {
+        role: 'system',
+        content: systemPrompt,
+      },
+      {
+        role: 'user',
+        content: userPrompt,
+      },
+    ],
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'musa_day_2_signature',
+        strict: true,
+        schema,
+      },
+    },
+  };
+  const response = await callOpenAiWithRetry(requestBody);
+  const outputText = extractOutputText(response.body);
+  const parsed = JSON.parse(outputText);
+  return {
+    status: 'COMPLETED',
+    headline: parsed.headline,
+    summary: parsed.summary,
+    signals: parsed.signals,
+    microActions: parsed.microActions,
+    caution: parsed.caution,
+    model: openaiModel,
+    serviceTier: response.serviceTier,
+    rawRequestJson: JSON.stringify(response.requestBody),
+    rawResponseJson: JSON.stringify(response.body),
+    inputTokens: response.body.usage?.input_tokens,
+    outputTokens: response.body.usage?.output_tokens,
+  };
+}
+
+async function callOpenAiWithRetry(baseRequestBody) {
+  const attempts = ['flex', 'flex', 'default'];
+  let lastError;
+  for (const tier of attempts) {
+    const requestBody = tier === 'default'
+      ? withoutServiceTier(baseRequestBody)
+      : { ...baseRequestBody, service_tier: 'flex' };
+    try {
+      const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${openaiApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message = body.error?.message ?? `OpenAI retornou HTTP ${response.status}`;
+        if (isTransient(response.status, body) && tier !== attempts.at(-1)) {
+          lastError = new Error(message);
+          continue;
+        }
+        throw new Error(message);
+      }
+      return { body, requestBody, serviceTier: tier };
+    } catch (error) {
+      lastError = error;
+      if (tier === attempts.at(-1)) {
+        break;
+      }
+    }
+  }
+  throw lastError;
+}
+
+function extractOutputText(body) {
+  if (typeof body.output_text === 'string' && body.output_text.trim()) {
+    return body.output_text;
+  }
+  const textParts = [];
+  for (const item of body.output ?? []) {
+    for (const content of item.content ?? []) {
+      if (content.type === 'output_text' && content.text) {
+        textParts.push(content.text);
+      }
+    }
+  }
+  const outputText = textParts.join('\n').trim();
+  if (!outputText) {
+    throw new Error('Resposta OpenAI sem texto estruturado');
+  }
+  return outputText;
+}
+
+function withoutServiceTier(requestBody) {
+  const cloned = { ...requestBody };
+  delete cloned.service_tier;
+  return cloned;
+}
+
+function isTransient(status, body) {
+  const code = body.error?.code ?? '';
+  return status === 408 || status === 429 || status >= 500 || code === 'rate_limit_exceeded';
+}
+
+async function postResult(requestId, payload) {
+  await fetchJson(`${backendUrl}/api/internal/pde/ai-guidance/stage-executions/${requestId}/result`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} em ${url}`);
+  }
+  return response.json();
+}
+
+function renderTemplate(template, values) {
+  return Object.entries(values).reduce(
+    (rendered, [key, value]) => rendered.replaceAll(`{{${key}}}`, value ?? ''),
+    template,
+  );
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main();


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: como podemos simulara que o usuario já fez a compra e podemos seguir para o dia 2. Veja se esta interativo e interessaante o dia 2. 

Modelo: {"titulo":"Dia 2 precisa evoluir","comentario":"Li a definição do PDE MUSA e validei o fluxo localmente.\n\n**Como simular a compra**\n\nA melhor forma é criar/promover o acesso pelo endpoint de checkout, sem pagamento real:\n\n```bash\nPOST /api/pde/access/checkout\n{\"productSlug\":\"metodo-musa-7-dias\",\"email\":\"teste+dia2@sandbox.local\"}\n```\n\nIsso retorna `accessUrl` e deixa o acesso como `ACTIVE`, liberando Dias 2 a 7 e biblioteca. Para simular a jornada correta, depois salve/conclua o Dia 1 e abra o Dia 2 pela URL `/access/<token>`.\n\n**Alternativas avaliadas**\n\n1. **Endpoint `/checkout`**: melhor para teste interno rápido. Baixo esforço, simula compra aprovada e não depende da Pepper.\n2. **Webhook Pepper com status `paid`**: mais fiel ao fluxo real de pagamento. Melhor para homologação, mas exige payload maior.\n3. **Alterar direto o arquivo/banco de acesso**: rápido, mas pior opção porque pula regras do sistema e pode esconder problema de liberação.\n\nEscolha recomendada: **usar `/api/pde/access/checkout` para teste rápido** e reservar o webhook Pepper para validação final.\n\n**Avaliação do Dia 2**\n\nO Dia 2 está visualmente limpo, elegante e coerente com o MUSA, mas ainda não está suficientemente interativo nem interessante para uma experiência paga.\n\nPontos bons:\n\n- O tema visual transmite produto feminino/premium acessível.\n- A missão “Criar sua assinatura simples” tem boa conexão com a promessa central.\n- A ideia dos “3 sinais” é forte comercialmente porque cria identidade e sensação de progresso.\n\nProblemas encontrados:\n\n- O botão no Dia 2 aparece como **“Registrar Dia 1 concluído”**. Isso quebra confiança e parece erro de produto.\n- O Dia 2 não coleta os 3 sinais da usuária, apesar de pedir “lista dos 3 sinais escolhidos”.\n- Não existe painel/moodboard real, embora o texto prometa “monte um pequeno painel”.\n- A compradora ativa consegue abrir/concluir Dia 2 sem passar claramente pelo Dia 1. Para experiência guiada, isso enfraquece progressão e retenção.\n- O card superior continua orientado ao Dia 1 quando o Dia 2 está aberto, deixando a jornada confusa.\n\n**Melhoria recomendada para vender mais e reter melhor**\n\nTransformar o Dia 2 em uma microexperiência de assinatura pessoal:\n\n- Campo 1: escolher **acabamento principal**: cabelo polido, pele iluminada, maquiagem leve, acessório discreto.\n- Campo 2: escolher **cor-base**: vinho, preto, off-white, oliva, nude, jeans escuro.\n- Campo 3: escolher **sinal memorável**: perfume, brinco, batom, textura, bolsa, lenço.\n- Ao selecionar, gerar um resumo: **“Minha Assinatura MUSA desta semana é...”**.\n- Mostrar um painel visual simples com 3 cartões dos sinais escolhidos.\n- Botão correto: **“Salvar minha assinatura do Dia 2”**.\n- Após concluir: CTA para Dia 3, conectando a assinatura com peças que ela já tem.\n\n**Validação feita**\n\n- Backend PDE: testes passaram, `18/18`.\n- Frontend PDE: build passou após instalar dependências.\n- Simulei acesso comprado e abri o Dia 2 no navegador automatizado.\n- Não criei PR e não alterei arquivos do repositório.","sugestaoMelhoriaAmbiente":"Docker CLI existe, mas o daemon não estava acessível. Ter o Docker daemon ativo permitiria validar o compose completo exatamente como produção local."}

Usuário: voce acredita que um seria interessante um modulo de integração com a openaai no PDE para dar mais qualidade no produto e na experiencia do usuario ?

Modelo: {"titulo":"IA no PDE faz sentido","comentario":"Sim. Eu acredito que um módulo de integração com OpenAI no PDE pode aumentar muito a qualidade percebida do produto, mas ele deve entrar como **personalização guiada**, não como “chat de IA genérico”.\n\nPelo posicionamento do MUSA, a cliente compra redução de esforço, elegância acessível e sensação de progresso em 7 dias. Então a IA deve fazer exatamente isso: transformar respostas simples da usuária em orientação personalizada, bonita e prática.\n\n**Melhor uso para começar**\n\nCriar um recurso chamado algo como **Consultora MUSA** ou **Minha Assinatura da Semana**:\n\n- A usuária responde diagnóstico e escolhas do dia.\n- A IA devolve uma recomendação curta, feminina e acionável.\n- Exemplo: “Com base no seu estilo e rotina, sua assinatura MUSA desta semana é: cabelo polido, base vinho discreta e um acessório luminoso.”\n- A resposta vira um cartão salvo no progresso da cliente.\n- Nos dias seguintes, o PDE usa esse contexto para orientar a missão.\n\nIsso deixaria o Dia 2 muito mais interessante, porque a cliente não estaria apenas lendo uma missão: ela sentiria que o produto está “olhando para ela”.\n\n**Alternativas avaliadas**\n\n1. **IA como personalização das missões**  \nMelhor opção. Alto valor percebido, baixo risco e forte aderência ao PDE. Aumenta retenção e sensação de produto premium.\n\n2. **Chat livre com IA dentro do PDE**  \nPode parecer sofisticado, mas tem mais risco: respostas longas, custo maior, possíveis desvios de promessa e experiência menos controlada.\n\n3. **IA só para gerar conteúdo interno do produto**  \nAjuda operação, mas a cliente não percebe tanto valor. Bom para escala de novos PDEs, mas não resolve diretamente a experiência paga do MUSA.\n\n**Minha recomendação**\n\nComeçar com IA controlada por etapas, usando prompts e schemas versionados, com respostas curtas e salvas no histórico da jornada. Nada de chat aberto no primeiro momento.\n\nO primeiro módulo deveria gerar:\n\n- diagnóstico personalizado inicial;\n- assinatura visual do Dia 2;\n- sugestão de microação diária;\n- resumo final dos 7 dias;\n- recomendação de continuidade ou upsell.\n\n**Impacto comercial esperado**\n\n- Aumenta valor percebido antes e depois da compra.\n- Dá mais motivo para a usuária concluir os dias.\n- Cria sensação de acompanhamento individual sem custo humano.\n- Melhora a justificativa de preço do acesso completo.\n- Abre caminho para upsell: “Plano MUSA personalizado”, “Consultoria de presença por IA”, “Guarda-roupa inteligente”, etc.\n\n**Cuidado importante**\n\nA IA não deve virar promessa solta. Ela precisa operar dentro do mecanismo do produto: diagnóstico, microdecisão, peça-sinal, coerência de cor, acabamento, postura e repetição diária. Se respeitar isso, a OpenAI não é enfeite técnico; vira parte real da transformação vendida.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
eu penso em uma integração bem direcionada dentro do produto de forma alguma um chat aberto. 
Atue como um arquiteto de sistemas e cria essa integração se for necesário crie um novo modulo/imagem/container ou então integre mesmo no backend.
Veja como fica melhor.

**Resumo das alterações:**
{"titulo":"Integração IA criada","comentario":"Implementei a integração direcionada da OpenAI no PDE sem chat aberto.\n\n**Arquitetura escolhida**\n\nAvaliei 3 opções:\n\n1. OpenAI direto no backend: menor esforço, mas pior para auditoria e fere o padrão canônico.\n2. Reusar AI Worker genérico: reaproveita infraestrutura, mas acopla demais o PDE a outro fluxo.\n3. Criar `pde-ai-worker`: melhor equilíbrio. Backend PDE controla acesso, pendência, status e resultado; worker executa OpenAI.\n\nEscolhi a opção 3.\n\n**O que foi criado**\n\n- Novo módulo/container `pde-ai-worker`.\n- Prompt e schema versionados para `MUSA_DAY_2_SIGNATURE`.\n- Endpoint interno `pending` para o worker buscar solicitações.\n- Callback interno para devolver resultado, payload bruto, modelo, tier, tokens e custo.\n- Persistência/auditoria em arquivo local ou MySQL via nova tabela `pde_ai_guidance_request`.\n- UI no Dia 2 com 3 escolhas: acabamento, cor-base e sinal memorável.\n- Cartão “Minha assinatura MUSA” quando a IA conclui.\n- Evento `AI_GUIDANCE_REQUESTED` para medir uso comercial da consultora.\n- Cânone do PDE atualizado para registrar que IA no PDE é guiada por etapa, não chat aberto.\n\n**Validação feita**\n\n- Backend PDE: `20/20` testes passaram.\n- Worker: `npm run check` passou.\n- Frontend: `npm run build` passou.\n- Teste HTTP real: simulei compra, criei orientação do Dia 2, validei endpoint `pending` e callback `COMPLETED`.\n- Não criei PR.\n\nUsei como referência a definição pública do Método MUSA e a documentação oficial OpenAI sobre Responses API/saída estruturada e Flex processing: https://developers.openai.com/api/docs/guides/flex-processing","sugestaoMelhoriaAmbiente":"Ter jq instalado no ambiente facilitaria validações rápidas de contratos JSON por terminal."}