### PR TITLE
AI Hub: {"titulo":"Spotless disponível","comentario":"Implementei a disponibilidade do Spotless no backend principal.\n\n**Arquivo alterado**\n- `backend/ads-service/pom.xml`\n\n**O que foi feito**\n- Adicionei `spotless-maven-plugin` versionado.\n- Fixei…

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -12,6 +12,8 @@
         <byte-buddy.version>1.14.11</byte-buddy.version>
         <glassfish-jaxb.version>4.0.2</glassfish-jaxb.version>
         <aws.sdk.version>2.25.44</aws.sdk.version>
+        <spotless.maven.plugin.version>3.8.0</spotless.maven.plugin.version>
+        <google.java.format.version>1.35.0</google.java.format.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -171,6 +173,27 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.maven.plugin.version}</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <version>${google.java.format.version}</version>
+                        </googleJavaFormat>
+                        <removeUnusedImports/>
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
+                    </java>
+                    <pom>
+                        <sortPom>
+                            <encoding>UTF-8</encoding>
+                            <keepBlankLines>true</keepBlankLines>
+                        </sortPom>
+                    </pom>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: Sobre o planejamento de semanas do mes vamos criar um novo conceito.
- semana 1 do mes - sempre começa na primeira segunda feira do mes indo até o proximo domingo
- semana 2 do mes - sempre começar na segunda segunda-feira do mes indo ate o proximo domingo
- semana 3 do mes - sempre começa na terceira segunda feira do mes indo até o proximo domingo
- semana 4 do mes - sempre começar na quarta segunda-feira do mes indo ate o proximo domingo
- semana 5 do mes - sempre começa na quinta segunda feira do mes ( se tiver ) indo até o proximo domingo ( mesmo que entre pelo mes seguinte )

O proximo mes: agosto-2026 pode montar o planejamento assim.

Escreva nos documentos canonicos essa nova organização de planejamento.


Modelo: {"titulo":"Planejamento semanal atualizado","comentario":"Atualizei a organização canônica das semanas comerciais do mês.\n\n**Arquivos alterados**\n- `docs/canonical/commercial-planning-canon.v1.md`\n- `docs/novos-modulos/planejamento/README.md`\n\n**Nova regra registrada**\n- A semana 1 começa na primeira segunda-feira do mês e vai até domingo.\n- A semana 2 começa na segunda segunda-feira e vai até domingo.\n- A semana 3 começa na terceira segunda-feira e vai até domingo.\n- A semana 4 começa na quarta segunda-feira e vai até domingo.\n- A semana 5 só existe quando houver quinta segunda-feira no mês, indo até o domingo seguinte, mesmo entrando no mês seguinte.\n- Dias antes da primeira segunda-feira não entram como semana comercial parcial; ficam como preparação, fechamento ou transição.\n\n**Agosto/2026 ficou assim**\n\n| Semana | Período |\n|---|---|\n| Semana 1 | 2026-08-03 a 2026-08-09 |\n| Semana 2 | 2026-08-10 a 2026-08-16 |\n| Semana 3 | 2026-08-17 a 2026-08-23 |\n| Semana 4 | 2026-08-24 a 2026-08-30 |\n| Semana 5 | 2026-08-31 a 2026-09-06 |\n\n**Decisão tomada**\nAvaliei 3 caminhos: criar um novo documento canônico, alterar só o README do módulo, ou atualizar o cânone principal e espelhar no README funcional. Escolhi a terceira opção porque preserva a fonte de verdade e já deixa o módulo de planejamento alinhado para implementação futura.\n\nNão criei Pull Request.","sugestaoMelhoriaAmbiente":""}

Usuário: pode fazer a implementação ( estamos atualmente no mes de julho ) e clicando no item de menu aparece o mes de julho mas coloque um botão de proximo mes e vai aparecer no caso agosto 2026

Modelo: {"titulo":"Planejamento mensal implementado","comentario":"Implementação concluída.\n\n**O que mudou**\n- Ao abrir o menu de Planejamento, a tela continua mostrando **Julho 2026**.\n- Adicionei o botão **Próximo mês**.\n- Ao clicar, a tela passa a mostrar **Agosto 2026**.\n- Agosto/2026 segue a nova regra canônica:\n\n| Semana | Período |\n|---|---|\n| Semana 1 | 03/08/2026 até 09/08/2026 |\n| Semana 2 | 10/08/2026 até 16/08/2026 |\n| Semana 3 | 17/08/2026 até 23/08/2026 |\n| Semana 4 | 24/08/2026 até 30/08/2026 |\n| Semana 5 | 31/08/2026 até 06/09/2026 |\n\n**Causa-raiz corrigida**\nO backend ainda montava semanas em blocos de 7 dias a partir do dia 1 do mês. Troquei para semanas comerciais baseadas nas segundas-feiras do mês.\n\n**Decisão de implementação**\nAvaliei 3 caminhos: calcular tudo só no frontend, criar um plano separado para agosto, ou parametrizar o backend por mês de referência. Escolhi parametrizar o backend porque preserva a fonte de verdade, mantém as métricas semanais vindas do banco e evita divergência entre tela e API.\n\n**Validação**\n- Backend: `CommercialPlanWeeklyExperimentServiceTest` passou com 5 testes.\n- Frontend: `CommercialPlanningPage.test.tsx` passou com 8 testes.\n\nNão criei Pull Request.","sugestaoMelhoriaAmbiente":"O plugin Spotless não está resolvível no `pom` do backend; disponibilizá-lo no projeto ajudaria a validar formatação Java exatamente como o CI."}

Última mensagem do usuário:
Faça isso:
O plugin Spotless não está resolvível no `pom` do backend; disponibilizá-lo no projeto ajudaria a validar formatação Java exatamente como o CI.

**Resumo das alterações:**
{"titulo":"Spotless disponível","comentario":"Implementei a disponibilidade do Spotless no backend principal.\n\n**Arquivo alterado**\n- `backend/ads-service/pom.xml`\n\n**O que foi feito**\n- Adicionei `spotless-maven-plugin` versionado.\n- Fixei `google-java-format` para validação reprodutível.\n- Configurei limpeza de imports, espaços finais e newline final.\n\n**Validação**\n- `mvn -B -DskipTests validate`: passou.\n- `mvn -B spotless:check`: o plugin resolveu e executou, mas encontrou dívida existente de formatação em 2.290 arquivos Java.\n\n**Decisão tomada**\nAvaliei 3 opções: só documentar o comando, adicionar o plugin sem execução automática, ou travar o build com `spotless:check`. Escolhi adicionar o plugin sem travar o build, porque resolve a causa imediata sem criar um diff massivo nem quebrar o CI atual por dívida antiga.\n\nNão criei Pull Request.","sugestaoMelhoriaAmbiente":""}