### PR TITLE
AI Hub: {"titulo":"Entrada MUSA simplificada","comentario":"Implementei a alteração.\n\n**O que mudou:**\n\n- A entrada pública do PDE deixou de mostrar várias opções.\n- Agora existe uma única ação principal: **“Descobrir o que minha imagem comunica hoje…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-musa-pde-single-action-entry.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-musa-pde-single-action-entry.yaml
@@ -1,0 +1,39 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-21-product-musa-pde-single-action-entry.yaml
+  - changeSet:
+      id: 2026-07-21-product-musa-pde-single-action-entry-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: pde_experience_json
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET pde_experience_json = JSON_SET(
+                       pde_experience_json,
+                       '$.diagnostic.intro',
+                       'Comece pelo espelho: descubra o primeiro ajuste para sua imagem comunicar mais intenção hoje, usando o que você já tem.',
+                       '$.diagnostic.questions',
+                       JSON_ARRAY('O que minha imagem comunica hoje?')
+                     ),
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias'
+                 AND pde_experience_json IS NOT NULL
+                 AND pde_experience_json <> ''
+                 AND JSON_VALID(pde_experience_json) = 1;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,6 +21,9 @@ databaseChangeLog:
       file: changesets/2026-07-21-product-pde-experience-json.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-21-product-musa-pde-single-action-entry.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-19-product-musa-seven-day-journey.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -18,6 +18,7 @@ O padrão obrigatório é:
 - **checkout externo automatizável**, começando por Pepper como caminho preferencial;
 - **Marketing Hub/FEO fabrica o pacote PDE**;
 - **PDE Platform entrega experiência, acesso, progresso e materiais**.
+- **Marketing Hub é a fonte de verdade para mudanças comerciais do PDE** quando a experiência estiver em campanha ou experimento ativo.
 
 Não criar um front/back novo para cada produto, salvo exceção explícita e registrada.
 
@@ -36,6 +37,38 @@ O FEO fabrica o pacote PDE com:
 - imagens, capa e infográficos;
 - metadados comerciais para página de venda.
 - pacote científico operacional versionado quando o produto usar artigos ou evidências externas para sustentar mecanismo, prova ou orientação por IA.
+
+### Atualização comercial de experiências PDE
+
+Toda mudança comercial em um PDE usado para campanha, experimento ou monitoramento pós-deploy deve ser feita pelo Marketing Hub, no contrato versionado da experiência do produto, e não diretamente no frontend/backend do `pde-platform`.
+
+Entram nessa regra:
+
+- primeira dobra;
+- promessa;
+- CTA;
+- diagnóstico;
+- quantidade de opções;
+- ordem das etapas;
+- copy de paywall;
+- materiais de apoio;
+- missões;
+- qualquer microinteração usada para medir interesse.
+
+O objetivo é preservar a associação entre versão da experiência, campanha, eventos de funil, painel pós-deploy e decisão comercial. Alterações diretas no código do PDE só são permitidas para capacidade técnica genérica do motor, correção de bug, tracking, integração, performance, segurança ou componentes reutilizáveis que não representem uma variação comercial específica do produto.
+
+Cada contrato PDE publicado pelo Marketing Hub deve declarar uma versão comercial explícita da experiência, como `experienceVersion`, `funnelVersion` ou campo equivalente canônico. Essa versão deve mudar sempre que a alteração puder afetar conversão, interesse ou comportamento do usuário. Eventos de analytics enviados pelo frontend PDE devem carregar essa versão nos metadados persistidos para permitir comparar resultados por versão sem misturar tráfego antigo e novo.
+
+Quando uma alteração de PDE for publicada, o relatório/painel deve separar pelo menos:
+
+- produto;
+- experimento/campanha quando disponível;
+- versão da experiência;
+- data/hora de publicação;
+- eventos de entrada, clique, login, paywall, checkout e compra;
+- decisão comercial tomada para aquela versão.
+
+Se a versão da experiência não estiver disponível nos eventos, a comparação deve ser considerada incompleta: pode indicar tendência por janela de tempo, mas não deve ser usada como prova limpa de melhora ou piora entre formatos.
 
 ### Checkout externo
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-21 — Clube MUSA: entrada PDE com uma ação principal
+
+- causa-raiz confirmada: a mudança anterior melhorou a promessa do `Mapa de Presença`, mas manteve duas escolhas e várias opções antes do e-mail; os dados seguiram com zero clique no mapa, indicando atrito antes do primeiro microcompromisso.
+- decisão comercial: reduzir a primeira tela para uma única ação principal, `Descobrir o que minha imagem comunica hoje`, antes de pedir e-mail.
+- foi feito: o frontend do PDE removeu a grade de opções da entrada pública e passou a registrar o clique único como `PRESENCE_MAP_CHOICE_SELECTED` e `DIAGNOSTIC_CHOICE_SELECTED`.
+- foi feito: o contrato PDE do produto MUSA no Marketing Hub recebeu novo changeset para simplificar a definição do diagnóstico para uma pergunta central: `O que minha imagem comunica hoje?`.
+- impacto esperado: diminuir confusão, aumentar o clique inicial no Mapa de Presença e separar melhor os próximos gargalos: clique no mapa, e-mail, login, paywall e checkout.
+
 ## 2026-07-21 — Painel pós-deploy MUSA: analytics PDE pelo domínio público
 
 - causa-raiz confirmada: o painel pós-deploy foi publicado, mas o backend do Marketing Hub tentava consultar o analytics PDE em `191.252.181.168:8096`, host que não expõe o `pde-platform`.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-21 — PDE: mudanças comerciais devem ser feitas pelo Marketing Hub
+
+- decisão operacional: mudanças comerciais em PDEs usados em campanha ou experimento devem ser feitas pelo Marketing Hub, no contrato `pde_experience_json`, para manter versão, métrica e decisão comercial associadas.
+- causa-raiz: alterações diretas no `pde-platform` podem mudar primeira dobra, CTA, opções ou diagnóstico sem deixar claro qual versão gerou cada evento de funil, contaminando a comparação entre formatos.
+- verificação do sistema: o Marketing Hub já armazena e expõe o contrato PDE por `/api/products/public/{productCode}/pde-experience`, e o backend PDE já tenta consumir esse contrato antes de usar o catálogo local.
+- lacuna identificada: o contrato e os eventos ainda precisam carregar uma versão comercial explícita da experiência nos metadados de analytics para comparação automática por versão, não apenas por janela de tempo.
+- orientação registrada: o cânone `docs/canonical/pde-platform-canon.v1.md` passa a exigir que alterações comerciais do PDE sejam publicadas pelo Hub e que a versão da experiência seja persistida nos eventos quando a mudança puder afetar conversão.
+
 ## 2026-07-21 — Clube MUSA: entrada PDE com uma ação principal
 
 - causa-raiz confirmada: a mudança anterior melhorou a promessa do `Mapa de Presença`, mas manteve duas escolhas e várias opções antes do e-mail; os dados seguiram com zero clique no mapa, indicando atrito antes do primeiro microcompromisso.

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
@@ -104,11 +104,8 @@ public class ProductCatalogService {
                 new ThemeDto("#7a2444", "#d6a75c", "#fff8f3", "/assets/musa-cover.png"),
                 new DiagnosticDto(
                         "Mapa de Presença MUSA",
-                        "Comece pelo momento do espelho: quando você está pronta, mas sente que sua imagem ainda não comunica a mulher que você quer ser vista como.",
-                        List.of(
-                                "Quando você se arruma, o que mais incomoda no resultado final?",
-                                "Qual sinal você gostaria que sua imagem comunicasse com mais clareza?",
-                                "Em qual situação dos próximos 7 dias você quer parecer mais alinhada com quem você é?")),
+                        "Comece pelo espelho: descubra o primeiro ajuste para sua imagem comunicar mais intenção hoje, usando o que você já tem.",
+                        List.of("O que minha imagem comunica hoje?")),
                 List.of(
                         new MissionDto(
                                 "dia-1-ruido-visual",

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -189,11 +189,9 @@ const fallbackProduct: ProductExperience = {
   },
   diagnostic: {
     title: 'Mapa de Presença MUSA',
-    intro: 'Comece pelo momento do espelho: quando você está pronta, mas sente que sua imagem ainda não comunica a mulher que você quer ser vista como.',
+    intro: 'Comece pelo espelho: descubra o primeiro ajuste para sua imagem comunicar mais intenção hoje, usando o que você já tem.',
     questions: [
-      'Quando você se arruma, o que mais incomoda no resultado final?',
-      'Qual sinal você gostaria que sua imagem comunicasse com mais clareza?',
-      'Em qual situação dos próximos 7 dias você quer parecer mais alinhada com quem você é?',
+      'O que minha imagem comunica hoje?',
     ],
   },
   missions: [
@@ -440,24 +438,9 @@ function readRuntimeConfigValue(key: 'VITE_MUSA_CHECKOUT_URL' | 'VITE_GOOGLE_CLI
 
 const presenceBlockers: DiagnosticOption[] = [
   {
-    key: 'comum_mesmo_caprichando',
-    label: 'Pareço comum mesmo tentando caprichar',
-    description: 'Você se arruma, mas sente que a imagem não acompanha a mulher que quer transmitir.',
-  },
-  {
-    key: 'visual_nao_comunica_quem_sou',
-    label: 'Meu visual não comunica a mulher que eu sou',
-    description: 'Roupa, beleza e detalhe final parecem corretos, mas sem uma mensagem clara.',
-  },
-  {
-    key: 'falta_acabamento_presenca_intencao',
-    label: 'Sinto que falta acabamento, presença ou intenção',
-    description: 'O conjunto fica quase bom, mas ainda transmite pouco cuidado ou pouca sofisticação.',
-  },
-  {
-    key: 'quero_sem_comprar_tudo_novo',
-    label: 'Quero parecer elegante sem comprar tudo novo',
-    description: 'Você quer usar melhor o que já tem antes de entrar em mais uma compra impulsiva.',
+    key: 'descobrir_imagem_comunica_hoje',
+    label: 'Descobrir o que minha imagem comunica hoje',
+    description: 'Receber uma leitura simples do primeiro sinal que pode deixar sua presença mais intencional.',
   },
 ];
 
@@ -471,11 +454,6 @@ const desiredPresenceSignals: DiagnosticOption[] = [
     key: 'imagem_com_intencao',
     label: 'Imagem com intenção',
     description: 'Sentir que roupa, beleza e detalhe final contam a mesma história.',
-  },
-  {
-    key: 'menos_duvida_ao_sair',
-    label: 'Menos dúvida ao sair',
-    description: 'Saber o que reforçar antes de sair, sem refazer tudo.',
   },
 ];
 
@@ -813,7 +791,7 @@ function App() {
 
   async function submitAccess() {
     if (authMode === 'register' && (!presenceBlocker || !desiredPresence)) {
-      setErrorMessage('Escolha primeiro o incômodo principal da sua imagem e o sinal que você quer comunicar.');
+      setErrorMessage('Toque primeiro para descobrir o que sua imagem comunica hoje.');
       return;
     }
     if (!email.trim()) {
@@ -1075,29 +1053,31 @@ function App() {
     emailInputRef.current?.select();
   }
 
-  function selectDiagnosticOption(kind: 'presenceBlocker' | 'desiredPresence', value: string) {
-    if (kind === 'presenceBlocker') {
-      setPresenceBlocker(value);
-    } else {
-      setDesiredPresence(value);
-    }
+  function startPresenceMap() {
+    const blocker = presenceBlockers[0];
+    const desiredSignal = desiredPresenceSignals[0];
+    setPresenceBlocker(blocker.key);
+    setDesiredPresence(desiredSignal.key);
     setErrorMessage('');
     trackEvent('PRESENCE_MAP_CHOICE_SELECTED', {
       metadata: {
         authMode,
-        diagnosticStep: kind,
-        selectedOption: value,
-        actionName: 'presence_map_choice_selected',
+        diagnosticStep: 'single_cta',
+        selectedOption: blocker.key,
+        desiredSignal: desiredSignal.key,
+        actionName: 'presence_map_single_cta_clicked',
       },
     });
     trackEvent('DIAGNOSTIC_CHOICE_SELECTED', {
       metadata: {
         authMode,
-        diagnosticStep: kind,
-        selectedOption: value,
-        actionName: 'diagnostic_choice_selected',
+        diagnosticStep: 'single_cta',
+        selectedOption: blocker.key,
+        desiredSignal: desiredSignal.key,
+        actionName: 'diagnostic_single_cta_clicked',
       },
     });
+    window.requestAnimationFrame(() => emailInputRef.current?.focus());
   }
 
   function resolveMagicLinkMessage(result: MagicLinkResponse) {
@@ -1353,8 +1333,8 @@ function App() {
             <img className="brand-logo login-brand-logo" src="/assets/logo-musa.svg" alt="Clube MUSA" />
             <h1>Sua imagem comunica a mulher que você quer ser vista como?</h1>
             <p className="promise">
-              Responda 2 escolhas rápidas e receba seu Mapa de Presença do Dia 1: o que hoje deixa seu visual comum,
-              qual sinal transmite mais intenção e como começar com o que você já tem.
+              Toque uma vez e receba seu Mapa de Presença do Dia 1: o primeiro sinal que pode deixar sua imagem mais
+              intencional hoje, usando o que você já tem.
             </p>
             <div className="diagnostic-promise-strip" aria-label="O que o diagnóstico gratuito entrega">
               <span><Sparkles size={16} /> Mapa de Presença do Dia 1</span>
@@ -1394,54 +1374,31 @@ function App() {
                 </>
               ) : (
                 <>
-                  <strong>Comece pelo espelho.</strong> Escolha o incômodo principal e veja qual presença você quer comunicar antes de informar seu e-mail.
+                  <strong>Comece pelo espelho.</strong> Primeiro veja o que sua imagem pode estar comunicando; depois informe seu e-mail para salvar o mapa.
                 </>
               )}
             </p>
             {authMode === 'register' && (
               <div className="interactive-diagnostic" data-analytics-section="interactive_diagnostic">
                 <div className="diagnostic-step">
-                  <span>1 de 2</span>
-                  <h2>Quando você se arruma, o que mais incomoda no resultado final?</h2>
-                  <div className="diagnostic-option-grid" role="group" aria-label="Quando você se arruma, o que mais incomoda no resultado final">
-                    {presenceBlockers.map((option) => (
-                      <button
-                        className={presenceBlocker === option.key ? 'selected' : ''}
-                        key={option.key}
-                        onClick={() => selectDiagnosticOption('presenceBlocker', option.key)}
-                        type="button"
-                      >
-                        <strong>{option.label}</strong>
-                        <small>{option.description}</small>
-                      </button>
-                    ))}
-                  </div>
+                  <span>Diagnóstico gratuito</span>
+                  <h2>Veja o primeiro ajuste para aumentar sua presença hoje.</h2>
+                  <button
+                    className={presenceBlocker ? 'diagnostic-start-button selected' : 'diagnostic-start-button'}
+                    onClick={startPresenceMap}
+                    type="button"
+                  >
+                    <Sparkles size={18} />
+                    <strong>Descobrir o que minha imagem comunica hoje</strong>
+                    <small>Sem escolher perfil, sem responder questionário longo e sem mostrar preço agora.</small>
+                  </button>
                 </div>
-                {presenceBlocker && (
-                  <div className="diagnostic-step">
-                    <span>2 de 2</span>
-                    <h2>Qual sinal você quer comunicar com mais clareza no Dia 1?</h2>
-                    <div className="diagnostic-option-grid compact" role="group" aria-label="Sinal desejado no Dia 1">
-                      {desiredPresenceSignals.map((option) => (
-                        <button
-                          className={desiredPresence === option.key ? 'selected' : ''}
-                          key={option.key}
-                          onClick={() => selectDiagnosticOption('desiredPresence', option.key)}
-                          type="button"
-                        >
-                          <strong>{option.label}</strong>
-                          <small>{option.description}</small>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
                 {selectedBlocker && selectedDesiredPresence && (
                   <div className="diagnostic-result-teaser">
                     <Check size={18} />
                     <p>
-                      Seu Mapa de Presença vai partir de <strong>{selectedBlocker.label.toLowerCase()}</strong> para ajudar você a comunicar
-                      <strong> {selectedDesiredPresence.label.toLowerCase()}</strong> com uma microação prática hoje.
+                      Seu Mapa de Presença vai mostrar o primeiro sinal que sua imagem comunica hoje e uma microação
+                      prática para reforçar <strong>{selectedDesiredPresence.label.toLowerCase()}</strong>.
                     </p>
                   </div>
                 )}
@@ -1460,7 +1417,7 @@ function App() {
             {diagnosticReadyForEmail && (
               <>
                 <div className="auth-divider">
-                  <span>{authMode === 'login' ? 'receba um link de retorno por e-mail' : 'salve seu Mapa de Presença por e-mail'}</span>
+                  <span>{authMode === 'login' ? 'receba um link de retorno por e-mail' : 'receba seu Mapa de Presença por e-mail'}</span>
                 </div>
                 <label className="email-box login-email-box">
                   {authMode === 'login' ? 'E-mail do seu acesso MUSA' : 'Seu melhor e-mail para receber o Mapa de Presença'}
@@ -1505,7 +1462,7 @@ function App() {
                 <Mail size={18} />
                 {loading
                   ? 'Enviando link...'
-                  : (authMode === 'login' ? 'Receber link de entrada' : 'Ver meu Mapa de Presença')}
+                  : (authMode === 'login' ? 'Receber link de entrada' : 'Receber meu Mapa de Presença')}
               </button>
             )}
             <div className="login-value-strip" aria-label="O que fica disponível ao entrar">

--- a/pde-platform/frontend/src/styles.css
+++ b/pde-platform/frontend/src/styles.css
@@ -759,6 +759,41 @@ h3 {
   text-align: left;
 }
 
+.diagnostic-start-button {
+  align-items: center;
+  background: #7a2444;
+  border: 0;
+  color: #fff8f3;
+  cursor: pointer;
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  min-height: 118px;
+  padding: 18px 16px;
+  text-align: center;
+}
+
+.diagnostic-start-button.selected {
+  background: #2f5952;
+}
+
+.diagnostic-start-button svg {
+  color: #f7e4c6;
+}
+
+.diagnostic-start-button strong {
+  color: #fff;
+  font-size: 1.02rem;
+  line-height: 1.18;
+}
+
+.diagnostic-start-button small {
+  color: rgba(255, 248, 243, 0.82);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  max-width: 420px;
+}
+
 .diagnostic-option-grid button.selected {
   background: #eef5f2;
   border-color: rgba(47, 89, 82, 0.52);
@@ -1783,6 +1818,11 @@ h3 {
 
   .diagnostic-option-grid button {
     min-height: 76px;
+  }
+
+  .diagnostic-start-button {
+    min-height: 104px;
+    padding: 16px 12px;
   }
 
   .auth-divider,

--- a/pde-platform/frontend/tests/musa-entry.visual.spec.ts
+++ b/pde-platform/frontend/tests/musa-entry.visual.spec.ts
@@ -4,14 +4,13 @@ test('carrega a entrada visual do Clube MUSA', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByAltText('Clube MUSA')).toBeVisible();
-  await expect(page.getByRole('heading', { name: /sua imagem comunica/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /Sua imagem comunica a mulher/i, level: 1 })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Diagnóstico gratuito', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Já tenho acesso', exact: true })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver meu Mapa de Presença/i })).toBeDisabled();
-  await page.getByRole('button', { name: /Pareço comum mesmo tentando caprichar/i }).click();
-  await page.getByRole('button', { name: /Presença elegante/i }).click();
+  await expect(page.getByRole('button', { name: /Receber meu Mapa de Presença/i })).toBeDisabled();
+  await page.getByRole('button', { name: /Descobrir o que minha imagem comunica hoje/i }).click();
   await expect(page.getByLabel(/Seu melhor e-mail para receber o Mapa de Presença/i)).toBeVisible();
-  await expect(page.getByRole('button', { name: /Ver meu Mapa de Presença/i })).toBeEnabled();
+  await expect(page.getByRole('button', { name: /Receber meu Mapa de Presença/i })).toBeEnabled();
   await expect(page.getByLabel(/Prévia da experiência Método MUSA/i)).toBeVisible();
 
   await page.screenshot({


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz o merge e o deploy vamos aguardar dados. Nos sabemos como comparar a versão antiga da nova ?

Modelo: {"titulo":"Comparação MUSA","comentario":"Sim. Sabemos comparar, mas a comparação correta não é apenas \"página antiga vs página nova\". Para o MUSA, a comparação precisa ser por **funil comercial completo**.\n\n**Fonte de verdade usada:** definição pública do PDE MUSA, registro do experimento 66, registro operacional do experimento 67 e cânone de experimentos.\n\n**O que comparar:**\n\n- **Versão antiga:** experimento 66, com venda do Método MUSA como experiência guiada simples, preço R$47/R$67 e foco em landing/checkout/Área MUSA.\n- **Versão nova:** experimento 67 pós-merge/deploy, com PDE publicado, analytics resetado e campanha Meta já iniciada.\n- **Métrica principal:** compra aprovada ou, se ainda não houver volume, avanço real no funil: clique no anúncio → acesso → diagnóstico/entrada no PDE → clique no paywall/checkout → início de checkout → compra.\n\n**Alternativas de comparação avaliadas:**\n\n1. **Comparar só criativo/anúncio**  \n   Benefício: rápido.  \n   Risco: mostra CTR/CPC, mas não prova venda.  \n   Aderência ao objetivo de vendas: baixa.\n\n2. **Comparar só página/PDE**  \n   Benefício: mostra se a nova experiência segura melhor o tráfego.  \n   Risco: se o anúncio ou público estiver ruim, a página pode ser culpada injustamente.  \n   Aderência: média.\n\n3. **Comparar funil completo por etapa**  \n   Benefício: identifica onde melhorou ou quebrou: anúncio, página, diagnóstico, paywall, checkout ou entrega.  \n   Risco: precisa aguardar dados mínimos.  \n   Aderência: alta.\n\n**Escolha recomendada:** alternativa 3.\n\n**Como vamos decidir se a versão nova é melhor:**\n\n- Se o **CTR subir**, mas checkout/compra não subir: criativo melhorou, oferta/paywall ainda precisa ajuste.\n- Se o **acesso ao PDE subir**, mas diagnóstico/paywall não avançar: problema de ativação da experiência.\n- Se houver **clique no checkout**, mas não compra: problema de preço, confiança, checkout ou objeção final.\n- Se houver **compra com gasto baixo**, mesmo com poucos dados: manter coleta e preparar escala gradual.\n- Se gastar perto de R$25 sem evento primário relevante, o cânone recomenda parar e corrigir causa-raiz antes de insistir.\n\n**Ponto importante:** o registro já mostra que o experimento 67 começou com 92 impressões, 3 cliques e R$0,61 de gasto em 2026-07-20. Isso ainda é pouco para conclusão, mas já confirma que a medição saiu do zero e que o reset de analytics do PDE aconteceu.\n\n**Próximo acompanhamento ideal:** quando tivermos mais dados, eu compararia em uma tabela simples:\n\n| Etapa | Exp. 66 | Exp. 67 | Leitura |\n|---|---:|---:|---|\n| Impressões | antigo | novo | entrega da mídia |\n| CTR | antigo | novo | força do criativo |\n| CPC | antigo | novo | custo de atenção |\n| Page view/PDE view | antigo | novo | tráfego real chegando |\n| Diagnóstico iniciado | antigo | novo | ativação |\n| Paywall/checkout click | antigo | novo | intenção de compra |\n| Checkout iniciado | antigo | novo | força da oferta |\n| Compra | antigo | novo | validação comercial |\n| CPA/ROAS | antigo | novo | escala |\n\nMinha recomendação agora é aguardar até termos pelo menos uma das duas condições: **R$25 de gasto sem compra/evento primário** ou **sinal positivo de checkout/compra antes disso**. Aí a leitura fica objetiva e não baseada em impressão inicial.","sugestaoMelhoriaAmbiente":""}

Usuário: mas fizemos uma alteraçaõ recente veja no github precisamos monitorar isso

Modelo: {"titulo":"Monitoramento do MUSA","comentario":"Sim. A alteração recente que precisamos monitorar é o PR #4435, mergeado em **21/07/2026 00:56 UTC**.\n\n**O que mudou comercialmente:** a entrada do PDE deixou de vender um diagnóstico genérico e passou a vender o **Mapa de Presença do Dia 1**, com duas escolhas antes do e-mail. Isso ataca diretamente o gargalo anterior: tráfego chegava, mas ninguém clicava, preenchia e-mail, iniciava login ou via paywall.\n\n**Status validado agora:**\n\n- Deploy do GitHub Actions concluiu com sucesso.\n- Site público já serve a nova copy: “Sua imagem comunica a mulher que você quer ser vista como?” e “Mapa de Presença”.\n- Backend PDE subiu após o merge, sem erro relevante no log.\n- MCP já consulta o schema real do PDE: `aihubdb`.\n- Banco PDE ainda não recebeu eventos depois do merge.\n- Último evento MUSA persistido: **20/07/2026 22:10:19**.\n\n**Linha de base antes da alteração:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE MUSA | 427 |\n| Entradas no PDE | 65 |\n| Sessões com entrada | 65 |\n| Cliques no diagnóstico/mapa | 0 |\n| E-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n| Compra aprovada | 0 |\n\n**Meta Ads:** a campanha `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA` está **ACTIVE**. Dados disponíveis no período do ad account: **1.565 impressões, 91 cliques, R$10,51 gastos, CTR 5,81%, CPC R$0,115 e 61 landing page views**.\n\n**Como vamos monitorar a nova versão:**\n\n1. **Primeiro sinal obrigatório:** aparecer `PRESENCE_MAP_CHOICE_SELECTED` ou `DIAGNOSTIC_CHOICE_SELECTED` no banco.  \n   Se isso não aparecer com tráfego ativo, o problema continua na primeira dobra ou no tracking.\n\n2. **Segundo sinal:** depois do primeiro clique, medir `FIELD_FILLED` e `LOGIN_STARTED`.  \n   Se houver clique no mapa mas não houver e-mail, a oferta inicial interessa, mas a transição para captura ainda está fraca.\n\n3. **Terceiro sinal:** `LOGIN_COMPLETED`, `PAYWALL_VIEWED` e `SUBSCRIPTION_CLICKED`.  \n   Se chegar aqui, finalmente poderemos avaliar preço, paywall e checkout.\n\n**Alternativas avaliadas:**\n\n1. Monitorar só Meta Ads: rápido, mas não mostra se o PDE destravou.\n2. Monitorar só banco PDE: mostra comportamento real, mas não separa falta de tráfego de falha da página.\n3. Monitorar Meta + eventos PDE por etapa: melhor opção, porque mostra se o anúncio entrega tráfego e se a nova entrada transforma atenção em ação.\n\n**Escolha:** alternativa 3.\n\n**Critério prático:** se a campanha continuar entregando tráfego e, após novo volume, o banco continuar com **zero clique no Mapa de Presença**, a alteração não resolveu o gargalo. Se aparecer clique no mapa, mas não e-mail/login, o próximo ajuste deve ser na transição para salvar o resultado por e-mail.","sugestaoMelhoriaAmbiente":"Ativar as tools de GitHub Actions no MCP e criar um painel/alerta automático para eventos PDE pós-deploy permitiria monitoramento contínuo sem depender de consultas manuais."}

Usuário: Precisamos colocar essa forma de atualização do PDE no Marketing Hub fazer isso atraves do Marketing Hub.

Modelo: {"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiência PDE.\n- O Hub expõe esse contrato em `/api/products/public/{productCode}/pde-experience`.\n- O formulário de Produto no frontend permite editar esse JSON.\n- O backend do `pde-platform` tenta carregar primeiro a experiência publicada pelo Hub.\n- Se o Hub estiver indisponível ou sem contrato publicado, o PDE usa o catálogo local atual como fallback, sem derrubar o Clube MUSA.\n- O deploy do PDE passa a receber `PDE_MARKETING_HUB_BASE_URL`, apontando por padrão para o backend do Marketing Hub.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Alternativas avaliadas:**\n\n1. Editar o PDE direto no código: rápido, mas mantém dependência de deploy técnico para mudança comercial.\n2. Criar endpoint administrativo só no PDE: melhora operação, mas tira o Hub da fonte de verdade.\n3. Fazer o Hub publicar o contrato PDE e o PDE consumir: melhor opção, porque centraliza produto, copy, jornada e oferta no Marketing Hub.\n\n**Escolha aplicada:** alternativa 3.\n\n**Validação feita:**\n\n- `ProductServiceTest` e `ProductControllerTest`: 10 testes passaram.\n- `ProductCatalogServiceTest` do PDE: 3 testes passaram.\n- `npm run typecheck` do frontend passou após instalar dependências locais com `npm ci`.\n- `git diff --check` sem problemas.\n- Changelog mestre revisado com `relativeToChangelogFile: true` no include novo.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso chegar em produção, o próximo passo é você pedir/abrir o PR e depois fazer o deploy do backend principal e do pde-platform."}

Usuário: eu fiz o deploy verifique se ficou ok. E veja se conseguimos ver se a mudança no PDE deu algum resultado positivo nas interação e interesse dos usuarios com o PDE.

Modelo: {"titulo":"Deploy parcial","comentario":"**Verificação concluída:** ficou **parcialmente ok**.\n\n**O que está ok:**\n\n- O frontend público do Clube MUSA foi atualizado em produção em **21/07/2026 00:57:41 UTC**.\n- A página pública contém a nova copy: **“Sua imagem comunica…”** e **“Mapa de Presença”**.\n- O backend do PDE subiu após o deploy.\n- O Marketing Hub expõe corretamente o contrato em `/api/products/public/metodo-musa-7-dias/pde-experience`.\n- A campanha Meta continua **ACTIVE**.\n\n**O que não está ok:**\n\n- O `pde-platform-backend` está falhando ao carregar a experiência PDE do Marketing Hub e usando o **catálogo local como fallback**.\n- Houve erro pós-deploy ao persistir evento PDE: `PED_ENTRY` em **21/07/2026 01:23:41 UTC**.\n- Portanto, a medição pós-deploy não está confiável neste momento.\n\n**Dados de interação disponíveis até agora:**\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais registrados | 493 |\n| Sessões | 76 |\n| Entradas no PDE | 74 |\n| Sessões que chegaram na seção interativa | 10 |\n| Sessões com scroll registrado | 5 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Campo de e-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n\n**Ponto crítico:** todos os eventos gravados no banco são de **20/07/2026**, antes do deploy da nova integração Hub → PDE. Depois do deploy, o banco mostra **0 sessões persistidas**, mas o log indica que pelo menos um evento tentou entrar e falhou. Então não dá para concluir que não houve tráfego; dá para concluir que a medição pós-deploy está quebrada ou instável.\n\n**Meta Ads:** a campanha mostra **1.826 impressões, 101 cliques, R$11,72 gastos, CTR 5,53%, CPC R$0,116 e 68 landing page views**. O anúncio está gerando atenção barata, mas o PDE ainda não registrou avanço comercial real.\n\n**Alternativas avaliadas:**\n\n1. **Concluir pelo Meta Ads:** parece positivo por CTR/CPC, mas não prova interesse no PDE.\n2. **Concluir pelo banco PDE:** mostraria funil real, mas a gravação pós-deploy falhou.\n3. **Separar saúde técnica de resultado comercial:** melhor leitura agora.\n\n**Conclusão:** a mudança ainda **não pode ser considerada positiva comercialmente**, porque não temos dados pós-deploy confiáveis. Antes de esperar mais tráfego, o ideal é corrigir a integração do PDE com o Marketing Hub e a persistência dos eventos. Só depois disso a comparação da nova versão será justa.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis."}

Usuário: Execute sua orientação : 
Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis.

Modelo: {"titulo":"Correção PDE pronta","comentario":"Executei a correção técnica no repositório.\n\n**Causa confirmada:**\n\n- O PDE tentava carregar o contrato do Marketing Hub por `http://191.252.181.168` e o container recebeu `Connection refused`.\n- A gravação de evento pós-deploy falhou por comunicação com MySQL, deixando o funil sem dados novos após **20/07/2026 22:55:19**.\n\n**Correção aplicada:**\n\n- O deploy do PDE agora prioriza `http://191.252.181.168:8000` e mantém `http://191.252.181.168` como fallback.\n- O `ProductCatalogService` agora aceita múltiplas URLs do Marketing Hub e tenta a próxima antes de cair no catálogo local.\n- O `AccessService` agora faz 3 tentativas para persistir eventos do funil quando houver oscilação de banco.\n- Adicionei teste garantindo fallback de URL do Marketing Hub.\n\n**Validação:**\n\n- `mvn -q -Dtest=ProductCatalogServiceTest,AccessServiceTest test` passou.\n- `mvn -q test` no backend PDE passou.\n- `git diff --check` passou.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar a correção, peça o PR ou abra um PR com essas mudanças e depois faça o deploy do `pde-platform`."}

Usuário: feito o deploy

Modelo: {"titulo":"Deploy PDE ok","comentario":"**Status técnico:** o deploy ficou ok.\n\n- O `pde-platform-backend` reiniciou em **21/07/2026 02:06 UTC**.\n- O endpoint público do Clube MUSA está no ar.\n- O endpoint do PDE está entregando o contrato do Marketing Hub com **Mapa de Presença MUSA**.\n- Não apareceu novo erro de fallback para catálogo local após o deploy.\n- Fiz um teste sintético `codex_healthcheck` e ele gravou no banco com status `RECORDED`, então o caminho **site → PDE backend → MySQL** está funcionando.\n\n**Resultado comercial até agora:** ainda não há sinal positivo suficiente.\n\nDepois do deploy, entrou **1 sessão real paga**, vinda do Instagram, mobile. Ela registrou:\n\n| Evento | Sessões |\n|---|---:|\n| Entrada no PDE | 1 |\n| Page view | 1 |\n| Screen view | 1 |\n| Clique no Mapa de Presença | 0 |\n| Campo/e-mail | 0 |\n| Login iniciado | 0 |\n| Paywall | 0 |\n| Checkout | 0 |\n\n**Meta Ads atualizado:** campanha ativa com **1.916 impressões, 109 cliques, 75 landing page views, R$12,22 gastos, CTR 5,69% e CPC R$0,112**.\n\n**Leitura:** a parte técnica foi estabilizada. O anúncio continua barato e chamando atenção, mas a nova versão ainda não provou aumento de interesse dentro do PDE. O gargalo segue na primeira interação: a pessoa chega, mas ainda não clica no Mapa de Presença nem inicia login.\n\n**Alternativas avaliadas:**\n\n1. Concluir que deu certo porque o deploy estabilizou: errado comercialmente, pois venda/interação ainda não apareceu.\n2. Parar agora: prematuro, porque só há 1 sessão real pós-correção.\n3. Continuar monitorando até volume mínimo: melhor escolha.\n\n**Recomendação:** manter a campanha rodando até pelo menos **R$25 de gasto total** ou até termos volume maior pós-deploy. Se continuar com clique barato e zero clique no Mapa, o próximo ajuste deve ser na primeira dobra/CTA do PDE, tornando a ação mais irresistível e menos parecida com login ou formulário.","sugestaoMelhoriaAmbiente":"Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil."}

Usuário: implemente isso
Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil.

Modelo: {"titulo":"Painel pós-deploy pronto","comentario":"Implementei o painel automático pós-deploy no Marketing Hub.\n\n**O que ficou pronto:**\n\n- Nova aba **Pós-deploy** dentro do detalhe do experimento.\n- Endpoint agregador no backend: `/api/experiments/{experimentId}/post-deploy-monitor`.\n- Cruzamento automático de:\n  - métricas Meta Ads: gasto, impressões, cliques, CTR, CPC e erro de sync;\n  - eventos PDE: entrada, page view, clique no Mapa/Diagnóstico, e-mail, login, paywall, checkout e compra;\n  - logs Meta Ads: total, erros recentes e último log.\n- Decisão automática: **aguardar dados**, **manter monitoramento**, **pausar e corrigir**, **corrigir medição** ou **escalar gradualmente**.\n- Auto-refresh da tela a cada 60 segundos.\n\n**Validação feita:**\n\n- Teste backend `PostDeployMonitorServiceTest` passou.\n- `npm run typecheck` do frontend passou.\n- Spotless focado nos arquivos novos passou.\n- `git diff --check` passou.\n\n**Observação:** o `spotless:check` global do backend continua falhando por violações antigas em milhares de arquivos fora do escopo. Não alterei esses arquivos para evitar churn desnecessário.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar isso, peça o PR e depois faça o deploy do backend principal e do frontend do Marketing Hub."}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy parcialmente ok","comentario":"**Verifiquei o deploy.**\n\nO painel pós-deploy está publicado e o endpoint do Marketing Hub responde, mas ele ainda ficou em **atenção técnica** porque o backend está tentando buscar analytics PDE no host errado: `191.252.181.168:8096`.\n\n**Causa confirmada:** o PDE real está respondendo pelo domínio público `https://clubemusa.com.br`, e o analytics funciona ali.\n\n**Dados reais do PDE agora:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE | 563 |\n| Visitantes únicos | 85 |\n| Sessões | 88 |\n| Entradas PDE | 85 |\n| Page views | 86 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout | 0 |\n| Compra | 0 |\n\n**Meta Ads no painel:** 2.049 impressões, 116 cliques, R$12,78 gastos, CTR 5,66%, CPC R$0,11.\n\n**Leitura comercial:** o anúncio continua bom para gerar atenção barata, mas ainda não apareceu sinal positivo forte dentro do PDE. O gargalo segue na primeira ação: a pessoa entra, mas não clica no Mapa de Presença, não inicia login e não chega no paywall.\n\n**Alternativas avaliadas:**\n\n1. Ajustar só variável de ambiente no servidor: rápido, mas pode voltar a quebrar em outro deploy.\n2. Apontar o Hub para o IP correto `191.252.102.54:8096`: funciona, mas mantém dependência de IP/porta.\n3. Usar `https://clubemusa.com.br` como default canônico: melhor opção, porque usa o mesmo domínio público do funil e reduz fragilidade operacional.\n\n**O que deixei pronto no repositório:**\n\n- Corrigi o default de `integrations.pde-platform.base-url` para `https://clubemusa.com.br`.\n- Corrigi o fallback do cliente HTTP do painel.\n- Registrei a causa em `docs/registros/experimentos.md`.\n- Validação focada passou: `PostDeployMonitorServiceTest`.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR dessa correção e depois faça novo deploy do backend principal do Marketing Hub para o painel passar a cruzar Meta Ads + PDE automaticamente em produção."}

Usuário: feito

Modelo: {"titulo":"Painel validado","comentario":"**Deploy verificado: agora ficou ok.**\n\nO painel pós-deploy do Marketing Hub está consultando corretamente o PDE em `https://clubemusa.com.br` e o resultado bate com o analytics direto do Clube MUSA.\n\n**Status atual:**\n\n| Área | Situação |\n|---|---|\n| Marketing Hub | Endpoint do painel responde ok |\n| PDE analytics | Disponível |\n| Cruzamento Meta + PDE | Funcionando |\n| Erro técnico do painel | Não apareceu |\n| Decisão automática | **Manter monitoramento** |\n\n**Dados atuais do painel:**\n\n| Métrica | Valor |\n|---|---:|\n| Impressões Meta | 2.074 |\n| Cliques Meta | 117 |\n| Gasto | R$12,92 |\n| CTR | 5,64% |\n| CPC | R$0,11 |\n| Eventos PDE | 575 |\n| Visitantes únicos PDE | 86 |\n| Sessões PDE | 90 |\n| Entradas PDE | 87 |\n| Page views | 88 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout/compra | 0 |\n\n**Leitura comercial:** o painel está pronto para decisão, mas a mudança do PDE ainda não mostrou sinal positivo de interesse ativo. O tráfego continua barato e com bom CTR, porém o usuário ainda não faz a primeira ação dentro do PDE.\n\n**Alternativas avaliadas:**\n\n1. **Manter como está até R$25 de gasto**: melhor para evitar decisão precipitada, já que o gasto ainda está em R$12,92.\n2. **Pausar agora**: reduz perda, mas seria cedo demais porque ainda não atingiu o limite combinado.\n3. **Já alterar a primeira dobra/CTA**: pode destravar o clique, mas misturaria variáveis antes de completar a medição mínima.\n\n**Escolha recomendada:** manter monitoramento até R$25 ou até aparecer clique no Mapa, login, paywall ou checkout antes disso.\n\nSe chegar perto de R$25 e continuar com **zero clique no Mapa**, a próxima ação deve ser mexer na primeira interação do PDE: CTA mais direto, promessa mais imediata e menos sensação de formulário/login.","sugestaoMelhoriaAmbiente":""}

Usuário: faça uma avaliaçaõ de a mudança de formato gerou ou não alguma melhora 

Modelo: {"titulo":"Formato ainda não melhorou","comentario":"**Conclusão:** a mudança de formato do PDE ainda **não gerou melhora comercial comprovada**.\n\nO que melhorou levemente:\n\n- O tráfego continua bom: **2.086 impressões, 120 cliques, CTR 5,75%, CPC R$0,11 e R$12,98 gastos**.\n- O PDE está medindo corretamente: **92 sessões, 89 entradas e 90 page views**.\n- Houve algum aumento de exploração: **18 views da seção interativa** e **17 eventos de scroll**.\n\nO que não melhorou:\n\n- **0 cliques no Mapa de Presença**.\n- **0 e-mails preenchidos**.\n- **0 logins iniciados**.\n- **0 paywalls vistos**.\n- **0 cliques em assinatura/checkout**.\n- Nas últimas 50 jornadas analisadas: **46 saíram na primeira dobra**, 4 consumiram a página sem ação e **0 clicaram no CTA**.\n\n**Leitura de negócio:** a nova copy/formato pode ter aumentado um pouco a permanência ou exploração, mas **não destravou a intenção ativa**. O gargalo continua antes do primeiro microcompromisso. A usuária chega, olha, mas não sente desejo/segurança/curiosidade suficiente para clicar.\n\n**Alternativas avaliadas:**\n\n1. **Esperar até R$25:** mantém o critério estatístico combinado, mas perde tempo se o padrão de zero clique continuar.\n2. **Pausar agora:** economiza verba, mas ainda estamos com gasto baixo e tráfego barato.\n3. **Preparar nova primeira dobra/CTA mantendo campanha monitorada:** melhor opção, porque corrige o ponto real de abandono sem depender de nova infraestrutura.\n\n**Recomendação:** manter o monitoramento até perto de **R$25**, mas já preparar a próxima alteração do PDE: transformar o CTA em uma ação mais imediata e menos abstrata, por exemplo algo como **“Descobrir o que minha imagem comunica hoje”**, com resultado prometido antes de qualquer login/e-mail.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
faça a alteração. Mas eu acho bom tbm reduzir a quantidade opções na tela isso pode confundir.

**Resumo das alterações:**
{"titulo":"Entrada MUSA simplificada","comentario":"Implementei a alteração.\n\n**O que mudou:**\n\n- A entrada pública do PDE deixou de mostrar várias opções.\n- Agora existe uma única ação principal: **“Descobrir o que minha imagem comunica hoje”**.\n- O e-mail só aparece depois desse clique, mantendo o primeiro interesse mensurável.\n- O clique continua registrando `PRESENCE_MAP_CHOICE_SELECTED` e `DIAGNOSTIC_CHOICE_SELECTED`.\n- Atualizei o contrato PDE do MUSA no Marketing Hub via Liquibase.\n- Atualizei o fallback local do PDE para não voltar ao formato antigo.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Racional comercial:** reduzir escolha antes do primeiro microcompromisso. A hipótese agora é: menos confusão na tela deve aumentar o clique inicial no Mapa de Presença.\n\n**Validação feita:**\n\n- Build do frontend PDE passou.\n- Teste visual Playwright passou em desktop e mobile.\n- Teste focado `ProductCatalogServiceTest` passou.\n- Validação de fronteira de API passou.\n- Validação Liquibase/MySQL 5.7 passou.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar em produção, peça o PR e depois faça deploy do backend principal do Marketing Hub e do `pde-platform`."}