### PR TITLE
Cadastra o PDE Nexo no catálogo comercial

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-product-commercial-catalog.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-product-commercial-catalog.yaml
@@ -197,3 +197,149 @@ databaseChangeLog:
                      ai_cost = 0.00,
                      updated_at = CURRENT_TIMESTAMP
                WHERE slug = 'metodo-musa-7-dias';
+  - changeSet:
+      id: 2026-07-20-product-commercial-catalog-005-nexo
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: name
+        - columnExists:
+            tableName: product
+            columnName: niche
+        - columnExists:
+            tableName: product
+            columnName: avatar
+        - columnExists:
+            tableName: product
+            columnName: explicit_pain
+        - columnExists:
+            tableName: product
+            columnName: promise
+        - columnExists:
+            tableName: product
+            columnName: unique_mechanism
+        - columnExists:
+            tableName: product
+            columnName: tripwire
+        - columnExists:
+            tableName: product
+            columnName: risk_reversal
+        - columnExists:
+            tableName: product
+            columnName: social_proof
+        - columnExists:
+            tableName: product
+            columnName: checkout_monetization
+        - columnExists:
+            tableName: product
+            columnName: funnel
+        - columnExists:
+            tableName: product
+            columnName: creative_volume
+        - columnExists:
+            tableName: product
+            columnName: storytelling
+        - columnExists:
+            tableName: product
+            columnName: ai_cost
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO product (
+                slug,
+                name,
+                public_url,
+                color_palette,
+                target_audience,
+                language_style,
+                code_modules,
+                product_type,
+                commercial_status,
+                current_price_brl,
+                primary_hypothesis,
+                associated_experiments,
+                commercial_notes,
+                niche,
+                avatar,
+                explicit_pain,
+                promise,
+                unique_mechanism,
+                tripwire,
+                risk_reversal,
+                social_proof,
+                checkout_monetization,
+                funnel,
+                creative_volume,
+                storytelling,
+                ai_cost,
+                created_at,
+                updated_at
+              )
+              SELECT
+                'nexo-clareza-sentido-acao',
+                'Nexo — Clareza, Sentido e Ação',
+                NULL,
+                'Azul profundo #1F2A44; violeta contemplativo #6C5CE7; turquesa de ativação #4FA3A5; areia clara #F5F1EA; grafite #23262F.',
+                'Pessoas que atravessam desânimo, transições, ruminação, sensação de mente lenta ou falta de direção e querem organizar o que estão vivendo sem precisar adotar uma crença específica.',
+                'Acolhedor, investigativo, claro, respeitoso e prático. Pode combinar perspectivas psicológica, filosófica, científica e espiritual quando escolhidas pela pessoa, sem impor conclusões.',
+                'pde-platform; backend/ads-service; frontend; módulo futuro de trajetória pensênica e sessões guiadas.',
+                'PDE - Produto Digital Experiencial',
+                'VALIDACAO_COMERCIAL',
+                NULL,
+                'Uma conversa estruturada que transforma estado interno em linguagem, perspectiva e ação pode ajudar a pessoa a sair de ruminação passiva para maior clareza, curiosidade e direção percebida.',
+                'Concepção inicial Nexo em 20/07/2026; MVP ainda sem campanha comercial e sem alegação clínica.',
+                'Experiências incomuns ou espiritualidade são módulos opcionais. O núcleo universal é acompanhar a mudança entre o estado inicial e o final da sessão e converter reflexão em ação significativa.',
+                'clareza mental / sentido de vida / desenvolvimento pessoal orientado à ação',
+                'Pessoas em momentos de mudança, perda de direção, desânimo ou excesso de pensamentos que desejam compreender o próprio estado e encontrar um próximo passo possível.',
+                'A pessoa sente peso mental, baixa energia, pensamentos circulares ou dificuldade de transformar questões profundas em uma direção concreta.',
+                'Ajudar a pessoa a organizar o estado interno, perceber o que mudou durante a conversa e terminar com mais clareza e uma ação significativa definida.',
+                'Trajetória Nexo: check-in multidimensional, conversa guiada adaptativa, separação entre fato, interpretação e hipótese, comparação antes/depois, identificação dos mobilizadores pessoais e escolha de uma microação concreta.',
+                'Sessão digital guiada com check-in, conversa adaptativa, mapa de mudança do estado interno e plano de ação. Histórico, padrões pessoais e acompanhamentos podem compor a oferta paga futura.',
+                'Primeira experiência sem exigir relato espiritual, controle explícito da perspectiva usada, linguagem não diagnóstica e possibilidade de encerrar ou pular qualquer tema. Não substitui atendimento médico ou psicológico.',
+                'Prova inicial de conceito baseada em demonstração do produto e medidas autorrelatadas antes/depois. O MVP não deve apresentar validação clínica nem atribuir mudanças a causas espirituais como fato.',
+                'Entrada gratuita com uma sessão inicial e visualização básica da mudança. Monetização futura por histórico longitudinal, relatórios pessoais, sessões adicionais, mapas de mobilização e programas guiados, com preço definido somente após validação.',
+                'Conteúdo ou anúncio sobre mente pesada, falta de direção ou transição -> check-in anônimo -> sessão guiada -> comparação antes/depois -> descoberta principal e microação -> convite opcional para salvar histórico e continuar.',
+                'Testar mensagens sobre mente lenta, pensamentos circulares, transições, busca de sentido, curiosidade, mudança de estado e passagem da reflexão para ação, evitando promessas de cura ou certeza espiritual.',
+                'Da sensação de fragilidade, confusão ou paralisia para a descoberta de que o próprio estado pode ser observado, reorganizado e convertido em uma direção possível.',
+                0.00,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+              ON DUPLICATE KEY UPDATE
+                name = VALUES(name),
+                public_url = VALUES(public_url),
+                color_palette = VALUES(color_palette),
+                target_audience = VALUES(target_audience),
+                language_style = VALUES(language_style),
+                code_modules = VALUES(code_modules),
+                product_type = VALUES(product_type),
+                commercial_status = VALUES(commercial_status),
+                current_price_brl = VALUES(current_price_brl),
+                primary_hypothesis = VALUES(primary_hypothesis),
+                associated_experiments = VALUES(associated_experiments),
+                commercial_notes = VALUES(commercial_notes),
+                niche = VALUES(niche),
+                avatar = VALUES(avatar),
+                explicit_pain = VALUES(explicit_pain),
+                promise = VALUES(promise),
+                unique_mechanism = VALUES(unique_mechanism),
+                tripwire = VALUES(tripwire),
+                risk_reversal = VALUES(risk_reversal),
+                social_proof = VALUES(social_proof),
+                checkout_monetization = VALUES(checkout_monetization),
+                funnel = VALUES(funnel),
+                creative_volume = VALUES(creative_volume),
+                storytelling = VALUES(storytelling),
+                ai_cost = VALUES(ai_cost),
+                updated_at = CURRENT_TIMESTAMP;

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-19-product-musa-logo-and-ai-positioning.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-19-product-musa-logo-and-ai-positioning.yaml
@@ -53,3 +53,53 @@ databaseChangeLog:
                      scientific_evidence_pack = 'Evidence Pack MUSA v1: princípios permitidos: roupa pode influenciar autopercepção e comportamento situacional; escolhas de vestimenta, formalidade e acabamento participam da percepção social e dos primeiros julgamentos; coerência visual, intenção e repetição de sinais podem reduzir ruído percebido e facilitar reconhecimento pessoal. Uso de IA no produto: a IA deve atuar como assistente de personalização e síntese prática, associando as respostas da usuária aos princípios extraídos dos artigos científicos citados para sugerir microações de roupa, cor, acabamento, postura e detalhe final; a IA não deve apresentar diagnóstico clínico, garantia de resultado universal ou afirmação científica além das evidências cadastradas. Aplicações práticas: transformar os princípios em microdecisões de roupa, cor, acabamento, postura e detalhe final; orientar uso do que a cliente já possui antes de compra nova; tratar presença elegante como percepção e coerência, não como garantia universal de aprovação externa. Linguagem permitida: isso ajuda você a comunicar mais intenção; pode reduzir ruído visual; favorece uma presença mais coerente; ajuda você a se sentir mais alinhada com a imagem que quer transmitir; a IA usa suas respostas para adaptar a orientação aos princípios científicos permitidos. Afirmações proibidas: garante elegância; muda como todos vão te ver; transforma sua personalidade; efeito comprovado em qualquer pessoa; substitui autoestima, terapia ou consultoria individual; a IA prova cientificamente qual roupa você deve usar. Referências: Adam e Galinsky (2012), Enclothed cognition, Journal of Experimental Social Psychology, DOI 10.1016/j.jesp.2012.02.008; Slepian, Ferber, Gold e Rutchick (2015), The Cognitive Consequences of Formal Clothing, Social Psychological and Personality Science, DOI 10.1177/1948550615579462; Howlett, Pine, Orakcioglu e Fletcher (2013), The influence of clothing on first impressions, Journal of Fashion Marketing and Management, DOI 10.1108/13612021311305128; Hester e Hehman (2023), Dress is a Fundamental Component of Person Perception, Personality and Social Psychology Review, DOI 10.1177/10888683231157961.',
                      updated_at = CURRENT_TIMESTAMP
                WHERE slug = 'metodo-musa-7-dias';
