### PR TITLE
AI Hub: {"titulo":"Evidence Pack MUSA implementado","comentario":"Implementei o recurso no Marketing Hub e já deixei o MUSA usando a base científica operacional.\n\n**O que foi feito**\n\n- Criei o campo `scientificEvidencePack` no cadastro comercial de p…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
@@ -121,6 +121,13 @@ public class Product {
     @Lob
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String socialProof;
+
+    /** Pacote científico operacional versionado usado por workers na criação e entrega do produto. */
+    @Lob
+    @Column(name = "scientific_evidence_pack", columnDefinition = "LONGTEXT")
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String scientificEvidencePack;
+
     @Lob
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String checkoutMonetization;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
@@ -31,6 +31,7 @@ public class CreateProductRequest {
     private String tripwire;
     private String riskReversal;
     private String socialProof;
+    private String scientificEvidencePack;
     private String checkoutMonetization;
     private String funnel;
     private String creativeVolume;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
@@ -33,6 +33,7 @@ public class ProductDto {
     private String tripwire;
     private String riskReversal;
     private String socialProof;
+    private String scientificEvidencePack;
     private String checkoutMonetization;
     private String funnel;
     private String creativeVolume;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -79,6 +79,7 @@ public class ProductService {
         product.setTripwire(request.getTripwire());
         product.setRiskReversal(request.getRiskReversal());
         product.setSocialProof(request.getSocialProof());
+        product.setScientificEvidencePack(request.getScientificEvidencePack());
         product.setCheckoutMonetization(request.getCheckoutMonetization());
         product.setFunnel(request.getFunnel());
         product.setCreativeVolume(request.getCreativeVolume());
@@ -145,6 +146,7 @@ public class ProductService {
                 line("Oferta", product.getTripwire()),
                 line("Reversão de risco", product.getRiskReversal()),
                 line("Prova", product.getSocialProof()),
+                optionalLine("Base científica operacional", product.getScientificEvidencePack()),
                 line("Checkout e monetização", product.getCheckoutMonetization()));
         appendSection(markdown, "7. Funil de aquisição e venda",
                 paragraph(product.getFunnel()));
@@ -184,6 +186,9 @@ public class ProductService {
     private void appendSection(StringBuilder markdown, String title, String... entries) {
         markdown.append("## ").append(title).append("\n\n");
         for (String entry : entries) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
             markdown.append(entry);
             if (!entry.endsWith("\n")) {
                 markdown.append("\n");
@@ -195,6 +200,14 @@ public class ProductService {
     /** Formata uma linha de definição de negócio. */
     private String line(String label, String value) {
         return "- **" + label + ":** " + valueOrFallback(value) + "\n";
+    }
+
+    /** Formata uma linha somente quando o campo comercial foi cadastrado. */
+    private String optionalLine(String label, String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return "- **" + label + ":** " + value.trim() + "\n";
     }
 
     /** Formata um parágrafo livre preservando um fallback quando não houver dado cadastrado. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-19-product-scientific-evidence-pack.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-19-product-scientific-evidence-pack.yaml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-19-product-scientific-evidence-pack.yaml
+  - changeSet:
+      id: 2026-07-19-product-scientific-evidence-pack-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - not:
+            columnExists:
+              tableName: product
+              columnName: scientific_evidence_pack
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE product
+                ADD COLUMN scientific_evidence_pack LONGTEXT NULL AFTER social_proof;
+  - changeSet:
+      id: 2026-07-19-product-scientific-evidence-pack-002
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: scientific_evidence_pack
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET scientific_evidence_pack = 'Evidence Pack MUSA v1: princípios permitidos: roupa pode influenciar autopercepção e comportamento situacional; escolhas de vestimenta, formalidade e acabamento participam da percepção social e dos primeiros julgamentos; coerência visual, intenção e repetição de sinais podem reduzir ruído percebido e facilitar reconhecimento pessoal. Aplicações práticas: transformar os princípios em microdecisões de roupa, cor, acabamento, postura e detalhe final; orientar uso do que a cliente já possui antes de compra nova; tratar presença elegante como percepção e coerência, não como garantia universal de aprovação externa. Linguagem permitida: isso ajuda você a comunicar mais intenção; pode reduzir ruído visual; favorece uma presença mais coerente; ajuda você a se sentir mais alinhada com a imagem que quer transmitir. Afirmações proibidas: garante elegância; muda como todos vão te ver; transforma sua personalidade; efeito comprovado em qualquer pessoa; substitui autoestima, terapia ou consultoria individual. Referências: Adam e Galinsky (2012), Enclothed cognition, Journal of Experimental Social Psychology, DOI 10.1016/j.jesp.2012.02.008; Slepian, Ferber, Gold e Rutchick (2015), The Cognitive Consequences of Formal Clothing, Social Psychological and Personality Science, DOI 10.1177/1948550615579462; Howlett, Pine, Orakcioglu e Fletcher (2013), The influence of clothing on first impressions, Journal of Fashion Marketing and Management, DOI 10.1108/13612021311305128; Hester e Hehman (2023), Dress is a Fundamental Component of Person Perception, Personality and Social Psychology Review, DOI 10.1177/10888683231157961.',
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,6 +15,9 @@ databaseChangeLog:
       file: changesets/2026-07-19-product-musa-portuguese-accents.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-19-product-scientific-evidence-pack.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-16-image-generation-request.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
@@ -23,9 +23,12 @@ class ProductRepositoryTest {
                 .explicitPain("Lack of energy")
                 .promise("More vitality in 30 days")
                 .uniqueMechanism("Special diet")
+                .scientificEvidencePack("Evidence Pack v1")
                 .aiCost(java.math.BigDecimal.TEN)
                 .build();
         repository.save(product);
         assertThat(repository.findById(product.getId())).isPresent();
+        assertThat(repository.findById(product.getId()).orElseThrow().getScientificEvidencePack())
+                .isEqualTo("Evidence Pack v1");
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -35,6 +35,7 @@ class ProductServiceTest {
         request.setMarketNicheId(10L);
         request.setCurrentPriceBrl(new BigDecimal("47.00"));
         request.setTargetAudience("Mulheres urbanas");
+        request.setScientificEvidencePack("Evidence Pack MUSA v1");
 
         when(productRepository.findById(1L)).thenReturn(Optional.of(product));
         when(marketNicheRepository.findById(10L)).thenReturn(Optional.of(niche));
@@ -46,6 +47,7 @@ class ProductServiceTest {
         assertThat(updated.getSlug()).isEqualTo(request.getSlug());
         assertThat(updated.getCurrentPriceBrl()).isEqualByComparingTo("47.00");
         assertThat(updated.getTargetAudience()).isEqualTo(request.getTargetAudience());
+        assertThat(updated.getScientificEvidencePack()).isEqualTo("Evidence Pack MUSA v1");
         assertThat(updated.getMarketNiche()).isSameAs(niche);
     }
 
@@ -74,6 +76,7 @@ class ProductServiceTest {
                 .colorPalette("1. Vinho MUSA #7A2444; 2. Dourado #D6A75C; 3. Creme #FFF8F3; 4. Grafite #2F2A2C; 5. Blush #F3C9C1; 6. Oliva #6F7A52; 7. Champanhe #F7E4C6.")
                 .tripwire("Experiência guiada de 7 dias com diagnóstico, missões, checklists e templates.")
                 .socialProof("Prova científica, prova visual e experimento 66.")
+                .scientificEvidencePack("Evidence Pack MUSA v1: princípios permitidos, linguagem permitida, afirmações proibidas e referências científicas.")
                 .funnel("Anúncio → login → experiência gratuita → paywall → compra.")
                 .codeModules("pde-platform, backend")
                 .aiCost(new BigDecimal("1.20"))
@@ -94,6 +97,8 @@ class ProductServiceTest {
         assertThat(markdown).contains("7. Champanhe #F7E4C6");
         assertThat(markdown).contains("Experiência guiada de 7 dias");
         assertThat(markdown).contains("Prova científica");
+        assertThat(markdown).contains("Base científica operacional");
+        assertThat(markdown).contains("afirmações proibidas");
         assertThat(markdown).doesNotContain("pde-platform");
         assertThat(markdown).doesNotContain("1.20");
     }

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -35,6 +35,7 @@ O FEO fabrica o pacote PDE com:
 - checklists, templates e materiais baixáveis;
 - imagens, capa e infográficos;
 - metadados comerciais para página de venda.
+- pacote científico operacional versionado quando o produto usar artigos ou evidências externas para sustentar mecanismo, prova ou orientação por IA.
 
 ### Checkout externo
 
@@ -75,11 +76,14 @@ Regras obrigatórias:
 - a chamada OpenAI deve ser executada por worker próprio ou módulo executor, não pelo frontend;
 - o worker deve consumir pendências pelo endpoint canônico `pending` do backend PDE;
 - prompt operacional e schema JSON de saída devem ficar versionados no worker;
+- quando o produto possuir pacote científico operacional, o backend PDE deve entregá-lo no contrato `pending` e o worker deve injetá-lo no prompt como base de plausibilidade, limites e linguagem permitida;
 - a resposta deve ser curta, estruturada e diretamente aplicável à missão;
 - o frontend deve exibir a orientação como cartão de produto, não como conversa livre;
 - toda solicitação deve ser mensurável no funil e associada ao token, produto e missão.
 
 Para o Método MUSA, a Consultora MUSA deve atuar nos 7 dias como orientação guiada por missão: a cliente preenche três sinais ou respostas práticas do dia e recebe um cartão curto, aplicável e coerente com o histórico da jornada. O Dia 1 pode ser usado como amostra gratuita de valor; os Dias 2 a 7 permanecem como parte do acesso completo quando o funil estiver em modo de paywall interno.
+
+Para o Método MUSA, a Consultora MUSA deve usar o `musa-evidence-pack-v1` como bastidor científico. O pacote apoia microações sobre roupa, cor, acabamento, postura, coerência visual e peça-sinal, mas a resposta visível não deve virar citação acadêmica recorrente nem promessa absoluta. A linguagem deve preservar o desejo de presença elegante acessível e evitar afirmações como garantia de elegância, mudança universal de percepção externa ou transformação de personalidade.
 
 ### Frontend PDE
 
@@ -180,6 +184,7 @@ Cada produto PDE deve ter, no mínimo:
 - `diagnostic`;
 - `missions`;
 - `supportMaterials`;
+- `scientificEvidencePack`, quando existir base científica operacional para IA, prova, materiais ou orientação;
 - `completionOffer`.
 
 ## Regra de qualidade comercial

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -77,6 +77,7 @@ Regras obrigatórias:
 - o worker deve consumir pendências pelo endpoint canônico `pending` do backend PDE;
 - prompt operacional e schema JSON de saída devem ficar versionados no worker;
 - quando o produto possuir pacote científico operacional, o backend PDE deve entregá-lo no contrato `pending` e o worker deve injetá-lo no prompt como base de plausibilidade, limites e linguagem permitida;
+- para chamadas MUSA, o worker deve falhar antes da OpenAI se o pacote científico operacional estiver ausente ou incompleto, evitando orientação genérica sem apoio dos artigos definidos para o produto;
 - a resposta deve ser curta, estruturada e diretamente aplicável à missão;
 - o frontend deve exibir a orientação como cartão de produto, não como conversa livre;
 - toda solicitação deve ser mensurável no funil e associada ao token, produto e missão.

--- a/docs/canonical/product-catalog-canon.v1.md
+++ b/docs/canonical/product-catalog-canon.v1.md
@@ -28,6 +28,7 @@ O produto não deve ficar preso a um único experimento. Experimento é evidênc
 - Preço atual quando houver venda direta.
 - Hipótese/oferta principal.
 - Experimentos associados quando houver histórico.
+- Pacote científico operacional versionado quando a criação do produto usar artigos, estudos, diretrizes ou evidências externas para sustentar mecanismo, prova ou orientação por IA.
 
 ## Primeiro produto canônico
 
@@ -40,6 +41,7 @@ O primeiro produto cadastrado é o Método MUSA - Presença Elegante em 7 Dias.
 - Preço atual: R$47.
 - Experimento associado inicial: Experimento 66.
 - Hipótese/oferta principal: mulher quer parecer mais elegante e marcante sem gastar com luxo, trocar o guarda-roupa inteiro ou depender de compras impulsivas.
+- Pacote científico operacional inicial: `musa-evidence-pack-v1`, baseado em cognição vestida, percepção social, primeiras impressões e roupa como componente da percepção de pessoa. O pacote deve orientar a Consultora MUSA a transformar as referências em microações de presença elegante, limitar promessas e evitar garantias universais de resultado.
 
 ## Funil comercial canônico do Clube MUSA
 
@@ -69,6 +71,23 @@ Regras comerciais:
 
 Novos atributos devem ser adicionados ao cadastro de produto quando ajudarem a aumentar vendas, reduzir retrabalho operacional ou preservar aprendizado comercial. Exemplos: checkout, domínio HTTPS, avatar detalhado, objeções, promessa principal, mecanismo único, upsells, canais ativos, criativos vencedores, métricas de conversão, taxa de ativação e aprendizados por experimento.
 
+## Pacote científico operacional
+
+Quando a criação de um produto usar artigos científicos ou evidências externas como apoio ao mecanismo, o Marketing Hub deve transformar esse material em um pacote operacional versionado antes de entregar contexto a workers de IA, PDE, anúncios, páginas ou materiais de produto.
+
+O pacote deve conter, no mínimo:
+
+- versão do pacote;
+- princípios defensáveis;
+- aplicações práticas permitidas;
+- linguagem comercial/orientativa permitida;
+- afirmações proibidas ou limites de promessa;
+- referências rastreáveis com autores, ano, título, fonte e DOI/link quando existir.
+
+O sistema não deve enviar artigo bruto, PDF inteiro ou texto acadêmico longo diretamente para prompts de orientação recorrente ao usuário final. A ciência deve funcionar como bastidor de plausibilidade, responsabilidade e diferenciação, enquanto a comunicação visível ao comprador deve continuar simples, desejável, prática e orientada à redução de esforço.
+
+Para Produtos Digitais Experienciais com orientação por IA, o backend/produto deve expor esse pacote no contrato entregue ao worker executor, e o worker deve usá-lo para gerar microações responsáveis, sem promessa absoluta e sem transformar a experiência em aula acadêmica.
+
 ## Documento público de definição de mercado
 
 Todo produto cadastrado pode expor uma definição pública em Markdown pela URL:
@@ -88,4 +107,5 @@ Quando houver definição comercial suficiente, o documento público deve explic
 - mecanismo único com justificativa plausível e, quando houver base científica usada na criação, citar os artigos pelo nome, autores, periódico e DOI/link;
 - oferta com entregáveis compreensíveis pelo comprador, sem termos técnicos internos;
 - prova, separando prova científica, prova de produto, prova visual, prova social ou prova operacional quando existirem;
+- base científica operacional quando ela for usada como apoio de criação, deixando claro quais princípios e limites sustentam a orientação sem expor implementação técnica;
 - paleta visual completa com 7 itens nomeados e seus códigos de cor.

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/ProductExperienceResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/ProductExperienceResponse.java
@@ -13,6 +13,7 @@ public record ProductExperienceResponse(
         DiagnosticDto diagnostic,
         List<MissionDto> missions,
         List<SupportMaterialDto> supportMaterials,
+        ScientificEvidencePackDto scientificEvidencePack,
         String completionOffer
 ) {
 
@@ -35,4 +36,17 @@ public record ProductExperienceResponse(
 
     /** Define um material de apoio disponível na biblioteca do produto. */
     public record SupportMaterialDto(String title, String type, String description, String url) {}
+
+    /** Define a base científica operacional usada pela IA sem expor artigo bruto à cliente. */
+    public record ScientificEvidencePackDto(
+            String version,
+            List<String> principles,
+            List<String> practicalApplications,
+            List<String> allowedLanguage,
+            List<String> forbiddenClaims,
+            List<ScientificReferenceDto> references
+    ) {}
+
+    /** Define uma referência científica rastreável usada na criação do produto. */
+    public record ScientificReferenceDto(String authors, String year, String title, String source, String doi) {}
 }

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
@@ -3,6 +3,8 @@ package com.marketinghub.pde.service;
 import com.marketinghub.pde.dto.ProductExperienceResponse;
 import com.marketinghub.pde.dto.ProductExperienceResponse.DiagnosticDto;
 import com.marketinghub.pde.dto.ProductExperienceResponse.MissionDto;
+import com.marketinghub.pde.dto.ProductExperienceResponse.ScientificEvidencePackDto;
+import com.marketinghub.pde.dto.ProductExperienceResponse.ScientificReferenceDto;
 import com.marketinghub.pde.dto.ProductExperienceResponse.SupportMaterialDto;
 import com.marketinghub.pde.dto.ProductExperienceResponse.ThemeDto;
 import java.util.List;
@@ -120,6 +122,57 @@ public class ProductCatalogService {
                                 "Infográfico",
                                 "Resumo visual do método: coerência, redução de ruído e assinatura pessoal.",
                                 "/materials/mapa-visual-musa.png")),
+                createMusaScientificEvidencePack(),
                 "Ao concluir os 7 dias, você pode continuar no Clube MUSA com novos desafios mensais de presença, estilo e autocuidado acessível.");
+    }
+
+    /** Cria o pacote científico operacional do MUSA usado pela Consultora MUSA. */
+    private static ScientificEvidencePackDto createMusaScientificEvidencePack() {
+        return new ScientificEvidencePackDto(
+                "musa-evidence-pack-v1",
+                List.of(
+                        "A roupa pode influenciar a forma como a pessoa se percebe e se comporta em uma situação.",
+                        "Escolhas de vestimenta, formalidade e acabamento participam da percepção social e dos primeiros julgamentos.",
+                        "Coerência visual, intenção e repetição de sinais podem reduzir ruído percebido e facilitar reconhecimento pessoal."),
+                List.of(
+                        "Transformar princípios de cognição vestida e percepção social em microdecisões simples de roupa, cor, acabamento, postura e detalhe final.",
+                        "Orientar a cliente a usar o que já possui antes de comprar novas peças.",
+                        "Reforçar presença elegante como percepção e coerência, não como garantia universal de aprovação externa."),
+                List.of(
+                        "isso ajuda você a comunicar mais intenção",
+                        "pode reduzir ruído visual",
+                        "favorece uma presença mais coerente",
+                        "ajuda você a se sentir mais alinhada com a imagem que quer transmitir"),
+                List.of(
+                        "garante elegância",
+                        "muda como todos vão te ver",
+                        "transforma sua personalidade",
+                        "efeito comprovado em qualquer pessoa",
+                        "substitui autoestima, terapia ou consultoria individual"),
+                List.of(
+                        new ScientificReferenceDto(
+                                "Adam e Galinsky",
+                                "2012",
+                                "Enclothed cognition",
+                                "Journal of Experimental Social Psychology",
+                                "10.1016/j.jesp.2012.02.008"),
+                        new ScientificReferenceDto(
+                                "Slepian, Ferber, Gold e Rutchick",
+                                "2015",
+                                "The Cognitive Consequences of Formal Clothing",
+                                "Social Psychological and Personality Science",
+                                "10.1177/1948550615579462"),
+                        new ScientificReferenceDto(
+                                "Howlett, Pine, Orakcioglu e Fletcher",
+                                "2013",
+                                "The influence of clothing on first impressions",
+                                "Journal of Fashion Marketing and Management",
+                                "10.1108/13612021311305128"),
+                        new ScientificReferenceDto(
+                                "Hester e Hehman",
+                                "2023",
+                                "Dress is a Fundamental Component of Person Perception",
+                                "Personality and Social Psychology Review",
+                                "10.1177/10888683231157961")));
     }
 }

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
@@ -393,6 +393,10 @@ class AccessServiceTest {
         assertThat(pending).isPresent();
         assertThat(pending.get().requestId()).isEqualTo(guidance.requestId());
         assertThat(pending.get().answers()).containsEntry("baseColor", "Vinho discreto");
+        assertThat(pending.get().product().scientificEvidencePack().version()).isEqualTo("musa-evidence-pack-v1");
+        assertThat(pending.get().product().scientificEvidencePack().references())
+                .extracting("doi")
+                .contains("10.1016/j.jesp.2012.02.008");
     }
 
     /** Confirma que todos os 7 dias possuem contrato de orientação por IA no backend. */

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/ProductCatalogServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/ProductCatalogServiceTest.java
@@ -20,6 +20,8 @@ class ProductCatalogServiceTest {
         assertThat(product.promise()).contains("7 dias");
         assertThat(product.missions()).hasSize(7);
         assertThat(product.supportMaterials()).hasSize(4);
+        assertThat(product.scientificEvidencePack().version()).isEqualTo("musa-evidence-pack-v1");
+        assertThat(product.scientificEvidencePack().forbiddenClaims()).contains("garante elegância");
     }
 
     /** Garante que o catálogo visível da MUSA usa português brasileiro com acentuação. */

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -51,6 +51,21 @@ type SupportMaterial = {
   url: string;
 };
 
+type ScientificEvidencePack = {
+  version: string;
+  principles: string[];
+  practicalApplications: string[];
+  allowedLanguage: string[];
+  forbiddenClaims: string[];
+  references: {
+    authors: string;
+    year: string;
+    title: string;
+    source: string;
+    doi: string;
+  }[];
+};
+
 type ProductExperience = {
   slug: string;
   name: string;
@@ -61,6 +76,7 @@ type ProductExperience = {
   diagnostic: Diagnostic;
   missions: Mission[];
   supportMaterials: SupportMaterial[];
+  scientificEvidencePack?: ScientificEvidencePack;
   completionOffer: string;
 };
 

--- a/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/user.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-daily-guidance/user.md
@@ -22,6 +22,9 @@ Ação prevista:
 Evidência esperada:
 {{missionEvidence}}
 
+Base científica operacional:
+{{scientificEvidencePackJson}}
+
 Respostas anteriores da cliente:
 {{previousMissionAnswersJson}}
 
@@ -29,3 +32,4 @@ Respostas da missão atual:
 {{answersJson}}
 
 Gere uma orientação personalizada para a cliente executar esta missão hoje. Escreva em português brasileiro com acentuação correta.
+Use a base científica operacional apenas como apoio de plausibilidade, limite e responsabilidade. Não cite estudos diretamente, salvo quando isso for necessário para uma explicação educativa breve. Respeite as afirmações proibidas do pacote científico e transforme os princípios em microações simples, elegantes e aplicáveis hoje.

--- a/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/user.md
+++ b/pde-platform/pde-ai-worker/prompts/musa-day-2-signature/user.md
@@ -10,6 +10,9 @@ Missão:
 Princípio:
 {{missionPrinciple}}
 
+Base científica operacional:
+{{scientificEvidencePackJson}}
+
 Respostas do Dia 1:
 {{previousMissionAnswersJson}}
 
@@ -17,3 +20,4 @@ Sinais escolhidos no Dia 2:
 {{answersJson}}
 
 Gere a Assinatura MUSA desta semana como uma orientação personalizada, curta e acionável. Escreva em português brasileiro com acentuação correta.
+Use a base científica operacional apenas como apoio de plausibilidade, limite e responsabilidade. Não cite estudos diretamente, salvo quando isso for necessário para uma explicação educativa breve. Respeite as afirmações proibidas do pacote científico e transforme os princípios em microações simples, elegantes e aplicáveis hoje.

--- a/pde-platform/pde-ai-worker/src/worker.js
+++ b/pde-platform/pde-ai-worker/src/worker.js
@@ -101,6 +101,7 @@ async function generateGuidance(execution) {
   const userTemplate = await fs.readFile(path.join(promptDefinition.dir, 'user.md'), 'utf8');
   const schema = JSON.parse(await fs.readFile(path.join(promptDefinition.dir, 'response-schema.json'), 'utf8'));
   const mission = execution.product.missions.find((item) => item.id === execution.missionId) ?? {};
+  const scientificEvidencePack = requireScientificEvidencePack(execution);
   const userPrompt = renderTemplate(userTemplate, {
     productName: execution.product.name,
     productPromise: execution.product.promise,
@@ -110,7 +111,7 @@ async function generateGuidance(execution) {
     missionPrinciple: mission.principle ?? '',
     missionAction: mission.action ?? '',
     missionEvidence: mission.evidence ?? '',
-    scientificEvidencePackJson: JSON.stringify(execution.product.scientificEvidencePack ?? {}, null, 2),
+    scientificEvidencePackJson: JSON.stringify(scientificEvidencePack, null, 2),
     previousMissionAnswersJson: JSON.stringify(execution.previousMissionAnswers ?? {}, null, 2),
     answersJson: JSON.stringify(execution.answers ?? {}, null, 2),
   });
@@ -153,6 +154,16 @@ async function generateGuidance(execution) {
     inputTokens: response.body.usage?.input_tokens,
     outputTokens: response.body.usage?.output_tokens,
   };
+}
+
+function requireScientificEvidencePack(execution) {
+  const pack = execution.product?.scientificEvidencePack;
+  const requiredLists = ['principles', 'practicalApplications', 'allowedLanguage', 'forbiddenClaims', 'references'];
+  const hasRequiredLists = requiredLists.every((field) => Array.isArray(pack?.[field]) && pack[field].length > 0);
+  if (!pack?.version || !hasRequiredLists) {
+    throw new Error(`Pacote cientifico operacional ausente ou incompleto para orientacao MUSA; requestId=${execution.requestId}`);
+  }
+  return pack;
 }
 
 async function callOpenAiWithRetry(baseRequestBody) {

--- a/pde-platform/pde-ai-worker/src/worker.js
+++ b/pde-platform/pde-ai-worker/src/worker.js
@@ -110,6 +110,7 @@ async function generateGuidance(execution) {
     missionPrinciple: mission.principle ?? '',
     missionAction: mission.action ?? '',
     missionEvidence: mission.evidence ?? '',
+    scientificEvidencePackJson: JSON.stringify(execution.product.scientificEvidencePack ?? {}, null, 2),
     previousMissionAnswersJson: JSON.stringify(execution.previousMissionAnswers ?? {}, null, 2),
     answersJson: JSON.stringify(execution.answers ?? {}, null, 2),
   });

--- a/pde-platform/pde-ai-worker/tests/prompt-portuguese.test.js
+++ b/pde-platform/pde-ai-worker/tests/prompt-portuguese.test.js
@@ -57,4 +57,17 @@ describe('prompts da Consultora MUSA', () => {
       assert.match(content, /acentuação correta|português brasileiro/i);
     });
   }
+
+  it('prompts recebem a base científica operacional do produto', async () => {
+    for (const promptFile of [
+      'prompts/musa-daily-guidance/user.md',
+      'prompts/musa-day-2-signature/user.md',
+    ]) {
+      const content = await readFile(new URL(`../${promptFile}`, import.meta.url), 'utf8');
+
+      assert.match(content, /{{scientificEvidencePackJson}}/);
+      assert.match(content, /afirmações proibidas/);
+      assert.match(content, /microações simples/);
+    }
+  });
 });

--- a/pde-platform/pde-ai-worker/tests/prompt-portuguese.test.js
+++ b/pde-platform/pde-ai-worker/tests/prompt-portuguese.test.js
@@ -70,4 +70,12 @@ describe('prompts da Consultora MUSA', () => {
       assert.match(content, /microações simples/);
     }
   });
+
+  it('worker exige pacote científico antes de montar a chamada OpenAI', async () => {
+    const worker = await readFile(new URL('../src/worker.js', import.meta.url), 'utf8');
+
+    assert.match(worker, /requireScientificEvidencePack\(execution\)/);
+    assert.match(worker, /scientificEvidencePackJson: JSON\.stringify\(scientificEvidencePack, null, 2\)/);
+    assert.match(worker, /Pacote cientifico operacional ausente ou incompleto/);
+  });
 });


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: como podemos no PDE do MUSA na hora de solicitar ao modelo openai orientações colocar os artigos cientificos pesquisados para a montagem do produto dar apoio nas orientações para a usuaria ?

