### PR TITLE
AI Hub: {"titulo":"Versionamento PDE pronto","comentario":"Implementei o versionamento comercial do PDE para comparar formato antigo vs novo com métricas associadas à versão.\n\n**O que ficou pronto:**\n\n- O contrato PDE agora suporta `experienceVersion`…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
@@ -6,6 +6,7 @@ import com.marketinghub.experiment.monitoring.dto.PostDeployFacebookLogSummaryDt
 import com.marketinghub.experiment.monitoring.dto.PostDeployMetaAdsSummaryDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorDecision;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeExperienceVersionDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSummaryDto;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
@@ -121,6 +122,7 @@ public class PostDeployMonitorService {
                     false,
                     "UNAVAILABLE",
                     ex.getMessage(),
+                    null,
                     0,
                     0,
                     0,
@@ -137,7 +139,8 @@ public class PostDeployMonitorService {
                     0,
                     0,
                     null,
-                    Map.<String, Long>of());
+                    Map.<String, Long>of(),
+                    List.of());
         }
     }
 
@@ -151,6 +154,7 @@ public class PostDeployMonitorService {
                 true,
                 "AVAILABLE",
                 null,
+                summary.currentExperienceVersion(),
                 summary.totalEvents(),
                 summary.uniqueVisitors(),
                 summary.sessions(),
@@ -167,7 +171,27 @@ public class PostDeployMonitorService {
                 summary.subscriptionApproved(),
                 summary.totalVisibleMs(),
                 null,
-                events);
+                events,
+                toExperienceVersionDtos(summary));
+    }
+
+    /** Converte as métricas por versão do PDE para exibição no painel administrativo. */
+    private List<PostDeployPdeExperienceVersionDto> toExperienceVersionDtos(PdeAnalyticsSummary summary) {
+        if (summary.experienceVersions() == null) {
+            return List.of();
+        }
+        return summary.experienceVersions().stream()
+                .map(version -> new PostDeployPdeExperienceVersionDto(
+                        version.experienceVersion(),
+                        version.totalEvents(),
+                        version.sessions(),
+                        version.pdeEntries(),
+                        version.presenceMapClicks() + version.diagnosticClicks(),
+                        version.loginStarted(),
+                        version.paywallViewed(),
+                        version.subscriptionClicked() + version.checkoutStarted(),
+                        version.subscriptionApproved()))
+                .toList();
     }
 
     /** Busca a contagem do evento considerando aliases de caixa alta e baixa. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeExperienceVersionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeExperienceVersionDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+/** Resume desempenho de uma versão comercial do PDE no painel pós-deploy. */