+  - changeSet:
+      id: 2026-07-20-product-nexo-experience-enrichment-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: logo_url
+        - columnExists:
+            tableName: product
+            columnName: scientific_evidence_pack
+        - columnExists:
+            tableName: product
+            columnName: seven_day_journey
+        - columnExists:
+            tableName: product
+            columnName: support_material_positioning
+        - columnExists:
+            tableName: product
+            columnName: primary_cta
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET logo_url = NULL,
+                     scientific_evidence_pack = 'Evidence Pack Nexo v0 — hipótese operacional pendente de revisão bibliográfica formal. Princípios permitidos: registrar o estado inicial e final pode apoiar autoconsciência; perguntas que despertam curiosidade podem aumentar engajamento; separar fatos, interpretações e hipóteses pode reduzir confusão; definir uma microação pode converter reflexão em comportamento observável. Uso de IA no produto: a IA organiza respostas, oferece perspectivas escolhidas pela pessoa, destaca mudanças autorrelatadas e sugere próximos passos pequenos. Linguagem permitida: isso pode ajudar você a organizar o que está vivendo; sua energia percebida mudou durante a sessão; esta é uma hipótese possível; escolha uma ação compatível com sua realidade. Afirmações proibidas: diagnostica depressão ou qualquer transtorno; cura desânimo; comprova mundo espiritual; identifica espíritos; substitui psicólogo, psiquiatra ou médico; garante mudança emocional; atribui experiência incomum a causa sobrenatural como fato. Experiências espirituais são opcionais e devem ser tratadas como relatos pessoais e hipóteses interpretativas.',
+                     seven_day_journey = '- **Dia 1 — Retrato do agora:** registrar clareza, emoção, energia percebida, curiosidade, peso mental e sensação de direção.
+              - **Dia 2 — Pensamento dominante:** identificar a ideia, preocupação ou pergunta que está organizando o estado atual.
+              - **Dia 3 — Ponto de curiosidade:** encontrar uma pergunta capaz de deslocar a pessoa da ruminação passiva para investigação ativa.
+              - **Dia 4 — Perspectivas possíveis:** observar a questão por lentes prática, psicológica, filosófica, científica ou espiritual, conforme escolha da pessoa.
+              - **Dia 5 — Mapa de mobilização:** reconhecer temas, perguntas, pessoas, ambientes e atividades que aumentam ou reduzem clareza e energia percebida.
+              - **Dia 6 — Ação significativa:** transformar a descoberta principal em uma microação concreta, segura e realizável.
+              - **Dia 7 — Meu Nexo pessoal:** comparar início e final, registrar padrões e criar uma regra simples para futuras mudanças de estado.',
+                     support_material_positioning = 'Materiais de apoio são secundários. O centro do produto é a experiência guiada e a percepção da trajetória entre estado inicial, conversa, descoberta e ação. Diário, mapa de mobilização, histórico e relatórios entram como instrumentos de continuidade, não como promessa principal.',
+                     primary_cta = 'Organizar o que estou vivendo agora',
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'nexo-clareza-sentido-acao';