Modelo: {"titulo":"Artigos como base das orientações","comentario":"Sim. O melhor caminho é colocar os artigos científicos como **base estruturada de evidência** antes da chamada OpenAI da Consultora MUSA, não jogar PDFs ou textos longos diretamente no prompt da orientação diária.\n\n**O que encontrei**\n\n- A definição oficial do MUSA já usa os artigos como prova do mecanismo: cognição vestida, percepção social, primeiras impressões e roupa como componente da percepção de pessoa.\n- O cânone da PDE Platform diz que a IA no PDE deve ser **orientação guiada por etapa**, curta, prática e exibida como cartão, não como chat aberto.\n- O prompt atual da Consultora MUSA recebe produto, promessa, missão e respostas da cliente, mas ainda não recebe um bloco estruturado de evidências científicas.\n- Já existe um padrão no `scientific-research-worker` para sintetizar evidências, separar afirmações permitidas/proibidas e bloquear base fraca.\n\n**3 alternativas boas**\n\n1. **Colocar os artigos diretamente no prompt diário**\n   - Benefício: implementação simples.\n   - Risco: prompt grande, caro, repetitivo e com maior chance do modelo usar linguagem técnica ou exagerar.\n   - Aderência ao MUSA: média.\n\n2. **Criar um “Pacote de Evidências MUSA” resumido e versionado**\n   - Benefício: cada artigo vira princípios simples, limites de uso e frases permitidas para orientar a usuária.\n   - Risco: exige uma etapa inicial de curadoria/síntese.\n   - Aderência ao MUSA: alta.\n\n3. **Usar busca dinâmica por artigo conforme a missão do dia**\n   - Benefício: mais flexível e sofisticado.\n   - Risco: mais caro, mais complexo e menos previsível para produto em escala.\n   - Aderência ao MUSA: boa para futuro, não para MVP.\n\n**Minha recomendação**\n\nEscolher a alternativa 2: criar um **Evidence Pack MUSA v1** e injetar esse pacote no pedido OpenAI da orientação diária.\n\nNa prática, o PDE deveria mandar ao modelo algo assim:\n\n```text\nBase científica permitida para esta orientação:\n- Princípio: escolhas de roupa podem influenciar percepção de si e percepção social.\n- Aplicação prática: orientar microdecisões de cor, acabamento, coerência visual e peça-sinal.\n- Linguagem permitida: “isso ajuda você a comunicar mais intenção”, “pode reduzir ruído visual”, “favorece uma presença mais coerente”.\n- Linguagem proibida: “garante elegância”, “muda como todos vão te ver”, “transforma sua personalidade”, “efeito comprovado em qualquer pessoa”.\n- Artigos de apoio: Adam e Galinsky 2012; Slepian et al. 2015; Howlett et al. 2013; Hester e Hehman 2023.\n```\n\n**Como isso entra na orientação da usuária**\n\nA Consultora MUSA não deve citar artigo academicamente em toda resposta. A usuária quer facilidade, prazer e presença elegante, não aula científica.\n\nO artigo deve aparecer como bastidor da orientação:\n\n- Em vez de: “Segundo Adam e Galinsky...”\n- Melhor: “Hoje, escolha uma peça que ajude você a se sentir mais alinhada com a mulher que quer comunicar. A ideia não é parecer outra pessoa, é reduzir ruído e deixar sua presença mais intencional.”\n\n**Estrutura ideal do fluxo**\n\n1. O Marketing Hub/PDE mantém os artigos pesquisados vinculados ao produto MUSA.\n2. O módulo científico transforma os artigos em um pacote estruturado:\n   - princípios defensáveis;\n   - aplicações práticas;\n   - limites;\n   - afirmações proibidas;\n   - referências.\n3. O backend PDE entrega esse pacote junto com a missão diária pendente.\n4. O `pde-ai-worker` injeta esse bloco no prompt da Consultora MUSA.\n5. O modelo gera uma orientação curta, feminina e prática.\n6. A resposta salva auditoria: missão, respostas da cliente, pacote científico usado, request, response e modelo.\n\n**A melhoria de maior impacto comercial**\n\nCriar dois níveis de uso da ciência:\n\n- **Interno ao modelo:** ciência forte, completa e com limites claros.\n- **Visível para a cliente:** frases leves como “baseado em princípios de percepção visual e presença pessoal”, sem parecer consulta acadêmica.\n\nIsso aumenta confiança e diferenciação sem quebrar a experiência emocional do MUSA.\n\n**Prompt recomendado para adicionar ao pedido OpenAI**\n\n```text\nEvidências científicas de apoio:\n{{scientificEvidencePackJson}}\n\nUse essas evidências apenas para tornar a orientação mais plausível e responsável.\nNão cite estudos diretamente, salvo se o tipo de orientação pedir uma explicação educativa.\nNão prometa garantia de resultado.\nTransforme os princípios científicos em microações simples, elegantes e aplicáveis hoje.\nRespeite as afirmações proibidas e os limites do pacote científico.\n```\n\n**Decisão objetiva**\n\nPara o PDE do MUSA, eu não colocaria os artigos brutos no prompt diário. Eu criaria um **resumo científico operacional versionado**, validado uma vez, e passaria esse resumo como contexto fixo para as orientações. Isso dá mais consistência, reduz custo, diminui risco de promessa exagerada e mantém a comunicação sedutora, simples e vendável.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
implemente esse recurso no marketing hub ( para criação de produtos ) e vamos já usar no MUSA. Coloque essa ideia nos documentos canonicos.

**Resumo das alterações:**
{"titulo":"Evidence Pack MUSA implementado","comentario":"Implementei o recurso no Marketing Hub e já deixei o MUSA usando a base científica operacional.\n\n**O que foi feito**\n\n- Criei o campo `scientificEvidencePack` no cadastro comercial de produtos do Marketing Hub.\n- Adicionei changelog Liquibase para criar `product.scientific_evidence_pack` e preencher o MUSA com o `Evidence Pack MUSA v1`.\n- A definição pública do produto agora pode exibir a **Base científica operacional** quando ela existir.\n- O backend PDE agora entrega o pacote científico junto com o produto MUSA.\n- O `pde-ai-worker` passou a injetar esse pacote no prompt da Consultora MUSA.\n- Os prompts foram ajustados para usar a ciência como bastidor: princípios, limites, linguagem permitida e afirmações proibidas.\n- O frontend PDE foi tipado para aceitar o novo campo sem exibir isso para a usuária.\n- Atualizei os cânones em:\n  - `docs/canonical/product-catalog-canon.v1.md`\n  - `docs/canonical/pde-platform-canon.v1.md`\n\n**Decisão aplicada**\n\nUsei a alternativa do **pacote científico operacional versionado**, não artigos brutos no prompt. Isso reduz custo, melhora consistência, evita promessa exagerada e mantém a experiência sedutora e simples para a cliente.\n\n**Validações executadas**\n\n- `pde-platform/backend`: `mvn test` passou.\n- `pde-ai-worker`: `npm test` passou.\n- `pde-ai-worker`: `npm run check` passou.\n- `pde-platform/frontend`: `npm run check:api-boundary` passou.\n- `pde-platform/frontend`: `npm run build` passou após instalar dependências locais com `npm install`.\n- `backend/ads-service`: testes focados de produto passaram.\n- Changelog mestre validado: nenhum include relativo novo ficou sem `relativeToChangelogFile: true`.\n\nNão criei Pull Request.","sugestaoMelhoriaAmbiente":""}