+public record PostDeployPdeExperienceVersionDto(
+        String experienceVersion,
+        long totalEvents,
+        long sessions,
+        long pdeEntries,
+        long firstInteractionClicks,
+        long loginStarted,
+        long paywallViewed,
+        long checkoutIntent,
+        long subscriptionApproved
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.monitoring.dto;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 /** Resume analytics do PDE usados para medir interação e intenção comercial. */
@@ -8,6 +9,7 @@ public record PostDeployPdeSummaryDto(
         boolean available,
         String status,
         String errorMessage,
+        String currentExperienceVersion,
         long totalEvents,
         long uniqueVisitors,
         long sessions,
@@ -24,5 +26,6 @@ public record PostDeployPdeSummaryDto(
         long subscriptionApproved,
         long totalVisibleMs,
         Instant lastEventAt,
-        Map<String, Long> events
+        Map<String, Long> events,
+        List<PostDeployPdeExperienceVersionDto> experienceVersions
 ) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
@@ -5,6 +5,7 @@ import java.util.List;
 /** Contrato mínimo do resumo de analytics retornado pelo backend PDE. */
 public record PdeAnalyticsSummary(
         String productSlug,
+        String currentExperienceVersion,
         long totalEvents,
         long uniqueVisitors,
         long sessions,
@@ -19,8 +20,24 @@ public record PdeAnalyticsSummary(
         long firstUse,
         long checkoutStarted,
         long totalVisibleMs,
-        List<PdeEventMetric> events
+        List<PdeEventMetric> events,
+        List<PdeExperienceVersionMetric> experienceVersions
 ) {
     /** Representa a contagem agregada por tipo de evento do PDE. */
     public record PdeEventMetric(String eventType, long total) {}
+
+    /** Representa a contagem comercial agregada por versão da experiência PDE. */
+    public record PdeExperienceVersionMetric(
+            String experienceVersion,
+            long totalEvents,
+            long sessions,
+            long pdeEntries,
+            long presenceMapClicks,
+            long diagnosticClicks,
+            long loginStarted,
+            long paywallViewed,
+            long subscriptionClicked,
+            long checkoutStarted,
+            long subscriptionApproved
+    ) {}
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-pde-funnel-events.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-pde-funnel-events.yaml
@@ -19,6 +19,7 @@ databaseChangeLog:
                 id BIGINT NOT NULL AUTO_INCREMENT,
                 event_id VARCHAR(36) NOT NULL,
                 product_slug VARCHAR(191) NOT NULL,
+                experience_version VARCHAR(80) NULL,
                 access_token VARCHAR(36) NULL,
                 email VARCHAR(320) NULL,
                 normalized_email VARCHAR(320) NULL,
@@ -31,6 +32,7 @@ databaseChangeLog:
                 PRIMARY KEY (id),
                 UNIQUE KEY uk_pde_funnel_event_id (event_id),
                 KEY idx_pde_funnel_product_event_time (product_slug, event_type, occurred_at),
+                KEY idx_pde_funnel_product_version_time (product_slug, experience_version, occurred_at),
                 KEY idx_pde_funnel_access_token (access_token),
                 KEY idx_pde_funnel_email (normalized_email),
                 CONSTRAINT fk_pde_funnel_access_grant

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-pde-funnel-experience-version.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-pde-funnel-experience-version.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-21-pde-funnel-experience-version-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pde_funnel_event
+        - not:
+            columnExists:
+              tableName: pde_funnel_event
+              columnName: experience_version
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pde_funnel_event
+                ADD COLUMN experience_version VARCHAR(80) NULL AFTER product_slug,
+                ADD KEY idx_pde_funnel_product_version_time (product_slug, experience_version, occurred_at);

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-musa-pde-experience-version.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-21-product-musa-pde-experience-version.yaml
@@ -1,0 +1,39 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-21-product-musa-pde-experience-version.yaml
+  - changeSet:
+      id: 2026-07-21-product-musa-pde-experience-version-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: pde_experience_json
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET pde_experience_json = JSON_SET(
+                       pde_experience_json,
+                       '$.experienceVersion',
+                       'musa-pde-entry-v3',
+                       '$.funnelVersion',
+                       'musa-membership-funnel-v1'
+                     ),
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias'
+                 AND pde_experience_json IS NOT NULL
+                 AND pde_experience_json <> ''
+                 AND JSON_VALID(pde_experience_json) = 1;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -24,6 +24,12 @@ databaseChangeLog:
       file: changesets/2026-07-21-product-musa-pde-single-action-entry.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-21-pde-funnel-experience-version.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-07-21-product-musa-pde-experience-version.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-19-product-musa-seven-day-journey.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
@@ -61,6 +61,7 @@ class PostDeployMonitorServiceTest {
         when(apiLogService.findLogs(67L, 50)).thenReturn(List.of());
         when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenReturn(new PdeAnalyticsSummary(
                 "metodo-musa-7-dias",
+                "musa-pde-entry-v3",
                 80,
                 20,
                 15,
@@ -75,13 +76,19 @@ class PostDeployMonitorServiceTest {
                 0,
                 0,
                 2000,
-                List.of()));
+                List.of(),
+                List.of(new PdeAnalyticsSummary.PdeExperienceVersionMetric(
+                        "musa-pde-entry-v3", 80, 15, 15, 0, 0, 0, 0, 0, 0, 0))));
 
         var response = service.summarize(67L, null);
 
         assertThat(response.decision()).isEqualTo(PostDeployMonitorDecision.PAUSE_AND_FIX);
         assertThat(response.alerts()).anyMatch(alert -> alert.contains("Mapa/Diagnóstico"));
         assertThat(response.metaAds().ctrPercent()).isEqualByComparingTo("5.00");
+        assertThat(response.pde().currentExperienceVersion()).isEqualTo("musa-pde-entry-v3");
+        assertThat(response.pde().experienceVersions())
+                .extracting("experienceVersion")
+                .contains("musa-pde-entry-v3");
     }
 
     /** Recomenda corrigir medição quando o PDE não responde ao Hub. */
@@ -109,6 +116,7 @@ class PostDeployMonitorServiceTest {
         when(apiLogService.findLogs(67L, 50)).thenReturn(List.of(successLog()));
         when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenReturn(new PdeAnalyticsSummary(
                 "metodo-musa-7-dias",
+                "musa-pde-entry-v3",
                 120,
                 30,
                 20,
@@ -123,7 +131,9 @@ class PostDeployMonitorServiceTest {
                 1,
                 1,
                 9000,
-                List.of(new PdeAnalyticsSummary.PdeEventMetric("PRESENCE_MAP_CHOICE_SELECTED", 6))));
+                List.of(new PdeAnalyticsSummary.PdeEventMetric("PRESENCE_MAP_CHOICE_SELECTED", 6)),
+                List.of(new PdeAnalyticsSummary.PdeExperienceVersionMetric(
+                        "musa-pde-entry-v3", 120, 20, 20, 6, 0, 5, 2, 2, 1, 1))));
 
         var response = service.summarize(67L, null);
 

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -59,6 +59,8 @@ O objetivo é preservar a associação entre versão da experiência, campanha, 
 
 Cada contrato PDE publicado pelo Marketing Hub deve declarar uma versão comercial explícita da experiência, como `experienceVersion`, `funnelVersion` ou campo equivalente canônico. Essa versão deve mudar sempre que a alteração puder afetar conversão, interesse ou comportamento do usuário. Eventos de analytics enviados pelo frontend PDE devem carregar essa versão nos metadados persistidos para permitir comparar resultados por versão sem misturar tráfego antigo e novo.
 
+O campo canônico para comparação automática é `experienceVersion`. O campo `funnelVersion` agrupa a arquitetura comercial maior do funil. O backend PDE deve persistir `experienceVersion` em coluna própria dos eventos de funil, mantendo os metadados como apoio auditável, para permitir consulta simples por SQL e painel pós-deploy.
+
 Quando uma alteração de PDE for publicada, o relatório/painel deve separar pelo menos:
 
 - produto;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3,7 +3,8 @@
 - decisão operacional: mudanças comerciais em PDEs usados em campanha ou experimento devem ser feitas pelo Marketing Hub, no contrato `pde_experience_json`, para manter versão, métrica e decisão comercial associadas.
 - causa-raiz: alterações diretas no `pde-platform` podem mudar primeira dobra, CTA, opções ou diagnóstico sem deixar claro qual versão gerou cada evento de funil, contaminando a comparação entre formatos.
 - verificação do sistema: o Marketing Hub já armazena e expõe o contrato PDE por `/api/products/public/{productCode}/pde-experience`, e o backend PDE já tenta consumir esse contrato antes de usar o catálogo local.
-- lacuna identificada: o contrato e os eventos ainda precisam carregar uma versão comercial explícita da experiência nos metadados de analytics para comparação automática por versão, não apenas por janela de tempo.
+- foi feito: o contrato MUSA passou a declarar `experienceVersion=musa-pde-entry-v3` e `funnelVersion=musa-membership-funnel-v1`.
+- foi feito: os eventos do PDE passaram a persistir `experience_version` em coluna própria e o painel pós-deploy passou a exibir comparação por versão.
 - orientação registrada: o cânone `docs/canonical/pde-platform-canon.v1.md` passa a exigir que alterações comerciais do PDE sejam publicadas pelo Hub e que a versão da experiência seja persistida nos eventos quando a mudança puder afetar conversão.
 
 ## 2026-07-21 — Clube MUSA: entrada PDE com uma ação principal

--- a/frontend/src/api/experiment/usePostDeployMonitor.ts
+++ b/frontend/src/api/experiment/usePostDeployMonitor.ts
@@ -27,6 +27,7 @@ export interface PostDeployPdeSummary {
   available: boolean;
   status: string;
   errorMessage?: string | null;
+  currentExperienceVersion?: string | null;
   totalEvents: number;
   uniqueVisitors: number;
   sessions: number;
@@ -44,6 +45,19 @@ export interface PostDeployPdeSummary {
   totalVisibleMs: number;
   lastEventAt?: string | null;
   events: Record<string, number>;
+  experienceVersions: PostDeployPdeExperienceVersion[];
+}
+
+export interface PostDeployPdeExperienceVersion {
+  experienceVersion: string;
+  totalEvents: number;
+  sessions: number;
+  pdeEntries: number;
+  firstInteractionClicks: number;
+  loginStarted: number;
+  paywallViewed: number;
+  checkoutIntent: number;
+  subscriptionApproved: number;
 }
 
 export interface PostDeployFacebookLogSummary {

--- a/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
@@ -193,6 +193,12 @@ export default function ExperimentPostDeployMonitorTab({
                   {monitor.pde.available ? "Online" : "Indisponível"}
                 </span>
               </div>
+              <div className="small text-muted mb-2">
+                Versão medida:{" "}
+                <span className="fw-semibold">
+                  {monitor.pde.currentExperienceVersion ?? "sem versão"}
+                </span>
+              </div>
               <div className="table-responsive">
                 <table className="table table-sm align-middle mb-0">
                   <tbody>
@@ -247,6 +253,44 @@ export default function ExperimentPostDeployMonitorTab({
           </div>
         </div>
       </div>
+
+      {monitor.pde.experienceVersions.length > 0 ? (
+        <div className="card">
+          <div className="card-body">
+            <h6 className="card-title">Comparação por versão PDE</h6>
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Versão</th>
+                    <th className="text-end">Sessões</th>
+                    <th className="text-end">Entradas</th>
+                    <th className="text-end">1ª ação</th>
+                    <th className="text-end">Login</th>
+                    <th className="text-end">Paywall</th>
+                    <th className="text-end">Checkout</th>
+                    <th className="text-end">Compra</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {monitor.pde.experienceVersions.map((version) => (
+                    <tr key={version.experienceVersion}>
+                      <td className="fw-semibold">{version.experienceVersion}</td>
+                      <td className="text-end">{formatNumber(version.sessions)}</td>
+                      <td className="text-end">{formatNumber(version.pdeEntries)}</td>
+                      <td className="text-end">{formatNumber(version.firstInteractionClicks)}</td>
+                      <td className="text-end">{formatNumber(version.loginStarted)}</td>
+                      <td className="text-end">{formatNumber(version.paywallViewed)}</td>
+                      <td className="text-end">{formatNumber(version.checkoutIntent)}</td>
+                      <td className="text-end">{formatNumber(version.subscriptionApproved)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsExperienceVersionMetricDto.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsExperienceVersionMetricDto.java
@@ -1,0 +1,16 @@
+package com.marketinghub.pde.dto;
+
+/** Resume o desempenho de uma versão comercial da experiência PDE. */
+public record FunnelAnalyticsExperienceVersionMetricDto(
+        String experienceVersion,
+        long totalEvents,
+        long sessions,
+        long pdeEntries,
+        long presenceMapClicks,
+        long diagnosticClicks,
+        long loginStarted,
+        long paywallViewed,
+        long subscriptionClicked,
+        long checkoutStarted,
+        long subscriptionApproved
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsSummaryResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsSummaryResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 /** Retorna o resumo de analytics e funil comercial do produto PDE. */
 public record FunnelAnalyticsSummaryResponse(
         String productSlug,
+        String currentExperienceVersion,
         long totalEvents,
         long uniqueVisitors,
         long sessions,
@@ -19,5 +20,6 @@ public record FunnelAnalyticsSummaryResponse(
         long firstUse,
         long checkoutStarted,
         long totalVisibleMs,
-        List<FunnelAnalyticsEventMetricDto> events
+        List<FunnelAnalyticsEventMetricDto> events,
+        List<FunnelAnalyticsExperienceVersionMetricDto> experienceVersions
 ) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/ProductExperienceResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/ProductExperienceResponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 /** Descreve o produto experiencial que o frontend renderiza para a cliente. */
 public record ProductExperienceResponse(
         String slug,
+        String experienceVersion,
+        String funnelVersion,
         String name,
         String promise,
         String audience,

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
@@ -3,6 +3,7 @@ package com.marketinghub.pde.service;
 import com.marketinghub.pde.dto.AccessResponse;
 import com.marketinghub.pde.dto.FunnelAnalyticsResetResponse;
 import com.marketinghub.pde.dto.FunnelAnalyticsEventMetricDto;
+import com.marketinghub.pde.dto.FunnelAnalyticsExperienceVersionMetricDto;
 import com.marketinghub.pde.dto.FunnelAnalyticsJourneyResponse;
 import com.marketinghub.pde.dto.FunnelAnalyticsSessionJourneyDto;
 import com.marketinghub.pde.dto.FunnelAnalyticsSessionStepDto;
@@ -248,11 +249,11 @@ public class AccessService {
 
     /** Registra um evento comercial da jornada PED/MUSA para medição do funil. */
     public FunnelEventResponse recordFunnelEvent(FunnelEventRequest request) {
-        productCatalogService.getProduct(request.productSlug());
+        ProductExperienceResponse product = productCatalogService.getProduct(request.productSlug());
         String normalizedEventType = normalizeEventType(request.eventType());
         String eventId = UUID.randomUUID().toString();
         if (usesJdbcStorage()) {
-            persistFunnelEventInDatabaseWithRetry(eventId, request, normalizedEventType);
+            persistFunnelEventInDatabaseWithRetry(eventId, request, normalizedEventType, product);
         } else {
             log.info(
                     "Evento PDE registrado sem persistência JDBC; eventId={}, productSlug={}, eventType={}, accessToken={}",
@@ -265,11 +266,12 @@ public class AccessService {
     }
 
     /** Persiste evento comercial com retentativa para oscilação transitória do MySQL. */
-    private void persistFunnelEventInDatabaseWithRetry(String eventId, FunnelEventRequest request, String eventType) {
+    private void persistFunnelEventInDatabaseWithRetry(
+            String eventId, FunnelEventRequest request, String eventType, ProductExperienceResponse product) {
         RuntimeException lastFailure = null;
         for (int attempt = 1; attempt <= FUNNEL_EVENT_PERSIST_ATTEMPTS; attempt++) {
             try {
-                persistFunnelEventInDatabase(eventId, request, eventType);
+                persistFunnelEventInDatabase(eventId, request, eventType, product);
                 if (attempt > 1) {
                     log.info(
                             "Evento PDE persistido após retentativa; eventId={}, productSlug={}, eventType={}, attempt={}",
@@ -300,7 +302,7 @@ public class AccessService {
 
     /** Consolida métricas de funil e analytics para decisão de próximas campanhas. */
     public FunnelAnalyticsSummaryResponse summarizeFunnelAnalytics(String productSlug) {
-        productCatalogService.getProduct(productSlug);
+        ProductExperienceResponse product = productCatalogService.getProduct(productSlug);
         if (!usesJdbcStorage()) {
             return emptyFunnelAnalytics(productSlug);
         }
@@ -330,6 +332,7 @@ public class AccessService {
                 if (resultSet.next()) {
                     return new FunnelAnalyticsSummaryResponse(
                             productSlug,
+                            product.experienceVersion(),
                             resultSet.getLong("total_events"),
                             resultSet.getLong("unique_visitors"),
                             resultSet.getLong("sessions"),
@@ -344,7 +347,8 @@ public class AccessService {
                             resultSet.getLong("first_use"),
                             resultSet.getLong("checkout_started"),
                             resultSet.getLong("total_visible_ms"),
-                            loadFunnelEventMetrics(connection, productSlug));
+                            loadFunnelEventMetrics(connection, productSlug),
+                            loadExperienceVersionMetrics(connection, productSlug));
                 }
             }
         } catch (SQLException ex) {
@@ -689,7 +693,8 @@ public class AccessService {
 
     /** Retorna métricas vazias quando o backend está em modo local sem banco analítico. */
     private FunnelAnalyticsSummaryResponse emptyFunnelAnalytics(String productSlug) {
-        return new FunnelAnalyticsSummaryResponse(productSlug, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of());
+        return new FunnelAnalyticsSummaryResponse(
+                productSlug, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of(), List.of());
     }
 
     /** Converte uma linha JDBC em evento normalizado de jornada. */
@@ -742,6 +747,50 @@ public class AccessService {
                     metrics.add(new FunnelAnalyticsEventMetricDto(
                             resultSet.getString("event_type"),
                             resultSet.getLong("total")));
+                }
+                return metrics;
+            }
+        }
+    }
+
+    /** Lê as métricas agregadas por versão comercial para comparar formatos do PDE. */
+    private List<FunnelAnalyticsExperienceVersionMetricDto> loadExperienceVersionMetrics(
+            Connection connection, String productSlug) throws SQLException {
+        String sql = """
+                SELECT
+                  COALESCE(NULLIF(experience_version, ''), 'sem-versao') AS resolved_experience_version,
+                  COUNT(*) AS total_events,
+                  COUNT(DISTINCT session_id) AS sessions,
+                  SUM(CASE WHEN event_type = 'PED_ENTRY' THEN 1 ELSE 0 END) AS pde_entries,
+                  SUM(CASE WHEN event_type = 'PRESENCE_MAP_CHOICE_SELECTED' THEN 1 ELSE 0 END) AS presence_map_clicks,
+                  SUM(CASE WHEN event_type = 'DIAGNOSTIC_CHOICE_SELECTED' THEN 1 ELSE 0 END) AS diagnostic_clicks,
+                  SUM(CASE WHEN event_type = 'LOGIN_STARTED' THEN 1 ELSE 0 END) AS login_started,
+                  SUM(CASE WHEN event_type = 'PAYWALL_VIEWED' THEN 1 ELSE 0 END) AS paywall_viewed,
+                  SUM(CASE WHEN event_type = 'SUBSCRIPTION_CLICKED' THEN 1 ELSE 0 END) AS subscription_clicked,
+                  SUM(CASE WHEN event_type = 'CHECKOUT_STARTED' THEN 1 ELSE 0 END) AS checkout_started,
+                  SUM(CASE WHEN event_type = 'SUBSCRIPTION_APPROVED' THEN 1 ELSE 0 END) AS subscription_approved
+                FROM pde_funnel_event
+                WHERE product_slug = ?
+                GROUP BY COALESCE(NULLIF(experience_version, ''), 'sem-versao')
+                ORDER BY MAX(occurred_at) DESC
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, productSlug);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<FunnelAnalyticsExperienceVersionMetricDto> metrics = new java.util.ArrayList<>();
+                while (resultSet.next()) {
+                    metrics.add(new FunnelAnalyticsExperienceVersionMetricDto(
+                            resultSet.getString("resolved_experience_version"),
+                            resultSet.getLong("total_events"),
+                            resultSet.getLong("sessions"),
+                            resultSet.getLong("pde_entries"),
+                            resultSet.getLong("presence_map_clicks"),
+                            resultSet.getLong("diagnostic_clicks"),
+                            resultSet.getLong("login_started"),
+                            resultSet.getLong("paywall_viewed"),
+                            resultSet.getLong("subscription_clicked"),
+                            resultSet.getLong("checkout_started"),
+                            resultSet.getLong("subscription_approved")));
                 }
                 return metrics;
             }
@@ -934,46 +983,48 @@ public class AccessService {
     }
 
     /** Persiste evento comercial PED/MUSA no banco Marketing Hub. */
-    private void persistFunnelEventInDatabase(String eventId, FunnelEventRequest request, String eventType) {
+    private void persistFunnelEventInDatabase(
+            String eventId, FunnelEventRequest request, String eventType, ProductExperienceResponse product) {
         String sql = """
                 INSERT INTO pde_funnel_event (
-                  event_id, product_slug, access_token, email, normalized_email, event_type,
+                  event_id, product_slug, experience_version, access_token, email, normalized_email, event_type,
                   provider, source, page_url, referrer_url, session_id, visitor_id,
                   utm_source, utm_medium, utm_campaign, utm_content, utm_term,
                   device_type, screen_width, screen_height, viewport_width, viewport_height,
                   visible_ms, section_id, action_name, metadata_json, occurred_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                 """;
         try (Connection connection = openConnection();
                 PreparedStatement statement = connection.prepareStatement(sql)) {
             Map<String, Object> metadata = request.metadata();
             statement.setString(1, eventId);
             statement.setString(2, request.productSlug());
-            statement.setString(3, blankToNull(request.accessToken()));
-            statement.setString(4, blankToNull(request.email()));
-            statement.setString(5, blankToNull(normalizeEmail(request.email())));
-            statement.setString(6, eventType);
-            statement.setString(7, blankToNull(request.provider()));
-            statement.setString(8, blankToNull(request.source()));
-            statement.setString(9, blankToNull(request.pageUrl()));
-            statement.setString(10, blankToNull(metadataString(metadata, "referrerUrl")));
-            statement.setString(11, blankToNull(metadataString(metadata, "sessionId")));
-            statement.setString(12, blankToNull(metadataString(metadata, "visitorId")));
-            statement.setString(13, blankToNull(metadataString(metadata, "utmSource")));
-            statement.setString(14, blankToNull(metadataString(metadata, "utmMedium")));
-            statement.setString(15, blankToNull(metadataString(metadata, "utmCampaign")));
-            statement.setString(16, blankToNull(metadataString(metadata, "utmContent")));
-            statement.setString(17, blankToNull(metadataString(metadata, "utmTerm")));
-            statement.setString(18, blankToNull(metadataString(metadata, "deviceType")));
-            setInteger(statement, 19, metadataLong(metadata, "screenWidth"));
-            setInteger(statement, 20, metadataLong(metadata, "screenHeight"));
-            setInteger(statement, 21, metadataLong(metadata, "viewportWidth"));
-            setInteger(statement, 22, metadataLong(metadata, "viewportHeight"));
-            setLong(statement, 23, metadataLong(metadata, "visibleMs"));
-            statement.setString(24, blankToNull(metadataString(metadata, "sectionId")));
-            statement.setString(25, blankToNull(metadataString(metadata, "actionName")));
-            statement.setString(26, metadata == null ? null : objectMapper.writeValueAsString(metadata));
+            statement.setString(3, blankToNull(resolveExperienceVersion(metadata, product)));
+            statement.setString(4, blankToNull(request.accessToken()));
+            statement.setString(5, blankToNull(request.email()));
+            statement.setString(6, blankToNull(normalizeEmail(request.email())));
+            statement.setString(7, eventType);
+            statement.setString(8, blankToNull(request.provider()));
+            statement.setString(9, blankToNull(request.source()));
+            statement.setString(10, blankToNull(request.pageUrl()));
+            statement.setString(11, blankToNull(metadataString(metadata, "referrerUrl")));
+            statement.setString(12, blankToNull(metadataString(metadata, "sessionId")));
+            statement.setString(13, blankToNull(metadataString(metadata, "visitorId")));
+            statement.setString(14, blankToNull(metadataString(metadata, "utmSource")));
+            statement.setString(15, blankToNull(metadataString(metadata, "utmMedium")));
+            statement.setString(16, blankToNull(metadataString(metadata, "utmCampaign")));
+            statement.setString(17, blankToNull(metadataString(metadata, "utmContent")));
+            statement.setString(18, blankToNull(metadataString(metadata, "utmTerm")));
+            statement.setString(19, blankToNull(metadataString(metadata, "deviceType")));
+            setInteger(statement, 20, metadataLong(metadata, "screenWidth"));
+            setInteger(statement, 21, metadataLong(metadata, "screenHeight"));
+            setInteger(statement, 22, metadataLong(metadata, "viewportWidth"));
+            setInteger(statement, 23, metadataLong(metadata, "viewportHeight"));
+            setLong(statement, 24, metadataLong(metadata, "visibleMs"));
+            statement.setString(25, blankToNull(metadataString(metadata, "sectionId")));
+            statement.setString(26, blankToNull(metadataString(metadata, "actionName")));
+            statement.setString(27, metadata == null ? null : objectMapper.writeValueAsString(metadata));
             statement.executeUpdate();
         } catch (SQLException | IOException ex) {
             log.error(
@@ -984,6 +1035,15 @@ public class AccessService {
                     ex);
             throw new IllegalStateException("Não foi possível persistir evento PDE no banco Marketing Hub", ex);
         }
+    }
+
+    /** Resolve a versão comercial do evento usando o payload ou o contrato ativo do produto. */
+    private String resolveExperienceVersion(Map<String, Object> metadata, ProductExperienceResponse product) {
+        String metadataVersion = metadataString(metadata, "experienceVersion");
+        if (metadataVersion != null && !metadataVersion.isBlank()) {
+            return metadataVersion;
+        }
+        return product == null ? null : product.experienceVersion();
     }
 
     /** Converte texto vazio em null para persistência normalizada. */

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/ProductCatalogService.java
@@ -97,6 +97,8 @@ public class ProductCatalogService {
     private static ProductExperienceResponse createMusaProduct() {
         return new ProductExperienceResponse(
                 "metodo-musa-7-dias",
+                "musa-pde-entry-v3",
+                "musa-membership-funnel-v1",
                 "Método MUSA - Experiência Guiada de 7 Dias",
                 "Descubra o que sua imagem comunica sem intenção e monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro.",
                 "Mulheres urbanas que querem se sentir mais marcantes, alinhadas e seguras usando escolhas acessíveis.",

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -68,6 +68,8 @@ type ScientificEvidencePack = {
 
 type ProductExperience = {
   slug: string;
+  experienceVersion?: string;
+  funnelVersion?: string;
   name: string;
   promise: string;
   audience: string;
@@ -177,6 +179,8 @@ declare global {
 
 const fallbackProduct: ProductExperience = {
   slug: 'metodo-musa-7-dias',
+  experienceVersion: 'musa-pde-entry-v3',
+  funnelVersion: 'musa-membership-funnel-v1',
   name: 'Método MUSA - Experiência Guiada de 7 Dias',
   promise: 'Descubra o que sua imagem comunica sem intenção e monte em 7 dias uma presença mais elegante, marcante e coerente sem depender de luxo caro.',
   audience: 'Mulheres urbanas que querem se sentir mais marcantes, alinhadas e seguras usando escolhas acessíveis.',
@@ -951,10 +955,16 @@ function App() {
         viewportWidth: window.innerWidth,
         viewportHeight: window.innerHeight,
         path: window.location.pathname,
+        experienceVersion: resolveExperienceVersion(product),
+        funnelVersion: product.funnelVersion,
         ...campaignParams,
         ...options.metadata,
       },
     };
+  }
+
+  function resolveExperienceVersion(productExperience: ProductExperience) {
+    return productExperience.experienceVersion || 'sem-versao';
   }
 
   function resolveScreenName() {


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz o merge e o deploy vamos aguardar dados. Nos sabemos como comparar a versão antiga da nova ?

Modelo: {"titulo":"Comparação MUSA","comentario":"Sim. Sabemos comparar, mas a comparação correta não é apenas \"página antiga vs página nova\". Para o MUSA, a comparação precisa ser por **funil comercial completo**.\n\n**Fonte de verdade usada:** definição pública do PDE MUSA, registro do experimento 66, registro operacional do experimento 67 e cânone de experimentos.\n\n**O que comparar:**\n\n- **Versão antiga:** experimento 66, com venda do Método MUSA como experiência guiada simples, preço R$47/R$67 e foco em landing/checkout/Área MUSA.\n- **Versão nova:** experimento 67 pós-merge/deploy, com PDE publicado, analytics resetado e campanha Meta já iniciada.\n- **Métrica principal:** compra aprovada ou, se ainda não houver volume, avanço real no funil: clique no anúncio → acesso → diagnóstico/entrada no PDE → clique no paywall/checkout → início de checkout → compra.\n\n**Alternativas de comparação avaliadas:**\n\n1. **Comparar só criativo/anúncio**  \n   Benefício: rápido.  \n   Risco: mostra CTR/CPC, mas não prova venda.  \n   Aderência ao objetivo de vendas: baixa.\n\n2. **Comparar só página/PDE**  \n   Benefício: mostra se a nova experiência segura melhor o tráfego.  \n   Risco: se o anúncio ou público estiver ruim, a página pode ser culpada injustamente.  \n   Aderência: média.\n\n3. **Comparar funil completo por etapa**  \n   Benefício: identifica onde melhorou ou quebrou: anúncio, página, diagnóstico, paywall, checkout ou entrega.  \n   Risco: precisa aguardar dados mínimos.  \n   Aderência: alta.\n\n**Escolha recomendada:** alternativa 3.\n\n**Como vamos decidir se a versão nova é melhor:**\n\n- Se o **CTR subir**, mas checkout/compra não subir: criativo melhorou, oferta/paywall ainda precisa ajuste.\n- Se o **acesso ao PDE subir**, mas diagnóstico/paywall não avançar: problema de ativação da experiência.\n- Se houver **clique no checkout**, mas não compra: problema de preço, confiança, checkout ou objeção final.\n- Se houver **compra com gasto baixo**, mesmo com poucos dados: manter coleta e preparar escala gradual.\n- Se gastar perto de R$25 sem evento primário relevante, o cânone recomenda parar e corrigir causa-raiz antes de insistir.\n\n**Ponto importante:** o registro já mostra que o experimento 67 começou com 92 impressões, 3 cliques e R$0,61 de gasto em 2026-07-20. Isso ainda é pouco para conclusão, mas já confirma que a medição saiu do zero e que o reset de analytics do PDE aconteceu.\n\n**Próximo acompanhamento ideal:** quando tivermos mais dados, eu compararia em uma tabela simples:\n\n| Etapa | Exp. 66 | Exp. 67 | Leitura |\n|---|---:|---:|---|\n| Impressões | antigo | novo | entrega da mídia |\n| CTR | antigo | novo | força do criativo |\n| CPC | antigo | novo | custo de atenção |\n| Page view/PDE view | antigo | novo | tráfego real chegando |\n| Diagnóstico iniciado | antigo | novo | ativação |\n| Paywall/checkout click | antigo | novo | intenção de compra |\n| Checkout iniciado | antigo | novo | força da oferta |\n| Compra | antigo | novo | validação comercial |\n| CPA/ROAS | antigo | novo | escala |\n\nMinha recomendação agora é aguardar até termos pelo menos uma das duas condições: **R$25 de gasto sem compra/evento primário** ou **sinal positivo de checkout/compra antes disso**. Aí a leitura fica objetiva e não baseada em impressão inicial.","sugestaoMelhoriaAmbiente":""}

Usuário: mas fizemos uma alteraçaõ recente veja no github precisamos monitorar isso

Modelo: {"titulo":"Monitoramento do MUSA","comentario":"Sim. A alteração recente que precisamos monitorar é o PR #4435, mergeado em **21/07/2026 00:56 UTC**.\n\n**O que mudou comercialmente:** a entrada do PDE deixou de vender um diagnóstico genérico e passou a vender o **Mapa de Presença do Dia 1**, com duas escolhas antes do e-mail. Isso ataca diretamente o gargalo anterior: tráfego chegava, mas ninguém clicava, preenchia e-mail, iniciava login ou via paywall.\n\n**Status validado agora:**\n\n- Deploy do GitHub Actions concluiu com sucesso.\n- Site público já serve a nova copy: “Sua imagem comunica a mulher que você quer ser vista como?” e “Mapa de Presença”.\n- Backend PDE subiu após o merge, sem erro relevante no log.\n- MCP já consulta o schema real do PDE: `aihubdb`.\n- Banco PDE ainda não recebeu eventos depois do merge.\n- Último evento MUSA persistido: **20/07/2026 22:10:19**.\n\n**Linha de base antes da alteração:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE MUSA | 427 |\n| Entradas no PDE | 65 |\n| Sessões com entrada | 65 |\n| Cliques no diagnóstico/mapa | 0 |\n| E-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n| Compra aprovada | 0 |\n\n**Meta Ads:** a campanha `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA` está **ACTIVE**. Dados disponíveis no período do ad account: **1.565 impressões, 91 cliques, R$10,51 gastos, CTR 5,81%, CPC R$0,115 e 61 landing page views**.\n\n**Como vamos monitorar a nova versão:**\n\n1. **Primeiro sinal obrigatório:** aparecer `PRESENCE_MAP_CHOICE_SELECTED` ou `DIAGNOSTIC_CHOICE_SELECTED` no banco.  \n   Se isso não aparecer com tráfego ativo, o problema continua na primeira dobra ou no tracking.\n\n2. **Segundo sinal:** depois do primeiro clique, medir `FIELD_FILLED` e `LOGIN_STARTED`.  \n   Se houver clique no mapa mas não houver e-mail, a oferta inicial interessa, mas a transição para captura ainda está fraca.\n\n3. **Terceiro sinal:** `LOGIN_COMPLETED`, `PAYWALL_VIEWED` e `SUBSCRIPTION_CLICKED`.  \n   Se chegar aqui, finalmente poderemos avaliar preço, paywall e checkout.\n\n**Alternativas avaliadas:**\n\n1. Monitorar só Meta Ads: rápido, mas não mostra se o PDE destravou.\n2. Monitorar só banco PDE: mostra comportamento real, mas não separa falta de tráfego de falha da página.\n3. Monitorar Meta + eventos PDE por etapa: melhor opção, porque mostra se o anúncio entrega tráfego e se a nova entrada transforma atenção em ação.\n\n**Escolha:** alternativa 3.\n\n**Critério prático:** se a campanha continuar entregando tráfego e, após novo volume, o banco continuar com **zero clique no Mapa de Presença**, a alteração não resolveu o gargalo. Se aparecer clique no mapa, mas não e-mail/login, o próximo ajuste deve ser na transição para salvar o resultado por e-mail.","sugestaoMelhoriaAmbiente":"Ativar as tools de GitHub Actions no MCP e criar um painel/alerta automático para eventos PDE pós-deploy permitiria monitoramento contínuo sem depender de consultas manuais."}

Usuário: Precisamos colocar essa forma de atualização do PDE no Marketing Hub fazer isso atraves do Marketing Hub.

Modelo: {"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiência PDE.\n- O Hub expõe esse contrato em `/api/products/public/{productCode}/pde-experience`.\n- O formulário de Produto no frontend permite editar esse JSON.\n- O backend do `pde-platform` tenta carregar primeiro a experiência publicada pelo Hub.\n- Se o Hub estiver indisponível ou sem contrato publicado, o PDE usa o catálogo local atual como fallback, sem derrubar o Clube MUSA.\n- O deploy do PDE passa a receber `PDE_MARKETING_HUB_BASE_URL`, apontando por padrão para o backend do Marketing Hub.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Alternativas avaliadas:**\n\n1. Editar o PDE direto no código: rápido, mas mantém dependência de deploy técnico para mudança comercial.\n2. Criar endpoint administrativo só no PDE: melhora operação, mas tira o Hub da fonte de verdade.\n3. Fazer o Hub publicar o contrato PDE e o PDE consumir: melhor opção, porque centraliza produto, copy, jornada e oferta no Marketing Hub.\n\n**Escolha aplicada:** alternativa 3.\n\n**Validação feita:**\n\n- `ProductServiceTest` e `ProductControllerTest`: 10 testes passaram.\n- `ProductCatalogServiceTest` do PDE: 3 testes passaram.\n- `npm run typecheck` do frontend passou após instalar dependências locais com `npm ci`.\n- `git diff --check` sem problemas.\n- Changelog mestre revisado com `relativeToChangelogFile: true` no include novo.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso chegar em produção, o próximo passo é você pedir/abrir o PR e depois fazer o deploy do backend principal e do pde-platform."}

Usuário: eu fiz o deploy verifique se ficou ok. E veja se conseguimos ver se a mudança no PDE deu algum resultado positivo nas interação e interesse dos usuarios com o PDE.

Modelo: {"titulo":"Deploy parcial","comentario":"**Verificação concluída:** ficou **parcialmente ok**.\n\n**O que está ok:**\n\n- O frontend público do Clube MUSA foi atualizado em produção em **21/07/2026 00:57:41 UTC**.\n- A página pública contém a nova copy: **“Sua imagem comunica…”** e **“Mapa de Presença”**.\n- O backend do PDE subiu após o deploy.\n- O Marketing Hub expõe corretamente o contrato em `/api/products/public/metodo-musa-7-dias/pde-experience`.\n- A campanha Meta continua **ACTIVE**.\n\n**O que não está ok:**\n\n- O `pde-platform-backend` está falhando ao carregar a experiência PDE do Marketing Hub e usando o **catálogo local como fallback**.\n- Houve erro pós-deploy ao persistir evento PDE: `PED_ENTRY` em **21/07/2026 01:23:41 UTC**.\n- Portanto, a medição pós-deploy não está confiável neste momento.\n\n**Dados de interação disponíveis até agora:**\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais registrados | 493 |\n| Sessões | 76 |\n| Entradas no PDE | 74 |\n| Sessões que chegaram na seção interativa | 10 |\n| Sessões com scroll registrado | 5 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Campo de e-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n\n**Ponto crítico:** todos os eventos gravados no banco são de **20/07/2026**, antes do deploy da nova integração Hub → PDE. Depois do deploy, o banco mostra **0 sessões persistidas**, mas o log indica que pelo menos um evento tentou entrar e falhou. Então não dá para concluir que não houve tráfego; dá para concluir que a medição pós-deploy está quebrada ou instável.\n\n**Meta Ads:** a campanha mostra **1.826 impressões, 101 cliques, R$11,72 gastos, CTR 5,53%, CPC R$0,116 e 68 landing page views**. O anúncio está gerando atenção barata, mas o PDE ainda não registrou avanço comercial real.\n\n**Alternativas avaliadas:**\n\n1. **Concluir pelo Meta Ads:** parece positivo por CTR/CPC, mas não prova interesse no PDE.\n2. **Concluir pelo banco PDE:** mostraria funil real, mas a gravação pós-deploy falhou.\n3. **Separar saúde técnica de resultado comercial:** melhor leitura agora.\n\n**Conclusão:** a mudança ainda **não pode ser considerada positiva comercialmente**, porque não temos dados pós-deploy confiáveis. Antes de esperar mais tráfego, o ideal é corrigir a integração do PDE com o Marketing Hub e a persistência dos eventos. Só depois disso a comparação da nova versão será justa.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis."}

Usuário: Execute sua orientação : 
Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis.

Modelo: {"titulo":"Correção PDE pronta","comentario":"Executei a correção técnica no repositório.\n\n**Causa confirmada:**\n\n- O PDE tentava carregar o contrato do Marketing Hub por `http://191.252.181.168` e o container recebeu `Connection refused`.\n- A gravação de evento pós-deploy falhou por comunicação com MySQL, deixando o funil sem dados novos após **20/07/2026 22:55:19**.\n\n**Correção aplicada:**\n\n- O deploy do PDE agora prioriza `http://191.252.181.168:8000` e mantém `http://191.252.181.168` como fallback.\n- O `ProductCatalogService` agora aceita múltiplas URLs do Marketing Hub e tenta a próxima antes de cair no catálogo local.\n- O `AccessService` agora faz 3 tentativas para persistir eventos do funil quando houver oscilação de banco.\n- Adicionei teste garantindo fallback de URL do Marketing Hub.\n\n**Validação:**\n\n- `mvn -q -Dtest=ProductCatalogServiceTest,AccessServiceTest test` passou.\n- `mvn -q test` no backend PDE passou.\n- `git diff --check` passou.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar a correção, peça o PR ou abra um PR com essas mudanças e depois faça o deploy do `pde-platform`."}

Usuário: feito o deploy

Modelo: {"titulo":"Deploy PDE ok","comentario":"**Status técnico:** o deploy ficou ok.\n\n- O `pde-platform-backend` reiniciou em **21/07/2026 02:06 UTC**.\n- O endpoint público do Clube MUSA está no ar.\n- O endpoint do PDE está entregando o contrato do Marketing Hub com **Mapa de Presença MUSA**.\n- Não apareceu novo erro de fallback para catálogo local após o deploy.\n- Fiz um teste sintético `codex_healthcheck` e ele gravou no banco com status `RECORDED`, então o caminho **site → PDE backend → MySQL** está funcionando.\n\n**Resultado comercial até agora:** ainda não há sinal positivo suficiente.\n\nDepois do deploy, entrou **1 sessão real paga**, vinda do Instagram, mobile. Ela registrou:\n\n| Evento | Sessões |\n|---|---:|\n| Entrada no PDE | 1 |\n| Page view | 1 |\n| Screen view | 1 |\n| Clique no Mapa de Presença | 0 |\n| Campo/e-mail | 0 |\n| Login iniciado | 0 |\n| Paywall | 0 |\n| Checkout | 0 |\n\n**Meta Ads atualizado:** campanha ativa com **1.916 impressões, 109 cliques, 75 landing page views, R$12,22 gastos, CTR 5,69% e CPC R$0,112**.\n\n**Leitura:** a parte técnica foi estabilizada. O anúncio continua barato e chamando atenção, mas a nova versão ainda não provou aumento de interesse dentro do PDE. O gargalo segue na primeira interação: a pessoa chega, mas ainda não clica no Mapa de Presença nem inicia login.\n\n**Alternativas avaliadas:**\n\n1. Concluir que deu certo porque o deploy estabilizou: errado comercialmente, pois venda/interação ainda não apareceu.\n2. Parar agora: prematuro, porque só há 1 sessão real pós-correção.\n3. Continuar monitorando até volume mínimo: melhor escolha.\n\n**Recomendação:** manter a campanha rodando até pelo menos **R$25 de gasto total** ou até termos volume maior pós-deploy. Se continuar com clique barato e zero clique no Mapa, o próximo ajuste deve ser na primeira dobra/CTA do PDE, tornando a ação mais irresistível e menos parecida com login ou formulário.","sugestaoMelhoriaAmbiente":"Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil."}

Usuário: implemente isso
Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil.

Modelo: {"titulo":"Painel pós-deploy pronto","comentario":"Implementei o painel automático pós-deploy no Marketing Hub.\n\n**O que ficou pronto:**\n\n- Nova aba **Pós-deploy** dentro do detalhe do experimento.\n- Endpoint agregador no backend: `/api/experiments/{experimentId}/post-deploy-monitor`.\n- Cruzamento automático de:\n  - métricas Meta Ads: gasto, impressões, cliques, CTR, CPC e erro de sync;\n  - eventos PDE: entrada, page view, clique no Mapa/Diagnóstico, e-mail, login, paywall, checkout e compra;\n  - logs Meta Ads: total, erros recentes e último log.\n- Decisão automática: **aguardar dados**, **manter monitoramento**, **pausar e corrigir**, **corrigir medição** ou **escalar gradualmente**.\n- Auto-refresh da tela a cada 60 segundos.\n\n**Validação feita:**\n\n- Teste backend `PostDeployMonitorServiceTest` passou.\n- `npm run typecheck` do frontend passou.\n- Spotless focado nos arquivos novos passou.\n- `git diff --check` passou.\n\n**Observação:** o `spotless:check` global do backend continua falhando por violações antigas em milhares de arquivos fora do escopo. Não alterei esses arquivos para evitar churn desnecessário.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar isso, peça o PR e depois faça o deploy do backend principal e do frontend do Marketing Hub."}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy parcialmente ok","comentario":"**Verifiquei o deploy.**\n\nO painel pós-deploy está publicado e o endpoint do Marketing Hub responde, mas ele ainda ficou em **atenção técnica** porque o backend está tentando buscar analytics PDE no host errado: `191.252.181.168:8096`.\n\n**Causa confirmada:** o PDE real está respondendo pelo domínio público `https://clubemusa.com.br`, e o analytics funciona ali.\n\n**Dados reais do PDE agora:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE | 563 |\n| Visitantes únicos | 85 |\n| Sessões | 88 |\n| Entradas PDE | 85 |\n| Page views | 86 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout | 0 |\n| Compra | 0 |\n\n**Meta Ads no painel:** 2.049 impressões, 116 cliques, R$12,78 gastos, CTR 5,66%, CPC R$0,11.\n\n**Leitura comercial:** o anúncio continua bom para gerar atenção barata, mas ainda não apareceu sinal positivo forte dentro do PDE. O gargalo segue na primeira ação: a pessoa entra, mas não clica no Mapa de Presença, não inicia login e não chega no paywall.\n\n**Alternativas avaliadas:**\n\n1. Ajustar só variável de ambiente no servidor: rápido, mas pode voltar a quebrar em outro deploy.\n2. Apontar o Hub para o IP correto `191.252.102.54:8096`: funciona, mas mantém dependência de IP/porta.\n3. Usar `https://clubemusa.com.br` como default canônico: melhor opção, porque usa o mesmo domínio público do funil e reduz fragilidade operacional.\n\n**O que deixei pronto no repositório:**\n\n- Corrigi o default de `integrations.pde-platform.base-url` para `https://clubemusa.com.br`.\n- Corrigi o fallback do cliente HTTP do painel.\n- Registrei a causa em `docs/registros/experimentos.md`.\n- Validação focada passou: `PostDeployMonitorServiceTest`.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR dessa correção e depois faça novo deploy do backend principal do Marketing Hub para o painel passar a cruzar Meta Ads + PDE automaticamente em produção."}

Usuário: feito

Modelo: {"titulo":"Painel validado","comentario":"**Deploy verificado: agora ficou ok.**\n\nO painel pós-deploy do Marketing Hub está consultando corretamente o PDE em `https://clubemusa.com.br` e o resultado bate com o analytics direto do Clube MUSA.\n\n**Status atual:**\n\n| Área | Situação |\n|---|---|\n| Marketing Hub | Endpoint do painel responde ok |\n| PDE analytics | Disponível |\n| Cruzamento Meta + PDE | Funcionando |\n| Erro técnico do painel | Não apareceu |\n| Decisão automática | **Manter monitoramento** |\n\n**Dados atuais do painel:**\n\n| Métrica | Valor |\n|---|---:|\n| Impressões Meta | 2.074 |\n| Cliques Meta | 117 |\n| Gasto | R$12,92 |\n| CTR | 5,64% |\n| CPC | R$0,11 |\n| Eventos PDE | 575 |\n| Visitantes únicos PDE | 86 |\n| Sessões PDE | 90 |\n| Entradas PDE | 87 |\n| Page views | 88 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout/compra | 0 |\n\n**Leitura comercial:** o painel está pronto para decisão, mas a mudança do PDE ainda não mostrou sinal positivo de interesse ativo. O tráfego continua barato e com bom CTR, porém o usuário ainda não faz a primeira ação dentro do PDE.\n\n**Alternativas avaliadas:**\n\n1. **Manter como está até R$25 de gasto**: melhor para evitar decisão precipitada, já que o gasto ainda está em R$12,92.\n2. **Pausar agora**: reduz perda, mas seria cedo demais porque ainda não atingiu o limite combinado.\n3. **Já alterar a primeira dobra/CTA**: pode destravar o clique, mas misturaria variáveis antes de completar a medição mínima.\n\n**Escolha recomendada:** manter monitoramento até R$25 ou até aparecer clique no Mapa, login, paywall ou checkout antes disso.\n\nSe chegar perto de R$25 e continuar com **zero clique no Mapa**, a próxima ação deve ser mexer na primeira interação do PDE: CTA mais direto, promessa mais imediata e menos sensação de formulário/login.","sugestaoMelhoriaAmbiente":""}

Usuário: faça uma avaliaçaõ de a mudança de formato gerou ou não alguma melhora 

Modelo: {"titulo":"Formato ainda não melhorou","comentario":"**Conclusão:** a mudança de formato do PDE ainda **não gerou melhora comercial comprovada**.\n\nO que melhorou levemente:\n\n- O tráfego continua bom: **2.086 impressões, 120 cliques, CTR 5,75%, CPC R$0,11 e R$12,98 gastos**.\n- O PDE está medindo corretamente: **92 sessões, 89 entradas e 90 page views**.\n- Houve algum aumento de exploração: **18 views da seção interativa** e **17 eventos de scroll**.\n\nO que não melhorou:\n\n- **0 cliques no Mapa de Presença**.\n- **0 e-mails preenchidos**.\n- **0 logins iniciados**.\n- **0 paywalls vistos**.\n- **0 cliques em assinatura/checkout**.\n- Nas últimas 50 jornadas analisadas: **46 saíram na primeira dobra**, 4 consumiram a página sem ação e **0 clicaram no CTA**.\n\n**Leitura de negócio:** a nova copy/formato pode ter aumentado um pouco a permanência ou exploração, mas **não destravou a intenção ativa**. O gargalo continua antes do primeiro microcompromisso. A usuária chega, olha, mas não sente desejo/segurança/curiosidade suficiente para clicar.\n\n**Alternativas avaliadas:**\n\n1. **Esperar até R$25:** mantém o critério estatístico combinado, mas perde tempo se o padrão de zero clique continuar.\n2. **Pausar agora:** economiza verba, mas ainda estamos com gasto baixo e tráfego barato.\n3. **Preparar nova primeira dobra/CTA mantendo campanha monitorada:** melhor opção, porque corrige o ponto real de abandono sem depender de nova infraestrutura.\n\n**Recomendação:** manter o monitoramento até perto de **R$25**, mas já preparar a próxima alteração do PDE: transformar o CTA em uma ação mais imediata e menos abstrata, por exemplo algo como **“Descobrir o que minha imagem comunica hoje”**, com resultado prometido antes de qualquer login/e-mail.","sugestaoMelhoriaAmbiente":""}

Usuário: faça a alteração. Mas eu acho bom tbm reduzir a quantidade opções na tela isso pode confundir.

Modelo: {"titulo":"Entrada MUSA simplificada","comentario":"Implementei a alteração.\n\n**O que mudou:**\n\n- A entrada pública do PDE deixou de mostrar várias opções.\n- Agora existe uma única ação principal: **“Descobrir o que minha imagem comunica hoje”**.\n- O e-mail só aparece depois desse clique, mantendo o primeiro interesse mensurável.\n- O clique continua registrando `PRESENCE_MAP_CHOICE_SELECTED` e `DIAGNOSTIC_CHOICE_SELECTED`.\n- Atualizei o contrato PDE do MUSA no Marketing Hub via Liquibase.\n- Atualizei o fallback local do PDE para não voltar ao formato antigo.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Racional comercial:** reduzir escolha antes do primeiro microcompromisso. A hipótese agora é: menos confusão na tela deve aumentar o clique inicial no Mapa de Presença.\n\n**Validação feita:**\n\n- Build do frontend PDE passou.\n- Teste visual Playwright passou em desktop e mobile.\n- Teste focado `ProductCatalogServiceTest` passou.\n- Validação de fronteira de API passou.\n- Validação Liquibase/MySQL 5.7 passou.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar em produção, peça o PR e depois faça deploy do backend principal do Marketing Hub e do `pde-platform`."}

Usuário: coloque a orientação que as mudanças nos PDEs preciam ser feitas pelo Marketing Hub para manter as metricas associadas a versão. Verifique se o sistema esta preparado para isso e gere a orientação.

Modelo: {"titulo":"Orientação PDE registrada","comentario":"Registrei a orientação no repositório.\n\n**O que foi definido:**\n\n- Mudanças comerciais dos PDEs devem ser feitas pelo **Marketing Hub**, no contrato `pde_experience_json` do produto.\n- Isso inclui primeira dobra, CTA, promessa, diagnóstico, número de opções, missões, materiais e microinterações.\n- O `pde-platform` deve ser alterado diretamente apenas para motor técnico, bug, tracking, integração, performance ou componente reutilizável.\n\n**Verificação do sistema:**\n\n- O sistema já está parcialmente preparado: o Marketing Hub armazena o contrato PDE e expõe `/api/products/public/{productCode}/pde-experience`.\n- O backend PDE já tenta carregar esse contrato do Hub antes de usar o catálogo local.\n- A lacuna é que ainda não existe uma versão comercial explícita da experiência sendo carregada automaticamente nos eventos.\n\n**Orientação comercial/técnica:** para comparar versões de forma limpa, cada contrato PDE publicado pelo Hub deve ter `experienceVersion` ou `funnelVersion`, e os eventos do PDE devem persistir essa versão nos metadados. Sem isso, conseguimos comparar por janela de tempo, mas não como prova limpa de versão antiga vs nova.\n\n**Arquivos atualizados:**\n\n- `docs/canonical/pde-platform-canon.v1.md`\n- `docs/registros/experimentos.md`\n\nValidação feita: `git diff --check` passou. Não criei PR.","sugestaoMelhoriaAmbiente":""}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy verificado","comentario":"**Status:** o deploy ficou funcional, mas ainda não está completo para comparar versões do PDE com precisão.\n\n**O que está ok:**\n\n- O Marketing Hub responde o contrato PDE do MUSA.\n- O Clube MUSA está no ar com a experiência atual.\n- O painel pós-deploy voltou a cruzar Meta Ads + PDE na maior parte das consultas.\n- O analytics direto do PDE mostra dados disponíveis: **640 eventos, 95 visitantes, 99 sessões, 96 entradas e 97 page views**.\n\n**Resultado da mudança até agora:** ainda **não houve melhora comprovada** no interesse ativo:\n\n- Clique no Mapa/Diagnóstico: **0**\n- E-mail preenchido: **0**\n- Login iniciado: **0**\n- Paywall visto: **0**\n- Checkout/compra: **0**\n\n**Ponto de atenção:** o contrato publicado ainda não traz `experienceVersion` ou `funnelVersion`, e os eventos ainda não persistem essa versão como campo explícito. Então hoje conseguimos comparar por janela de tempo, mas ainda não temos comparação limpa por versão comercial.\n\n**Alternativas avaliadas:**\n\n1. **Seguir comparando por horário de deploy**: baixo esforço, mas menos confiável.\n2. **Criar versão manual em relatório**: ajuda na leitura, mas depende de disciplina operacional.\n3. **Implementar versionamento do PDE no contrato e nos eventos**: melhor opção, porque associa cada métrica à versão real da experiência.\n\n**Recomendação:** próxima melhoria deve ser implementar `experienceVersion`/`funnelVersion` no contrato do Marketing Hub, propagar para o PDE e gravar nos eventos. Isso fecha a causa-raiz da comparação entre versões.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a implementação do versionamento comercial do PDE nos contratos e eventos para a comparação antiga vs nova ficar confiável."}

Última mensagem do usuário:
Execute sua orientação : 
Autorize a implementação do versionamento comercial do PDE nos contratos e eventos para a comparação antiga vs nova ficar confiável.

**Resumo das alterações:**
{"titulo":"Versionamento PDE pronto","comentario":"Implementei o versionamento comercial do PDE para comparar formato antigo vs novo com métricas associadas à versão.\n\n**O que ficou pronto:**\n\n- O contrato PDE agora suporta `experienceVersion` e `funnelVersion`.\n- O MUSA atual foi marcado como `experienceVersion=musa-pde-entry-v3` e `funnelVersion=musa-membership-funnel-v1`.\n- Os eventos do PDE agora gravam `experience_version` em coluna própria na tabela `pde_funnel_event`.\n- O frontend do Clube MUSA envia a versão da experiência em todos os eventos de funil.\n- O analytics do PDE agora retorna métricas agrupadas por versão.\n- O painel pós-deploy do Marketing Hub mostra a versão medida e uma tabela de comparação por versão: sessões, entradas, primeira ação, login, paywall, checkout e compra.\n- Atualizei o cânone e o registro operacional para reforçar que mudanças comerciais de PDE devem ser feitas pelo Marketing Hub.\n\n**Validação feita:**\n\n- Testes PDE backend passaram: `ProductCatalogServiceTest` e `AccessServiceTest`.\n- Teste backend do painel passou: `PostDeployMonitorServiceTest`.\n- Build do frontend PDE passou.\n- Typecheck do frontend Marketing Hub passou.\n- `git diff --check` passou.\n- Changelogs revisados para `relativeToChangelogFile`, temporal MySQL 5.7 e risco 1093.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR e depois faça deploy do backend principal, frontend do Marketing Hub, backend PDE e frontend PDE. Depois do deploy, os novos eventos já entram vinculados à versão `musa-pde-entry-v3`."}