### PR DESCRIPTION
## O que mudou

- cadastra o produto `nexo-clareza-sentido-acao` no catálogo comercial exibido em `/products`;
- define público, dor, promessa, mecanismo, oferta, funil, posicionamento e limites éticos;
- adiciona a jornada Nexo de 7 dias;
- registra o CTA principal `Organizar o que estou vivendo agora`;
- mantém experiências espirituais como módulo opcional, sem diagnóstico, promessa de cura ou alegação de comprovação sobrenatural;
- usa `INSERT ... ON DUPLICATE KEY UPDATE` para manter o cadastro idempotente.

## Por que

Transformar a concepção desta conversa em um PDE utilizável pelo Marketing Hub: uma experiência para ajudar pessoas a organizar o estado interno, perceber mudanças durante uma conversa guiada e terminar com mais clareza e uma ação significativa.

## Impacto

Após merge e deploy do backend, o Liquibase cadastrará o Nexo e ele deverá aparecer na lista administrativa de produtos.

Esta PR cria a definição comercial completa. A experiência final de usuário no `pde-platform` ainda precisa ser implementada, pois o frontend executável atual está especializado no MUSA.

## Validação

- diff revisado contra `main`;
- somente dois arquivos Liquibase já incluídos no changelog mestre foram alterados;
- branch está 2 commits à frente e 0 atrás;
- não foi possível validar no ambiente ao vivo porque o host recusou conexões nas portas documentadas durante esta execução.