### PR TITLE
AI Hub: {"titulo":"Vídeos via Hub","comentario":"Corrigi a funcionalidade de vídeos para seguir o procedimento correto.\n\n**Causa-raiz:** a tela `Vídeos` salvava o plano só no navegador (`localStorage`). Isso não criava artefato no Marketing Hub, não ger…

### DIFF
--- a/docs/registros/sales-video.md
+++ b/docs/registros/sales-video.md
@@ -1,5 +1,12 @@
 # Registro operacional — Sales Video
 
+## 2026-07-21 — Vídeos de entrada do PDE pelo Marketing Hub
+
+- Problema observado: a nova área `Vídeos` existia como planejamento local no navegador, mas isso não criava artefato rastreável no Marketing Hub.
+- Causa-raiz: a tela usava `localStorage` como fonte de verdade e não acionava o módulo canônico `sales-video`.
+- Correção preparada: a tela `/videos` passou a selecionar produto, criar perfil de vídeo do PDE, salvar roteiro aprovado e solicitar job de criação pelo backend do Marketing Hub.
+- Regra operacional: código de vídeo muda via GitHub; artefato comercial de vídeo para PDE deve nascer e evoluir pelo Marketing Hub, preservando perfil, roteiro, job, asset e versão comercial associada.
+
 ## 2026-07-12 — Token Gemini via arquivo no container de video
 
 - Problema observado: jobs de video VEO podiam falhar por provider sem token configurado quando o container nao recebia `GEMINI_API_KEY`.

--- a/frontend/src/pages/video/VideoHubPage.css
+++ b/frontend/src/pages/video/VideoHubPage.css
@@ -69,6 +69,20 @@
   font-size: 0.9rem;
 }
 
