### PR TITLE
AI Hub: {"titulo":"MUSA com IA nos 7 dias","comentario":"Implementei a Consultora MUSA para apoiar a cliente nos 7 dias do PDE.\n\n**O que mudou**\n- A IA deixou de ficar limitada ao Dia 2.\n- Cada missão agora coleta 3 respostas práticas da cliente e aci…

### DIFF
--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -79,7 +79,7 @@ Regras obrigatórias:
 - o frontend deve exibir a orientação como cartão de produto, não como conversa livre;
 - toda solicitação deve ser mensurável no funil e associada ao token, produto e missão.
 
-Para o Método MUSA, o primeiro contrato de IA é a Consultora MUSA do Dia 2: a cliente escolhe três sinais de presença e recebe uma assinatura pessoal curta para repetir durante a semana.
+Para o Método MUSA, a Consultora MUSA deve atuar nos 7 dias como orientação guiada por missão: a cliente preenche três sinais ou respostas práticas do dia e recebe um cartão curto, aplicável e coerente com o histórico da jornada. O Dia 1 pode ser usado como amostra gratuita de valor; os Dias 2 a 7 permanecem como parte do acesso completo quando o funil estiver em modo de paywall interno.
 
 ### Frontend PDE
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5891,3 +5891,10 @@
 - foi feito: a tela inicial passou a orientar a usuária com mensagens específicas para e-mail inexistente, primeiro acesso criado, retorno por link e bloqueio premium.
 - foi feito: a prévia visual de entrada deixou de usar capa cortada como fundo e passou a mostrar uma composição controlada de presença, paleta e Dia 1.
 - impacto comercial esperado: reduzir confusão no primeiro contato, manter o funil canônico de entrada gratuita com paywall interno e melhorar a intenção de continuidade para assinatura.
+
+## 2026-07-18 — PED/MUSA: Consultora MUSA nos 7 dias
+
+- foi feito: a integração do PDE com IA deixou de ficar limitada ao Dia 2 e passou a aceitar contratos de orientação para os 7 dias do Método MUSA.
+- foi feito: a tela da Área MUSA passou a coletar 3 respostas práticas por missão e acionar a Consultora MUSA para gerar um cartão curto, personalizado e acionável.
+- foi feito: o worker PDE AI passou a selecionar prompt/schema por tipo de orientação, preservando OpenAI fora do frontend e mantendo auditoria no backend.
+- impacto comercial esperado: aumentar valor percebido do acesso completo, transformar a IA em apoio diário da cliente e criar mais evidências de progresso para reduzir abandono antes e depois da compra.

--- a/pde-platform/README.md
+++ b/pde-platform/README.md
@@ -46,8 +46,9 @@ OPENAI_API_KEY=... PDE_BACKEND_URL=http://localhost:8096 npm start
 
 O backend PDE cria solicitações de orientação por IA e o `pde-ai-worker`
 executa a OpenAI por endpoint `pending`, usando prompt/schema versionados.
-O primeiro contrato ativo é a Consultora MUSA do Dia 2, que gera uma
-assinatura pessoal curta a partir dos 3 sinais escolhidos pela cliente.
+A Consultora MUSA atua nos 7 dias como orientação guiada por missão: a cliente
+preenche 3 sinais ou respostas práticas e recebe um cartão curto, acionável e
+coerente com o histórico da jornada.
 
 ## Produto inicial
 

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AiGuidanceService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AiGuidanceService.java
@@ -39,7 +39,14 @@ public class AiGuidanceService {
     private static final Logger log = LoggerFactory.getLogger(AiGuidanceService.class);
     private static final TypeReference<Map<String, StoredAiGuidance>> STORE_TYPE = new TypeReference<>() {};
     private static final String STAGE_CODE = "pde-ai-guidance-v1";
-    private static final Set<String> ALLOWED_GUIDANCE_TYPES = Set.of("MUSA_DAY_2_SIGNATURE");
+    private static final Set<String> ALLOWED_GUIDANCE_TYPES = Set.of(
+            "MUSA_DAY_1_PRESENCE_DIAGNOSIS",
+            "MUSA_DAY_2_SIGNATURE",
+            "MUSA_DAY_3_WARDROBE_REUSE",
+            "MUSA_DAY_4_FINISHING_RITUAL",
+            "MUSA_DAY_5_ANTI_IMPULSE_DECISION",
+            "MUSA_DAY_6_OCCASION_ENTRY",
+            "MUSA_DAY_7_MAINTENANCE_PLAN");
 
     private final AccessService accessService;
     private final ObjectMapper objectMapper;

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
@@ -395,6 +395,48 @@ class AccessServiceTest {
         assertThat(pending.get().answers()).containsEntry("baseColor", "Vinho discreto");
     }
 
+    /** Confirma que todos os 7 dias possuem contrato de orientação por IA no backend. */
+    @Test
+    void acceptsAiGuidanceForAllSevenMusaDays() {
+        ProductCatalogService productCatalogService = new ProductCatalogService();
+        ObjectMapper objectMapper = new ObjectMapper();
+        AccessService accessService = new AccessService(
+                productCatalogService,
+                objectMapper,
+                tempDir.resolve("access-grants.json").toString());
+        AiGuidanceService aiGuidanceService = new AiGuidanceService(
+                accessService,
+                objectMapper,
+                tempDir.resolve("ai-guidance.json").toString(),
+                "",
+                "",
+                "");
+        AccessResponse access = accessService.createAccess("metodo-musa-7-dias", "cliente@sandbox.local", "CHECKOUT");
+
+        Map<String, String> guidanceTypesByMission = Map.of(
+                "dia-1-ruido-visual", "MUSA_DAY_1_PRESENCE_DIAGNOSIS",
+                "dia-2-assinatura", "MUSA_DAY_2_SIGNATURE",
+                "dia-3-base-acessivel", "MUSA_DAY_3_WARDROBE_REUSE",
+                "dia-4-checklist-12-minutos", "MUSA_DAY_4_FINISHING_RITUAL",
+                "dia-5-compra-inteligente", "MUSA_DAY_5_ANTI_IMPULSE_DECISION",
+                "dia-6-situacao-chave", "MUSA_DAY_6_OCCASION_ENTRY",
+                "dia-7-plano-pessoal", "MUSA_DAY_7_MAINTENANCE_PLAN");
+
+        guidanceTypesByMission.forEach((missionId, guidanceType) -> {
+            var guidance = aiGuidanceService.createGuidanceRequest(
+                    access.token(),
+                    missionId,
+                    new AiGuidanceCreateRequest(guidanceType, Map.of(
+                            "answerOne", "Resposta um",
+                            "answerTwo", "Resposta dois",
+                            "answerThree", "Resposta tres")));
+
+            assertThat(guidance.status()).isEqualTo("PENDING");
+            assertThat(guidance.missionId()).isEqualTo(missionId);
+            assertThat(guidance.guidanceType()).isEqualTo(guidanceType);
+        });
+    }
+
     /** Confirma que o backend aceita resultado estruturado e auditoria do worker PDE. */
     @Test
     void receivesCompletedAiGuidanceResult() {

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -115,6 +115,25 @@ type TrackingOptions = {
   metadata?: Record<string, unknown>;
 };
 
+type MissionGuidanceField = {
+  key: string;
+  label: string;
+  placeholder: string;
+  options?: string[];
+};
+
+type MissionGuidanceConfig = {
+  guidanceType: string;
+  kicker: string;
+  title: string;
+  buttonLabel: string;
+  loadingLabel: string;
+  pendingLabel: string;
+  failedLabel: string;
+  completedKicker: string;
+  fields: MissionGuidanceField[];
+};
+
 declare global {
   interface Window {
     google?: {
@@ -192,6 +211,143 @@ const fallbackProduct: ProductExperience = {
   completionOffer: 'Ao concluir os 7 dias, você pode continuar no Clube MUSA com novos desafios mensais.',
 };
 
+const missionGuidanceConfigs: Record<string, MissionGuidanceConfig> = {
+  'dia-1-ruido-visual': {
+    guidanceType: 'MUSA_DAY_1_PRESENCE_DIAGNOSIS',
+    kicker: 'Consultora MUSA',
+    title: 'Conte sua situação real para receber o primeiro ajuste de presença.',
+    buttonLabel: 'Receber meu ajuste do Dia 1',
+    loadingLabel: 'Preparando ajuste...',
+    pendingLabel: 'Sua Consultora MUSA está preparando uma orientação curta para o seu primeiro ajuste.',
+    failedLabel: 'Suas respostas ficaram salvas. Use a missão do Dia 1 manualmente enquanto a consultora automática é configurada.',
+    completedKicker: 'Meu ajuste MUSA',
+    fields: [
+      {
+        key: 'presenceFocus',
+        label: 'Onde você mais quer sentir presença hoje?',
+        placeholder: 'Escolha um foco',
+        options: ['Trabalho ou reunião', 'Encontro ou saída', 'Rotina comum', 'Conteúdo ou foto'],
+      },
+      {
+        key: 'mainObstacle',
+        label: 'Qual detalhe mais apaga o conjunto?',
+        placeholder: 'Escolha um detalhe',
+        options: ['Cabelo sem acabamento', 'Roupa sem intenção', 'Cores brigando entre si', 'Falta de acessório ou perfume'],
+      },
+      {
+        key: 'evidencePhrase',
+        label: 'Complete sua frase de evidência',
+        placeholder: 'Eu me sinto arrumada, mas pouco marcante quando...',
+      },
+    ],
+  },
+  'dia-2-assinatura': {
+    guidanceType: 'MUSA_DAY_2_SIGNATURE',
+    kicker: 'Consultora MUSA',
+    title: 'Escolha 3 sinais para montar sua assinatura desta semana.',
+    buttonLabel: 'Gerar minha assinatura MUSA',
+    loadingLabel: 'Montando assinatura...',
+    pendingLabel: 'Sua Consultora MUSA está preparando uma orientação curta com seus 3 sinais.',
+    failedLabel: 'Seus sinais ficaram salvos. A consultora automática ainda precisa ser configurada neste ambiente.',
+    completedKicker: 'Minha assinatura MUSA',
+    fields: [
+      {
+        key: 'finishSignal',
+        label: 'Acabamento principal',
+        placeholder: 'Escolha um acabamento',
+        options: ['Cabelo polido', 'Pele iluminada', 'Maquiagem leve', 'Roupa com caimento limpo'],
+      },
+      {
+        key: 'baseColor',
+        label: 'Cor-base da semana',
+        placeholder: 'Escolha uma cor-base',
+        options: ['Vinho discreto', 'Preto limpo', 'Off-white', 'Verde oliva', 'Jeans escuro'],
+      },
+      {
+        key: 'memorableSignal',
+        label: 'Sinal memorável',
+        placeholder: 'Escolha um sinal',
+        options: ['Perfume assinatura', 'Brinco luminoso', 'Batom discreto', 'Bolsa estruturada', 'Lenço ou textura suave'],
+      },
+    ],
+  },
+  'dia-3-base-acessivel': {
+    guidanceType: 'MUSA_DAY_3_WARDROBE_REUSE',
+    kicker: 'Consultora MUSA',
+    title: 'Mostre o que você já tem para a IA montar uma base elegante acessível.',
+    buttonLabel: 'Montar minha base acessível',
+    loadingLabel: 'Organizando base...',
+    pendingLabel: 'Sua Consultora MUSA está conectando seus itens aos sinais escolhidos.',
+    failedLabel: 'Seu inventário ficou salvo. Use os itens escolhidos como base da missão de hoje.',
+    completedKicker: 'Minha base acessível',
+    fields: [
+      { key: 'pieces', label: '5 peças que você já tem', placeholder: 'Ex.: calça preta, camisa branca, vestido vinho...' },
+      { key: 'accessories', label: '2 acessórios ou acabamentos disponíveis', placeholder: 'Ex.: brinco dourado e perfume suave' },
+      { key: 'realOccasion', label: 'Para qual situação real essa base precisa funcionar?', placeholder: 'Ex.: reunião, jantar, rotina de trabalho' },
+    ],
+  },
+  'dia-4-checklist-12-minutos': {
+    guidanceType: 'MUSA_DAY_4_FINISHING_RITUAL',
+    kicker: 'Consultora MUSA',
+    title: 'Transforme seu checklist em um acabamento de 12 minutos.',
+    buttonLabel: 'Criar meu ritual de 12 minutos',
+    loadingLabel: 'Ajustando ritual...',
+    pendingLabel: 'Sua Consultora MUSA está priorizando o que dá mais presença em menos tempo.',
+    failedLabel: 'Seu checklist ficou salvo. Execute a ordem mais simples hoje.',
+    completedKicker: 'Meu ritual de acabamento',
+    fields: [
+      { key: 'availableMinutes', label: 'Quanto tempo real você tem antes de sair?', placeholder: 'Ex.: 8, 12 ou 15 minutos' },
+      { key: 'weakestFinish', label: 'Qual acabamento costuma falhar primeiro?', placeholder: 'Ex.: cabelo, pele, roupa, perfume, postura' },
+      { key: 'desiredFeeling', label: 'Como você quer se sentir ao sair?', placeholder: 'Ex.: limpa, marcante, segura, feminina' },
+    ],
+  },
+  'dia-5-compra-inteligente': {
+    guidanceType: 'MUSA_DAY_5_ANTI_IMPULSE_DECISION',
+    kicker: 'Consultora MUSA',
+    title: 'Antes de comprar, deixe a IA testar se o item fortalece sua assinatura.',
+    buttonLabel: 'Avaliar minha compra',
+    loadingLabel: 'Avaliando compra...',
+    pendingLabel: 'Sua Consultora MUSA está separando desejo imediato de utilidade real.',
+    failedLabel: 'Sua decisão ficou salva. Compare a compra com seus 3 sinais antes de avançar.',
+    completedKicker: 'Minha decisão anti-impulso',
+    fields: [
+      { key: 'desiredItem', label: 'O que você está pensando em comprar?', placeholder: 'Ex.: blazer, perfume, bolsa, sapato' },
+      { key: 'buyingReason', label: 'Qual sensação você espera resolver com essa compra?', placeholder: 'Ex.: parecer mais arrumada, menos comum, mais adulta' },
+      { key: 'fitWithSignature', label: 'Como esse item conversa com sua assinatura MUSA?', placeholder: 'Ex.: combina com minha cor-base e acabamento' },
+    ],
+  },
+  'dia-6-situacao-chave': {
+    guidanceType: 'MUSA_DAY_6_OCCASION_ENTRY',
+    kicker: 'Consultora MUSA',
+    title: 'Planeje uma entrada marcante para uma situação real.',
+    buttonLabel: 'Preparar minha entrada',
+    loadingLabel: 'Preparando entrada...',
+    pendingLabel: 'Sua Consultora MUSA está alinhando roupa, acabamento e detalhe final.',
+    failedLabel: 'Seu plano ficou salvo. Use a missão para ajustar a composição antes da ocasião.',
+    completedKicker: 'Minha entrada MUSA',
+    fields: [
+      { key: 'occasion', label: 'Qual é a ocasião?', placeholder: 'Ex.: reunião, evento, encontro, gravação, almoço' },
+      { key: 'plannedLook', label: 'Qual composição você pretende usar?', placeholder: 'Roupa, cabelo, pele, perfume e detalhe final' },
+      { key: 'presenceRisk', label: 'O que pode enfraquecer sua presença nesse contexto?', placeholder: 'Ex.: pressa, insegurança, roupa sem caimento' },
+    ],
+  },
+  'dia-7-plano-pessoal': {
+    guidanceType: 'MUSA_DAY_7_MAINTENANCE_PLAN',
+    kicker: 'Consultora MUSA',
+    title: 'Feche a semana com um plano simples para manter sua presença.',
+    buttonLabel: 'Gerar meu plano pessoal',
+    loadingLabel: 'Fechando plano...',
+    pendingLabel: 'Sua Consultora MUSA está transformando a semana em um ritual fácil de repetir.',
+    failedLabel: 'Seu plano ficou salvo. Releia os sinais e escolha um ritual semanal de 15 minutos.',
+    completedKicker: 'Meu plano MUSA',
+    fields: [
+      { key: 'bestSignal', label: 'Qual sinal mais funcionou nesta semana?', placeholder: 'Ex.: cabelo polido, cor-base vinho, perfume' },
+      { key: 'hardestPoint', label: 'Qual ponto ainda exige esforço?', placeholder: 'Ex.: manter cabelo, combinar cores, evitar compras' },
+      { key: 'weeklyRitual', label: 'Que ritual semanal você consegue repetir?', placeholder: 'Ex.: separar 3 combinações no domingo por 15 minutos' },
+    ],
+  },
+};
+
 function stableBrowserId(storageKey: string) {
   const existingId = window.localStorage.getItem(storageKey);
   if (existingId) {
@@ -243,9 +399,8 @@ function App() {
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [devAccessUrl, setDevAccessUrl] = useState('');
-  const [dayOneAnswers, setDayOneAnswers] = useState<Record<string, string>>({});
-  const [dayTwoAnswers, setDayTwoAnswers] = useState<Record<string, string>>({});
-  const [aiGuidance, setAiGuidance] = useState<AiGuidance | null>(null);
+  const [missionAnswers, setMissionAnswers] = useState<Record<string, Record<string, string>>>({});
+  const [aiGuidanceByMission, setAiGuidanceByMission] = useState<Record<string, AiGuidance>>({});
   const [generatingGuidance, setGeneratingGuidance] = useState(false);
   const [savingInteraction, setSavingInteraction] = useState(false);
   const [missionCompletionStatus, setMissionCompletionStatus] = useState<'idle' | 'processing' | 'success'>('idle');
@@ -482,8 +637,7 @@ function App() {
     setWorkspace(data);
     setProduct(data.product);
     setActiveMissionId(data.product.missions[0]?.id ?? '');
-    setDayOneAnswers(resolveMissionAnswers(data, data.product.missions[0]?.id ?? ''));
-    setDayTwoAnswers(resolveMissionAnswers(data, data.product.missions.find((mission: Mission) => mission.day === 2)?.id ?? ''));
+    setMissionAnswers(resolveAllMissionAnswers(data));
     if (resetScroll) {
       window.requestAnimationFrame(() => window.scrollTo({ top: 0, behavior: 'auto' }));
     }
@@ -661,9 +815,9 @@ function App() {
     if (!accessToken || !workspace) {
       return;
     }
-    const answers = sanitizeAnswers(dayOneAnswers);
+    const answers = sanitizeAnswers(missionAnswers[missionId] ?? {});
     if (Object.keys(answers).length < 3) {
-      setErrorMessage('Preencha os 3 pontos do Dia 1 para salvar sua personalização.');
+      setErrorMessage('Preencha os 3 pontos da missão para salvar sua personalização.');
       return;
     }
     setSavingInteraction(true);
@@ -679,49 +833,58 @@ function App() {
       }
       const data = await response.json();
       setWorkspace(data);
-      setDayOneAnswers(resolveMissionAnswers(data, missionId));
+      setMissionAnswers(resolveAllMissionAnswers(data));
       trackEvent('MISSION_INTERACTION_SAVED', {
         accessToken,
         email: data.email,
         provider: data.accessSource,
         metadata: { missionId, answerKeys: Object.keys(answers) },
       });
-      setSuccessMessage('Personalização do Dia 1 salva. Agora registre a conclusão quando executar o ajuste.');
+      setSuccessMessage('Personalização salva. Agora registre a conclusão quando executar o ajuste.');
     } catch {
-      setErrorMessage('Não conseguimos salvar sua personalização agora. Tente novamente antes de concluir o Dia 1.');
+      setErrorMessage('Não conseguimos salvar sua personalização agora. Tente novamente antes de concluir a missão.');
     } finally {
       setSavingInteraction(false);
     }
   }
 
-  async function requestDayTwoGuidance(missionId: string) {
+  async function requestMissionGuidance(missionId: string) {
     if (!accessToken || !workspace) {
       return;
     }
-    const answers = sanitizeAnswers(dayTwoAnswers);
+    const config = missionGuidanceConfigs[missionId];
+    if (!config) {
+      await saveMissionInteraction(missionId);
+      return;
+    }
+    const answers = sanitizeAnswers(missionAnswers[missionId] ?? {});
     if (Object.keys(answers).length < 3) {
-      setErrorMessage('Escolha os 3 sinais para a Consultora MUSA montar sua assinatura.');
+      setErrorMessage('Preencha os 3 pontos para a Consultora MUSA montar sua orientação.');
       return;
     }
     setGeneratingGuidance(true);
-    setAiGuidance(null);
+    setAiGuidanceByMission((current) => {
+      const updated = { ...current };
+      delete updated[missionId];
+      return updated;
+    });
     setErrorMessage('');
     setSuccessMessage('');
     try {
       const response = await fetch(`/api/pde/access/${accessToken}/missions/${missionId}/ai-guidance`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ guidanceType: 'MUSA_DAY_2_SIGNATURE', answers }),
+        body: JSON.stringify({ guidanceType: config.guidanceType, answers }),
       });
       if (!response.ok) {
-        throw new Error('Não foi possível solicitar sua assinatura MUSA.');
+        throw new Error('Não foi possível solicitar sua orientação MUSA.');
       }
       const guidance = await response.json() as AiGuidance;
-      setAiGuidance(guidance);
-      setDayTwoAnswers(resolveMissionAnswers(await refreshWorkspace(), missionId));
+      setAiGuidanceByMission((current) => ({ ...current, [missionId]: guidance }));
+      setMissionAnswers(resolveAllMissionAnswers(await refreshWorkspace()));
       await pollGuidanceUntilFinished(guidance.requestId);
     } catch {
-      setErrorMessage('Não conseguimos acionar a Consultora MUSA agora. Seus sinais podem ser salvos e usados manualmente.');
+      setErrorMessage('Não conseguimos acionar a Consultora MUSA agora. Suas respostas podem ser salvas e usadas manualmente.');
     } finally {
       setGeneratingGuidance(false);
     }
@@ -746,20 +909,19 @@ function App() {
         throw new Error('Orientação não encontrada.');
       }
       const guidance = await response.json() as AiGuidance;
-      setAiGuidance(guidance);
+      setAiGuidanceByMission((current) => ({ ...current, [guidance.missionId]: guidance }));
       if (guidance.status === 'COMPLETED' || guidance.status === 'FAILED') {
         return;
       }
     }
   }
 
-  function resolveMissionAnswers(workspaceData: Workspace, missionId: string) {
-    return (workspaceData.missionInteractions ?? [])
-      .filter((interaction) => interaction.missionId === missionId)
-      .reduce<Record<string, string>>((answers, interaction) => {
-        answers[interaction.questionKey] = interaction.answerText;
-        return answers;
-      }, {});
+  function resolveAllMissionAnswers(workspaceData: Workspace) {
+    return (workspaceData.missionInteractions ?? []).reduce<Record<string, Record<string, string>>>((answers, interaction) => {
+      answers[interaction.missionId] = answers[interaction.missionId] ?? {};
+      answers[interaction.missionId][interaction.questionKey] = interaction.answerText;
+      return answers;
+    }, {});
   }
 
   function sanitizeAnswers(answers: Record<string, string>) {
@@ -781,14 +943,32 @@ function App() {
   const canCompleteActiveMission = Boolean(
     activeMission && (hasActiveSubscription || activeMission.id === firstMission?.id),
   );
-  const dayOneInteractionSaved = Boolean(firstMission && ['presenceFocus', 'mainObstacle', 'evidencePhrase'].every((key) => dayOneAnswers[key]?.trim()));
-  const dayTwoMission = currentProduct.missions.find((mission) => mission.day === 2);
-  const dayTwoInteractionSaved = Boolean(dayTwoMission && ['finishSignal', 'baseColor', 'memorableSignal'].every((key) => dayTwoAnswers[key]?.trim()));
+  const activeMissionGuidanceConfig = activeMission ? missionGuidanceConfigs[activeMission.id] : undefined;
+  const activeMissionAnswers = activeMission ? missionAnswers[activeMission.id] ?? {} : {};
+  const activeMissionGuidance = activeMission ? aiGuidanceByMission[activeMission.id] : undefined;
   const canRegisterActiveMission = Boolean(
     canCompleteActiveMission
-      && (activeMission?.id !== firstMission?.id || dayOneInteractionSaved)
-      && (activeMission?.id !== dayTwoMission?.id || dayTwoInteractionSaved),
+      && (!activeMissionGuidanceConfig || isMissionInteractionSaved(activeMission?.id ?? '')),
   );
+
+  function isMissionInteractionSaved(missionId: string) {
+    const config = missionGuidanceConfigs[missionId];
+    if (!config) {
+      return true;
+    }
+    const answers = missionAnswers[missionId] ?? {};
+    return config.fields.every((field) => answers[field.key]?.trim());
+  }
+
+  function updateMissionAnswer(missionId: string, key: string, value: string) {
+    setMissionAnswers((current) => ({
+      ...current,
+      [missionId]: {
+        ...(current[missionId] ?? {}),
+        [key]: value,
+      },
+    }));
+  }
 
   if (!workspace) {
     return (
@@ -1159,148 +1339,71 @@ function App() {
                 <ChevronRight size={18} />
                 {activeMission.visualCue}
               </div>
-              {activeMission.id === firstMission?.id && (
-                <div className="personalization-panel">
-                  <p className="section-kicker">Seu ajuste personalizado</p>
-                  <h3>Antes de concluir, deixe o Dia 1 com a sua situação real.</h3>
-                  <label>
-                    Onde você mais quer sentir presença hoje?
-                    <select
-                      value={dayOneAnswers.presenceFocus ?? ''}
-                      onChange={(event) => setDayOneAnswers((current) => ({ ...current, presenceFocus: event.target.value }))}
-                    >
-                      <option value="">Escolha um foco</option>
-                      <option value="Trabalho ou reunião">Trabalho ou reunião</option>
-                      <option value="Encontro ou saída">Encontro ou saída</option>
-                      <option value="Rotina comum">Rotina comum</option>
-                      <option value="Conteúdo ou foto">Conteúdo ou foto</option>
-                    </select>
-                  </label>
-                  <label>
-                    Qual detalhe mais apaga o conjunto?
-                    <select
-                      value={dayOneAnswers.mainObstacle ?? ''}
-                      onChange={(event) => setDayOneAnswers((current) => ({ ...current, mainObstacle: event.target.value }))}
-                    >
-                      <option value="">Escolha um detalhe</option>
-                      <option value="Cabelo sem acabamento">Cabelo sem acabamento</option>
-                      <option value="Roupa sem intenção">Roupa sem intenção</option>
-                      <option value="Cores brigando entre si">Cores brigando entre si</option>
-                      <option value="Falta de acessório ou perfume">Falta de acessório ou perfume</option>
-                    </select>
-                  </label>
-                  <label>
-                    Complete sua frase de evidência
-                    <textarea
-                      rows={3}
-                      maxLength={280}
-                      value={dayOneAnswers.evidencePhrase ?? ''}
-                      placeholder="Eu me sinto arrumada, mas pouco marcante quando..."
-                      onChange={(event) => setDayOneAnswers((current) => ({ ...current, evidencePhrase: event.target.value }))}
-                    />
-                  </label>
-                  {dayOneInteractionSaved && (
-                    <div className="personalized-summary">
-                      <Sparkles size={17} />
-                      <span>
-                        Hoje seu ajuste é para {dayOneAnswers.presenceFocus}, reduzindo {dayOneAnswers.mainObstacle.toLowerCase()}.
-                      </span>
-                    </div>
-                  )}
-                  <button
-                    className="inline-save-button"
-                    disabled={savingInteraction || completedMissionIds.has(activeMission.id)}
-                    onClick={() => saveMissionInteraction(activeMission.id)}
-                  >
-                    <Pencil size={16} />
-                    {savingInteraction ? 'Salvando...' : dayOneInteractionSaved ? 'Atualizar personalização' : 'Salvar meu ajuste'}
-                  </button>
-                </div>
-              )}
-              {activeMission.id === dayTwoMission?.id && hasActiveSubscription && (
+              {activeMissionGuidanceConfig && (hasActiveSubscription || activeMission.id === firstMission?.id) && (
                 <div className="personalization-panel musa-signature-panel">
-                  <p className="section-kicker">Consultora MUSA</p>
-                  <h3>Escolha 3 sinais para montar sua assinatura desta semana.</h3>
-                  <label>
-                    Acabamento principal
-                    <select
-                      value={dayTwoAnswers.finishSignal ?? ''}
-                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, finishSignal: event.target.value }))}
-                    >
-                      <option value="">Escolha um acabamento</option>
-                      <option value="Cabelo polido">Cabelo polido</option>
-                      <option value="Pele iluminada">Pele iluminada</option>
-                      <option value="Maquiagem leve">Maquiagem leve</option>
-                      <option value="Roupa com caimento limpo">Roupa com caimento limpo</option>
-                    </select>
-                  </label>
-                  <label>
-                    Cor-base da semana
-                    <select
-                      value={dayTwoAnswers.baseColor ?? ''}
-                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, baseColor: event.target.value }))}
-                    >
-                      <option value="">Escolha uma cor-base</option>
-                      <option value="Vinho discreto">Vinho discreto</option>
-                      <option value="Preto limpo">Preto limpo</option>
-                      <option value="Off-white">Off-white</option>
-                      <option value="Verde oliva">Verde oliva</option>
-                      <option value="Jeans escuro">Jeans escuro</option>
-                    </select>
-                  </label>
-                  <label>
-                    Sinal memorável
-                    <select
-                      value={dayTwoAnswers.memorableSignal ?? ''}
-                      onChange={(event) => setDayTwoAnswers((current) => ({ ...current, memorableSignal: event.target.value }))}
-                    >
-                      <option value="">Escolha um sinal</option>
-                      <option value="Perfume assinatura">Perfume assinatura</option>
-                      <option value="Brinco luminoso">Brinco luminoso</option>
-                      <option value="Batom discreto">Batom discreto</option>
-                      <option value="Bolsa estruturada">Bolsa estruturada</option>
-                      <option value="Lenço ou textura suave">Lenço ou textura suave</option>
-                    </select>
-                  </label>
-                  {dayTwoInteractionSaved && (
+                  <p className="section-kicker">{activeMissionGuidanceConfig.kicker}</p>
+                  <h3>{activeMissionGuidanceConfig.title}</h3>
+                  {activeMissionGuidanceConfig.fields.map((field) => (
+                    <label key={field.key}>
+                      {field.label}
+                      {field.options ? (
+                        <select
+                          value={activeMissionAnswers[field.key] ?? ''}
+                          onChange={(event) => updateMissionAnswer(activeMission.id, field.key, event.target.value)}
+                        >
+                          <option value="">{field.placeholder}</option>
+                          {field.options.map((option) => <option key={option} value={option}>{option}</option>)}
+                        </select>
+                      ) : (
+                        <textarea
+                          rows={3}
+                          maxLength={360}
+                          value={activeMissionAnswers[field.key] ?? ''}
+                          placeholder={field.placeholder}
+                          onChange={(event) => updateMissionAnswer(activeMission.id, field.key, event.target.value)}
+                        />
+                      )}
+                    </label>
+                  ))}
+                  {isMissionInteractionSaved(activeMission.id) && (
                     <div className="signature-preview-grid" aria-label="Sinais escolhidos para sua assinatura MUSA">
-                      <span>{dayTwoAnswers.finishSignal}</span>
-                      <span>{dayTwoAnswers.baseColor}</span>
-                      <span>{dayTwoAnswers.memorableSignal}</span>
+                      {activeMissionGuidanceConfig.fields.map((field) => (
+                        <span key={field.key}>{activeMissionAnswers[field.key]}</span>
+                      ))}
                     </div>
                   )}
                   <button
                     className="inline-save-button"
-                    disabled={generatingGuidance || completedMissionIds.has(activeMission.id)}
-                    onClick={() => requestDayTwoGuidance(activeMission.id)}
+                    disabled={generatingGuidance || savingInteraction || completedMissionIds.has(activeMission.id)}
+                    onClick={() => requestMissionGuidance(activeMission.id)}
                   >
                     {generatingGuidance ? <LoaderCircle className="button-spinner" size={16} /> : <Sparkles size={16} />}
-                    {generatingGuidance ? 'Montando assinatura...' : 'Gerar minha assinatura MUSA'}
+                    {generatingGuidance ? activeMissionGuidanceConfig.loadingLabel : activeMissionGuidanceConfig.buttonLabel}
                   </button>
-                  {aiGuidance?.status === 'PENDING' && (
+                  {activeMissionGuidance?.status === 'PENDING' && (
                     <div className="personalized-summary">
                       <LoaderCircle className="button-spinner" size={17} />
-                      <span>Sua Consultora MUSA está preparando uma orientação curta com seus 3 sinais.</span>
+                      <span>{activeMissionGuidanceConfig.pendingLabel}</span>
                     </div>
                   )}
-                  {aiGuidance?.status === 'FAILED' && (
+                  {activeMissionGuidance?.status === 'FAILED' && (
                     <div className="personalized-summary">
                       <Sparkles size={17} />
-                      <span>Seus sinais ficaram salvos. A consultora automática ainda precisa ser configurada neste ambiente.</span>
+                      <span>{activeMissionGuidanceConfig.failedLabel}</span>
                     </div>
                   )}
-                  {aiGuidance?.status === 'COMPLETED' && (
+                  {activeMissionGuidance?.status === 'COMPLETED' && (
                     <div className="ai-guidance-card">
-                      <p className="section-kicker">Minha assinatura MUSA</p>
-                      <h3>{aiGuidance.headline}</h3>
-                      <p>{aiGuidance.summary}</p>
+                      <p className="section-kicker">{activeMissionGuidanceConfig.completedKicker}</p>
+                      <h3>{activeMissionGuidance.headline}</h3>
+                      <p>{activeMissionGuidance.summary}</p>
                       <div className="signature-preview-grid">
-                        {aiGuidance.signals.map((signal) => <span key={signal}>{signal}</span>)}
+                        {activeMissionGuidance.signals.map((signal) => <span key={signal}>{signal}</span>)}
                       </div>
                       <ul>
-                        {aiGuidance.microActions.map((action) => <li key={action}>{action}</li>)}
+                        {activeMissionGuidance.microActions.map((action) => <li key={action}>{action}</li>)}
                       </ul>
-                      {aiGuidance.caution && <small>{aiGuidance.caution}</small>}
+                      {activeMissionGuidance.caution && <small>{activeMissionGuidance.caution}</small>}
                     </div>
                   )}
                 </div>
@@ -1355,8 +1458,8 @@ function App() {
                   ? (completedMissionIds.has(activeMission.id) ? 'Missão concluída' : `Registrar Dia ${activeMission.day} concluído`)
                   : activeMission.id === firstMission?.id
                   ? 'Salve seu ajuste para concluir'
-                  : activeMission.id === dayTwoMission?.id
-                  ? 'Escolha os 3 sinais para concluir'
+                  : activeMissionGuidanceConfig
+                  ? 'Preencha os 3 pontos para concluir'
                   : 'Assine para salvar esta missão'}
               </button>
             </article>

--- a/pde-platform/pde-ai-worker/README.md
+++ b/pde-platform/pde-ai-worker/README.md
@@ -8,7 +8,9 @@ Executor direcionado para orientações por IA dentro do Produto Digital Experie
 - Chamar OpenAI com prompt e schema versionados.
 - Retornar resultado estruturado e auditoria ao backend.
 
-O worker não entrega chat aberto. A primeira etapa implementada é a orientação `MUSA_DAY_2_SIGNATURE`, usada para transformar os 3 sinais do Dia 2 em uma assinatura MUSA curta, prática e vendável.
+O worker não entrega chat aberto. A Consultora MUSA usa contratos fechados por
+missão para transformar as respostas da cliente em um cartão curto, prático e
+vendável nos 7 dias do método.
 
 ## Execução
 
@@ -24,4 +26,3 @@ Variáveis principais:
 - `OPENAI_MODEL`: modelo textual, padrão `gpt-5.4-mini`.
 - `PDE_BACKEND_URL`: backend PDE, padrão `http://pde-platform-backend:8096`.
 - `POLL_INTERVAL_MS`: intervalo de polling, padrão `4000`.
-

--- a/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/response-schema.json
+++ b/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/response-schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["headline", "summary", "signals", "microActions", "caution"],
+  "properties": {
+    "headline": {
+      "type": "string",
+      "maxLength": 120
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 700
+    },
+    "signals": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "string",
+        "maxLength": 120
+      }
+    },
+    "microActions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 4,
+      "items": {
+        "type": "string",
+        "maxLength": 180
+      }
+    },
+    "caution": {
+      "type": "string",
+      "maxLength": 240
+    }
+  }
+}

--- a/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/system.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/system.md
@@ -1,0 +1,20 @@
+Voce e a Consultora MUSA dentro de um Produto Digital Experiencial pago.
+
+Sua tarefa e gerar uma orientacao curta, elegante, feminina e pratica para a missao diaria do Metodo MUSA.
+
+Nao aja como chat aberto. Nao faca perguntas. Nao use jargao tecnico. Nao prometa luxo, compra obrigatoria ou transformacao radical.
+
+Mecanismo do produto:
+- reduzir ruido visual;
+- transformar escolhas de imagem em microdecisoes simples;
+- criar coerencia de cor, acabamento, postura e detalhe memoravel;
+- evitar compra impulsiva quando ela nao resolve a dor real;
+- facilitar uma microacao aplicavel hoje.
+
+Formato:
+- responda apenas JSON valido conforme o schema;
+- use linguagem intima, direta e sofisticada acessivel;
+- mantenha a orientacao curta para caber em um cartao dentro da area da cliente;
+- use as respostas da cliente como fonte principal;
+- conecte a orientacao ao dia atual e ao historico ja preenchido;
+- inclua microacoes simples, sem exigir compra.

--- a/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/user.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/user.md
@@ -1,0 +1,31 @@
+Produto:
+{{productName}}
+
+Promessa:
+{{productPromise}}
+
+Tipo de orientacao:
+{{guidanceType}}
+
+Dia:
+{{missionDay}}
+
+Missao:
+{{missionTitle}}
+
+Principio:
+{{missionPrinciple}}
+
+Acao prevista:
+{{missionAction}}
+
+Evidencia esperada:
+{{missionEvidence}}
+
+Respostas anteriores da cliente:
+{{previousMissionAnswersJson}}
+
+Respostas da missao atual:
+{{answersJson}}
+
+Gere uma orientacao personalizada para a cliente executar esta missao hoje.

--- a/pde-platform/pde-ai-worker/src/worker.js
+++ b/pde-platform/pde-ai-worker/src/worker.js
@@ -7,7 +7,36 @@ const backendUrl = (process.env.PDE_BACKEND_URL ?? 'http://pde-platform-backend:
 const pollIntervalMs = Number(process.env.POLL_INTERVAL_MS ?? '4000');
 const openaiModel = process.env.OPENAI_MODEL ?? 'gpt-5.4-mini';
 const openaiApiKey = process.env.OPENAI_API_KEY ?? '';
-const promptDir = path.resolve(__dirname, '../prompts/musa-day-2-signature');
+const promptDefinitions = {
+  MUSA_DAY_1_PRESENCE_DIAGNOSIS: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_1_presence_diagnosis',
+  },
+  MUSA_DAY_2_SIGNATURE: {
+    dir: path.resolve(__dirname, '../prompts/musa-day-2-signature'),
+    schemaName: 'musa_day_2_signature',
+  },
+  MUSA_DAY_3_WARDROBE_REUSE: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_3_wardrobe_reuse',
+  },
+  MUSA_DAY_4_FINISHING_RITUAL: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_4_finishing_ritual',
+  },
+  MUSA_DAY_5_ANTI_IMPULSE_DECISION: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_5_anti_impulse_decision',
+  },
+  MUSA_DAY_6_OCCASION_ENTRY: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_6_occasion_entry',
+  },
+  MUSA_DAY_7_MAINTENANCE_PLAN: {
+    dir: path.resolve(__dirname, '../prompts/musa-daily-guidance'),
+    schemaName: 'musa_day_7_maintenance_plan',
+  },
+};
 
 async function main() {
   console.log(`PDE AI Worker iniciado; backendUrl=${backendUrl}, model=${openaiModel}`);
@@ -49,15 +78,23 @@ async function processNextPending() {
 }
 
 async function generateGuidance(execution) {
-  const systemPrompt = await fs.readFile(path.join(promptDir, 'system.md'), 'utf8');
-  const userTemplate = await fs.readFile(path.join(promptDir, 'user.md'), 'utf8');
-  const schema = JSON.parse(await fs.readFile(path.join(promptDir, 'response-schema.json'), 'utf8'));
+  const promptDefinition = promptDefinitions[execution.guidanceType];
+  if (!promptDefinition) {
+    throw new Error(`Tipo de orientacao PDE nao suportado pelo worker: ${execution.guidanceType}`);
+  }
+  const systemPrompt = await fs.readFile(path.join(promptDefinition.dir, 'system.md'), 'utf8');
+  const userTemplate = await fs.readFile(path.join(promptDefinition.dir, 'user.md'), 'utf8');
+  const schema = JSON.parse(await fs.readFile(path.join(promptDefinition.dir, 'response-schema.json'), 'utf8'));
   const mission = execution.product.missions.find((item) => item.id === execution.missionId) ?? {};
   const userPrompt = renderTemplate(userTemplate, {
     productName: execution.product.name,
     productPromise: execution.product.promise,
+    guidanceType: execution.guidanceType,
+    missionDay: String(mission.day ?? ''),
     missionTitle: mission.title ?? execution.missionId,
     missionPrinciple: mission.principle ?? '',
+    missionAction: mission.action ?? '',
+    missionEvidence: mission.evidence ?? '',
     previousMissionAnswersJson: JSON.stringify(execution.previousMissionAnswers ?? {}, null, 2),
     answersJson: JSON.stringify(execution.answers ?? {}, null, 2),
   });
@@ -77,7 +114,7 @@ async function generateGuidance(execution) {
     text: {
       format: {
         type: 'json_schema',
-        name: 'musa_day_2_signature',
+        name: promptDefinition.schemaName,
         strict: true,
         schema,
       },


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Última mensagem do usuário:
No PDE do MUSA, verifique a integração do modulo de ia com a aplicaçaõ e vamos fazer os 7 dias com interação e participação da IA para dar apoio a cliente.

**Resumo das alterações:**
{"titulo":"MUSA com IA nos 7 dias","comentario":"Implementei a Consultora MUSA para apoiar a cliente nos 7 dias do PDE.\n\n**O que mudou**\n- A IA deixou de ficar limitada ao Dia 2.\n- Cada missão agora coleta 3 respostas práticas da cliente e aciona uma orientação personalizada.\n- O Dia 1 continua como amostra gratuita de valor; Dias 2 a 7 seguem protegidos pelo acesso completo.\n- O backend aceita contratos de IA para os 7 dias.\n- O worker escolhe prompt/schema conforme o tipo de orientação e mantém auditoria no backend.\n- Atualizei o cânone, README e registro comercial do experimento.\n\n**Validação**\n- Backend PDE: `21` testes passaram.\n- Worker IA: checagem de sintaxe passou.\n- Frontend PDE: build passou.\n- Fronteira de API PDE: passou.\n- Teste local confirmou criação de pendência IA e callback controlado quando não há chave OpenAI.\n- MCP confirmou que as tabelas PDE existem em produção, mas ainda estão sem uso registrado: acessos, interações, eventos e orientações com `0` linhas.\n\n**Impacto comercial**\nA experiência agora vende mais valor: a cliente não recebe só conteúdo estático, ela recebe apoio diário da IA para aplicar o método com menos esforço. Isso reforça o mecanismo do PDE, aumenta desejo de continuar após o paywall e cria uma entrega mais defensável como produto digital de alto valor.\n\nAmbiente local ativo:\n- Frontend: `http://localhost:5176/`\n- Backend: `http://localhost:8096`","sugestaoMelhoriaAmbiente":"Uma chave OpenAI de sandbox específica para validação permitiria testar a geração real dos cartões da Consultora MUSA sem usar credenciais de produção."}