### PR TITLE
AI Hub: {"titulo":"Action corrigida","comentario":"**Causa-raiz:** o deploy da PDE Platform Metodo MUSA falhou porque o `docker compose` exigia `OPENAI_API_KEY`, mas o workflow não exportava essa variável no servidor. Também havia risco de nova falha porq…

### DIFF
--- a/.github/workflows/pde-platform-metodo-musa-ci.yml
+++ b/.github/workflows/pde-platform-metodo-musa-ci.yml
@@ -17,6 +17,7 @@ env:
   IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
   BACKEND_IMAGE_NAME: pde-platform-backend
   FRONTEND_IMAGE_NAME: pde-platform-frontend
+  AI_WORKER_IMAGE_NAME: pde-ai-worker
 
 jobs:
   backend:
@@ -91,6 +92,10 @@ jobs:
             echo "${IMAGE_NAMESPACE}/${FRONTEND_IMAGE_NAME}:latest"
             echo "${IMAGE_NAMESPACE}/${FRONTEND_IMAGE_NAME}:${GITHUB_SHA}"
             echo "EOF"
+            echo "ai_worker_tags<<EOF"
+            echo "${IMAGE_NAMESPACE}/${AI_WORKER_IMAGE_NAME}:latest"
+            echo "${IMAGE_NAMESPACE}/${AI_WORKER_IMAGE_NAME}:${GITHUB_SHA}"
+            echo "EOF"
             echo "labels<<EOF"
             echo "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
             echo "org.opencontainers.image.revision=${GITHUB_SHA}"
@@ -116,6 +121,16 @@ jobs:
           labels: ${{ steps.image_metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}:buildcache,mode=max
+      - name: Build and push PDE AI worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: pde-platform/pde-ai-worker
+          file: pde-platform/pde-ai-worker/Dockerfile
+          push: true
+          tags: ${{ steps.image_metadata.outputs.ai_worker_tags }}
+          labels: ${{ steps.image_metadata.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.AI_WORKER_IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/${{ env.AI_WORKER_IMAGE_NAME }}:buildcache,mode=max
       - name: Expose image tag
         id: image_tag
         run: echo "value=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
@@ -145,6 +160,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.PDE_MAIL_AWS_ACCESS_KEY_ID != '' && secrets.PDE_MAIL_AWS_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PDE_MAIL_AWS_SECRET_ACCESS_KEY != '' && secrets.PDE_MAIL_AWS_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_SESSION_TOKEN: ${{ secrets.PDE_MAIL_AWS_SESSION_TOKEN != '' && secrets.PDE_MAIL_AWS_SESSION_TOKEN || secrets.AWS_SESSION_TOKEN }}
+      OPENAI_API_KEY: ${{ secrets.PDE_OPENAI_API_KEY != '' && secrets.PDE_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - name: Configure SSH
@@ -176,6 +192,7 @@ jobs:
             && (docker network inspect ${PDE_PLATFORM_NETWORK} >/dev/null 2>&1 || docker network create ${PDE_PLATFORM_NETWORK}) \
             && export PDE_PLATFORM_BACKEND_IMAGE='${IMAGE_NAMESPACE}/${BACKEND_IMAGE_NAME}:${IMAGE_TAG}' \
             && export PDE_PLATFORM_FRONTEND_IMAGE='${IMAGE_NAMESPACE}/${FRONTEND_IMAGE_NAME}:${IMAGE_TAG}' \
+            && export PDE_AI_WORKER_IMAGE='${IMAGE_NAMESPACE}/${AI_WORKER_IMAGE_NAME}:${IMAGE_TAG}' \
             && export PDE_PLATFORM_NETWORK='${PDE_PLATFORM_NETWORK}' \
             && export PDE_PLATFORM_FRONTEND_PORT='${PDE_PLATFORM_FRONTEND_PORT}' \
             && export PDE_PLATFORM_BACKEND_PORT='${PDE_PLATFORM_BACKEND_PORT}' \
@@ -183,6 +200,7 @@ jobs:
             && export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}' \
             && export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}' \
             && export AWS_SESSION_TOKEN='${AWS_SESSION_TOKEN}' \
+            && export OPENAI_API_KEY='${OPENAI_API_KEY}' \
             && export COMPOSE_PROJECT_NAME=metodo-musa-pde-platform \
             && docker compose -f docker-compose.deploy.yml pull \
             && docker compose -f docker-compose.deploy.yml up -d --remove-orphans \


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Última mensagem do usuário:
deu erro do github action verifica e conserta

**Resumo das alterações:**
{"titulo":"Action corrigida","comentario":"**Causa-raiz:** o deploy da PDE Platform Metodo MUSA falhou porque o `docker compose` exigia `OPENAI_API_KEY`, mas o workflow não exportava essa variável no servidor. Também havia risco de nova falha porque o compose exigia `PDE_AI_WORKER_IMAGE`, mas o workflow só publicava backend e frontend.\n\n**Correção aplicada na worktree:**\n- Workflow agora publica também a imagem `pde-ai-worker`.\n- Deploy agora exporta `PDE_AI_WORKER_IMAGE`.\n- Deploy agora repassa `OPENAI_API_KEY`, usando `PDE_OPENAI_API_KEY` e, como fallback, `OPENAI_API_KEY`.\n\n**Validação feita:**\n- `docker compose config` passou com todas as variáveis obrigatórias simuladas.\n- `npm --prefix pde-platform/pde-ai-worker run check` passou.\n- `git diff --check` passou.\n\n**Limitação:** não consegui rodar `docker build` local porque o daemon Docker não está ativo no ambiente.","sugestaoMelhoriaAmbiente":"Ter `gh` e `actionlint` instalados no ambiente permitiria revalidar a Action e a sintaxe do workflow de forma mais completa antes do push.","orientacaoProximaAcao":"Para a correção chegar ao GitHub Actions, é preciso publicar esta alteração na branch. Também confirme que existe um secret `PDE_OPENAI_API_KEY` ou `OPENAI_API_KEY` configurado no repositório."}