+.video-hub-page__setup {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.video-hub-page__setup .btn,
+.video-hub-page__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
 .video-hub-page__panel {
   padding: 1rem;
 }
@@ -95,6 +109,18 @@
 
 .video-hub-page__metric-value {
   font-weight: 700;
+}
+
+.video-hub-page__notice {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  background: #f0fdf4;
+  color: #166534;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .video-hub-page__stages {
@@ -148,13 +174,45 @@
 .video-hub-page__actions {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 1rem;
 }
 
+.video-hub-page__job {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  border-top: 1px solid #e5e7eb;
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.video-hub-page__job strong,
+.video-hub-page__job span {
+  display: block;
+}
+
+.video-hub-page__job span {
+  color: #475569;
+}
+
+.video-hub-page__job-ready {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534 !important;
+  padding: 0.3rem 0.6rem;
+  white-space: nowrap;
+}
+
 @media (max-width: 960px) {
   .video-hub-page__header,
-  .video-hub-page__stage-header {
+  .video-hub-page__stage-header,
+  .video-hub-page__job {
     display: block;
   }
 

--- a/frontend/src/pages/video/VideoHubPage.tsx
+++ b/frontend/src/pages/video/VideoHubPage.tsx
@@ -1,7 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
-import { CheckCircle2, Save, Video } from "lucide-react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  Clapperboard,
+  FileText,
+  PlayCircle,
+  RefreshCcw,
+  Save,
+  Video,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import PageTitle from "../../components/PageTitle";
+import { TenantContextBanner } from "../../components/TenantContextBanner";
+import { useProducts } from "../../api/product/useProducts";
+import { useCreateSalesVideoProfile } from "../../api/salesVideo/useCreateSalesVideoProfile";
+import { useSalesVideoProfiles } from "../../api/salesVideo/useSalesVideoProfiles";
+import { useApproveSalesVideoScript } from "../../api/salesVideo/useApproveSalesVideoScript";
+import { useRequestVideoRender } from "../../api/salesVideo/useRequestVideoRender";
+import { useSalesVideoJobs } from "../../api/salesVideo/useSalesVideoJobs";
+import { useTenantContext } from "../../utils/tenantContext";
 import "./VideoHubPage.css";
 
 type VideoStageStatus = "READY" | "DRAFT";
@@ -12,8 +28,6 @@ type VideoStage = {
   status: VideoStageStatus;
   content: string;
 };
-
-const STORAGE_KEY = "marketing-hub:pde-entry-explainer-video:v1";
 
 const DEFAULT_STAGES: VideoStage[] = [
   {
@@ -35,10 +49,10 @@ const DEFAULT_STAGES: VideoStage[] = [
     title: "Roteiro",
     status: "DRAFT",
     content:
-      "Abertura: \"Antes de mudar roupa, maquiagem ou postura, você precisa entender uma coisa: sua imagem já está comunicando algo.\"\nValor: \"O Mapa de Presença mostra qual mensagem você passa hoje e qual ajuste simples pode aproximar você da mulher que quer ser percebida.\"\nRedução de fricção: \"É uma leitura rápida, sem julgamento e feita para começar pelo Dia 1.\"\nCTA: \"Clique em Descobrir o que minha imagem comunica hoje e veja seu primeiro mapa.\"",
+      "Antes de mudar roupa, maquiagem ou postura, você precisa entender uma coisa: sua imagem já está comunicando algo.\nO Mapa de Presença mostra qual mensagem você passa hoje e qual ajuste simples pode aproximar você da mulher que quer ser percebida.\nÉ uma leitura rápida, sem julgamento e feita para começar pelo Dia 1.\nClique em Descobrir o que minha imagem comunica hoje e veja seu primeiro mapa.",
   },
   {
-    id: "creative",
+    id: "creation",
     title: "Criação",
     status: "DRAFT",
     content:
@@ -58,34 +72,52 @@ const STATUS_LABELS: Record<VideoStageStatus, string> = {
   DRAFT: "Rascunho",
 };
 
+const CURRENT_PDE_VERSION = "musa-pde-entry-v4-video-hero";
+
 export default function VideoHubPage() {
+  const tenantContext = useTenantContext();
+  const { data: products, isLoading: productsLoading } = useProducts();
+  const [selectedProductId, setSelectedProductId] = useState<string>("");
+  const [selectedProfileId, setSelectedProfileId] = useState<string>("");
   const [stages, setStages] = useState<VideoStage[]>(DEFAULT_STAGES);
 
+  const { data: profiles, isLoading: profilesLoading } =
+    useSalesVideoProfiles(selectedProductId || undefined);
+  const { data: jobs } = useSalesVideoJobs(selectedProfileId || undefined);
+  const createProfile = useCreateSalesVideoProfile(selectedProductId || undefined);
+  const approveScript = useApproveSalesVideoScript(selectedProfileId || undefined);
+  const requestRender = useRequestVideoRender(selectedProfileId || undefined);
+
+  const productList = useMemo(() => products ?? [], [products]);
+  const profileList = useMemo(() => profiles ?? [], [profiles]);
+  const selectedProduct = productList.find((product) => String(product.id) === selectedProductId);
+  const selectedProfile = profileList.find((profile) => String(profile.id) === selectedProfileId);
+  const latestJob = jobs?.[0];
+  const scriptStage = stages.find((stage) => stage.id === "script") ?? stages[2];
+  const readyCount = stages.filter((stage) => stage.status === "READY").length;
+
   useEffect(() => {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (!stored) {
+    if (selectedProductId || productList.length === 0) {
       return;
     }
-    try {
-      const parsed = JSON.parse(stored) as VideoStage[];
-      if (Array.isArray(parsed)) {
-        setStages(parsed);
-      }
-    } catch {
-      window.localStorage.removeItem(STORAGE_KEY);
-    }
-  }, []);
+    const musaProduct =
+      productList.find((product) => product.slug === "metodo-musa-7-dias") ?? productList[0];
+    setSelectedProductId(String(musaProduct.id));
+  }, [productList, selectedProductId]);
 
-  const readyCount = useMemo(
-    () => stages.filter((stage) => stage.status === "READY").length,
-    [stages],
-  );
+  useEffect(() => {
+    if (profileList.length === 0) {
+      setSelectedProfileId("");
+      return;
+    }
+    const pdeProfile =
+      profileList.find((profile) => profile.title.includes(CURRENT_PDE_VERSION)) ?? profileList[0];
+    setSelectedProfileId(String(pdeProfile.id));
+  }, [profileList]);
 
   const updateStageContent = (stageId: string, content: string) => {
     setStages((current) =>
-      current.map((stage) =>
-        stage.id === stageId ? { ...stage, content } : stage,
-      ),
+      current.map((stage) => (stage.id === stageId ? { ...stage, content } : stage)),
     );
   };
 
@@ -102,15 +134,81 @@ export default function VideoHubPage() {
     );
   };
 
-  const savePlan = () => {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stages));
-    toast.success("Plano de vídeo salvo neste navegador");
-  };
-
   const resetPlan = () => {
     setStages(DEFAULT_STAGES);
-    window.localStorage.removeItem(STORAGE_KEY);
     toast.info("Plano de vídeo restaurado");
+  };
+
+  const buildScriptText = () => {
+    return stages.map((stage) => `## ${stage.title}\n${stage.content.trim()}`).join("\n\n");
+  };
+
+  const handleCreateProfile = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedProductId) {
+      toast.error("Selecione um produto para criar o vídeo");
+      return;
+    }
+    try {
+      const profile = await createProfile.mutateAsync({
+        videoKind: "HERO",
+        title: `PDE entrada explicativa - ${CURRENT_PDE_VERSION}`,
+        personaName: "Visitante MUSA",
+        personaStyle: "mulher buscando presença visual, elegância e segurança",
+        voiceStyle: "íntima, elegante, direta e comercialmente clara",
+        language: "pt-BR",
+        targetDurationSeconds: 25,
+      });
+      setSelectedProfileId(String(profile.id));
+      toast.success("Perfil de vídeo criado no Marketing Hub");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Falha ao criar perfil de vídeo";
+      toast.error(message);
+    }
+  };
+
+  const handleApproveScript = async () => {
+    if (!selectedProfileId) {
+      toast.error("Crie ou selecione um perfil de vídeo antes do roteiro");
+      return;
+    }
+    if (!scriptStage.content.trim()) {
+      toast.error("O roteiro precisa de conteúdo");
+      return;
+    }
+    try {
+      await approveScript.mutateAsync({
+        scriptText: buildScriptText(),
+        hookText: "Sua imagem já está comunicando algo antes de você dizer uma palavra.",
+        ctaText: "Descobrir o que minha imagem comunica hoje",
+        captionText:
+          "Mapa de Presença MUSA: uma leitura rápida para entender o que sua imagem comunica hoje.",
+        approvedBy: tenantContext.userEmail,
+      });
+      toast.success("Roteiro aprovado e salvo no Marketing Hub");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Falha ao aprovar roteiro";
+      toast.error(message);
+    }
+  };
+
+  const handleRequestRender = async () => {
+    if (!selectedProfileId) {
+      toast.error("Selecione um perfil de vídeo antes de solicitar criação");
+      return;
+    }
+    try {
+      await requestRender.mutateAsync({
+        requestedBy: tenantContext.userEmail,
+        providerFamily: "EXTERNAL_VIDEO_MODULE",
+        providerName: "video-management-service",
+        executionMode: "TEST",
+      });
+      toast.success("Criação do vídeo solicitada pelo Marketing Hub");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Falha ao solicitar criação do vídeo";
+      toast.error(message);
+    }
   };
 
   return (
@@ -119,8 +217,8 @@ export default function VideoHubPage() {
         <div>
           <PageTitle>Vídeos</PageTitle>
           <p className="video-hub-page__subtitle">
-            Produção comercial de vídeos do Marketing Hub, começando por vídeos
-            explicativos para a entrada do PDE.
+            Produção e rastreabilidade de vídeos comerciais pelo Marketing Hub. O primeiro fluxo
+            cria vídeos explicativos para entrada do PDE, sem publicação manual de artefato.
           </p>
         </div>
         <span className="video-hub-page__badge">
@@ -129,22 +227,78 @@ export default function VideoHubPage() {
         </span>
       </div>
 
+      <TenantContextBanner className="mb-3" />
+
       <div className="video-hub-page__grid">
         <aside className="video-hub-page__type-list">
           <button type="button" className="video-hub-page__type-button">
             <strong>Vídeo explicativo de entrada do PDE</strong>
-            <span>
-              Objetivos, briefing, roteiro, criação, publicação e medição.
-            </span>
+            <span>Objetivos, roteiro, criação por job e validação por versão comercial.</span>
           </button>
+
+          <form className="video-hub-page__setup" onSubmit={handleCreateProfile}>
+            <label className="form-label" htmlFor="video-product">
+              Produto
+            </label>
+            <select
+              id="video-product"
+              className="form-select"
+              value={selectedProductId}
+              disabled={productsLoading}
+              onChange={(event) => setSelectedProductId(event.target.value)}
+            >
+              {productList.map((product) => (
+                <option key={product.id} value={product.id}>
+                  {product.name || product.slug || `Produto #${product.id}`}
+                </option>
+              ))}
+            </select>
+
+            <label className="form-label" htmlFor="video-profile">
+              Perfil de vídeo
+            </label>
+            <select
+              id="video-profile"
+              className="form-select"
+              value={selectedProfileId}
+              disabled={profilesLoading || profileList.length === 0}
+              onChange={(event) => setSelectedProfileId(event.target.value)}
+            >
+              {profileList.length === 0 ? (
+                <option value="">Nenhum perfil criado</option>
+              ) : null}
+              {profileList.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  #{profile.id} · {profile.title}
+                </option>
+              ))}
+            </select>
+
+            <button
+              type="submit"
+              className="btn btn-primary w-100"
+              disabled={createProfile.isPending || !selectedProductId}
+            >
+              <Clapperboard size={16} aria-hidden="true" />
+              Criar perfil PDE v4
+            </button>
+          </form>
         </aside>
 
         <section className="video-hub-page__panel">
           <div className="video-hub-page__summary">
-            <SummaryMetric label="Tipo" value="PDE explicativo" />
-            <SummaryMetric label="Produto inicial" value="Método MUSA" />
+            <SummaryMetric label="Produto" value={selectedProduct?.name || selectedProduct?.slug || "-"} />
+            <SummaryMetric label="Versão PDE" value={CURRENT_PDE_VERSION} />
             <SummaryMetric label="Etapas prontas" value={`${readyCount}/5`} />
-            <SummaryMetric label="Destino" value="Primeira dobra" />
+            <SummaryMetric label="Status do vídeo" value={selectedProfile?.status ?? "Sem perfil"} />
+          </div>
+
+          <div className="video-hub-page__notice">
+            <CheckCircle2 size={18} aria-hidden="true" />
+            <span>
+              Procedimento correto: código muda via GitHub; artefato de vídeo nasce como perfil,
+              roteiro aprovado e job dentro do Marketing Hub.
+            </span>
           </div>
 
           <div className="video-hub-page__stages">
@@ -152,12 +306,8 @@ export default function VideoHubPage() {
               <article className="video-hub-page__stage" key={stage.id}>
                 <div className="video-hub-page__stage-header">
                   <div>
-                    <span className="video-hub-page__stage-kicker">
-                      Etapa {index + 1}
-                    </span>
-                    <strong className="video-hub-page__stage-title">
-                      {stage.title}
-                    </strong>
+                    <span className="video-hub-page__stage-kicker">Etapa {index + 1}</span>
+                    <strong className="video-hub-page__stage-title">{stage.title}</strong>
                   </div>
                   <button
                     type="button"
@@ -168,18 +318,14 @@ export default function VideoHubPage() {
                     }`}
                     onClick={() => toggleStageStatus(stage.id)}
                   >
-                    {stage.status === "READY" ? (
-                      <CheckCircle2 size={14} aria-hidden="true" />
-                    ) : null}{" "}
+                    {stage.status === "READY" ? <CheckCircle2 size={14} aria-hidden="true" /> : null}{" "}
                     {STATUS_LABELS[stage.status]}
                   </button>
                 </div>
                 <textarea
                   className="form-control video-hub-page__textarea"
                   value={stage.content}
-                  onChange={(event) =>
-                    updateStageContent(stage.id, event.target.value)
-                  }
+                  onChange={(event) => updateStageContent(stage.id, event.target.value)}
                   aria-label={stage.title}
                 />
               </article>
@@ -187,16 +333,45 @@ export default function VideoHubPage() {
           </div>
 
           <div className="video-hub-page__actions">
-            <button
-              type="button"
-              className="btn btn-outline-secondary"
-              onClick={resetPlan}
-            >
+            <button type="button" className="btn btn-outline-secondary" onClick={resetPlan}>
+              <RefreshCcw size={16} aria-hidden="true" />
               Restaurar
             </button>
-            <button type="button" className="btn btn-primary" onClick={savePlan}>
-              <Save size={16} aria-hidden="true" /> Salvar
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={handleApproveScript}
+              disabled={approveScript.isPending || !selectedProfileId}
+            >
+              <FileText size={16} aria-hidden="true" />
+              Salvar roteiro no Hub
             </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleRequestRender}
+              disabled={requestRender.isPending || !selectedProfileId}
+            >
+              <Save size={16} aria-hidden="true" />
+              Solicitar criação
+            </button>
+          </div>
+
+          <div className="video-hub-page__job">
+            <div>
+              <strong>Último job</strong>
+              <span>
+                {latestJob
+                  ? `#${latestJob.id} · ${latestJob.jobType} · ${latestJob.status}`
+                  : "Nenhum job de criação solicitado para este perfil."}
+              </span>
+            </div>
+            {latestJob?.assetId ? (
+              <span className="video-hub-page__job-ready">
+                <PlayCircle size={16} aria-hidden="true" />
+                Asset #{latestJob.assetId}
+              </span>
+            ) : null}
           </div>
         </section>
       </div>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz o merge e o deploy vamos aguardar dados. Nos sabemos como comparar a versão antiga da nova ?

Modelo: {"titulo":"Comparação MUSA","comentario":"Sim. Sabemos comparar, mas a comparação correta não é apenas \"página antiga vs página nova\". Para o MUSA, a comparação precisa ser por **funil comercial completo**.\n\n**Fonte de verdade usada:** definição pública do PDE MUSA, registro do experimento 66, registro operacional do experimento 67 e cânone de experimentos.\n\n**O que comparar:**\n\n- **Versão antiga:** experimento 66, com venda do Método MUSA como experiência guiada simples, preço R$47/R$67 e foco em landing/checkout/Área MUSA.\n- **Versão nova:** experimento 67 pós-merge/deploy, com PDE publicado, analytics resetado e campanha Meta já iniciada.\n- **Métrica principal:** compra aprovada ou, se ainda não houver volume, avanço real no funil: clique no anúncio → acesso → diagnóstico/entrada no PDE → clique no paywall/checkout → início de checkout → compra.\n\n**Alternativas de comparação avaliadas:**\n\n1. **Comparar só criativo/anúncio**  \n   Benefício: rápido.  \n   Risco: mostra CTR/CPC, mas não prova venda.  \n   Aderência ao objetivo de vendas: baixa.\n\n2. **Comparar só página/PDE**  \n   Benefício: mostra se a nova experiência segura melhor o tráfego.  \n   Risco: se o anúncio ou público estiver ruim, a página pode ser culpada injustamente.  \n   Aderência: média.\n\n3. **Comparar funil completo por etapa**  \n   Benefício: identifica onde melhorou ou quebrou: anúncio, página, diagnóstico, paywall, checkout ou entrega.  \n   Risco: precisa aguardar dados mínimos.  \n   Aderência: alta.\n\n**Escolha recomendada:** alternativa 3.\n\n**Como vamos decidir se a versão nova é melhor:**\n\n- Se o **CTR subir**, mas checkout/compra não subir: criativo melhorou, oferta/paywall ainda precisa ajuste.\n- Se o **acesso ao PDE subir**, mas diagnóstico/paywall não avançar: problema de ativação da experiência.\n- Se houver **clique no checkout**, mas não compra: problema de preço, confiança, checkout ou objeção final.\n- Se houver **compra com gasto baixo**, mesmo com poucos dados: manter coleta e preparar escala gradual.\n- Se gastar perto de R$25 sem evento primário relevante, o cânone recomenda parar e corrigir causa-raiz antes de insistir.\n\n**Ponto importante:** o registro já mostra que o experimento 67 começou com 92 impressões, 3 cliques e R$0,61 de gasto em 2026-07-20. Isso ainda é pouco para conclusão, mas já confirma que a medição saiu do zero e que o reset de analytics do PDE aconteceu.\n\n**Próximo acompanhamento ideal:** quando tivermos mais dados, eu compararia em uma tabela simples:\n\n| Etapa | Exp. 66 | Exp. 67 | Leitura |\n|---|---:|---:|---|\n| Impressões | antigo | novo | entrega da mídia |\n| CTR | antigo | novo | força do criativo |\n| CPC | antigo | novo | custo de atenção |\n| Page view/PDE view | antigo | novo | tráfego real chegando |\n| Diagnóstico iniciado | antigo | novo | ativação |\n| Paywall/checkout click | antigo | novo | intenção de compra |\n| Checkout iniciado | antigo | novo | força da oferta |\n| Compra | antigo | novo | validação comercial |\n| CPA/ROAS | antigo | novo | escala |\n\nMinha recomendação agora é aguardar até termos pelo menos uma das duas condições: **R$25 de gasto sem compra/evento primário** ou **sinal positivo de checkout/compra antes disso**. Aí a leitura fica objetiva e não baseada em impressão inicial.","sugestaoMelhoriaAmbiente":""}

Usuário: mas fizemos uma alteraçaõ recente veja no github precisamos monitorar isso

Modelo: {"titulo":"Monitoramento do MUSA","comentario":"Sim. A alteração recente que precisamos monitorar é o PR #4435, mergeado em **21/07/2026 00:56 UTC**.\n\n**O que mudou comercialmente:** a entrada do PDE deixou de vender um diagnóstico genérico e passou a vender o **Mapa de Presença do Dia 1**, com duas escolhas antes do e-mail. Isso ataca diretamente o gargalo anterior: tráfego chegava, mas ninguém clicava, preenchia e-mail, iniciava login ou via paywall.\n\n**Status validado agora:**\n\n- Deploy do GitHub Actions concluiu com sucesso.\n- Site público já serve a nova copy: “Sua imagem comunica a mulher que você quer ser vista como?” e “Mapa de Presença”.\n- Backend PDE subiu após o merge, sem erro relevante no log.\n- MCP já consulta o schema real do PDE: `aihubdb`.\n- Banco PDE ainda não recebeu eventos depois do merge.\n- Último evento MUSA persistido: **20/07/2026 22:10:19**.\n\n**Linha de base antes da alteração:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE MUSA | 427 |\n| Entradas no PDE | 65 |\n| Sessões com entrada | 65 |\n| Cliques no diagnóstico/mapa | 0 |\n| E-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n| Compra aprovada | 0 |\n\n**Meta Ads:** a campanha `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA` está **ACTIVE**. Dados disponíveis no período do ad account: **1.565 impressões, 91 cliques, R$10,51 gastos, CTR 5,81%, CPC R$0,115 e 61 landing page views**.\n\n**Como vamos monitorar a nova versão:**\n\n1. **Primeiro sinal obrigatório:** aparecer `PRESENCE_MAP_CHOICE_SELECTED` ou `DIAGNOSTIC_CHOICE_SELECTED` no banco.  \n   Se isso não aparecer com tráfego ativo, o problema continua na primeira dobra ou no tracking.\n\n2. **Segundo sinal:** depois do primeiro clique, medir `FIELD_FILLED` e `LOGIN_STARTED`.  \n   Se houver clique no mapa mas não houver e-mail, a oferta inicial interessa, mas a transição para captura ainda está fraca.\n\n3. **Terceiro sinal:** `LOGIN_COMPLETED`, `PAYWALL_VIEWED` e `SUBSCRIPTION_CLICKED`.  \n   Se chegar aqui, finalmente poderemos avaliar preço, paywall e checkout.\n\n**Alternativas avaliadas:**\n\n1. Monitorar só Meta Ads: rápido, mas não mostra se o PDE destravou.\n2. Monitorar só banco PDE: mostra comportamento real, mas não separa falta de tráfego de falha da página.\n3. Monitorar Meta + eventos PDE por etapa: melhor opção, porque mostra se o anúncio entrega tráfego e se a nova entrada transforma atenção em ação.\n\n**Escolha:** alternativa 3.\n\n**Critério prático:** se a campanha continuar entregando tráfego e, após novo volume, o banco continuar com **zero clique no Mapa de Presença**, a alteração não resolveu o gargalo. Se aparecer clique no mapa, mas não e-mail/login, o próximo ajuste deve ser na transição para salvar o resultado por e-mail.","sugestaoMelhoriaAmbiente":"Ativar as tools de GitHub Actions no MCP e criar um painel/alerta automático para eventos PDE pós-deploy permitiria monitoramento contínuo sem depender de consultas manuais."}

Usuário: Precisamos colocar essa forma de atualização do PDE no Marketing Hub fazer isso atraves do Marketing Hub.

Modelo: {"titulo":"PDE pelo Hub","comentario":"Implementei a atualização para o PDE passar a ser controlável pelo **Marketing Hub**.\n\n**O que mudou:**\n\n- O cadastro de Produto agora tem o campo `pdeExperienceJson`, com o contrato completo da experiência PDE.\n- O Hub expõe esse contrato em `/api/products/public/{productCode}/pde-experience`.\n- O formulário de Produto no frontend permite editar esse JSON.\n- O backend do `pde-platform` tenta carregar primeiro a experiência publicada pelo Hub.\n- Se o Hub estiver indisponível ou sem contrato publicado, o PDE usa o catálogo local atual como fallback, sem derrubar o Clube MUSA.\n- O deploy do PDE passa a receber `PDE_MARKETING_HUB_BASE_URL`, apontando por padrão para o backend do Marketing Hub.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Alternativas avaliadas:**\n\n1. Editar o PDE direto no código: rápido, mas mantém dependência de deploy técnico para mudança comercial.\n2. Criar endpoint administrativo só no PDE: melhora operação, mas tira o Hub da fonte de verdade.\n3. Fazer o Hub publicar o contrato PDE e o PDE consumir: melhor opção, porque centraliza produto, copy, jornada e oferta no Marketing Hub.\n\n**Escolha aplicada:** alternativa 3.\n\n**Validação feita:**\n\n- `ProductServiceTest` e `ProductControllerTest`: 10 testes passaram.\n- `ProductCatalogServiceTest` do PDE: 3 testes passaram.\n- `npm run typecheck` do frontend passou após instalar dependências locais com `npm ci`.\n- `git diff --check` sem problemas.\n- Changelog mestre revisado com `relativeToChangelogFile: true` no include novo.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso chegar em produção, o próximo passo é você pedir/abrir o PR e depois fazer o deploy do backend principal e do pde-platform."}

Usuário: eu fiz o deploy verifique se ficou ok. E veja se conseguimos ver se a mudança no PDE deu algum resultado positivo nas interação e interesse dos usuarios com o PDE.

Modelo: {"titulo":"Deploy parcial","comentario":"**Verificação concluída:** ficou **parcialmente ok**.\n\n**O que está ok:**\n\n- O frontend público do Clube MUSA foi atualizado em produção em **21/07/2026 00:57:41 UTC**.\n- A página pública contém a nova copy: **“Sua imagem comunica…”** e **“Mapa de Presença”**.\n- O backend do PDE subiu após o deploy.\n- O Marketing Hub expõe corretamente o contrato em `/api/products/public/metodo-musa-7-dias/pde-experience`.\n- A campanha Meta continua **ACTIVE**.\n\n**O que não está ok:**\n\n- O `pde-platform-backend` está falhando ao carregar a experiência PDE do Marketing Hub e usando o **catálogo local como fallback**.\n- Houve erro pós-deploy ao persistir evento PDE: `PED_ENTRY` em **21/07/2026 01:23:41 UTC**.\n- Portanto, a medição pós-deploy não está confiável neste momento.\n\n**Dados de interação disponíveis até agora:**\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais registrados | 493 |\n| Sessões | 76 |\n| Entradas no PDE | 74 |\n| Sessões que chegaram na seção interativa | 10 |\n| Sessões com scroll registrado | 5 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Campo de e-mail preenchido | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout clicado | 0 |\n\n**Ponto crítico:** todos os eventos gravados no banco são de **20/07/2026**, antes do deploy da nova integração Hub → PDE. Depois do deploy, o banco mostra **0 sessões persistidas**, mas o log indica que pelo menos um evento tentou entrar e falhou. Então não dá para concluir que não houve tráfego; dá para concluir que a medição pós-deploy está quebrada ou instável.\n\n**Meta Ads:** a campanha mostra **1.826 impressões, 101 cliques, R$11,72 gastos, CTR 5,53%, CPC R$0,116 e 68 landing page views**. O anúncio está gerando atenção barata, mas o PDE ainda não registrou avanço comercial real.\n\n**Alternativas avaliadas:**\n\n1. **Concluir pelo Meta Ads:** parece positivo por CTR/CPC, mas não prova interesse no PDE.\n2. **Concluir pelo banco PDE:** mostraria funil real, mas a gravação pós-deploy falhou.\n3. **Separar saúde técnica de resultado comercial:** melhor leitura agora.\n\n**Conclusão:** a mudança ainda **não pode ser considerada positiva comercialmente**, porque não temos dados pós-deploy confiáveis. Antes de esperar mais tráfego, o ideal é corrigir a integração do PDE com o Marketing Hub e a persistência dos eventos. Só depois disso a comparação da nova versão será justa.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis."}

Usuário: Execute sua orientação : 
Autorize a correção técnica do PDE para estabilizar o carregamento pelo Marketing Hub e a gravação dos eventos pós-deploy; depois disso podemos monitorar novamente com dados confiáveis.

Modelo: {"titulo":"Correção PDE pronta","comentario":"Executei a correção técnica no repositório.\n\n**Causa confirmada:**\n\n- O PDE tentava carregar o contrato do Marketing Hub por `http://191.252.181.168` e o container recebeu `Connection refused`.\n- A gravação de evento pós-deploy falhou por comunicação com MySQL, deixando o funil sem dados novos após **20/07/2026 22:55:19**.\n\n**Correção aplicada:**\n\n- O deploy do PDE agora prioriza `http://191.252.181.168:8000` e mantém `http://191.252.181.168` como fallback.\n- O `ProductCatalogService` agora aceita múltiplas URLs do Marketing Hub e tenta a próxima antes de cair no catálogo local.\n- O `AccessService` agora faz 3 tentativas para persistir eventos do funil quando houver oscilação de banco.\n- Adicionei teste garantindo fallback de URL do Marketing Hub.\n\n**Validação:**\n\n- `mvn -q -Dtest=ProductCatalogServiceTest,AccessServiceTest test` passou.\n- `mvn -q test` no backend PDE passou.\n- `git diff --check` passou.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar a correção, peça o PR ou abra um PR com essas mudanças e depois faça o deploy do `pde-platform`."}

Usuário: feito o deploy

Modelo: {"titulo":"Deploy PDE ok","comentario":"**Status técnico:** o deploy ficou ok.\n\n- O `pde-platform-backend` reiniciou em **21/07/2026 02:06 UTC**.\n- O endpoint público do Clube MUSA está no ar.\n- O endpoint do PDE está entregando o contrato do Marketing Hub com **Mapa de Presença MUSA**.\n- Não apareceu novo erro de fallback para catálogo local após o deploy.\n- Fiz um teste sintético `codex_healthcheck` e ele gravou no banco com status `RECORDED`, então o caminho **site → PDE backend → MySQL** está funcionando.\n\n**Resultado comercial até agora:** ainda não há sinal positivo suficiente.\n\nDepois do deploy, entrou **1 sessão real paga**, vinda do Instagram, mobile. Ela registrou:\n\n| Evento | Sessões |\n|---|---:|\n| Entrada no PDE | 1 |\n| Page view | 1 |\n| Screen view | 1 |\n| Clique no Mapa de Presença | 0 |\n| Campo/e-mail | 0 |\n| Login iniciado | 0 |\n| Paywall | 0 |\n| Checkout | 0 |\n\n**Meta Ads atualizado:** campanha ativa com **1.916 impressões, 109 cliques, 75 landing page views, R$12,22 gastos, CTR 5,69% e CPC R$0,112**.\n\n**Leitura:** a parte técnica foi estabilizada. O anúncio continua barato e chamando atenção, mas a nova versão ainda não provou aumento de interesse dentro do PDE. O gargalo segue na primeira interação: a pessoa chega, mas ainda não clica no Mapa de Presença nem inicia login.\n\n**Alternativas avaliadas:**\n\n1. Concluir que deu certo porque o deploy estabilizou: errado comercialmente, pois venda/interação ainda não apareceu.\n2. Parar agora: prematuro, porque só há 1 sessão real pós-correção.\n3. Continuar monitorando até volume mínimo: melhor escolha.\n\n**Recomendação:** manter a campanha rodando até pelo menos **R$25 de gasto total** ou até termos volume maior pós-deploy. Se continuar com clique barato e zero clique no Mapa, o próximo ajuste deve ser na primeira dobra/CTA do PDE, tornando a ação mais irresistível e menos parecida com login ou formulário.","sugestaoMelhoriaAmbiente":"Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil."}

Usuário: implemente isso
Um painel automático pós-deploy cruzando Meta Ads, eventos PDE e logs reduziria consultas manuais e aceleraria a decisão de manter, pausar ou ajustar o funil.

Modelo: {"titulo":"Painel pós-deploy pronto","comentario":"Implementei o painel automático pós-deploy no Marketing Hub.\n\n**O que ficou pronto:**\n\n- Nova aba **Pós-deploy** dentro do detalhe do experimento.\n- Endpoint agregador no backend: `/api/experiments/{experimentId}/post-deploy-monitor`.\n- Cruzamento automático de:\n  - métricas Meta Ads: gasto, impressões, cliques, CTR, CPC e erro de sync;\n  - eventos PDE: entrada, page view, clique no Mapa/Diagnóstico, e-mail, login, paywall, checkout e compra;\n  - logs Meta Ads: total, erros recentes e último log.\n- Decisão automática: **aguardar dados**, **manter monitoramento**, **pausar e corrigir**, **corrigir medição** ou **escalar gradualmente**.\n- Auto-refresh da tela a cada 60 segundos.\n\n**Validação feita:**\n\n- Teste backend `PostDeployMonitorServiceTest` passou.\n- `npm run typecheck` do frontend passou.\n- Spotless focado nos arquivos novos passou.\n- `git diff --check` passou.\n\n**Observação:** o `spotless:check` global do backend continua falhando por violações antigas em milhares de arquivos fora do escopo. Não alterei esses arquivos para evitar churn desnecessário.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar isso, peça o PR e depois faça o deploy do backend principal e do frontend do Marketing Hub."}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy parcialmente ok","comentario":"**Verifiquei o deploy.**\n\nO painel pós-deploy está publicado e o endpoint do Marketing Hub responde, mas ele ainda ficou em **atenção técnica** porque o backend está tentando buscar analytics PDE no host errado: `191.252.181.168:8096`.\n\n**Causa confirmada:** o PDE real está respondendo pelo domínio público `https://clubemusa.com.br`, e o analytics funciona ali.\n\n**Dados reais do PDE agora:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos PDE | 563 |\n| Visitantes únicos | 85 |\n| Sessões | 88 |\n| Entradas PDE | 85 |\n| Page views | 86 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout | 0 |\n| Compra | 0 |\n\n**Meta Ads no painel:** 2.049 impressões, 116 cliques, R$12,78 gastos, CTR 5,66%, CPC R$0,11.\n\n**Leitura comercial:** o anúncio continua bom para gerar atenção barata, mas ainda não apareceu sinal positivo forte dentro do PDE. O gargalo segue na primeira ação: a pessoa entra, mas não clica no Mapa de Presença, não inicia login e não chega no paywall.\n\n**Alternativas avaliadas:**\n\n1. Ajustar só variável de ambiente no servidor: rápido, mas pode voltar a quebrar em outro deploy.\n2. Apontar o Hub para o IP correto `191.252.102.54:8096`: funciona, mas mantém dependência de IP/porta.\n3. Usar `https://clubemusa.com.br` como default canônico: melhor opção, porque usa o mesmo domínio público do funil e reduz fragilidade operacional.\n\n**O que deixei pronto no repositório:**\n\n- Corrigi o default de `integrations.pde-platform.base-url` para `https://clubemusa.com.br`.\n- Corrigi o fallback do cliente HTTP do painel.\n- Registrei a causa em `docs/registros/experimentos.md`.\n- Validação focada passou: `PostDeployMonitorServiceTest`.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR dessa correção e depois faça novo deploy do backend principal do Marketing Hub para o painel passar a cruzar Meta Ads + PDE automaticamente em produção."}

Usuário: feito

Modelo: {"titulo":"Painel validado","comentario":"**Deploy verificado: agora ficou ok.**\n\nO painel pós-deploy do Marketing Hub está consultando corretamente o PDE em `https://clubemusa.com.br` e o resultado bate com o analytics direto do Clube MUSA.\n\n**Status atual:**\n\n| Área | Situação |\n|---|---|\n| Marketing Hub | Endpoint do painel responde ok |\n| PDE analytics | Disponível |\n| Cruzamento Meta + PDE | Funcionando |\n| Erro técnico do painel | Não apareceu |\n| Decisão automática | **Manter monitoramento** |\n\n**Dados atuais do painel:**\n\n| Métrica | Valor |\n|---|---:|\n| Impressões Meta | 2.074 |\n| Cliques Meta | 117 |\n| Gasto | R$12,92 |\n| CTR | 5,64% |\n| CPC | R$0,11 |\n| Eventos PDE | 575 |\n| Visitantes únicos PDE | 86 |\n| Sessões PDE | 90 |\n| Entradas PDE | 87 |\n| Page views | 88 |\n| Section views | 18 |\n| Scroll depth | 17 |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout/compra | 0 |\n\n**Leitura comercial:** o painel está pronto para decisão, mas a mudança do PDE ainda não mostrou sinal positivo de interesse ativo. O tráfego continua barato e com bom CTR, porém o usuário ainda não faz a primeira ação dentro do PDE.\n\n**Alternativas avaliadas:**\n\n1. **Manter como está até R$25 de gasto**: melhor para evitar decisão precipitada, já que o gasto ainda está em R$12,92.\n2. **Pausar agora**: reduz perda, mas seria cedo demais porque ainda não atingiu o limite combinado.\n3. **Já alterar a primeira dobra/CTA**: pode destravar o clique, mas misturaria variáveis antes de completar a medição mínima.\n\n**Escolha recomendada:** manter monitoramento até R$25 ou até aparecer clique no Mapa, login, paywall ou checkout antes disso.\n\nSe chegar perto de R$25 e continuar com **zero clique no Mapa**, a próxima ação deve ser mexer na primeira interação do PDE: CTA mais direto, promessa mais imediata e menos sensação de formulário/login.","sugestaoMelhoriaAmbiente":""}

Usuário: faça uma avaliaçaõ de a mudança de formato gerou ou não alguma melhora 

Modelo: {"titulo":"Formato ainda não melhorou","comentario":"**Conclusão:** a mudança de formato do PDE ainda **não gerou melhora comercial comprovada**.\n\nO que melhorou levemente:\n\n- O tráfego continua bom: **2.086 impressões, 120 cliques, CTR 5,75%, CPC R$0,11 e R$12,98 gastos**.\n- O PDE está medindo corretamente: **92 sessões, 89 entradas e 90 page views**.\n- Houve algum aumento de exploração: **18 views da seção interativa** e **17 eventos de scroll**.\n\nO que não melhorou:\n\n- **0 cliques no Mapa de Presença**.\n- **0 e-mails preenchidos**.\n- **0 logins iniciados**.\n- **0 paywalls vistos**.\n- **0 cliques em assinatura/checkout**.\n- Nas últimas 50 jornadas analisadas: **46 saíram na primeira dobra**, 4 consumiram a página sem ação e **0 clicaram no CTA**.\n\n**Leitura de negócio:** a nova copy/formato pode ter aumentado um pouco a permanência ou exploração, mas **não destravou a intenção ativa**. O gargalo continua antes do primeiro microcompromisso. A usuária chega, olha, mas não sente desejo/segurança/curiosidade suficiente para clicar.\n\n**Alternativas avaliadas:**\n\n1. **Esperar até R$25:** mantém o critério estatístico combinado, mas perde tempo se o padrão de zero clique continuar.\n2. **Pausar agora:** economiza verba, mas ainda estamos com gasto baixo e tráfego barato.\n3. **Preparar nova primeira dobra/CTA mantendo campanha monitorada:** melhor opção, porque corrige o ponto real de abandono sem depender de nova infraestrutura.\n\n**Recomendação:** manter o monitoramento até perto de **R$25**, mas já preparar a próxima alteração do PDE: transformar o CTA em uma ação mais imediata e menos abstrata, por exemplo algo como **“Descobrir o que minha imagem comunica hoje”**, com resultado prometido antes de qualquer login/e-mail.","sugestaoMelhoriaAmbiente":""}

Usuário: faça a alteração. Mas eu acho bom tbm reduzir a quantidade opções na tela isso pode confundir.

Modelo: {"titulo":"Entrada MUSA simplificada","comentario":"Implementei a alteração.\n\n**O que mudou:**\n\n- A entrada pública do PDE deixou de mostrar várias opções.\n- Agora existe uma única ação principal: **“Descobrir o que minha imagem comunica hoje”**.\n- O e-mail só aparece depois desse clique, mantendo o primeiro interesse mensurável.\n- O clique continua registrando `PRESENCE_MAP_CHOICE_SELECTED` e `DIAGNOSTIC_CHOICE_SELECTED`.\n- Atualizei o contrato PDE do MUSA no Marketing Hub via Liquibase.\n- Atualizei o fallback local do PDE para não voltar ao formato antigo.\n- Registrei a decisão em `docs/registros/experimentos.md`.\n\n**Racional comercial:** reduzir escolha antes do primeiro microcompromisso. A hipótese agora é: menos confusão na tela deve aumentar o clique inicial no Mapa de Presença.\n\n**Validação feita:**\n\n- Build do frontend PDE passou.\n- Teste visual Playwright passou em desktop e mobile.\n- Teste focado `ProductCatalogServiceTest` passou.\n- Validação de fronteira de API passou.\n- Validação Liquibase/MySQL 5.7 passou.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar em produção, peça o PR e depois faça deploy do backend principal do Marketing Hub e do `pde-platform`."}

Usuário: coloque a orientação que as mudanças nos PDEs preciam ser feitas pelo Marketing Hub para manter as metricas associadas a versão. Verifique se o sistema esta preparado para isso e gere a orientação.

Modelo: {"titulo":"Orientação PDE registrada","comentario":"Registrei a orientação no repositório.\n\n**O que foi definido:**\n\n- Mudanças comerciais dos PDEs devem ser feitas pelo **Marketing Hub**, no contrato `pde_experience_json` do produto.\n- Isso inclui primeira dobra, CTA, promessa, diagnóstico, número de opções, missões, materiais e microinterações.\n- O `pde-platform` deve ser alterado diretamente apenas para motor técnico, bug, tracking, integração, performance ou componente reutilizável.\n\n**Verificação do sistema:**\n\n- O sistema já está parcialmente preparado: o Marketing Hub armazena o contrato PDE e expõe `/api/products/public/{productCode}/pde-experience`.\n- O backend PDE já tenta carregar esse contrato do Hub antes de usar o catálogo local.\n- A lacuna é que ainda não existe uma versão comercial explícita da experiência sendo carregada automaticamente nos eventos.\n\n**Orientação comercial/técnica:** para comparar versões de forma limpa, cada contrato PDE publicado pelo Hub deve ter `experienceVersion` ou `funnelVersion`, e os eventos do PDE devem persistir essa versão nos metadados. Sem isso, conseguimos comparar por janela de tempo, mas não como prova limpa de versão antiga vs nova.\n\n**Arquivos atualizados:**\n\n- `docs/canonical/pde-platform-canon.v1.md`\n- `docs/registros/experimentos.md`\n\nValidação feita: `git diff --check` passou. Não criei PR.","sugestaoMelhoriaAmbiente":""}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy verificado","comentario":"**Status:** o deploy ficou funcional, mas ainda não está completo para comparar versões do PDE com precisão.\n\n**O que está ok:**\n\n- O Marketing Hub responde o contrato PDE do MUSA.\n- O Clube MUSA está no ar com a experiência atual.\n- O painel pós-deploy voltou a cruzar Meta Ads + PDE na maior parte das consultas.\n- O analytics direto do PDE mostra dados disponíveis: **640 eventos, 95 visitantes, 99 sessões, 96 entradas e 97 page views**.\n\n**Resultado da mudança até agora:** ainda **não houve melhora comprovada** no interesse ativo:\n\n- Clique no Mapa/Diagnóstico: **0**\n- E-mail preenchido: **0**\n- Login iniciado: **0**\n- Paywall visto: **0**\n- Checkout/compra: **0**\n\n**Ponto de atenção:** o contrato publicado ainda não traz `experienceVersion` ou `funnelVersion`, e os eventos ainda não persistem essa versão como campo explícito. Então hoje conseguimos comparar por janela de tempo, mas ainda não temos comparação limpa por versão comercial.\n\n**Alternativas avaliadas:**\n\n1. **Seguir comparando por horário de deploy**: baixo esforço, mas menos confiável.\n2. **Criar versão manual em relatório**: ajuda na leitura, mas depende de disciplina operacional.\n3. **Implementar versionamento do PDE no contrato e nos eventos**: melhor opção, porque associa cada métrica à versão real da experiência.\n\n**Recomendação:** próxima melhoria deve ser implementar `experienceVersion`/`funnelVersion` no contrato do Marketing Hub, propagar para o PDE e gravar nos eventos. Isso fecha a causa-raiz da comparação entre versões.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a implementação do versionamento comercial do PDE nos contratos e eventos para a comparação antiga vs nova ficar confiável."}

Usuário: Execute sua orientação : 
Autorize a implementação do versionamento comercial do PDE nos contratos e eventos para a comparação antiga vs nova ficar confiável.

Modelo: {"titulo":"Versionamento PDE pronto","comentario":"Implementei o versionamento comercial do PDE para comparar formato antigo vs novo com métricas associadas à versão.\n\n**O que ficou pronto:**\n\n- O contrato PDE agora suporta `experienceVersion` e `funnelVersion`.\n- O MUSA atual foi marcado como `experienceVersion=musa-pde-entry-v3` e `funnelVersion=musa-membership-funnel-v1`.\n- Os eventos do PDE agora gravam `experience_version` em coluna própria na tabela `pde_funnel_event`.\n- O frontend do Clube MUSA envia a versão da experiência em todos os eventos de funil.\n- O analytics do PDE agora retorna métricas agrupadas por versão.\n- O painel pós-deploy do Marketing Hub mostra a versão medida e uma tabela de comparação por versão: sessões, entradas, primeira ação, login, paywall, checkout e compra.\n- Atualizei o cânone e o registro operacional para reforçar que mudanças comerciais de PDE devem ser feitas pelo Marketing Hub.\n\n**Validação feita:**\n\n- Testes PDE backend passaram: `ProductCatalogServiceTest` e `AccessServiceTest`.\n- Teste backend do painel passou: `PostDeployMonitorServiceTest`.\n- Build do frontend PDE passou.\n- Typecheck do frontend Marketing Hub passou.\n- `git diff --check` passou.\n- Changelogs revisados para `relativeToChangelogFile`, temporal MySQL 5.7 e risco 1093.\n\nNão criei PR, conforme combinado.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR e depois faça deploy do backend principal, frontend do Marketing Hub, backend PDE e frontend PDE. Depois do deploy, os novos eventos já entram vinculados à versão `musa-pde-entry-v3`."}

Usuário: veja como esta a performance do pde agora

Modelo: {"titulo":"PDE sem melhora ainda","comentario":"**Performance atual do PDE MUSA:** ainda não houve melhora comercial comprovada.\n\n**Meta Ads está bom na atenção:**\n\n| Métrica | Valor |\n|---|---:|\n| Impressões | 2.833 |\n| Cliques | 158 |\n| CTR | 5,58% |\n| CPC | R$0,109 |\n| Landing page views | 115 |\n| Gasto | R$17,16 |\n\n**PDE está fraco na ação:**\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais | 640 |\n| Sessões | 99 |\n| Visitantes | 95 |\n| Sessões pagas nas jornadas | 93 |\n| Cliques no Mapa/Diagnóstico | 0 |\n| Campo/e-mail iniciado | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout/compra | 0 |\n\n**Depois de 21/07/2026 00:00 UTC:** entraram 11 sessões novas no PDE, mas elas geraram apenas page view, screen view, section view e scroll. Nenhuma ação comercial apareceu.\n\n**Leitura:** o anúncio continua gerando tráfego barato e suficiente para atenção inicial, mas o PDE ainda não está convertendo essa atenção em microcompromisso. O gargalo continua na primeira dobra/primeira ação.\n\n**Ponto técnico importante:** o resumo automático por versão está quebrado agora porque o backend PDE já espera a coluna `experience_version`, mas o banco PDE em produção ainda não tem essa coluna. O erro confirmado foi: `Unknown column 'experience_version'`. Então conseguimos medir performance geral e por janela de tempo, mas ainda não conseguimos comparar limpo por versão.\n\n**Alternativas avaliadas:**\n\n1. **Esperar até R$25 sem mexer:** mantém o critério combinado, mas o padrão de 0 ação está muito forte.\n2. **Pausar campanha agora:** economiza verba, mas ainda falta completar o limite de decisão.\n3. **Corrigir primeiro o versionamento no banco e preparar nova hipótese de primeira dobra:** melhor opção, porque restaura medição confiável e já ataca o gargalo real.\n\n**Minha recomendação:** corrigir a migração do `experience_version` no banco PDE antes de nova decisão forte. Comercialmente, se até R$25 continuar com 0 clique no Mapa, a próxima mudança deve ser mais agressiva na primeira dobra: promessa mais concreta, CTA ainda mais direto e menos aparência de login/formulário.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a correção da migração do banco PDE para criar `experience_version`; depois disso o painel volta a comparar performance por versão com confiabilidade."}

Usuário: Execute sua orientação : 
Autorize a correção da migração do banco PDE para criar `experience_version`; depois disso o painel volta a comparar performance por versão com confiabilidade.

Modelo: {"titulo":"Migração PDE pronta","comentario":"Executei a correção.\n\n**Causa-raiz confirmada:** a coluna `experience_version` foi criada no changelog do backend principal, mas a tabela `pde_funnel_event` pertence ao schema operacional do `pde-platform`. Por isso o PDE em produção já tentava usar a coluna, mas o banco efetivo ainda não tinha recebido a alteração.\n\n**O que foi feito:**\n\n- Criei uma migração idempotente no startup do backend PDE.\n- Ela cria `pde_funnel_event.experience_version` quando a coluna estiver ausente.\n- Ela cria o índice para consulta por produto, versão e data.\n- Ajustei o índice com prefixo para manter compatibilidade com MySQL 5.7.\n- O `AccessService` agora executa essa migração antes de ler/gravar analytics.\n- Registrei a causa e prevenção em `docs/registros/experimentos.md`.\n\n**Validação:**\n\n- `mvn -q test` no backend PDE passou.\n- `git diff --check` passou.\n- Não criei PR.\n\nDepois do deploy do `pde-platform`, o próximo startup deve corrigir o schema e o painel volta a comparar métricas por versão da experiência.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR e depois faça o deploy do `pde-platform` backend. Após subir, valide se o painel voltou a mostrar comparação por versão sem erro de `experience_version`."}

Usuário: fiz o deploy

Modelo: {"titulo":"Deploy parcial","comentario":"**Verificação do deploy:** ficou **parcialmente ok**.\n\n**O que ficou ok:**\n\n- O backend PDE reiniciou em **21/07/2026 12:49 UTC**.\n- A migração funcionou: a coluna `experience_version` foi criada e o erro `Unknown column 'experience_version'` não aparece mais após o startup.\n- O frontend público do Clube MUSA está com a versão nova no bundle: `musa-pde-entry-v3`, CTA **“Descobrir o que minha imagem comunica hoje”** e eventos `PRESENCE_MAP_CHOICE_SELECTED` / `DIAGNOSTIC_CHOICE_SELECTED`.\n- O banco PDE está acessível.\n\n**O que ainda não ficou ok:**\n\n- O PDE ainda não consegue carregar o contrato vivo do Marketing Hub. Ele tenta `191.252.181.168:8000` e `191.252.181.168`, recebe `Connection refused` e cai no catálogo local.\n- No banco do Marketing Hub, o produto MUSA ainda está sem `experienceVersion` e `funnelVersion` no `pde_experience_json`.\n- O changeset de versionamento `2026-07-21-product-musa-pde-experience-version` ainda não aparece aplicado no `DATABASECHANGELOG` do backend principal.\n\n**Performance agora:** ainda não dá para concluir melhora da nova versão.\n\n| Métrica PDE | Valor |\n|---|---:|\n| Eventos totais | 640 |\n| Sessões | 99 |\n| Eventos com versão `musa-pde-entry-v3` | 0 |\n| Eventos sem versão | 640 |\n| Último evento persistido | 21/07/2026 00:58:52 UTC |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall/checkout | 0 |\n\n**Leitura:** tecnicamente a correção do schema do PDE funcionou, mas ainda não temos tráfego novo persistido com a versão `musa-pde-entry-v3`. Comercialmente, portanto, a nova entrada simplificada ainda não pode ser avaliada com confiança.\n\n**Alternativas avaliadas:**\n\n1. Considerar resolvido só porque o PDE subiu: não recomendo, porque o Hub ainda não está alimentando o PDE.\n2. Avaliar por janela de horário: possível, mas fraco porque não associa métrica à versão.\n3. Fechar primeiro Hub + versão + conectividade PDE→Hub: melhor opção, porque mantém as métricas ligadas à versão comercial correta.\n\n**Próxima correção necessária:** publicar/aplicar o backend principal do Marketing Hub com o changeset de versionamento e ajustar o `PDE_MARKETING_HUB_BASE_URL` para uma URL realmente acessível pelo container PDE.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Faça o deploy do backend principal do Marketing Hub garantindo que o changeset de versionamento rode, e ajuste a variável `PDE_MARKETING_HUB_BASE_URL` do PDE para o endereço do Hub que responda de dentro do container. Depois disso eu valido novamente se os eventos entram como `musa-pde-entry-v3`."}

Usuário: vamos produzir um video curto para colocar na primeira dobra da proxima versão do PDE explicando o funcionando e gerando mais valor.

Modelo: {"titulo":"Vídeo para nova dobra","comentario":"**Sim, faz sentido produzir um vídeo curto para a próxima versão do PDE.**\n\nA evidência atual é clara: o tráfego chega, mas não executa a primeira ação. O analytics do Clube MUSA mostra **99 sessões, 96 entradas, 97 page views e 0 cliques no Mapa/Diagnóstico, 0 login, 0 paywall e 0 checkout**. Então o vídeo não deve ser decorativo; ele precisa explicar rapidamente o valor e reduzir a dúvida antes do CTA.\n\n**Melhor formato recomendado:** vídeo vertical curto, de **15 a 20 segundos**, acima ou junto da primeira dobra, com legenda sempre visível e CTA logo abaixo.\n\n**Roteiro recomendado:**\n\n> “Em poucos minutos, o Mapa de Presença mostra o que sua imagem comunica hoje. Você responde uma pergunta simples e recebe um primeiro direcionamento para parecer mais alinhada, segura e elegante no dia a dia. Comece pelo seu mapa gratuito.”\n\n**Texto na tela:**\n\n- “O que sua imagem comunica hoje?”\n- “Receba um primeiro direcionamento de presença”\n- “Comece pelo Mapa de Presença gratuito”\n\n**CTA abaixo do vídeo:**\n\n**Descobrir meu Mapa de Presença agora**\n\n**Alternativas avaliadas:**\n\n1. **Vídeo explicativo com pessoa falando**  \n   Mais humano e confiável, mas exige produção ou avatar convincente.\n\n2. **Vídeo motion com textos e cenas de estilo/imagem pessoal**  \n   Mais rápido, controlável e suficiente para testar o impacto na primeira ação.\n\n3. **Vídeo demonstrando a tela do PDE**  \n   Explica bem o funcionamento, mas pode ficar técnico e menos sedutor.\n\n**Escolha recomendada:** alternativa 2 agora. É a mais rápida para validar se vídeo destrava o clique inicial sem depender de gravação humana.\n\n**Orientação operacional:** essa deve ser a próxima versão comercial do PDE, publicada pelo **Marketing Hub**, com nova versão explícita, por exemplo:\n\n- `experienceVersion`: `musa-pde-entry-v4-video-hero`\n- `funnelVersion`: `musa-membership-funnel-v1`\n\nAssim conseguimos comparar v3 vs v4 sem misturar métricas.\n\n**Hipótese da versão v4:** vídeo curto + CTA único deve aumentar o primeiro microcompromisso: `PRESENCE_MAP_CHOICE_SELECTED` / `DIAGNOSTIC_CHOICE_SELECTED`.\n\n**Critério de sucesso:** sair de 0 clique no Mapa para qualquer taxa mensurável de clique inicial. Se houver clique mas não login, o próximo gargalo será captura de e-mail/login. Se continuar 0 clique, o problema é promessa/encaixe de público, não apenas formato.","sugestaoMelhoriaAmbiente":"Uma ferramenta integrada de geração/edição de vídeo curto dentro do ambiente permitiria produzir o asset final já versionado no repositório e pronto para deploy.","orientacaoProximaAcao":"Aprove o roteiro e o formato motion de 15-20 segundos para eu preparar a especificação final da versão v4 e orientar a implementação pelo Marketing Hub."}

Usuário: crie no Marketing Hub um item de menu voltado somente para videos e o primeiro tipo são videos explicativos para a entrada do PDE como o solcitado anteriormente. E vamos dividir em etapas, produção de objetivos, roteiro, criação, etc

Modelo: {"titulo":"Menu Vídeos criado","comentario":"Implementei no Marketing Hub a nova área **Vídeos**.\n\n**O que foi criado:**\n\n- Novo item de menu: **IA e Conteúdo → Vídeos**.\n- Nova rota: `/videos`.\n- Nova tela dedicada para produção de vídeos comerciais.\n- Primeiro tipo disponível: **Vídeo explicativo de entrada do PDE**.\n- Fluxo dividido em etapas:\n  - Objetivos\n  - Briefing comercial\n  - Roteiro\n  - Criação\n  - Validação\n- Já deixei o primeiro plano preenchido para o caso **Método MUSA / entrada do PDE**, focado em aumentar o clique no CTA da primeira dobra.\n\n**Alternativas avaliadas:**\n\n1. Criar só um item de menu apontando para vídeos antigos de produto: rápido, mas não organiza o novo processo do PDE.\n2. Criar backend completo agora: mais robusto, mas aumentaria escopo antes de validarmos o fluxo operacional.\n3. Criar menu + tela funcional de planejamento por etapas: melhor escolha agora, porque já coloca o processo dentro do Hub e permite evoluir depois para persistência, IA e renderização.\n\n**Validação feita:**\n\n- `npm run typecheck` passou.\n- `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"O endpoint informado para leitura do PDE em `191.252.181.168:8000` recusou conexão na sandbox; acesso estável a esse documento permitiria vincular a tela automaticamente à fonte pública mais recente do produto.","orientacaoProximaAcao":"Peça o PR e depois faça o deploy do frontend do Marketing Hub para o novo menu aparecer em produção."}

Usuário: como esta a performance atual do PDE ?

Modelo: {"titulo":"PDE ainda sem melhora","comentario":"**Performance atual do PDE MUSA:** ainda não há melhora comercial comprovada.\n\n**PDE atual:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos totais | 791 |\n| Visitantes únicos | 115 |\n| Sessões | 119 |\n| Entradas PDE | 116 |\n| Page views | 117 |\n| Tempo visível médio | ~51s por sessão |\n| Clique no Mapa/Diagnóstico | 0 |\n| Login iniciado | 0 |\n| Paywall visto | 0 |\n| Checkout/compra | 0 |\n\n**Por versão:**\n\n| Versão | Sessões | Entradas | Clique inicial | Login | Paywall | Checkout |\n|---|---:|---:|---:|---:|---:|---:|\n| sem versão | 99 | 96 | 0 | 0 | 0 | 0 |\n| musa-pde-entry-v3 | 20 | 20 | 0 | 0 | 0 | 0 |\n\n**Jornadas recentes:** nas últimas 50 sessões analisadas, **45 saíram na primeira dobra** e **5 consumiram a página sem ação**. Nenhuma clicou no CTA, iniciou campo/e-mail, login ou checkout.\n\n**Meta Ads último dado persistido:** 2.175 impressões, 124 cliques, R$13,61 gastos, CPC R$0,11 e CTR ~5,70%. O tráfego continua barato, mas o sync Meta está defasado desde **21/07/2026 04:38 UTC** e a consulta em tempo real falhou por permissão `ads_read/ads_management`.\n\n**Leitura de negócio:** o problema não está na geração de atenção. O gargalo continua dentro do PDE: a pessoa chega, olha, mas não sente impulso suficiente para fazer a primeira ação.\n\n**Alternativas avaliadas:**\n\n1. **Esperar mais dados:** baixo esforço, mas o padrão de 0 clique já está forte.\n2. **Mexer só no texto do CTA:** simples, mas provavelmente insuficiente.\n3. **Criar a v4 com vídeo curto na primeira dobra + CTA único:** melhor opção, porque ataca a dúvida inicial e aumenta valor percebido antes do clique.\n\n**Recomendação:** avançar para a próxima versão `musa-pde-entry-v4-video-hero`, com vídeo curto explicando o Mapa de Presença e mantendo uma única ação principal. A hipótese deve ser medida pelo primeiro evento: sair de **0 clique no Mapa** para qualquer taxa real de clique inicial.","sugestaoMelhoriaAmbiente":"Restaurar a permissão Meta `ads_read`/`ads_management` no MCP e corrigir a conectividade PDE → Marketing Hub permitiria cruzar tráfego pago, versão do PDE e resultado comercial em tempo real sem lacunas."}

Usuário: fiz o deploy veja como ficou

Modelo: {"titulo":"Deploy com atenção","comentario":"**Verificação concluída.**\n\nO PDE público está no ar e medindo eventos, mas **não entrou vídeo na primeira dobra ainda**. A experiência pública continua como `musa-pde-entry-v3`, com CTA único: **“Descobrir o que minha imagem comunica hoje”**.\n\n**Performance atual do PDE MUSA:**\n\n| Métrica | Valor |\n|---|---:|\n| Eventos totais | 851 |\n| Visitantes únicos | 121 |\n| Sessões | 126 |\n| Entradas PDE | 123 |\n| Page views | 124 |\n| Versão atual medida | musa-pde-entry-v3 |\n| Sessões na v3 | 27 |\n| Cliques no Mapa/Diagnóstico | 0 |\n| E-mail/login iniciado | 0 |\n| Paywall/checkout/compra | 0 |\n\n**Leitura comercial:** ainda não houve melhora. A v3 já recebeu 27 sessões versionadas e continua com **zero primeira ação**. O gargalo segue sendo a primeira dobra/primeiro microcompromisso.\n\n**Sobre o deploy do menu Vídeos:** no repositório, o menu existe em **IA e Conteúdo → Vídeos** e a rota `/videos` está criada com o fluxo por etapas: objetivos, briefing, roteiro, criação e validação. Porém, não consegui validar visualmente a produção do Marketing Hub porque `191.252.181.168:8000`, `191.252.181.168` e `191.252.181.168:3000` recusaram conexão a partir da sandbox.\n\n**Ponto técnico importante:** o PDE ainda está tentando buscar o contrato do Marketing Hub em `http://191.252.181.168:8000` e `http://191.252.181.168`, falhando e usando catálogo local. Isso não derruba a página, mas impede que a regra “PDE muda pelo Marketing Hub” funcione de forma limpa em produção.\n\n**Alternativas avaliadas:**\n\n1. Considerar o deploy ok só porque o PDE abre: não recomendo, porque o Hub ainda não alimenta o PDE.\n2. Seguir só monitorando a v3: baixo esforço, mas o padrão de zero clique já está forte.\n3. Corrigir conectividade Hub → PDE e preparar a v4 com vídeo na primeira dobra: melhor opção, porque fecha a causa técnica e ataca o gargalo comercial real.\n\n**Recomendação:** antes de publicar a v4 com vídeo, corrigir a URL acessível do Marketing Hub para o container PDE. Depois, criar/publicar a versão `musa-pde-entry-v4-video-hero` pelo Hub e medir contra a v3.","sugestaoMelhoriaAmbiente":"Um endereço público/operacional acessível do frontend do Marketing Hub permitiria validar visualmente o menu Vídeos em produção, não apenas pelo código e pelos logs.","orientacaoProximaAcao":"Informe a URL de produção do frontend do Marketing Hub ou ajuste a conectividade/variável `PDE_MARKETING_HUB_BASE_URL` para um endereço que o container PDE consiga acessar."}

Última mensagem do usuário:
Não podemos simplesmente colocar uma versão nova no servidor. O procedimento precisa ser feito via github se for codigo e via Marketing Hub se for algum artefato. No caso do video se ainda não esta funcioanndo bem precisamos consertar a funcionalidade de video.

**Resumo das alterações:**
{"titulo":"Vídeos via Hub","comentario":"Corrigi a funcionalidade de vídeos para seguir o procedimento correto.\n\n**Causa-raiz:** a tela `Vídeos` salvava o plano só no navegador (`localStorage`). Isso não criava artefato no Marketing Hub, não gerava job, não mantinha roteiro aprovado e não deixava rastreabilidade para associar o vídeo à versão do PDE.\n\n**O que foi implementado:**\n\n- A tela `/videos` agora usa o backend do Marketing Hub como fonte de verdade.\n- Permite selecionar produto, com preferência automática pelo MUSA.\n- Cria um perfil real de vídeo para `musa-pde-entry-v4-video-hero`.\n- Salva o roteiro como script aprovado no módulo `sales-video`.\n- Solicita criação/render pelo `video-management-service` via job do Marketing Hub.\n- Mostra status do perfil e último job criado.\n- Registrei a regra em `docs/registros/sales-video.md`: código muda via GitHub; artefato comercial de vídeo para PDE nasce e evolui pelo Marketing Hub.\n\n**Validação feita:**\n\n- `npm run typecheck` passou.\n- `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR e depois faça o deploy do frontend do Marketing Hub. Em produção, use IA e Conteúdo → Vídeos para criar o perfil PDE v4, salvar o roteiro no Hub e solicitar a criação do vídeo pelo job."}