### PR TITLE
AI Hub: {"titulo":"Painel pós-deploy pronto","comentario":"Implementei o painel automático pós-deploy no Marketing Hub.\n\n**O que ficou pronto:**\n\n- Nova aba **Pós-deploy** dentro do detalhe do experimento.\n- Endpoint agregador no backend: `/api/exper…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
@@ -1,0 +1,309 @@
+package com.marketinghub.experiment.monitoring;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.experiment.monitoring.dto.PostDeployFacebookLogSummaryDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployMetaAdsSummaryDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorDecision;
+import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSummaryDto;
+import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
+import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
+import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
+import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
+import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Consolida Meta Ads, analytics PDE e logs para decisão pós-deploy do experimento. */
+@Service
+@Slf4j
+public class PostDeployMonitorService {
+
+    private static final String DEFAULT_PDE_PRODUCT_SLUG = "metodo-musa-7-dias";
+    private static final BigDecimal ZERO_INTERACTION_SPEND_THRESHOLD = BigDecimal.valueOf(25);
+
+    private final ExperimentRepository experimentRepository;
+    private final ExperimentCampaignMetricRepository campaignMetricRepository;
+    private final ExperimentFacebookApiLogService apiLogService;
+    private final PdeAnalyticsClient pdeAnalyticsClient;
+
+    /** Inicializa o agregador com as fontes persistidas do Hub e o cliente do PDE. */
+    public PostDeployMonitorService(
+            ExperimentRepository experimentRepository,
+            ExperimentCampaignMetricRepository campaignMetricRepository,
+            ExperimentFacebookApiLogService apiLogService,
+            PdeAnalyticsClient pdeAnalyticsClient) {
+        this.experimentRepository = experimentRepository;
+        this.campaignMetricRepository = campaignMetricRepository;
+        this.apiLogService = apiLogService;
+        this.pdeAnalyticsClient = pdeAnalyticsClient;
+    }
+
+    /** Monta o painel pós-deploy para o experimento e produto PDE informados. */
+    public PostDeployMonitorResponseDto summarize(Long experimentId, String productSlug) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experimento %d não encontrado".formatted(experimentId)));
+        String resolvedProductSlug = resolveProductSlug(productSlug);
+        ExperimentCampaignMetric metric = campaignMetricRepository.findByExperiment(experiment).orElse(null);
+        PostDeployMetaAdsSummaryDto metaAds = toMetaAdsSummary(metric);
+        PostDeployPdeSummaryDto pde = fetchPdeSummary(resolvedProductSlug);
+        PostDeployFacebookLogSummaryDto logs = summarizeLogs(experimentId);
+        List<String> alerts = buildAlerts(metaAds, pde, logs);
+        PostDeployMonitorDecision decision = decide(metaAds, pde, logs);
+        return new PostDeployMonitorResponseDto(
+                experimentId,
+                resolvedProductSlug,
+                Instant.now(),
+                decision,
+                decisionLabel(decision),
+                recommendation(decision, pde),
+                metaAds,
+                pde,
+                logs,
+                alerts);
+    }
+
+    /** Resolve o produto PDE padrão quando a tela não informa um slug específico. */
+    private String resolveProductSlug(String productSlug) {
+        return StringUtils.hasText(productSlug) ? productSlug.trim() : DEFAULT_PDE_PRODUCT_SLUG;
+    }
+
+    /** Converte a métrica persistida da campanha em resumo do painel. */
+    private PostDeployMetaAdsSummaryDto toMetaAdsSummary(ExperimentCampaignMetric metric) {
+        if (metric == null) {
+            return new PostDeployMetaAdsSummaryDto(null, null, null, null, null, null, null, null, null, null, null, null);
+        }
+        return new PostDeployMetaAdsSummaryDto(
+                metric.getDateStart(),
+                metric.getDateStop(),
+                metric.getReach(),
+                metric.getImpressions(),
+                metric.getClicks(),
+                metric.getLeads(),
+                metric.getSpend(),
+                metric.getCpc(),
+                metric.getCpl(),
+                calculateCtrPercent(metric),
+                metric.getCampaign() != null ? metric.getCampaign().getMetricsLastSyncedAt() : null,
+                metric.getCampaign() != null ? metric.getCampaign().getMetricsLastError() : null);
+    }
+
+    /** Calcula CTR percentual com arredondamento estável para exibição administrativa. */
+    private BigDecimal calculateCtrPercent(ExperimentCampaignMetric metric) {
+        if (metric.getClicks() == null || metric.getImpressions() == null || metric.getImpressions() == 0) {
+            return null;
+        }
+        return BigDecimal.valueOf(metric.getClicks())
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(metric.getImpressions()), 2, RoundingMode.HALF_UP);
+    }
+
+    /** Consulta o PDE e retorna um resumo indisponível quando houver falha técnica. */
+    private PostDeployPdeSummaryDto fetchPdeSummary(String productSlug) {
+        try {
+            PdeAnalyticsSummary summary = pdeAnalyticsClient.fetchSummary(productSlug);
+            return toPdeSummary(summary);
+        } catch (Exception ex) {
+            log.error("Falha ao consultar analytics PDE no monitor pós-deploy; productSlug={}", productSlug, ex);
+            return new PostDeployPdeSummaryDto(
+                    false,
+                    "UNAVAILABLE",
+                    ex.getMessage(),
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    null,
+                    Map.<String, Long>of());
+        }
+    }
+
+    /** Converte o contrato do PDE em métricas comerciais específicas do painel. */
+    private PostDeployPdeSummaryDto toPdeSummary(PdeAnalyticsSummary summary) {
+        Map<String, Long> events = new LinkedHashMap<>();
+        if (summary.events() != null) {
+            summary.events().forEach(event -> events.put(event.eventType(), event.total()));
+        }
+        return new PostDeployPdeSummaryDto(
+                true,
+                "AVAILABLE",
+                null,
+                summary.totalEvents(),
+                summary.uniqueVisitors(),
+                summary.sessions(),
+                summary.pedEntries(),
+                summary.pageViews(),
+                eventTotal(events, "PRESENCE_MAP_CHOICE_SELECTED"),
+                eventTotal(events, "DIAGNOSTIC_CHOICE_SELECTED"),
+                eventTotal(events, "FIELD_FILLED"),
+                summary.loginStarted(),
+                summary.loginCompleted(),
+                summary.paywallViewed(),
+                summary.subscriptionClicked(),
+                summary.checkoutStarted(),
+                summary.subscriptionApproved(),
+                summary.totalVisibleMs(),
+                null,
+                events);
+    }
+
+    /** Busca a contagem do evento considerando aliases de caixa alta e baixa. */
+    private long eventTotal(Map<String, Long> events, String eventType) {
+        Long direct = events.get(eventType);
+        if (direct != null) {
+            return direct;
+        }
+        String normalized = eventType.toLowerCase(Locale.ROOT);
+        return events.entrySet().stream()
+                .filter(entry -> normalized.equals(entry.getKey().toLowerCase(Locale.ROOT)))
+                .mapToLong(Map.Entry::getValue)
+                .sum();
+    }
+
+    /** Resume os logs recentes da API Meta vinculados ao experimento. */
+    private PostDeployFacebookLogSummaryDto summarizeLogs(Long experimentId) {
+        List<ExperimentFacebookApiLogDto> logs = apiLogService.findLogs(experimentId, 50);
+        int errorLogs = (int) logs.stream().filter(this::isErrorLog).count();
+        List<String> recentErrors = logs.stream()
+                .filter(this::isErrorLog)
+                .map(this::formatLogError)
+                .limit(5)
+                .toList();
+        Instant lastLogAt = logs.stream()
+                .map(this::logInstant)
+                .filter(java.util.Objects::nonNull)
+                .max(Instant::compareTo)
+                .orElse(null);
+        return new PostDeployFacebookLogSummaryDto(logs.size(), errorLogs, lastLogAt, recentErrors);
+    }
+
+    /** Identifica falhas de integração por status HTTP ou mensagem de erro. */
+    private boolean isErrorLog(ExperimentFacebookApiLogDto log) {
+        return (log.statusCode() != null && log.statusCode() >= 400)
+                || StringUtils.hasText(log.errorMessage());
+    }
+
+    /** Formata um erro recente sem expor payloads sensíveis. */
+    private String formatLogError(ExperimentFacebookApiLogDto log) {
+        String endpoint = StringUtils.hasText(log.endpoint()) ? log.endpoint() : "endpoint não informado";
+        String status = log.statusCode() != null ? "HTTP " + log.statusCode() : "sem status";
+        String message = StringUtils.hasText(log.errorMessage()) ? " - " + log.errorMessage() : "";
+        return endpoint + " (" + status + ")" + message;
+    }
+
+    /** Resolve o horário operacional mais útil do log. */
+    private Instant logInstant(ExperimentFacebookApiLogDto log) {
+        if (log.requestedAt() != null) {
+            return log.requestedAt();
+        }
+        if (log.respondedAt() != null) {
+            return log.respondedAt();
+        }
+        return log.createdAt();
+    }
+
+    /** Monta alertas objetivos para separar falha técnica de leitura comercial. */
+    private List<String> buildAlerts(PostDeployMetaAdsSummaryDto metaAds,
+                                     PostDeployPdeSummaryDto pde,
+                                     PostDeployFacebookLogSummaryDto logs) {
+        List<String> alerts = new ArrayList<>();
+        if (!pde.available()) {
+            alerts.add("Analytics PDE indisponível; validar saúde do pde-platform antes de concluir resultado comercial.");
+        }
+        if (StringUtils.hasText(metaAds.lastSyncError())) {
+            alerts.add("Sincronização de métricas Meta Ads possui erro recente.");
+        }
+        if (logs.errorLogs() > 0) {
+            alerts.add("Há erros recentes nos logs da API Meta Ads.");
+        }
+        if (spendAtLeast(metaAds, ZERO_INTERACTION_SPEND_THRESHOLD) && pde.available() && firstInteractionCount(pde) == 0) {
+            alerts.add("Gasto atingiu o limite de atenção sem clique no Mapa/Diagnóstico.");
+        }
+        return alerts;
+    }
+
+    /** Decide a ação operacional recomendada com base em gasto, interação e saúde técnica. */
+    private PostDeployMonitorDecision decide(PostDeployMetaAdsSummaryDto metaAds,
+                                             PostDeployPdeSummaryDto pde,
+                                             PostDeployFacebookLogSummaryDto logs) {
+        if (!pde.available() || StringUtils.hasText(metaAds.lastSyncError()) || logs.errorLogs() > 0) {
+            return PostDeployMonitorDecision.TECHNICAL_ATTENTION;
+        }
+        if (pde.subscriptionApproved() > 0) {
+            return PostDeployMonitorDecision.SCALE_GRADUALLY;
+        }
+        if (spendAtLeast(metaAds, ZERO_INTERACTION_SPEND_THRESHOLD) && firstInteractionCount(pde) == 0) {
+            return PostDeployMonitorDecision.PAUSE_AND_FIX;
+        }
+        if ((metaAds.spend() == null || BigDecimal.ZERO.compareTo(metaAds.spend()) == 0) && pde.sessions() == 0) {
+            return PostDeployMonitorDecision.WAITING_DATA;
+        }
+        return PostDeployMonitorDecision.KEEP_MONITORING;
+    }
+
+    /** Verifica se o gasto rastreado atingiu o limite informado. */
+    private boolean spendAtLeast(PostDeployMetaAdsSummaryDto metaAds, BigDecimal threshold) {
+        return metaAds.spend() != null && metaAds.spend().compareTo(threshold) >= 0;
+    }
+
+    /** Conta a primeira interação comercial relevante dentro do PDE. */
+    private long firstInteractionCount(PostDeployPdeSummaryDto pde) {
+        return pde.presenceMapClicks() + pde.diagnosticClicks();
+    }
+
+    /** Retorna o rótulo em português da decisão sugerida. */
+    private String decisionLabel(PostDeployMonitorDecision decision) {
+        return switch (decision) {
+            case WAITING_DATA -> "Aguardando dados";
+            case KEEP_MONITORING -> "Manter monitoramento";
+            case PAUSE_AND_FIX -> "Pausar e corrigir";
+            case SCALE_GRADUALLY -> "Escalar gradualmente";
+            case TECHNICAL_ATTENTION -> "Corrigir medição";
+        };
+    }
+
+    /** Retorna a recomendação executiva para a próxima decisão comercial. */
+    private String recommendation(PostDeployMonitorDecision decision, PostDeployPdeSummaryDto pde) {
+        return switch (decision) {
+            case WAITING_DATA -> "Ainda não há volume suficiente para leitura. Aguarde tráfego real pós-deploy.";
+            case KEEP_MONITORING -> buildKeepMonitoringRecommendation(pde);
+            case PAUSE_AND_FIX -> "Pausar a campanha e ajustar a primeira dobra/CTA do PDE antes de gastar mais mídia.";
+            case SCALE_GRADUALLY -> "Compra aprovada detectada. Manter a versão e escalar orçamento em passos pequenos.";
+            case TECHNICAL_ATTENTION -> "Corrigir integração, logs ou sincronização antes de tomar decisão comercial.";
+        };
+    }
+
+    /** Detalha a recomendação quando ainda existe sinal intermediário no funil. */
+    private String buildKeepMonitoringRecommendation(PostDeployPdeSummaryDto pde) {
+        if (firstInteractionCount(pde) > 0 && pde.fieldFilled() == 0) {
+            return "Há clique inicial no PDE, mas o e-mail ainda não avançou. Monitorar e preparar ajuste na captura.";
+        }
+        if (pde.paywallViewed() > 0 && pde.subscriptionApproved() == 0) {
+            return "O funil chegou ao paywall, mas ainda não comprou. Monitorar oferta, preço e objeções finais.";
+        }
+        return "Continuar coletando dados até atingir volume mínimo ou sinal de checkout/compra.";
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployFacebookLogSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployFacebookLogSummaryDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Resume os logs recentes da Meta Ads usados no monitoramento pós-deploy. */
+public record PostDeployFacebookLogSummaryDto(
+        int totalLogs,
+        int errorLogs,
+        Instant lastLogAt,
+        List<String> recentErrors
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMetaAdsSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMetaAdsSummaryDto.java
@@ -1,0 +1,21 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+/** Resume métricas de mídia paga vinculadas ao experimento monitorado. */
+public record PostDeployMetaAdsSummaryDto(
+        LocalDate dateStart,
+        LocalDate dateStop,
+        Long reach,
+        Long impressions,
+        Long clicks,
+        Long leads,
+        BigDecimal spend,
+        BigDecimal cpc,
+        BigDecimal cpl,
+        BigDecimal ctrPercent,
+        Instant lastSyncedAt,
+        String lastSyncError
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorDecision.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorDecision.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+/** Classifica a decisão operacional sugerida pelo painel pós-deploy. */
+public enum PostDeployMonitorDecision {
+    WAITING_DATA,
+    KEEP_MONITORING,
+    PAUSE_AND_FIX,
+    SCALE_GRADUALLY,
+    TECHNICAL_ATTENTION
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorResponseDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Resposta consolidada do painel de monitoramento pós-deploy do experimento. */
+public record PostDeployMonitorResponseDto(
+        Long experimentId,
+        String productSlug,
+        Instant generatedAt,
+        PostDeployMonitorDecision decision,
+        String decisionLabel,
+        String recommendation,
+        PostDeployMetaAdsSummaryDto metaAds,
+        PostDeployPdeSummaryDto pde,
+        PostDeployFacebookLogSummaryDto logs,
+        List<String> alerts
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
@@ -1,0 +1,28 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+/** Resume analytics do PDE usados para medir interação e intenção comercial. */
+public record PostDeployPdeSummaryDto(
+        boolean available,
+        String status,
+        String errorMessage,
+        long totalEvents,
+        long uniqueVisitors,
+        long sessions,
+        long pdeEntries,
+        long pageViews,
+        long presenceMapClicks,
+        long diagnosticClicks,
+        long fieldFilled,
+        long loginStarted,
+        long loginCompleted,
+        long paywallViewed,
+        long subscriptionClicked,
+        long checkoutStarted,
+        long subscriptionApproved,
+        long totalVisibleMs,
+        Instant lastEventAt,
+        Map<String, Long> events
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsClient.java
@@ -1,0 +1,8 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+/** Cliente responsável por consultar analytics públicos administrativos do PDE. */
+public interface PdeAnalyticsClient {
+
+    /** Busca o resumo de analytics do produto PDE informado. */
+    PdeAnalyticsSummary fetchSummary(String productSlug);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClient.java
@@ -1,0 +1,42 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/** Consulta o backend PDE por HTTP para obter métricas administrativas do funil. */
+@Component
+public class PdeAnalyticsHttpClient implements PdeAnalyticsClient {
+
+    private final RestClient restClient;
+
+    /** Inicializa o cliente HTTP com timeouts curtos para não travar o painel do Hub. */
+    public PdeAnalyticsHttpClient(
+            @Value("${integrations.pde-platform.base-url:http://191.252.181.168:8096}") String baseUrl) {
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory();
+        requestFactory.setReadTimeout(Duration.ofSeconds(4));
+        this.restClient = RestClient.builder()
+                .baseUrl(trimTrailingSlash(baseUrl))
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    /** Busca o resumo consolidado de analytics do produto no backend PDE. */
+    @Override
+    public PdeAnalyticsSummary fetchSummary(String productSlug) {
+        return restClient.get()
+                .uri("/api/pde/access/analytics/{productSlug}/summary", productSlug)
+                .retrieve()
+                .body(PdeAnalyticsSummary.class);
+    }
+
+    /** Remove barra final para montar rotas internas de forma previsível. */
+    private String trimTrailingSlash(String value) {
+        if (value == null || value.isBlank()) {
+            return "http://191.252.181.168:8096";
+        }
+        return value.replaceAll("/+$", "");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
@@ -1,0 +1,26 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+import java.util.List;
+
+/** Contrato mínimo do resumo de analytics retornado pelo backend PDE. */
+public record PdeAnalyticsSummary(
+        String productSlug,
+        long totalEvents,
+        long uniqueVisitors,
+        long sessions,
+        long pedEntries,
+        long pageViews,
+        long loginStarted,
+        long loginCompleted,
+        long paywallViewed,
+        long subscriptionClicked,
+        long subscriptionApproved,
+        long accessReleased,
+        long firstUse,
+        long checkoutStarted,
+        long totalVisibleMs,
+        List<PdeEventMetric> events
+) {
+    /** Representa a contagem agregada por tipo de evento do PDE. */
+    public record PdeEventMetric(String eventType, long total) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/PostDeployMonitorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/PostDeployMonitorController.java
@@ -1,0 +1,30 @@
+package com.marketinghub.experiment.web;
+
+import com.marketinghub.experiment.monitoring.PostDeployMonitorService;
+import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe o painel de monitoramento pós-deploy para experimentos do Marketing Hub. */
+@RestController
+@RequestMapping("/api/experiments/{experimentId}/post-deploy-monitor")
+public class PostDeployMonitorController {
+
+    private final PostDeployMonitorService service;
+
+    /** Inicializa o controller com o serviço agregador de monitoramento. */
+    public PostDeployMonitorController(PostDeployMonitorService service) {
+        this.service = service;
+    }
+
+    /** Retorna a decisão consolidada cruzando Meta Ads, eventos PDE e logs. */
+    @GetMapping
+    public PostDeployMonitorResponseDto summarize(
+            @PathVariable Long experimentId,
+            @RequestParam(name = "productSlug", required = false) String productSlug) {
+        return service.summarize(experimentId, productSlug);
+    }
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -103,6 +103,8 @@ integrations.fashion-chat.base-url=${FASHION_CHAT_SERVICE_BASE_URL:http://191.25
 integrations.fashion-chat.connect-timeout=${FASHION_CHAT_CONNECT_TIMEOUT:PT2S}
 integrations.fashion-chat.read-timeout=${FASHION_CHAT_READ_TIMEOUT:PT0S}
 
+integrations.pde-platform.base-url=${PDE_PLATFORM_BASE_URL:http://191.252.181.168:8096}
+
 # Lead portal asset storage (Cloudflare R2)
 lead-portal.storage.bucket=${LEAD_PORTAL_STORAGE_BUCKET:leadportal}
 lead-portal.storage.endpoint=${LEAD_PORTAL_STORAGE_ENDPOINT:https://95b059f4f73518a658d07a19438f38c9.r2.cloudflarestorage.com}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
@@ -1,0 +1,177 @@
+package com.marketinghub.experiment.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorDecision;
+import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
+import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
+import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
+import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Testa a decisão pós-deploy cruzando Meta Ads, PDE e logs. */
+@ExtendWith(MockitoExtension.class)
+class PostDeployMonitorServiceTest {
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private ExperimentCampaignMetricRepository campaignMetricRepository;
+
+    @Mock
+    private ExperimentFacebookApiLogService apiLogService;
+
+    @Mock
+    private PdeAnalyticsClient pdeAnalyticsClient;
+
+    private PostDeployMonitorService service;
+
+    /** Monta o serviço com dependências controladas para cenários comerciais. */
+    @BeforeEach
+    void setUp() {
+        service = new PostDeployMonitorService(
+                experimentRepository,
+                campaignMetricRepository,
+                apiLogService,
+                pdeAnalyticsClient);
+    }
+
+    /** Recomenda pausa quando há gasto relevante sem primeira interação no PDE. */
+    @Test
+    void recommendsPauseWhenSpendReachesThresholdWithoutPdeInteraction() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(campaignMetricRepository.findByExperiment(experiment)).thenReturn(Optional.of(metric("25.00", null)));
+        when(apiLogService.findLogs(67L, 50)).thenReturn(List.of());
+        when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenReturn(new PdeAnalyticsSummary(
+                "metodo-musa-7-dias",
+                80,
+                20,
+                15,
+                15,
+                15,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2000,
+                List.of()));
+
+        var response = service.summarize(67L, null);
+
+        assertThat(response.decision()).isEqualTo(PostDeployMonitorDecision.PAUSE_AND_FIX);
+        assertThat(response.alerts()).anyMatch(alert -> alert.contains("Mapa/Diagnóstico"));
+        assertThat(response.metaAds().ctrPercent()).isEqualByComparingTo("5.00");
+    }
+
+    /** Recomenda corrigir medição quando o PDE não responde ao Hub. */
+    @Test
+    void recommendsTechnicalAttentionWhenPdeAnalyticsFails() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(campaignMetricRepository.findByExperiment(experiment)).thenReturn(Optional.of(metric("12.00", null)));
+        when(apiLogService.findLogs(67L, 50)).thenReturn(List.of());
+        when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenThrow(new IllegalStateException("offline"));
+
+        var response = service.summarize(67L, "metodo-musa-7-dias");
+
+        assertThat(response.decision()).isEqualTo(PostDeployMonitorDecision.TECHNICAL_ATTENTION);
+        assertThat(response.pde().available()).isFalse();
+        assertThat(response.alerts()).anyMatch(alert -> alert.contains("Analytics PDE indisponível"));
+    }
+
+    /** Recomenda escala gradual quando há compra aprovada no PDE. */
+    @Test
+    void recommendsScaleWhenPdeHasApprovedPurchase() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(campaignMetricRepository.findByExperiment(experiment)).thenReturn(Optional.of(metric("8.00", null)));
+        when(apiLogService.findLogs(67L, 50)).thenReturn(List.of(successLog()));
+        when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenReturn(new PdeAnalyticsSummary(
+                "metodo-musa-7-dias",
+                120,
+                30,
+                20,
+                20,
+                20,
+                5,
+                3,
+                2,
+                2,
+                1,
+                1,
+                1,
+                1,
+                9000,
+                List.of(new PdeAnalyticsSummary.PdeEventMetric("PRESENCE_MAP_CHOICE_SELECTED", 6))));
+
+        var response = service.summarize(67L, null);
+
+        assertThat(response.decision()).isEqualTo(PostDeployMonitorDecision.SCALE_GRADUALLY);
+        assertThat(response.pde().presenceMapClicks()).isEqualTo(6);
+        assertThat(response.logs().totalLogs()).isEqualTo(1);
+    }
+
+    /** Cria uma métrica Meta Ads mínima para os cenários do painel. */
+    private ExperimentCampaignMetric metric(String spend, String lastError) {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("campaign-67");
+        campaign.setMetricsLastSyncedAt(Instant.parse("2026-07-21T02:00:00Z"));
+        campaign.setMetricsLastError(lastError);
+        return ExperimentCampaignMetric.builder()
+                .experiment(experiment)
+                .campaign(campaign)
+                .dateStart(LocalDate.parse("2026-07-21"))
+                .dateStop(LocalDate.parse("2026-07-21"))
+                .impressions(100L)
+                .clicks(5L)
+                .spend(new BigDecimal(spend))
+                .cpc(new BigDecimal("0.10"))
+                .build();
+    }
+
+    /** Cria um log de integração sem falha para validar o resumo de logs. */
+    private ExperimentFacebookApiLogDto successLog() {
+        return new ExperimentFacebookApiLogDto(
+                1L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "METRICS",
+                "META",
+                "/insights",
+                "GET",
+                200,
+                null,
+                Instant.parse("2026-07-21T02:00:00Z"),
+                Instant.parse("2026-07-21T02:00:01Z"),
+                1000L,
+                null,
+                null,
+                Instant.parse("2026-07-21T02:00:01Z"));
+    }
+}

--- a/frontend/src/api/experiment/usePostDeployMonitor.ts
+++ b/frontend/src/api/experiment/usePostDeployMonitor.ts
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export type PostDeployMonitorDecision =
+  | "WAITING_DATA"
+  | "KEEP_MONITORING"
+  | "PAUSE_AND_FIX"
+  | "SCALE_GRADUALLY"
+  | "TECHNICAL_ATTENTION";
+
+export interface PostDeployMetaAdsSummary {
+  dateStart?: string | null;
+  dateStop?: string | null;
+  reach?: number | null;
+  impressions?: number | null;
+  clicks?: number | null;
+  leads?: number | null;
+  spend?: number | null;
+  cpc?: number | null;
+  cpl?: number | null;
+  ctrPercent?: number | null;
+  lastSyncedAt?: string | null;
+  lastSyncError?: string | null;
+}
+
+export interface PostDeployPdeSummary {
+  available: boolean;
+  status: string;
+  errorMessage?: string | null;
+  totalEvents: number;
+  uniqueVisitors: number;
+  sessions: number;
+  pdeEntries: number;
+  pageViews: number;
+  presenceMapClicks: number;
+  diagnosticClicks: number;
+  fieldFilled: number;
+  loginStarted: number;
+  loginCompleted: number;
+  paywallViewed: number;
+  subscriptionClicked: number;
+  checkoutStarted: number;
+  subscriptionApproved: number;
+  totalVisibleMs: number;
+  lastEventAt?: string | null;
+  events: Record<string, number>;
+}
+
+export interface PostDeployFacebookLogSummary {
+  totalLogs: number;
+  errorLogs: number;
+  lastLogAt?: string | null;
+  recentErrors: string[];
+}
+
+export interface PostDeployMonitorResponse {
+  experimentId: number;
+  productSlug: string;
+  generatedAt: string;
+  decision: PostDeployMonitorDecision;
+  decisionLabel: string;
+  recommendation: string;
+  metaAds: PostDeployMetaAdsSummary;
+  pde: PostDeployPdeSummary;
+  logs: PostDeployFacebookLogSummary;
+  alerts: string[];
+}
+
+export function usePostDeployMonitor(
+  experimentId?: string,
+  productSlug = "metodo-musa-7-dias",
+) {
+  return useQuery<PostDeployMonitorResponse>({
+    queryKey: ["experiment", experimentId, "post-deploy-monitor", productSlug],
+    enabled: Boolean(experimentId),
+    refetchInterval: 60_000,
+    queryFn: async () => {
+      const { data } = await axios.get<PostDeployMonitorResponse>(
+        `/api/experiments/${experimentId}/post-deploy-monitor`,
+        { params: { productSlug } },
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../api/experiment/useExperimentCampaignReset";
 import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import ExperimentLandingAnalyticsTab from "./ExperimentLandingAnalyticsTab";
+import ExperimentPostDeployMonitorTab from "./ExperimentPostDeployMonitorTab";
 import ExperimentSalesPageAbTab from "./ExperimentSalesPageAbTab";
 import ExperimentContentGenerationTab from "./ExperimentContentGenerationTab";
 import { ExperimentAudienceTab } from "./ExperimentAudienceTab";
@@ -69,6 +70,7 @@ const experimentDetailTabs = [
   { value: "overview", label: "Overview" },
   { value: "construction", label: "Construção", manualOnly: true },
   { value: "funnel", label: "Funil de vendas" },
+  { value: "post-deploy", label: "Pós-deploy" },
   { value: "ab-test", label: "Teste A/B" },
   { value: "analytics", label: "Analytics" },
   { value: "creatives", label: "Criativos" },
@@ -1943,12 +1945,11 @@ export default function ExperimentDetailPage() {
     data.experimentType === "PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL";
   const isSalesObjectiveExperiment =
     isLowTicketProduct || isPdeMembershipSubscriptionFunnel;
-  const experimentTypeLabel =
-    isPdeMembershipSubscriptionFunnel
-      ? "PDE / assinatura MUSA"
-      : isLowTicketProduct
-        ? "Produto low-ticket"
-        : "Teste de nicho / lead";
+  const experimentTypeLabel = isPdeMembershipSubscriptionFunnel
+    ? "PDE / assinatura MUSA"
+    : isLowTicketProduct
+      ? "Produto low-ticket"
+      : "Teste de nicho / lead";
   const productAiSubtypeLabel: Record<string, string> = {
     AI_VISUAL_PREVIEW: "Prévia visual IA",
     AI_PERSONALIZED_SAMPLE: "Amostra personalizada IA",
@@ -2072,7 +2073,9 @@ export default function ExperimentDetailPage() {
       value: data.singlePain || "—",
     },
     {
-      label: isSalesObjectiveExperiment ? "Prova/preview da oferta" : "Isca digital",
+      label: isSalesObjectiveExperiment
+        ? "Prova/preview da oferta"
+        : "Isca digital",
       value:
         data.freeReward ||
         (isSalesObjectiveExperiment ? "Sem prova/preview informada" : "—"),
@@ -2556,7 +2559,7 @@ export default function ExperimentDetailPage() {
                 ? "Campanha de Facebook Ads para assinatura PDE"
                 : isLowTicketProduct
                   ? "Campanha de Facebook Ads para venda"
-                : "Campanha de Facebook Ads"}
+                  : "Campanha de Facebook Ads"}
             </h5>
             <span
               className={`badge ${
@@ -2571,7 +2574,7 @@ export default function ExperimentDetailPage() {
               ? "Checklist consolidado para publicar anúncio, entrada no PED/MUSA, checkout, assinatura e ativação pós-compra."
               : isLowTicketProduct
                 ? "Checklist consolidado para publicar anúncio, página curta, checkout e entrega com foco na primeira compra."
-              : "Checklist consolidado das regras de publicação. Ele reflete o documento interno e o diagnóstico automático do worker."}
+                : "Checklist consolidado das regras de publicação. Ele reflete o documento interno e o diagnóstico automático do worker."}
           </p>
           {isLoadingReadiness ? (
             <div
@@ -2904,6 +2907,9 @@ export default function ExperimentDetailPage() {
               spendLastSyncedAt={data?.campaignMetric?.lastSyncedAt}
               alterationLocked={alterationLocked}
             />
+          </Tabs.Content>
+          <Tabs.Content value="post-deploy" asChild>
+            <ExperimentPostDeployMonitorTab experimentId={expId} />
           </Tabs.Content>
           <Tabs.Content value="ab-test" asChild>
             <ExperimentSalesPageAbTab experimentId={expId} />

--- a/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
@@ -1,0 +1,263 @@
+import { useMemo } from "react";
+import {
+  usePostDeployMonitor,
+  type PostDeployMonitorDecision,
+} from "../../api/experiment/usePostDeployMonitor";
+
+interface ExperimentPostDeployMonitorTabProps {
+  experimentId: string;
+}
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+});
+
+const numberFormatter = new Intl.NumberFormat("pt-BR");
+
+const BRAZIL_OPERATIONAL_TIME_ZONE = "America/Sao_Paulo";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: BRAZIL_OPERATIONAL_TIME_ZONE,
+  });
+}
+
+function formatCurrency(value?: number | null) {
+  return value == null ? "—" : currencyFormatter.format(value);
+}
+
+function formatNumber(value?: number | null) {
+  return value == null ? "—" : numberFormatter.format(value);
+}
+
+function formatPercent(value?: number | null) {
+  return value == null ? "—" : `${value.toFixed(2)}%`;
+}
+
+function decisionBadgeClass(decision: PostDeployMonitorDecision) {
+  switch (decision) {
+    case "SCALE_GRADUALLY":
+      return "text-bg-success";
+    case "PAUSE_AND_FIX":
+      return "text-bg-danger";
+    case "TECHNICAL_ATTENTION":
+      return "text-bg-warning";
+    case "KEEP_MONITORING":
+      return "text-bg-primary";
+    default:
+      return "text-bg-secondary";
+  }
+}
+
+export default function ExperimentPostDeployMonitorTab({
+  experimentId,
+}: ExperimentPostDeployMonitorTabProps) {
+  const monitorQuery = usePostDeployMonitor(experimentId);
+  const monitor = monitorQuery.data;
+
+  const pdeRows = useMemo(
+    () =>
+      monitor
+        ? [
+            ["Entrada no PDE", monitor.pde.pdeEntries],
+            ["Page views PDE", monitor.pde.pageViews],
+            [
+              "Clique Mapa/Diagnóstico",
+              monitor.pde.presenceMapClicks + monitor.pde.diagnosticClicks,
+            ],
+            ["E-mail preenchido", monitor.pde.fieldFilled],
+            ["Login iniciado", monitor.pde.loginStarted],
+            ["Paywall visto", monitor.pde.paywallViewed],
+            ["Checkout clicado", monitor.pde.subscriptionClicked],
+            ["Compra aprovada", monitor.pde.subscriptionApproved],
+          ]
+        : [],
+    [monitor],
+  );
+
+  if (monitorQuery.isLoading) {
+    return (
+      <div className="card">
+        <div className="card-body text-muted">
+          Carregando painel pós-deploy...
+        </div>
+      </div>
+    );
+  }
+
+  if (monitorQuery.isError || !monitor) {
+    return (
+      <div className="alert alert-danger">
+        Não foi possível carregar o painel pós-deploy agora.
+      </div>
+    );
+  }
+
+  return (
+    <div className="d-flex flex-column gap-3">
+      <div className="card">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+            <div>
+              <h5 className="card-title mb-1">Painel pós-deploy</h5>
+              <p className="text-muted small mb-0">
+                Meta Ads, eventos PDE e logs cruzados automaticamente para
+                decidir se o funil deve continuar, pausar ou escalar.
+              </p>
+            </div>
+            <div className="text-end">
+              <span
+                className={`badge fs-6 ${decisionBadgeClass(monitor.decision)}`}
+              >
+                {monitor.decisionLabel}
+              </span>
+              <div className="text-muted small mt-1">
+                Atualizado em {formatDate(monitor.generatedAt)}
+              </div>
+            </div>
+          </div>
+          <div className="alert alert-light border mt-3 mb-0">
+            <strong>Recomendação:</strong> {monitor.recommendation}
+          </div>
+          {monitor.alerts.length > 0 ? (
+            <div className="alert alert-warning mt-3 mb-0">
+              <div className="fw-semibold mb-1">Alertas</div>
+              <ul className="mb-0">
+                {monitor.alerts.map((alert) => (
+                  <li key={alert}>{alert}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="row g-3">
+        <div className="col-12 col-xl-4">
+          <div className="card h-100">
+            <div className="card-body">
+              <h6 className="card-title">Meta Ads</h6>
+              <div className="row g-2">
+                <Metric
+                  label="Gasto"
+                  value={formatCurrency(monitor.metaAds.spend)}
+                />
+                <Metric
+                  label="Impressões"
+                  value={formatNumber(monitor.metaAds.impressions)}
+                />
+                <Metric
+                  label="Cliques"
+                  value={formatNumber(monitor.metaAds.clicks)}
+                />
+                <Metric
+                  label="CTR"
+                  value={formatPercent(monitor.metaAds.ctrPercent)}
+                />
+                <Metric
+                  label="CPC"
+                  value={formatCurrency(monitor.metaAds.cpc)}
+                />
+                <Metric
+                  label="Última sync"
+                  value={formatDate(monitor.metaAds.lastSyncedAt)}
+                />
+              </div>
+              {monitor.metaAds.lastSyncError ? (
+                <div className="alert alert-warning small mt-3 mb-0">
+                  {monitor.metaAds.lastSyncError}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-5">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-start gap-2 mb-2">
+                <h6 className="card-title mb-0">PDE</h6>
+                <span
+                  className={`badge ${monitor.pde.available ? "text-bg-success" : "text-bg-danger"}`}
+                >
+                  {monitor.pde.available ? "Online" : "Indisponível"}
+                </span>
+              </div>
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <tbody>
+                    {pdeRows.map(([label, value]) => (
+                      <tr key={label}>
+                        <td>{label}</td>
+                        <td className="text-end fw-semibold">
+                          {formatNumber(Number(value))}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {monitor.pde.errorMessage ? (
+                <div className="alert alert-danger small mt-3 mb-0">
+                  {monitor.pde.errorMessage}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-3">
+          <div className="card h-100">
+            <div className="card-body">
+              <h6 className="card-title">Logs</h6>
+              <Metric
+                label="Logs Meta"
+                value={formatNumber(monitor.logs.totalLogs)}
+              />
+              <Metric
+                label="Erros recentes"
+                value={formatNumber(monitor.logs.errorLogs)}
+              />
+              <Metric
+                label="Último log"
+                value={formatDate(monitor.logs.lastLogAt)}
+              />
+              {monitor.logs.recentErrors.length > 0 ? (
+                <ul className="small text-muted mt-3 mb-0 ps-3">
+                  {monitor.logs.recentErrors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="small text-muted mb-0 mt-3">
+                  Sem erro recente de integração Meta Ads.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="col-6">
+      <div className="border rounded-3 p-2 h-100">
+        <div className="text-muted small">{label}</div>
+        <div className="fw-semibold">{value}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz o merge e o deploy vamos aguardar dados. Nos sabemos como comparar a versão antiga da nova ?

Modelo: {"titulo":"Comparação MUSA","comentario":"Sim. Sabemos comparar, mas a comparação correta não é apenas \"página antiga vs página nova\". Para o MUSA, a comparação precisa ser por **funil comercial completo**.\n\n**Fonte de verdade usada:** definição pública do PDE MUSA, registro do experimento 66, registro operacional do experimento 67 e cânone de experimentos.\n\n**O que comparar:**\n\n- **Versão antiga:** experimento 66, com venda do Método MUSA como experiência guiada simples, preço R$47/R$67 e foco em landing/checkout/Área MUSA.\n- **Versão nova:** experimento 67 pós-merge/deploy, com PDE publicado, analytics resetado e campanha Meta já iniciada.\n- **Métrica principal:** compra aprovada ou, se ainda não houver volume, avanço real no funil: clique no anúncio → acesso → diagnóstico/entrada no PDE → clique no paywall/checkout → início de checkout → compra.\n\n**Alternativas de comparação avaliadas:**\n\n1. **Comparar só criativo/anúncio**  \n   Benefício: rápido.  \n   Risco: mostra CTR/CPC, mas não prova venda.  \n   Aderência ao objetivo de vendas: baixa.\n\n2. **Comparar só página/PDE**  \n   Benefício: mostra se a nova experiência segura melhor o tráfego.  \n   Risco: se o anúncio ou público estiver ruim, a página pode ser culpada injustamente.  \n   Aderência: média.\n\n3. **Comparar funil completo por etapa**  \n   Benefício: identifica onde melhorou ou quebrou: anúncio, página, diagnóstico, paywall, checkout ou entrega.  \n   Risco: precisa aguardar dados mínimos.  \n   Aderência: alta.\n\n**Escolha recomendada:** alternativa 3.\n\n**Como vamos decidir se a versão nova é melhor:**\n\n- Se o **CTR subir**, mas checkout/compra não subir: criativo melhorou, oferta/paywall ainda precisa ajuste.\n- Se o **acesso ao PDE subir**, mas diagnóstico/paywall não avançar: problema de ativação da experiência.\n- Se houver **clique no checkout**, mas não compra: problema de preço, confiança, checkout ou objeção final.\n- Se houver **compra com gasto baixo**, mesmo com poucos dados: manter coleta e preparar escala gradual.\n- Se gastar perto de R$25 sem evento primário relevante, o cânone recomenda parar e corrigir causa-raiz antes de insistir.\n\n**Ponto importante:** o registro já mostra que o experimento 67 começou com 92 impressões, 3 cliques e R$0,61 de gasto em 2026-07-20. Isso ainda é pouco para conclusão, mas já confirma que a medição saiu do zero e que o reset de analytics do PDE aconteceu.\n\n**Próximo acompanhamento ideal:** quando tivermos mais dados, eu compararia em uma tabela simples:\n\n| Etapa | Exp. 66 | Exp. 67 | Leitura |\n|---|---:|---:|---|\n| Impressões | antigo | novo | entrega da mídia |\n| CTR | antigo | novo | força do criativo |\n| CPC | antigo | novo | custo de atenção |\n| Page view/PDE view | antigo | novo | tráfego real chegando |\n| Diagnóstico iniciado | antigo | novo | ativação |\n| Paywall/checkout click | antigo | novo | intenção de compra |\n| Checkout iniciado | antigo | novo | força da oferta |\n| Compra | antigo | novo | validação comercial |\n| CPA/ROAS | antigo | novo | escala |\n\nMinha recomendação agora é aguardar até termos pelo menos uma das duas condições: **R$25 de gasto sem compra/evento primário** ou **sinal positivo de checkout/compra antes disso**. Aí a leitura fica objetiva e não baseada em impressão inicial.","sugestaoMelhoriaAmbiente":""}

Usuário: mas fizemos uma alteraçaõ recente veja no github precisamos monitorar isso

Modelo: {"titulo":"Monitoramento do MUSA","comentario":"Sim. A alteração recente que precisamos monitorar é o PR #4435, mergeado em **21/07/2026 00:56 UTC**.\n\n**O que mudou comercialmente:** a entrada do PDE deixou de vender um diagnóstico genérico e passou a vender o **Mapa de Presença do Dia 1**, com duas escolhas antes do e-mail. Isso ataca diretamente o gargalo anterior: tráfego chegava, mas ninguém clicava, preenchia e-mail, iniciava login ou via paywall.\n\n**Status validado agora:**\n\n- Deploy do GitHub Actions concluiu com sucesso.\n- Site público já serve a nova copy: “Sua imagem comunica a mulher que você quer ser vista como?” e “Mapa de Presença”.\n- Backend PDE subiu após o merge, sem erro relevante no log.\n- MCP já consulta o schema real do PDE: `aihubdb`.\n- Banco PDE ainda não recebeu eventos depois do merge.\n- Último evento MUSA persistido: **20/07/2026 22:10:19**.\n\n**Linha de base antes da alteração:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE MUSA | 427 |\n| Entradas no PDE | 65 |\n| Sessões com entrada | 65 |\n| Cliques no diagnóstico/mapa | 0 |\n| E-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n| Compra aprovada | 0 |\n\n**Meta Ads:** a campanha `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA` está **ACTIVE**. Dados disponíveis no período do ad account: **1.565 impressões, 91 cliques, R$10,51 gastos, CTR 5,81%, CPC R$0,115 e 61 landing page views**.\n\n**Como vamos monitorar a nova versão:**\n\n1. **Primeiro sinal obrigatório:** aparecer `PRESENCE_MAP_CHOICE_SELECTED` ou `DIAGNOSTIC_CHOICE_SELECTED` no banco.  \n   Se isso não aparecer com tráfego ativo, o problema continua na primeira dobra ou no tracking.\n\n2. **Segundo sinal:** depois do primeiro clique, medir `FIELD_FILLED` e `LOGIN_STARTED`.  \n   Se houver clique no mapa mas não houver e-mail, a oferta inicial interessa, mas a transição para captura ainda está fraca.\n\n3. **Terceiro sinal:** `LOGIN_COMPLETED`, `PAYWALL_VIEWED` e `SUBSCRIPTION_CLICKED`.  \n   Se chegar aqui, finalmente poderemos avaliar preço, paywall e checkout.\n\n**Alternativas avaliadas:**\n\n1. Monitorar só Meta Ads: rápido, mas não mostra se o PDE destravou.\n2. Monitorar só banco PDE: mostra comportamento real, mas não separa falta de tráfego de falha da página.\n3. Monitorar Meta + eventos PDE por etapa: melhor opção, porque mostra se o anúncio entrega tráfego e se a nova entrada transforma atenção em ação.\n\n**Escolha:** alternativa 3.\n\n**Critério prático:** se a campanha continuar entregando tráfego e, após novo volume, o banco continuar com **zero clique no Mapa de Presença**, a alteração não resolveu o gargalo. Se aparecer clique no mapa, mas não e-mail/login, o próximo ajuste deve ser na transição para salvar o resultado por e-mail.","sugestaoMelhoriaAmbiente":"Ativar as tools de GitHub Actions no MCP e criar um painel/alerta automático para eventos PDE pós-deploy permitiria monitoramento contínuo sem depender de consultas manuais."}

Usuário: Precisamos colocar essa forma de atualização do PDE no Marketing Hub fazer isso atraves do Marketing Hub.

Modelo: {"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiência PDE.\n- O Hub expõe esse contrato em `/api/products/public/{productCode}/pde-experience`.\n- O formulário de Produto no frontend permite editar esse JSON.\n- O backend do `pde-platform` tenta carregar primeiro a experiência publicada pelo Hub.\n- Se o Hub estiver indisponível ou sem contrato publicado, o PDE usa o catálogo local atual como fallback, sem derrubar o Clube MUSA.\n- O deploy do PDE passa a receber `PDE_MARKETING_HUB_BASE_URL`, apontando por padrão para o backend do Marketing Hub.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Alternativas avaliadas:**\n\n1. Editar o PDE direto no código: rápido, mas mantém dependência de deploy técnico para mudança comercial.\n2. Criar endpoint administrativo só no PDE: melhora operação, mas tira o Hub da fonte de verdade.\n3. Fazer o Hub publicar o contrato PDE e o PDE consumir: melhor opção, porque centraliza produto, copy, jornada e oferta no Marketing Hub.\n\n**Escolha aplicada:** alternativa 3.\n\n**Validação feita:**\n\n- `ProductServiceTest` e `ProductControllerTest`: 10 testes passaram.\n- `ProductCatalogServiceTest` do PDE: 3 testes passaram.\n- `npm run typecheck` do frontend passou após instalar dependências locais com `npm ci`.\n- `git diff --check` sem problemas.\n- Changelog mestre revisado com `relativeToChangelogFile: true` no include novo.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso chegar em produção, o próximo passo é você pedir/abrir o PR e depois fazer o deploy do backend principal e do pde-platform."}

Usuário: eu fiz o deploy verifique se ficou ok. E veja se conseguimos ver se a mudança no PDE deu algum resultado positivo nas interação e interesse dos usuarios com o PDE.

Modelo: {"titulo":"Deploy parcial","comentario":"**Verificação concluída:** ficou **parcialmente ok**.\n\n**O que está ok:**\n\n- O frontend público do Clube MUSA foi atualizado em produção em **21/07/2026 00:57:41 UTC**.\n- A página pública contém a nova copy: **“Sua imagem comunica…”** e **“Mapa de Presença”**.\n- O backend do PDE subiu após o deploy.\n- O Marketing Hub expõe corretamente o contrato em `/api/products/public/metodo-musa-7-dias/pde-experience`.\n- A campanha Meta continua **ACTIVE**.\n\n**O que não está ok:**\n\n- O `pde-platform-backend` está falhando ao carregar a experiência PDE do Marketing Hub e usando o **catálogo local como fallback**.\n- Houve erro pós-deploy ao persistir evento PDE: `PED_ENTRY` em **21/07/2026 01:23:41 UTC**.\n- Portanto, a medição pós-deploy não está confiável neste momento.\n\n**Dados de interação disponíveis até agora:**\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais registrados | 493 |\n| Sessões | 76 |\n| Entradas no PDE | 74 |\n| Sessões que chegaram na seção interativa | 10 |\n| Sessões com scroll registrado | 5 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Campo de e-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n\n**Ponto crítico:** todos os eventos gravados no banco são de **20/07/2026**, antes do deploy da nova integração Hub → PDE. Depois do deploy, o banco mostra **0 sessões persistidas**, mas o log indica que pelo menos um evento tentou entrar e falhou. Então não dá para concluir que não houve tráfego; dá para concluir que a medição pós-deploy está quebrada ou instável.\n\n**Meta Ads:** a campanha mostra **1.826 impressões, 101 cliques, R$11,72 gastos, CTR 5,53%, CPC R$0,116 e 68 landing page views**. O anúncio está gerando atenção barata, mas o PDE ainda não registrou avanço comercial real.\n\n**Alternativas avaliadas:**\n\n1. **Concluir pelo Meta Ads:** parece positivo por CTR/CPC, mas não prova interesse no PDE.\n2. **Concluir pelo banco PDE:** mostraria funil real, mas a gravação pós-deploy falhou.\n3. **Separar saúde técnica de resultado comercial:** melhor leitura agora.\n\n**Conclusão:** a mudança ainda **não pode ser considerada positiva comercialmente**, porque não temos dados pós-deploy confiáveis. Antes de esperar mais tráfego, o ideal é corrigir a integração do PDE com o Marketing Hub e a persistência dos eventos. Só depois disso a comparação da nova versão será justa.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis."}

Usuário: Execute sua orientação : 
Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis.

Modelo: {"titulo":"Correção PDE pronta","comentario":"Executei a correção técnica no repositório.\n\n**Causa confirmada:**\n\n- O PDE tentava carregar o contrato do Marketing Hub por `http://191.252.181.168` e o container recebeu `Connection refused`.\n- A gravação de evento pós-deploy falhou por comunicação com MySQL, deixando o funil sem dados novos após **20/07/2026 22:55:19**.\n\n**Correção aplicada:**\n\n- O deploy do PDE agora prioriza `http://191.252.181.168:8000` e mantém `http://191.252.181.168` como fallback.\n- O `ProductCatalogService` agora aceita múltiplas URLs do Marketing Hub e tenta a próxima antes de cair no catálogo local.\n- O `AccessService` agora faz 3 tentativas para persistir eventos do funil quando houver oscilação de banco.\n- Adicionei teste garantindo fallback de URL do Marketing Hub.\n\n**Validação:**\n\n- `mvn -q -Dtest=ProductCatalogServiceTest,AccessServiceTest test` passou.\n- `mvn -q test` no backend PDE passou.\n- `git diff --check` passou.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar a correção, peça o PR ou abra um PR com essas mudanças e depois faça o deploy do `pde-platform`."}

Usuário: feito o deploy

Modelo: {"titulo":"Deploy PDE ok","comentario":"**Status técnico:** o deploy ficou ok.\n\n- O `pde-platform-backend` reiniciou em **21/07/2026 02:06 UTC**.\n- O endpoint público do Clube MUSA está no ar.\n- O endpoint do PDE está entregando o contrato do Marketing Hub com **Mapa de Presença MUSA**.\n- Não apareceu novo erro de fallback para catálogo local após o deploy.\n- Fiz um teste sintético `codex_healthcheck` e ele gravou no banco com status `RECORDED`, então o caminho **site → PDE backend → MySQL** está funcionando.\n\n**Resultado comercial até agora:** ainda não há sinal positivo suficiente.\n\nDepois do deploy, entrou **1 sessão real paga**, vinda do Instagram, mobile. Ela registrou:\n\n| Evento | Sessões |\n|---|---:|\n| Entrada no PDE | 1 |\n| Page view | 1 |\n| Screen view | 1 |\n| Clique no Mapa de Presença | 0 |\n| Campo/e-mail | 0 |\n| Login iniciado | 0 |\n| Paywall | 0 |\n| Checkout | 0 |\n\n**Meta Ads atualizado:** campanha ativa com **1.916 impressões, 109 cliques, 75 landing page views, R$12,22 gastos, CTR 5,69% e CPC R$0,112**.\n\n**Leitura:** a parte técnica foi estabilizada. O anúncio continua barato e chamando atenção, mas a nova versão ainda não provou aumento de interesse dentro do PDE. O gargalo segue na primeira interação: a pessoa chega, mas ainda não clica no Mapa de Presença nem inicia login.\n\n**Alternativas avaliadas:**\n\n1. Concluir que deu certo porque o deploy estabilizou: errado comercialmente, pois venda/interação ainda não apareceu.\n2. Parar agora: prematuro, porque só há 1 sessão real pós-correção.\n3. Continuar monitorando até volume mínimo: melhor escolha.\n\n**Recomendação:** manter a campanha rodando até pelo menos **R$25 de gasto total** ou até termos volume maior pós-deploy. Se continuar com clique barato e zero clique no Mapa, o próximo ajuste deve ser na primeira dobra/CTA do PDE, tornando a ação mais irresistível e menos parecida com login ou formulário.","sugestaoMelhoriaAmbiente":"Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil."}

Última mensagem do usuário:
implemente isso
Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil.

**Resumo das alterações:**
{"titulo":"Painel pós-deploy pronto","comentario":"Implementei o painel automático pós-deploy no Marketing Hub.\n\n**O que ficou pronto:**\n\n- Nova aba **Pós-deploy** dentro do detalhe do experimento.\n- Endpoint agregador no backend: `/api/experiments/{experimentId}/post-deploy-monitor`.\n- Cruzamento automático de:\n  - métricas Meta Ads: gasto, impressões, cliques, CTR, CPC e erro de sync;\n  - eventos PDE: entrada, page view, clique no Mapa/Diagnóstico, e-mail, login, paywall, checkout e compra;\n  - logs Meta Ads: total, erros recentes e último log.\n- Decisão automática: **aguardar dados**, **manter monitoramento**, **pausar e corrigir**, **corrigir medição** ou **escalar gradualmente**.\n- Auto-refresh da tela a cada 60 segundos.\n\n**Validação feita:**\n\n- Teste backend `PostDeployMonitorServiceTest` passou.\n- `npm run typecheck` do frontend passou.\n- Spotless focado nos arquivos novos passou.\n- `git diff --check` passou.\n\n**Observação:** o `spotless:check` global do backend continua falhando por violações antigas em milhares de arquivos fora do escopo. Não alterei esses arquivos para evitar churn desnecessário.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar isso, peça o PR e depois faça o deploy do backend principal e do frontend do Marketing Hub."}