### PR TITLE
AI Hub: {"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiênc…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
@@ -146,6 +146,12 @@ public class Product {
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String scientificEvidencePack;
 
+    /** Contrato JSON versionado que a PDE Platform consome para renderizar a experiência do produto. */
+    @Lob
+    @Column(name = "pde_experience_json", columnDefinition = "LONGTEXT")
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String pdeExperienceJson;
+
     @Lob
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String checkoutMonetization;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
@@ -36,6 +36,7 @@ public class CreateProductRequest {
     private String riskReversal;
     private String socialProof;
     private String scientificEvidencePack;
+    private String pdeExperienceJson;
     private String checkoutMonetization;
     private String funnel;
     private String creativeVolume;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
@@ -38,6 +38,7 @@ public class ProductDto {
     private String riskReversal;
     private String socialProof;
     private String scientificEvidencePack;
+    private String pdeExperienceJson;
     private String checkoutMonetization;
     private String funnel;
     private String creativeVolume;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package com.marketinghub.product.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.product.Product;
@@ -26,15 +28,18 @@ public class ProductService {
     private final ProductRepository repository;
     private final InstagramAccountRepository accountRepository;
     private final MarketNicheRepository marketNicheRepository;
+    private final ObjectMapper objectMapper;
 
     /** Inicializa o serviço com os repositórios necessários para cadastro de produtos. */
     public ProductService(
             ProductRepository repository,
             InstagramAccountRepository accountRepository,
-            MarketNicheRepository marketNicheRepository) {
+            MarketNicheRepository marketNicheRepository,
+            ObjectMapper objectMapper) {
         this.repository = repository;
         this.accountRepository = accountRepository;
         this.marketNicheRepository = marketNicheRepository;
+        this.objectMapper = objectMapper;
     }
 
     /** Cria e persiste um produto comercial com seus atributos de venda e entrega. */
@@ -84,6 +89,7 @@ public class ProductService {
         product.setRiskReversal(request.getRiskReversal());
         product.setSocialProof(request.getSocialProof());
         product.setScientificEvidencePack(request.getScientificEvidencePack());
+        product.setPdeExperienceJson(validatePdeExperienceJson(request.getPdeExperienceJson()));
         product.setCheckoutMonetization(request.getCheckoutMonetization());
         product.setFunnel(request.getFunnel());
         product.setCreativeVolume(request.getCreativeVolume());
@@ -165,6 +171,30 @@ public class ProductService {
         appendSection(markdown, "10. Aprendizados e próximos ajustes de marketing",
                 paragraph(product.getCommercialNotes()));
         return markdown.toString();
+    }
+
+    /** Retorna o contrato JSON da experiência PDE publicada pelo Marketing Hub. */
+    @Transactional(readOnly = true)
+    public String getPublicPdeExperienceJson(String productCode) {
+        Product product = findProductByCode(productCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Produto não encontrado"));
+        if (product.getPdeExperienceJson() == null || product.getPdeExperienceJson().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Experiência PDE não publicada para o produto");
+        }
+        return product.getPdeExperienceJson().trim();
+    }
+
+    /** Valida que o contrato PDE informado é JSON antes de persistir no cadastro comercial. */
+    private String validatePdeExperienceJson(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
+            return rawJson;
+        }
+        try {
+            objectMapper.readTree(rawJson);
+            return rawJson.trim();
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Contrato JSON da experiência PDE inválido", ex);
+        }
     }
 
     /** Busca o produto por slug público ou por identificador interno numérico. */

--- a/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
@@ -75,4 +75,14 @@ public class ProductController {
                 .contentType(MediaType.parseMediaType("text/html;charset=UTF-8"))
                 .body(htmlRenderer.render(markdown));
     }
+
+    /** Retorna o contrato JSON público da experiência PDE publicada pelo Marketing Hub. */
+    @GetMapping(
+            value = "/public/{productCode}/pde-experience",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> getPublicPdeExperience(@PathVariable String productCode) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(service.getPublicPdeExperienceJson(productCode));
+    }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-pde-experience-json.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-pde-experience-json.yaml
@@ -1,0 +1,224 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-21-product-pde-experience-json.yaml
+  - changeSet:
+      id: 2026-07-21-product-pde-experience-json-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: scientific_evidence_pack
+        - not:
+            columnExists:
+              tableName: product
+              columnName: pde_experience_json
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE product
+                ADD COLUMN pde_experience_json LONGTEXT NULL AFTER scientific_evidence_pack;
+  - changeSet:
+      id: 2026-07-21-product-pde-experience-json-002
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: pde_experience_json
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET pde_experience_json = '{
+                "slug": "metodo-musa-7-dias",
+                "name": "Método MUSA - Experiência Guiada de 7 Dias",
+                "promise": "Descubra o que sua imagem comunica sem intenção e monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro.",
+                "audience": "Mulheres urbanas que querem se sentir mais marcantes, alinhadas e seguras usando escolhas acessíveis.",
+                "priceLabel": "",
+                "theme": {
+                  "primary": "#7a2444",
+                  "accent": "#d6a75c",
+                  "background": "#fff8f3",
+                  "imageUrl": "/assets/musa-cover.png"
+                },
+                "diagnostic": {
+                  "title": "Mapa de Presença MUSA",
+                  "intro": "Comece pelo momento do espelho: quando você está pronta, mas sente que sua imagem ainda não comunica a mulher que você quer ser vista como.",
+                  "questions": [
+                    "Quando você se arruma, o que mais incomoda no resultado final?",
+                    "Qual sinal você gostaria que sua imagem comunicasse com mais clareza?",
+                    "Em qual situação dos próximos 7 dias você quer parecer mais alinhada com quem você é?"
+                  ]
+                },
+                "missions": [
+                  {
+                    "id": "dia-1-ruido-visual",
+                    "day": 1,
+                    "title": "Ler o sinal que sua imagem comunica",
+                    "principle": "A presença cresce quando você identifica o sinal visual que mais distancia sua imagem da mulher que você quer transmitir.",
+                    "action": "Hoje você não vai tentar mudar tudo. Vista ou separe uma combinação real, olhe roupa, cabelo, pele, perfume e detalhe final, identifique o sinal que deixa sua imagem comum ou desalinhada e escolha uma microação para comunicar mais intenção.",
+                    "evidence": "Frase preenchida: hoje minha imagem comunica menos intenção quando...",
+                    "visualCue": "Compare a sensação antes/depois de remover ruído visual ou reforçar um sinal de presença."
+                  },
+                  {
+                    "id": "dia-2-assinatura",
+                    "day": 2,
+                    "title": "Criar sua assinatura simples",
+                    "principle": "Coerência repetida cria reconhecimento sem exigir roupa nova.",
+                    "action": "Defina 3 sinais que você quer repetir: acabamento do cabelo, cor-base, textura, perfume, acessório ou maquiagem leve.",
+                    "evidence": "Lista dos 3 sinais escolhidos.",
+                    "visualCue": "Monte um pequeno painel com seus sinais recorrentes."
+                  },
+                  {
+                    "id": "dia-3-base-acessivel",
+                    "day": 3,
+                    "title": "Usar o que já existe melhor",
+                    "principle": "A mudança fica mais viável quando começa pelo que já está no armário.",
+                    "action": "Separe 5 peças, 2 acessórios e 1 perfume que já podem sustentar a presença desejada.",
+                    "evidence": "Inventário simples dos itens reaproveitados.",
+                    "visualCue": "Organize os itens em uma combinação para uma saída real."
+                  },
+                  {
+                    "id": "dia-4-checklist-12-minutos",
+                    "day": 4,
+                    "title": "Fazer o acabamento de 12 minutos",
+                    "principle": "Rotinas curtas reduzem atrito e aumentam consistência.",
+                    "action": "Passe pelo checklist cabelo, pele, roupa, perfume, acessório e postura antes de sair.",
+                    "evidence": "Checklist marcado com o tempo gasto.",
+                    "visualCue": "Use uma escala de 1 a 5 para medir coerência final."
+                  },
+                  {
+                    "id": "dia-5-compra-inteligente",
+                    "day": 5,
+                    "title": "Segurar a compra que não resolve",
+                    "principle": "Compra boa é aquela que fortalece sua assinatura, não a que compensa insegurança momentânea.",
+                    "action": "Antes de comprar algo, responda se o item combina com seus 3 sinais de presença.",
+                    "evidence": "Decisão registrada: comprar, esperar ou descartar.",
+                    "visualCue": "Compare desejo imediato com utilidade real na sua rotina."
+                  },
+                  {
+                    "id": "dia-6-situacao-chave",
+                    "day": 6,
+                    "title": "Preparar sua entrada",
+                    "principle": "A presença fica mais forte quando é planejada para contextos reais.",
+                    "action": "Escolha uma ocasião e monte uma composição completa com intenção: roupa, cabelo, pele, perfume e detalhe final.",
+                    "evidence": "Plano da ocasião com roupa, cabelo, pele, perfume e detalhe final.",
+                    "visualCue": "Visualize a entrada no ambiente e ajuste o que estiver incoerente."
+                  },
+                  {
+                    "id": "dia-7-plano-pessoal",
+                    "day": 7,
+                    "title": "Fechar seu antes e depois",
+                    "principle": "A transformação continua quando vira padrão simples de repetição.",
+                    "action": "Monte seu plano de manutenção com sinais, checklist e regra anti-impulso.",
+                    "evidence": "Plano pessoal preenchido.",
+                    "visualCue": "Escolha um ritual semanal de 15 minutos para manter sua presença."
+                  }
+                ],
+                "supportMaterials": [
+                  {
+                    "title": "E-book Método MUSA",
+                    "type": "PDF",
+                    "description": "Guia de consulta para entender o método, ver exemplos e revisar sua semana.",
+                    "url": "/materials/metodo-musa-ebook.pdf"
+                  },
+                  {
+                    "title": "Experiência Guiada MUSA",
+                    "type": "HTML",
+                    "description": "Versão navegável da experiência para consultar a ordem, o diagnóstico e as missões de 7 dias.",
+                    "url": "/materials/experiencia-guiada-musa.html"
+                  },
+                  {
+                    "title": "Plano, Checklists e Templates",
+                    "type": "CSV",
+                    "description": "Planilha com a ordem de aplicação, critérios de conclusão e pontos de atenção de cada material.",
+                    "url": "/materials/plano-checklists-e-templates.csv"
+                  },
+                  {
+                    "title": "Mapa Visual MUSA",
+                    "type": "Infográfico",
+                    "description": "Resumo visual do método: coerência, redução de ruído e assinatura pessoal.",
+                    "url": "/materials/mapa-visual-musa.png"
+                  }
+                ],
+                "scientificEvidencePack": {
+                  "version": "musa-evidence-pack-v1",
+                  "principles": [
+                    "A roupa pode influenciar a forma como a pessoa se percebe e se comporta em uma situação.",
+                    "Escolhas de vestimenta, formalidade e acabamento participam da percepção social e dos primeiros julgamentos.",
+                    "Coerência visual, intenção e repetição de sinais podem reduzir ruído percebido e facilitar reconhecimento pessoal."
+                  ],
+                  "practicalApplications": [
+                    "Transformar princípios de cognição vestida e percepção social em microdecisões simples de roupa, cor, acabamento, postura e detalhe final.",
+                    "Orientar a cliente a usar o que já possui antes de comprar novas peças.",
+                    "Reforçar presença elegante como percepção e coerência, não como garantia universal de aprovação externa."
+                  ],
+                  "allowedLanguage": [
+                    "isso ajuda você a comunicar mais intenção",
+                    "pode reduzir ruído visual",
+                    "favorece uma presença mais coerente",
+                    "ajuda você a se sentir mais alinhada com a imagem que quer transmitir"
+                  ],
+                  "forbiddenClaims": [
+                    "garante elegância",
+                    "muda como todos vão te ver",
+                    "transforma sua personalidade",
+                    "efeito comprovado em qualquer pessoa",
+                    "substitui autoestima, terapia ou consultoria individual"
+                  ],
+                  "references": [
+                    {
+                      "authors": "Adam e Galinsky",
+                      "year": "2012",
+                      "title": "Enclothed cognition",
+                      "source": "Journal of Experimental Social Psychology",
+                      "doi": "10.1016/j.jesp.2012.02.008"
+                    },
+                    {
+                      "authors": "Slepian, Ferber, Gold e Rutchick",
+                      "year": "2015",
+                      "title": "The Cognitive Consequences of Formal Clothing",
+                      "source": "Social Psychological and Personality Science",
+                      "doi": "10.1177/1948550615579462"
+                    },
+                    {
+                      "authors": "Howlett, Pine, Orakcioglu e Fletcher",
+                      "year": "2013",
+                      "title": "The influence of clothing on first impressions",
+                      "source": "Journal of Fashion Marketing and Management",
+                      "doi": "10.1108/13612021311305128"
+                    },
+                    {
+                      "authors": "Hester e Hehman",
+                      "year": "2023",
+                      "title": "Dress is a Fundamental Component of Person Perception",
+                      "source": "Personality and Social Psychology Review",
+                      "doi": "10.1177/10888683231157961"
+                    }
+                  ]
+                },
+                "completionOffer": "Ao concluir os 7 dias, você pode continuar no Clube MUSA com novos desafios mensais de presença, estilo e autocuidado acessível."
+              }',
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias'
+                 AND (pde_experience_json IS NULL OR pde_experience_json = '');

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -18,6 +18,9 @@ databaseChangeLog:
       file: changesets/2026-07-19-product-scientific-evidence-pack.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-21-product-pde-experience-json.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-19-product-musa-seven-day-journey.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.product.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.product.Product;
 import com.marketinghub.product.dto.CreateProductRequest;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 /** Responsabilidade: validar as regras de cadastro comercial de produtos. */
 class ProductServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /** Deve persistir alterações comerciais em um produto já existente. */
     @Test
@@ -26,7 +28,7 @@ class ProductServiceTest {
         ProductRepository productRepository = mock(ProductRepository.class);
         InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
         MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
-        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
         Product product = Product.builder().id(1L).name("Nome antigo").build();
         MarketNiche niche = new MarketNiche();
         CreateProductRequest request = new CreateProductRequest();
@@ -37,6 +39,7 @@ class ProductServiceTest {
         request.setCurrentPriceBrl(new BigDecimal("47.00"));
         request.setTargetAudience("Mulheres urbanas");
         request.setScientificEvidencePack("Evidence Pack MUSA v1");
+        request.setPdeExperienceJson("{\"slug\":\"metodo-musa-7-dias\",\"missions\":[]}");
         request.setSevenDayJourney("Dia 1: diagnóstico; Dia 2: limpeza visual.");
         request.setSupportMaterialPositioning("Material de apoio como reforço secundário.");
         request.setPrimaryCta("Ver meu plano MUSA de 7 dias");
@@ -53,6 +56,7 @@ class ProductServiceTest {
         assertThat(updated.getCurrentPriceBrl()).isEqualByComparingTo("47.00");
         assertThat(updated.getTargetAudience()).isEqualTo(request.getTargetAudience());
         assertThat(updated.getScientificEvidencePack()).isEqualTo("Evidence Pack MUSA v1");
+        assertThat(updated.getPdeExperienceJson()).contains("\"metodo-musa-7-dias\"");
         assertThat(updated.getSevenDayJourney()).isEqualTo("Dia 1: diagnóstico; Dia 2: limpeza visual.");
         assertThat(updated.getSupportMaterialPositioning()).isEqualTo("Material de apoio como reforço secundário.");
         assertThat(updated.getPrimaryCta()).isEqualTo("Ver meu plano MUSA de 7 dias");
@@ -65,7 +69,7 @@ class ProductServiceTest {
         ProductRepository productRepository = mock(ProductRepository.class);
         InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
         MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
-        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
         MarketNiche niche = MarketNiche.builder().name("Elegância feminina prática").build();
         Product product = Product.builder()
                 .id(1L)
@@ -132,7 +136,7 @@ class ProductServiceTest {
         ProductRepository productRepository = mock(ProductRepository.class);
         InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
         MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
-        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
         Product product = Product.builder().id(7L).name("Produto 7").build();
 
         when(productRepository.findBySlug("7")).thenReturn(Optional.empty());
@@ -149,12 +153,52 @@ class ProductServiceTest {
         ProductRepository productRepository = mock(ProductRepository.class);
         InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
         MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
-        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
 
         when(productRepository.findBySlug("inexistente")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buildPublicMarketingDefinitionMarkdown("inexistente"))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("Produto não encontrado");
+    }
+
+    /** Deve expor o contrato JSON de experiência PDE salvo no cadastro do produto. */
+    @Test
+    void getPublicPdeExperienceJson() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
+        Product product = Product.builder()
+                .slug("metodo-musa-7-dias")
+                .pdeExperienceJson("{\"slug\":\"metodo-musa-7-dias\"}")
+                .build();
+
+        when(productRepository.findBySlug("metodo-musa-7-dias")).thenReturn(Optional.of(product));
+
+        String json = service.getPublicPdeExperienceJson("metodo-musa-7-dias");
+
+        assertThat(json).isEqualTo("{\"slug\":\"metodo-musa-7-dias\"}");
+    }
+
+    /** Deve rejeitar contrato PDE que não seja JSON válido antes de salvar o produto. */
+    @Test
+    void updateProductRejectsInvalidPdeExperienceJson() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
+        Product product = Product.builder().id(1L).build();
+        MarketNiche niche = new MarketNiche();
+        CreateProductRequest request = new CreateProductRequest();
+        request.setMarketNicheId(10L);
+        request.setPdeExperienceJson("{json inválido");
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(marketNicheRepository.findById(10L)).thenReturn(Optional.of(niche));
+
+        assertThatThrownBy(() -> service.updateProduct(1L, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Contrato JSON da experiência PDE inválido");
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
@@ -107,4 +107,17 @@ class ProductControllerTest {
                 .andExpect(content().string(containsString("<blockquote>Documento público de posicionamento comercial do produto.</blockquote>")))
                 .andExpect(content().string(containsString("<li><strong>Nome comercial:</strong> Método MUSA</li>")));
     }
+
+    /** Deve expor o contrato JSON da experiência PDE publicado pelo Marketing Hub. */
+    @Test
+    void getPublicPdeExperience() throws Exception {
+        String json = "{\"slug\":\"metodo-musa-7-dias\",\"missions\":[]}";
+
+        when(service.getPublicPdeExperienceJson("metodo-musa-7-dias")).thenReturn(json);
+
+        mockMvc.perform(get("/api/products/public/{productCode}/pde-experience", "metodo-musa-7-dias"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.slug").value("metodo-musa-7-dias"));
+    }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,10 @@
+## 2026-07-21 — PDE MUSA atualizável pelo Marketing Hub
+
+- causa-raiz confirmada: a experiência MUSA do PDE estava definida no código do `pde-platform`, então mudanças de primeira dobra, diagnóstico, missões e materiais exigiam alteração técnica e deploy do módulo PDE.
+- foi feito: o cadastro de produto do Marketing Hub passou a armazenar o contrato JSON versionado da experiência PDE em `pde_experience_json` e a expor esse contrato por `/api/products/public/{productCode}/pde-experience`.
+- foi feito: o backend PDE passou a buscar primeiro a experiência publicada pelo Marketing Hub e usar o catálogo local apenas como fallback de disponibilidade.
+- impacto esperado: próximas atualizações comerciais do MUSA podem ser feitas pelo cadastro de produtos do Hub, mantendo a campanha dependente de dados de produto editáveis e não de mudança manual no código do PDE.
+
 ## 2026-07-21 — Clube MUSA: primeira dobra orientada a Mapa de Presença
 
 - causa-raiz confirmada: a campanha trazia cliques e sessões, mas a entrada do PDE não gerava microcompromisso; a copy anterior dependia de termos genéricos como ajuste/detalhe e o evento de escolha de diagnóstico não estava aceito no backend.

--- a/frontend/src/api/product/useCreateProduct.ts
+++ b/frontend/src/api/product/useCreateProduct.ts
@@ -32,6 +32,7 @@ export interface CreateProduct {
   riskReversal: string;
   socialProof: string;
   scientificEvidencePack?: string;
+  pdeExperienceJson?: string;
   checkoutMonetization: string;
   funnel: string;
   creativeVolume: string;

--- a/frontend/src/api/product/useProducts.ts
+++ b/frontend/src/api/product/useProducts.ts
@@ -32,6 +32,7 @@ export interface Product {
   riskReversal: string;
   socialProof: string;
   scientificEvidencePack?: string;
+  pdeExperienceJson?: string;
   checkoutMonetization: string;
   funnel: string;
   creativeVolume: string;

--- a/frontend/src/pages/product/ProductForm.tsx
+++ b/frontend/src/pages/product/ProductForm.tsx
@@ -49,6 +49,7 @@ const defaultForm: ProductFormValues = {
   riskReversal: "",
   socialProof: "",
   scientificEvidencePack: "",
+  pdeExperienceJson: "",
   checkoutMonetization: "",
   funnel: "",
   creativeVolume: "",
@@ -93,6 +94,7 @@ function toFormValues(product?: Product): ProductFormValues {
     riskReversal: product.riskReversal ?? "",
     socialProof: product.socialProof ?? "",
     scientificEvidencePack: product.scientificEvidencePack ?? "",
+    pdeExperienceJson: product.pdeExperienceJson ?? "",
     checkoutMonetization: product.checkoutMonetization ?? "",
     funnel: product.funnel ?? "",
     creativeVolume: product.creativeVolume ?? "",
@@ -529,6 +531,14 @@ export default function ProductForm({
             multiline
             rows={5}
             value={form.scientificEvidencePack}
+            onChange={setField}
+          />
+          <ProductField
+            field="pdeExperienceJson"
+            label="Contrato JSON da experiência PDE"
+            multiline
+            rows={12}
+            value={form.pdeExperienceJson}
             onChange={setField}
           />
         </ProductEditorSection>

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
@@ -9,22 +9,70 @@ import com.marketinghub.pde.dto.ProductExperienceResponse.SupportMaterialDto;
 import com.marketinghub.pde.dto.ProductExperienceResponse.ThemeDto;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
 
 /** Mantém o catálogo configurável dos produtos experienciais disponíveis. */
 @Service
 public class ProductCatalogService {
+    private static final Logger log = LoggerFactory.getLogger(ProductCatalogService.class);
 
     private final Map<String, ProductExperienceResponse> products = Map.of(
             "metodo-musa-7-dias", createMusaProduct());
+    private final RestClient marketingHubClient;
+    private final String marketingHubBaseUrl;
+
+    /** Cria o catálogo com integração opcional ao Marketing Hub como fonte de verdade comercial. */
+    @Autowired
+    public ProductCatalogService(
+            RestClient.Builder restClientBuilder,
+            @Value("${pde.catalog.marketing-hub-base-url:}") String marketingHubBaseUrl) {
+        this.marketingHubBaseUrl = marketingHubBaseUrl;
+        this.marketingHubClient = StringUtils.hasText(marketingHubBaseUrl)
+                ? restClientBuilder.baseUrl(marketingHubBaseUrl.trim()).build()
+                : restClientBuilder.build();
+    }
+
+    /** Cria o catálogo em testes unitários sem dependência do Marketing Hub. */
+    ProductCatalogService() {
+        this(RestClient.builder(), "");
+    }
 
     /** Retorna a experiência configurada para o produto informado. */
     public ProductExperienceResponse getProduct(String slug) {
+        Optional<ProductExperienceResponse> marketingHubProduct = loadMarketingHubProduct(slug);
+        if (marketingHubProduct.isPresent()) {
+            return marketingHubProduct.get();
+        }
         ProductExperienceResponse product = products.get(slug);
         if (product == null) {
             throw new IllegalArgumentException("Produto PDE não encontrado: " + slug);
         }
         return product;
+    }
+
+    /** Carrega o contrato PDE publicado pelo Marketing Hub quando a integração estiver configurada. */
+    private Optional<ProductExperienceResponse> loadMarketingHubProduct(String slug) {
+        if (!StringUtils.hasText(marketingHubBaseUrl)) {
+            return Optional.empty();
+        }
+        try {
+            ProductExperienceResponse product = marketingHubClient.get()
+                    .uri("/api/products/public/{slug}/pde-experience", slug)
+                    .retrieve()
+                    .body(ProductExperienceResponse.class);
+            return Optional.ofNullable(product);
+        } catch (RuntimeException ex) {
+            log.warn("Falha ao carregar experiência PDE do Marketing Hub; usando catálogo local: slug={}, baseUrl={}",
+                    slug, marketingHubBaseUrl, ex);
+            return Optional.empty();
+        }
     }
 
     /** Cria a primeira configuração do produto MUSA para o experimento 66. */

--- a/pde-platform/backend/src/main/resources/application.yml
+++ b/pde-platform/backend/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     name: pde-platform-backend
 
 pde:
+  catalog:
+    marketing-hub-base-url: ${PDE_MARKETING_HUB_BASE_URL:}
   access:
     storage-path: ${PDE_ACCESS_STORAGE_PATH:/data/pde/access-grants.json}
     jdbc-url: ${PDE_ACCESS_JDBC_URL:}

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/ProductCatalogServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/ProductCatalogServiceTest.java
@@ -6,6 +6,12 @@ import com.marketinghub.pde.dto.ProductExperienceResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /** Valida o catálogo inicial de produtos PDE. */
 class ProductCatalogServiceTest {
@@ -22,6 +28,52 @@ class ProductCatalogServiceTest {
         assertThat(product.supportMaterials()).hasSize(4);
         assertThat(product.scientificEvidencePack().version()).isEqualTo("musa-evidence-pack-v1");
         assertThat(product.scientificEvidencePack().forbiddenClaims()).contains("garante elegância");
+    }
+
+    /** Confirma que o catálogo prioriza o contrato PDE publicado pelo Marketing Hub. */
+    @Test
+    void returnsMarketingHubProductWhenConfigured() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        ProductCatalogService service = new ProductCatalogService(builder, "http://marketing-hub");
+        server.expect(requestTo("http://marketing-hub/api/products/public/metodo-musa-7-dias/pde-experience"))
+                .andRespond(withSuccess("""
+                        {
+                          "slug": "metodo-musa-7-dias",
+                          "name": "Método MUSA pelo Hub",
+                          "promise": "Promessa publicada pelo Marketing Hub",
+                          "audience": "Mulheres urbanas",
+                          "priceLabel": "",
+                          "theme": {
+                            "primary": "#7a2444",
+                            "accent": "#d6a75c",
+                            "background": "#fff8f3",
+                            "imageUrl": "/assets/musa-cover.png"
+                          },
+                          "diagnostic": {
+                            "title": "Mapa de Presença",
+                            "intro": "Entrada publicada no Hub",
+                            "questions": ["Pergunta 1"]
+                          },
+                          "missions": [],
+                          "supportMaterials": [],
+                          "scientificEvidencePack": {
+                            "version": "musa-evidence-pack-v1",
+                            "principles": [],
+                            "practicalApplications": [],
+                            "allowedLanguage": [],
+                            "forbiddenClaims": [],
+                            "references": []
+                          },
+                          "completionOffer": "Continuidade"
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        var product = service.getProduct("metodo-musa-7-dias");
+
+        assertThat(product.name()).isEqualTo("Método MUSA pelo Hub");
+        assertThat(product.promise()).isEqualTo("Promessa publicada pelo Marketing Hub");
+        server.verify();
     }
 
     /** Garante que o catálogo visível da MUSA usa português brasileiro com acentuação. */

--- a/pde-platform/docker-compose.deploy.yml
+++ b/pde-platform/docker-compose.deploy.yml
@@ -7,6 +7,7 @@ services:
       - "${PDE_PLATFORM_BACKEND_PORT:-8096}:8096"
     environment:
       PDE_ACCESS_REQUIRE_JDBC: "true"
+      PDE_MARKETING_HUB_BASE_URL: ${PDE_MARKETING_HUB_BASE_URL:-http://191.252.181.168}
       PDE_ACCESS_JDBC_URL: ${PDE_ACCESS_JDBC_URL:?PDE_ACCESS_JDBC_URL is required for PDE production analytics}
       PDE_ACCESS_JDBC_USERNAME: ${PDE_ACCESS_JDBC_USERNAME:?PDE_ACCESS_JDBC_USERNAME is required for PDE production analytics}
       PDE_ACCESS_JDBC_PASSWORD: ${PDE_ACCESS_JDBC_PASSWORD:?PDE_ACCESS_JDBC_PASSWORD is required for PDE production analytics}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz o merge e o deploy vamos aguardar dados. Nos sabemos como comparar a versão antiga da nova ?

Modelo: {"titulo":"Comparação MUSA","comentario":"Sim. Sabemos comparar, mas a comparação correta não é apenas \"página antiga vs página nova\". Para o MUSA, a comparação precisa ser por **funil comercial completo**.\n\n**Fonte de verdade usada:** definição pública do PDE MUSA, registro do experimento 66, registro operacional do experimento 67 e cânone de experimentos.\n\n**O que comparar:**\n\n- **Versão antiga:** experimento 66, com venda do Método MUSA como experiência guiada simples, preço R$47/R$67 e foco em landing/checkout/Área MUSA.\n- **Versão nova:** experimento 67 pós-merge/deploy, com PDE publicado, analytics resetado e campanha Meta já iniciada.\n- **Métrica principal:** compra aprovada ou, se ainda não houver volume, avanço real no funil: clique no anúncio → acesso → diagnóstico/entrada no PDE → clique no paywall/checkout → início de checkout → compra.\n\n**Alternativas de comparação avaliadas:**\n\n1. **Comparar só criativo/anúncio**  \n   Benefício: rápido.  \n   Risco: mostra CTR/CPC, mas não prova venda.  \n   Aderência ao objetivo de vendas: baixa.\n\n2. **Comparar só página/PDE**  \n   Benefício: mostra se a nova experiência segura melhor o tráfego.  \n   Risco: se o anúncio ou público estiver ruim, a página pode ser culpada injustamente.  \n   Aderência: média.\n\n3. **Comparar funil completo por etapa**  \n   Benefício: identifica onde melhorou ou quebrou: anúncio, página, diagnóstico, paywall, checkout ou entrega.  \n   Risco: precisa aguardar dados mínimos.  \n   Aderência: alta.\n\n**Escolha recomendada:** alternativa 3.\n\n**Como vamos decidir se a versão nova é melhor:**\n\n- Se o **CTR subir**, mas checkout/compra não subir: criativo melhorou, oferta/paywall ainda precisa ajuste.\n- Se o **acesso ao PDE subir**, mas diagnóstico/paywall não avançar: problema de ativação da experiência.\n- Se houver **clique no checkout**, mas não compra: problema de preço, confiança, checkout ou objeção final.\n- Se houver **compra com gasto baixo**, mesmo com poucos dados: manter coleta e preparar escala gradual.\n- Se gastar perto de R$25 sem evento primário relevante, o cânone recomenda parar e corrigir causa-raiz antes de insistir.\n\n**Ponto importante:** o registro já mostra que o experimento 67 começou com 92 impressões, 3 cliques e R$0,61 de gasto em 2026-07-20. Isso ainda é pouco para conclusão, mas já confirma que a medição saiu do zero e que o reset de analytics do PDE aconteceu.\n\n**Próximo acompanhamento ideal:** quando tivermos mais dados, eu compararia em uma tabela simples:\n\n| Etapa | Exp. 66 | Exp. 67 | Leitura |\n|---|---:|---:|---|\n| Impressões | antigo | novo | entrega da mídia |\n| CTR | antigo | novo | força do criativo |\n| CPC | antigo | novo | custo de atenção |\n| Page view/PDE view | antigo | novo | tráfego real chegando |\n| Diagnóstico iniciado | antigo | novo | ativação |\n| Paywall/checkout click | antigo | novo | intenção de compra |\n| Checkout iniciado | antigo | novo | força da oferta |\n| Compra | antigo | novo | validação comercial |\n| CPA/ROAS | antigo | novo | escala |\n\nMinha recomendação agora é aguardar até termos pelo menos uma das duas condições: **R$25 de gasto sem compra/evento primário** ou **sinal positivo de checkout/compra antes disso**. Aí a leitura fica objetiva e não baseada em impressão inicial.","sugestaoMelhoriaAmbiente":""}

Usuário: mas fizemos uma alteraçaõ recente veja no github precisamos monitorar isso

Modelo: {"titulo":"Monitoramento do MUSA","comentario":"Sim. A alteração recente que precisamos monitorar é o PR #4435, mergeado em **21/07/2026 00:56 UTC**.\n\n**O que mudou comercialmente:** a entrada do PDE deixou de vender um diagnóstico genérico e passou a vender o **Mapa de Presença do Dia 1**, com duas escolhas antes do e-mail. Isso ataca diretamente o gargalo anterior: tráfego chegava, mas ninguém clicava, preenchia e-mail, iniciava login ou via paywall.\n\n**Status validado agora:**\n\n- Deploy do GitHub Actions concluiu com sucesso.\n- Site público já serve a nova copy: “Sua imagem comunica a mulher que você quer ser vista como?” e “Mapa de Presença”.\n- Backend PDE subiu após o merge, sem erro relevante no log.\n- MCP já consulta o schema real do PDE: `aihubdb`.\n- Banco PDE ainda não recebeu eventos depois do merge.\n- Último evento MUSA persistido: **20/07/2026 22:10:19**.\n\n**Linha de base antes da alteração:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE MUSA | 427 |\n| Entradas no PDE | 65 |\n| Sessões com entrada | 65 |\n| Cliques no diagnóstico/mapa | 0 |\n| E-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n| Compra aprovada | 0 |\n\n**Meta Ads:** a campanha `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA` está **ACTIVE**. Dados disponíveis no período do ad account: **1.565 impressões, 91 cliques, R$10,51 gastos, CTR 5,81%, CPC R$0,115 e 61 landing page views**.\n\n**Como vamos monitorar a nova versão:**\n\n1. **Primeiro sinal obrigatório:** aparecer `PRESENCE_MAP_CHOICE_SELECTED` ou `DIAGNOSTIC_CHOICE_SELECTED` no banco.  \n   Se isso não aparecer com tráfego ativo, o problema continua na primeira dobra ou no tracking.\n\n2. **Segundo sinal:** depois do primeiro clique, medir `FIELD_FILLED` e `LOGIN_STARTED`.  \n   Se houver clique no mapa mas não houver e-mail, a oferta inicial interessa, mas a transição para captura ainda está fraca.\n\n3. **Terceiro sinal:** `LOGIN_COMPLETED`, `PAYWALL_VIEWED` e `SUBSCRIPTION_CLICKED`.  \n   Se chegar aqui, finalmente poderemos avaliar preço, paywall e checkout.\n\n**Alternativas avaliadas:**\n\n1. Monitorar só Meta Ads: rápido, mas não mostra se o PDE destravou.\n2. Monitorar só banco PDE: mostra comportamento real, mas não separa falta de tráfego de falha da página.\n3. Monitorar Meta + eventos PDE por etapa: melhor opção, porque mostra se o anúncio entrega tráfego e se a nova entrada transforma atenção em ação.\n\n**Escolha:** alternativa 3.\n\n**Critério prático:** se a campanha continuar entregando tráfego e, após novo volume, o banco continuar com **zero clique no Mapa de Presença**, a alteração não resolveu o gargalo. Se aparecer clique no mapa, mas não e-mail/login, o próximo ajuste deve ser na transição para salvar o resultado por e-mail.","sugestaoMelhoriaAmbiente":"Ativar as tools de GitHub Actions no MCP e criar um painel/alerta automático para eventos PDE pós-deploy permitiria monitoramento contínuo sem depender de consultas manuais."}

Última mensagem do usuário:
Precisamos colocar essa forma de atualização do PDE no Marketing Hub fazer isso atraves do Marketing Hub.

**Resumo das alterações:**
{"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiência PDE.\n- O Hub expõe esse contrato em `/api/products/public/{productCode}/pde-experience`.\n- O formulário de Produto no frontend permite editar esse JSON.\n- O backend do `pde-platform` tenta carregar primeiro a experiência publicada pelo Hub.\n- Se o Hub estiver indisponível ou sem contrato publicado, o PDE usa o catálogo local atual como fallback, sem derrubar o Clube MUSA.\n- O deploy do PDE passa a receber `PDE_MARKETING_HUB_BASE_URL`, apontando por padrão para o backend do Marketing Hub.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Alternativas avaliadas:**\n\n1. Editar o PDE direto no código: rápido, mas mantém dependência de deploy técnico para mudança comercial.\n2. Criar endpoint administrativo só no PDE: melhora operação, mas tira o Hub da fonte de verdade.\n3. Fazer o Hub publicar o contrato PDE e o PDE consumir: melhor opção, porque centraliza produto, copy, jornada e oferta no Marketing Hub.\n\n**Escolha aplicada:** alternativa 3.\n\n**Validação feita:**\n\n- `ProductServiceTest` e `ProductControllerTest`: 10 testes passaram.\n- `ProductCatalogServiceTest` do PDE: 3 testes passaram.\n- `npm run typecheck` do frontend passou após instalar dependências locais com `npm ci`.\n- `git diff --check` sem problemas.\n- Changelog mestre revisado com `relativeToChangelogFile: true` no include novo.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso chegar em produção, o próximo passo é você pedir/abrir o PR e depois fazer o deploy do backend principal e do pde-platform."}