### PR TITLE
AI Hub: {"titulo":"Painel PDE implementado","comentario":"Implementei o painel único no monitor pós-deploy do experimento.\n\n**O que ficou pronto**\n- PDE agora retorna analytics por origem/campanha/criativo via UTM.\n- Monitor pós-deploy agora exibe blo…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
@@ -7,7 +7,9 @@ import com.marketinghub.experiment.monitoring.dto.PostDeployMetaAdsSummaryDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorDecision;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeExperienceVersionDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSessionJourneyDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSummaryDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeTrafficSourceDto;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
@@ -140,6 +142,8 @@ public class PostDeployMonitorService {
                     0,
                     null,
                     Map.<String, Long>of(),
+                    List.of(),
+                    List.of(),
                     List.of());
         }
     }
@@ -172,7 +176,9 @@ public class PostDeployMonitorService {
                 summary.totalVisibleMs(),
                 null,
                 events,
-                toExperienceVersionDtos(summary));
+                toExperienceVersionDtos(summary),
+                toTrafficSourceDtos(summary),
+                toSessionJourneyDtos(summary));
     }
 
     /** Converte as métricas por versão do PDE para exibição no painel administrativo. */
@@ -191,6 +197,58 @@ public class PostDeployMonitorService {
                         version.paywallViewed(),
                         version.subscriptionClicked() + version.checkoutStarted(),
                         version.subscriptionApproved()))
+                .toList();
+    }
+
+    /** Converte métricas por UTM/criativo para exibição no painel administrativo. */
+    private List<PostDeployPdeTrafficSourceDto> toTrafficSourceDtos(PdeAnalyticsSummary summary) {
+        if (summary.trafficSources() == null) {
+            return List.of();
+        }
+        return summary.trafficSources().stream()
+                .map(source -> new PostDeployPdeTrafficSourceDto(
+                        source.utmSource(),
+                        source.utmCampaign(),
+                        source.utmContent(),
+                        source.sessions(),
+                        source.pdeEntries(),
+                        source.firstInteractionClicks(),
+                        source.loginStarted(),
+                        source.paywallViewed(),
+                        source.checkoutStarted(),
+                        source.subscriptionApproved(),
+                        source.totalVisibleMs(),
+                        source.lastEventAt()))
+                .toList();
+    }
+
+    /** Converte jornadas recentes do PDE sem expor a lista completa de passos técnicos. */
+    private List<PostDeployPdeSessionJourneyDto> toSessionJourneyDtos(PdeAnalyticsSummary summary) {
+        if (summary.recentJourneys() == null) {
+            return List.of();
+        }
+        return summary.recentJourneys().stream()
+                .map(journey -> new PostDeployPdeSessionJourneyDto(
+                        journey.sessionId(),
+                        journey.visitorId(),
+                        journey.firstEventAt(),
+                        journey.lastEventAt(),
+                        journey.totalVisibleMs(),
+                        journey.maxScrollDepthPercent(),
+                        journey.screenNames(),
+                        journey.sectionIds(),
+                        journey.fieldFocused(),
+                        journey.fieldInputStarted(),
+                        journey.fieldFilled(),
+                        journey.ctaClicked(),
+                        journey.loginStarted(),
+                        journey.loginCompleted(),
+                        journey.paywallViewed(),
+                        journey.checkoutStarted(),
+                        journey.subscriptionApproved(),
+                        journey.abandonmentPoint(),
+                        journey.lastEventType(),
+                        journey.lastActionName()))
                 .toList();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSessionJourneyDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSessionJourneyDto.java
@@ -1,0 +1,27 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.util.List;
+
+/** Resume uma jornada recente do PDE no painel pós-deploy administrativo. */
+public record PostDeployPdeSessionJourneyDto(
+        String sessionId,
+        String visitorId,
+        String firstEventAt,
+        String lastEventAt,
+        long totalVisibleMs,
+        long maxScrollDepthPercent,
+        List<String> screenNames,
+        List<String> sectionIds,
+        boolean fieldFocused,
+        boolean fieldInputStarted,
+        boolean fieldFilled,
+        boolean ctaClicked,
+        boolean loginStarted,
+        boolean loginCompleted,
+        boolean paywallViewed,
+        boolean checkoutStarted,
+        boolean subscriptionApproved,
+        String abandonmentPoint,
+        String lastEventType,
+        String lastActionName
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeSummaryDto.java
@@ -27,5 +27,7 @@ public record PostDeployPdeSummaryDto(
         long totalVisibleMs,
         Instant lastEventAt,
         Map<String, Long> events,
-        List<PostDeployPdeExperienceVersionDto> experienceVersions
+        List<PostDeployPdeExperienceVersionDto> experienceVersions,
+        List<PostDeployPdeTrafficSourceDto> trafficSources,
+        List<PostDeployPdeSessionJourneyDto> recentJourneys
 ) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeTrafficSourceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeTrafficSourceDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+/** Resume desempenho do PDE por UTM/criativo no painel pós-deploy. */
+public record PostDeployPdeTrafficSourceDto(
+        String utmSource,
+        String utmCampaign,
+        String utmContent,
+        long sessions,
+        long pdeEntries,
+        long firstInteractionClicks,
+        long loginStarted,
+        long paywallViewed,
+        long checkoutStarted,
+        long subscriptionApproved,
+        long totalVisibleMs,
+        String lastEventAt
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsSummary.java
@@ -21,7 +21,9 @@ public record PdeAnalyticsSummary(
         long checkoutStarted,
         long totalVisibleMs,
         List<PdeEventMetric> events,
-        List<PdeExperienceVersionMetric> experienceVersions
+        List<PdeExperienceVersionMetric> experienceVersions,
+        List<PdeTrafficSourceMetric> trafficSources,
+        List<PdeSessionJourney> recentJourneys
 ) {
     /** Representa a contagem agregada por tipo de evento do PDE. */
     public record PdeEventMetric(String eventType, long total) {}
@@ -39,5 +41,45 @@ public record PdeAnalyticsSummary(
             long subscriptionClicked,
             long checkoutStarted,
             long subscriptionApproved
+    ) {}
+
+    /** Representa desempenho por origem, campanha e criativo identificado por UTM. */
+    public record PdeTrafficSourceMetric(
+            String utmSource,
+            String utmCampaign,
+            String utmContent,
+            long sessions,
+            long pdeEntries,
+            long firstInteractionClicks,
+            long loginStarted,
+            long paywallViewed,
+            long checkoutStarted,
+            long subscriptionApproved,
+            long totalVisibleMs,
+            String lastEventAt
+    ) {}
+
+    /** Representa uma jornada recente por sessão retornada pelo PDE. */
+    public record PdeSessionJourney(
+            String sessionId,
+            String visitorId,
+            String firstEventAt,
+            String lastEventAt,
+            long totalVisibleMs,
+            long maxScrollDepthPercent,
+            List<String> screenNames,
+            List<String> sectionIds,
+            boolean fieldFocused,
+            boolean fieldInputStarted,
+            boolean fieldFilled,
+            boolean ctaClicked,
+            boolean loginStarted,
+            boolean loginCompleted,
+            boolean paywallViewed,
+            boolean checkoutStarted,
+            boolean subscriptionApproved,
+            String abandonmentPoint,
+            String lastEventType,
+            String lastActionName
     ) {}
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
@@ -78,7 +78,41 @@ class PostDeployMonitorServiceTest {
                 2000,
                 List.of(),
                 List.of(new PdeAnalyticsSummary.PdeExperienceVersionMetric(
-                        "musa-pde-entry-v3", 80, 15, 15, 0, 0, 0, 0, 0, 0, 0))));
+                        "musa-pde-entry-v3", 80, 15, 15, 0, 0, 0, 0, 0, 0, 0)),
+                List.of(new PdeAnalyticsSummary.PdeTrafficSourceMetric(
+                        "facebook",
+                        "musa-campanha",
+                        "criativo-a",
+                        15,
+                        15,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        2000,
+                        "2026-07-21T02:00:00Z")),
+                List.of(new PdeAnalyticsSummary.PdeSessionJourney(
+                        "session-1",
+                        "visitor-1",
+                        "2026-07-21T01:59:00Z",
+                        "2026-07-21T02:00:00Z",
+                        2000,
+                        42,
+                        List.of("login_first_access"),
+                        List.of("login_hero"),
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        "SAIU_NA_PRIMEIRA_DOBRA",
+                        "PAGE_VIEW",
+                        "page_loaded"))));
 
         var response = service.summarize(67L, null);
 
@@ -89,6 +123,12 @@ class PostDeployMonitorServiceTest {
         assertThat(response.pde().experienceVersions())
                 .extracting("experienceVersion")
                 .contains("musa-pde-entry-v3");
+        assertThat(response.pde().trafficSources())
+                .extracting("utmContent")
+                .contains("criativo-a");
+        assertThat(response.pde().recentJourneys())
+                .extracting("abandonmentPoint")
+                .contains("SAIU_NA_PRIMEIRA_DOBRA");
     }
 
     /** Recomenda corrigir medição quando o PDE não responde ao Hub. */
@@ -133,7 +173,9 @@ class PostDeployMonitorServiceTest {
                 9000,
                 List.of(new PdeAnalyticsSummary.PdeEventMetric("PRESENCE_MAP_CHOICE_SELECTED", 6)),
                 List.of(new PdeAnalyticsSummary.PdeExperienceVersionMetric(
-                        "musa-pde-entry-v3", 120, 20, 20, 6, 0, 5, 2, 2, 1, 1))));
+                        "musa-pde-entry-v3", 120, 20, 20, 6, 0, 5, 2, 2, 1, 1)),
+                List.of(),
+                List.of()));
 
         var response = service.summarize(67L, null);
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5984,3 +5984,9 @@
 - comparação de causa-raiz: o mesmo payload cria criativo normalmente com `Produtividade 360`, então o bloqueio é permissão/tarefa de página no ativo reaproveitado, não erro de copy, imagem, campanha ou destino.
 - métrica real sincronizada: a campanha `120250451632930326` já registrou `92` impressões, `3` cliques e `R$ 0,61` de gasto em 2026-07-20; o Marketing Hub gravou `funnel_reset_at` para o experimento 67 quando as impressões saíram de zero.
 - validação PDE: log do `pde-platform-backend` confirmou reset de analytics do produto `metodo-musa-7-dias` no início da campanha, removendo `263` eventos anteriores de teste.
+
+## 2026-07-21 — PED/MUSA: painel único de mídia, criativo e jornada
+
+- foi feito: o resumo de analytics do PDE passou a devolver desempenho por origem/campanha/criativo via UTM, além das jornadas recentes por sessão.
+- foi feito: o monitor pós-deploy do experimento passou a exibir blocos de `Criativos e UTMs` e `Jornadas recentes por sessão`, cruzando Meta Ads, eventos PDE, tempo visível, scroll, última ação e ponto de abandono.
+- impacto comercial esperado: acelerar a decisão sobre qual criativo atrai visita útil, onde cada sessão abandona e se o gargalo está no anúncio, primeira dobra, e-mail, paywall ou checkout.

--- a/frontend/src/api/experiment/usePostDeployMonitor.ts
+++ b/frontend/src/api/experiment/usePostDeployMonitor.ts
@@ -46,6 +46,8 @@ export interface PostDeployPdeSummary {
   lastEventAt?: string | null;
   events: Record<string, number>;
   experienceVersions: PostDeployPdeExperienceVersion[];
+  trafficSources: PostDeployPdeTrafficSource[];
+  recentJourneys: PostDeployPdeSessionJourney[];
 }
 
 export interface PostDeployPdeExperienceVersion {
@@ -58,6 +60,44 @@ export interface PostDeployPdeExperienceVersion {
   paywallViewed: number;
   checkoutIntent: number;
   subscriptionApproved: number;
+}
+
+export interface PostDeployPdeTrafficSource {
+  utmSource: string;
+  utmCampaign: string;
+  utmContent: string;
+  sessions: number;
+  pdeEntries: number;
+  firstInteractionClicks: number;
+  loginStarted: number;
+  paywallViewed: number;
+  checkoutStarted: number;
+  subscriptionApproved: number;
+  totalVisibleMs: number;
+  lastEventAt?: string | null;
+}
+
+export interface PostDeployPdeSessionJourney {
+  sessionId: string;
+  visitorId?: string | null;
+  firstEventAt?: string | null;
+  lastEventAt?: string | null;
+  totalVisibleMs: number;
+  maxScrollDepthPercent: number;
+  screenNames: string[];
+  sectionIds: string[];
+  fieldFocused: boolean;
+  fieldInputStarted: boolean;
+  fieldFilled: boolean;
+  ctaClicked: boolean;
+  loginStarted: boolean;
+  loginCompleted: boolean;
+  paywallViewed: boolean;
+  checkoutStarted: boolean;
+  subscriptionApproved: boolean;
+  abandonmentPoint: string;
+  lastEventType?: string | null;
+  lastActionName?: string | null;
 }
 
 export interface PostDeployFacebookLogSummary {

--- a/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
@@ -44,6 +44,30 @@ function formatPercent(value?: number | null) {
   return value == null ? "—" : `${value.toFixed(2)}%`;
 }
 
+function formatDuration(ms?: number | null) {
+  if (!ms) return "0s";
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}min ${seconds}s` : `${seconds}s`;
+}
+
+function abandonmentLabel(value?: string | null) {
+  const labels: Record<string, string> = {
+    ASSINATURA_APROVADA: "Compra aprovada",
+    ABANDONOU_CHECKOUT: "Abandonou no checkout",
+    ABANDONOU_PAYWALL: "Abandonou no paywall",
+    ENTROU_SEM_CHEGAR_AO_PAYWALL: "Entrou sem ver paywall",
+    ABANDONOU_APOS_SOLICITAR_ACESSO: "Parou após pedir acesso",
+    ABANDONOU_NO_CAMPO_EMAIL: "Parou no e-mail",
+    FOCOU_EMAIL_SEM_ENVIAR: "Focou e-mail sem enviar",
+    CLICOU_CTA_SEM_LOGIN: "Clicou CTA sem login",
+    CONSUMIU_PAGINA_SEM_ACAO: "Consumiu página sem ação",
+    SAIU_NA_PRIMEIRA_DOBRA: "Saiu na primeira dobra",
+  };
+  return value ? labels[value] ?? value : "—";
+}
+
 function decisionBadgeClass(decision: PostDeployMonitorDecision) {
   switch (decision) {
     case "SCALE_GRADUALLY":
@@ -64,6 +88,8 @@ export default function ExperimentPostDeployMonitorTab({
 }: ExperimentPostDeployMonitorTabProps) {
   const monitorQuery = usePostDeployMonitor(experimentId);
   const monitor = monitorQuery.data;
+  const trafficSources = monitor?.pde.trafficSources ?? [];
+  const recentJourneys = monitor?.pde.recentJourneys ?? [];
 
   const pdeRows = useMemo(
     () =>
@@ -283,6 +309,95 @@ export default function ExperimentPostDeployMonitorTab({
                       <td className="text-end">{formatNumber(version.paywallViewed)}</td>
                       <td className="text-end">{formatNumber(version.checkoutIntent)}</td>
                       <td className="text-end">{formatNumber(version.subscriptionApproved)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {trafficSources.length > 0 ? (
+        <div className="card">
+          <div className="card-body">
+            <div className="d-flex justify-content-between align-items-start gap-2 flex-wrap mb-2">
+              <div>
+                <h6 className="card-title mb-1">Criativos e UTMs</h6>
+                <p className="text-muted small mb-0">
+                  Liga a origem do clique com a ação real dentro do PDE.
+                </p>
+              </div>
+            </div>
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Origem</th>
+                    <th>Campanha</th>
+                    <th>Criativo</th>
+                    <th className="text-end">Sessões</th>
+                    <th className="text-end">Entrada</th>
+                    <th className="text-end">1ª ação</th>
+                    <th className="text-end">Login</th>
+                    <th className="text-end">Paywall</th>
+                    <th className="text-end">Compra</th>
+                    <th className="text-end">Tempo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {trafficSources.map((source) => (
+                    <tr key={`${source.utmSource}-${source.utmCampaign}-${source.utmContent}`}>
+                      <td>{source.utmSource}</td>
+                      <td>{source.utmCampaign}</td>
+                      <td className="fw-semibold">{source.utmContent}</td>
+                      <td className="text-end">{formatNumber(source.sessions)}</td>
+                      <td className="text-end">{formatNumber(source.pdeEntries)}</td>
+                      <td className="text-end">{formatNumber(source.firstInteractionClicks)}</td>
+                      <td className="text-end">{formatNumber(source.loginStarted)}</td>
+                      <td className="text-end">{formatNumber(source.paywallViewed)}</td>
+                      <td className="text-end">{formatNumber(source.subscriptionApproved)}</td>
+                      <td className="text-end">{formatDuration(source.totalVisibleMs)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {recentJourneys.length > 0 ? (
+        <div className="card">
+          <div className="card-body">
+            <h6 className="card-title">Jornadas recentes por sessão</h6>
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Sessão</th>
+                    <th>Abandono</th>
+                    <th>Última ação</th>
+                    <th>Telas/seções</th>
+                    <th className="text-end">Scroll</th>
+                    <th className="text-end">Tempo</th>
+                    <th className="text-end">Último evento</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentJourneys.map((journey) => (
+                    <tr key={journey.sessionId}>
+                      <td className="font-monospace small">
+                        {(journey.sessionId ?? "sem-sessao").slice(0, 12)}
+                      </td>
+                      <td className="fw-semibold">{abandonmentLabel(journey.abandonmentPoint)}</td>
+                      <td>{journey.lastActionName ?? journey.lastEventType ?? "—"}</td>
+                      <td className="small text-muted">
+                        {[...(journey.screenNames ?? []), ...(journey.sectionIds ?? [])].slice(0, 3).join(" / ") || "—"}
+                      </td>
+                      <td className="text-end">{formatNumber(journey.maxScrollDepthPercent)}%</td>
+                      <td className="text-end">{formatDuration(journey.totalVisibleMs)}</td>
+                      <td className="text-end">{formatDate(journey.lastEventAt)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsSummaryResponse.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsSummaryResponse.java
@@ -21,5 +21,7 @@ public record FunnelAnalyticsSummaryResponse(
         long checkoutStarted,
         long totalVisibleMs,
         List<FunnelAnalyticsEventMetricDto> events,
-        List<FunnelAnalyticsExperienceVersionMetricDto> experienceVersions
+        List<FunnelAnalyticsExperienceVersionMetricDto> experienceVersions,
+        List<FunnelAnalyticsTrafficSourceMetricDto> trafficSources,
+        List<FunnelAnalyticsSessionJourneyDto> recentJourneys
 ) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsTrafficSourceMetricDto.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/dto/FunnelAnalyticsTrafficSourceMetricDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.pde.dto;
+
+/** Resume desempenho do PDE por origem, campanha e criativo identificados por UTM. */
+public record FunnelAnalyticsTrafficSourceMetricDto(
+        String utmSource,
+        String utmCampaign,
+        String utmContent,
+        long sessions,
+        long pdeEntries,
+        long firstInteractionClicks,
+        long loginStarted,
+        long paywallViewed,
+        long checkoutStarted,
+        long subscriptionApproved,
+        long totalVisibleMs,
+        String lastEventAt
+) {}

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
@@ -8,6 +8,7 @@ import com.marketinghub.pde.dto.FunnelAnalyticsJourneyResponse;
 import com.marketinghub.pde.dto.FunnelAnalyticsSessionJourneyDto;
 import com.marketinghub.pde.dto.FunnelAnalyticsSessionStepDto;
 import com.marketinghub.pde.dto.FunnelAnalyticsSummaryResponse;
+import com.marketinghub.pde.dto.FunnelAnalyticsTrafficSourceMetricDto;
 import com.marketinghub.pde.dto.FunnelEventRequest;
 import com.marketinghub.pde.dto.FunnelEventResponse;
 import com.marketinghub.pde.dto.MagicLinkResponse;
@@ -342,7 +343,7 @@ public class AccessService {
                 SELECT
                   COUNT(*) AS total_events,
                   COUNT(DISTINCT visitor_id) AS unique_visitors,
-                  COUNT(DISTINCT session_id) AS sessions,
+                  COUNT(DISTINCT COALESCE(session_id, event_id)) AS sessions,
                   SUM(CASE WHEN event_type = 'PED_ENTRY' THEN 1 ELSE 0 END) AS ped_entries,
                   SUM(CASE WHEN event_type = 'PAGE_VIEW' THEN 1 ELSE 0 END) AS page_views,
                   SUM(CASE WHEN event_type = 'LOGIN_STARTED' THEN 1 ELSE 0 END) AS login_started,
@@ -380,10 +381,12 @@ public class AccessService {
                             resultSet.getLong("checkout_started"),
                             resultSet.getLong("total_visible_ms"),
                             loadFunnelEventMetrics(connection, productSlug),
-                            loadExperienceVersionMetrics(connection, productSlug));
+                            loadExperienceVersionMetrics(connection, productSlug),
+                            loadTrafficSourceMetrics(connection, productSlug),
+                            loadSessionJourneyDtos(connection, productSlug, 20));
                 }
             }
-        } catch (SQLException ex) {
+        } catch (SQLException | IOException ex) {
             log.error("Falha ao consolidar analytics PDE; productSlug={}", productSlug, ex);
             throw new IllegalStateException("Não foi possível consolidar analytics PDE", ex);
         }
@@ -397,6 +400,18 @@ public class AccessService {
             return new FunnelAnalyticsJourneyResponse(productSlug, 0, List.of());
         }
         int safeLimit = Math.max(1, Math.min(limit, 100));
+        try (Connection connection = openConnection()) {
+            List<FunnelAnalyticsSessionJourneyDto> sessions = loadSessionJourneyDtos(connection, productSlug, safeLimit);
+            return new FunnelAnalyticsJourneyResponse(productSlug, sessions.size(), sessions);
+        } catch (SQLException | IOException ex) {
+            log.error("Falha ao consolidar jornadas PDE; productSlug={}, limit={}", productSlug, safeLimit, ex);
+            throw new IllegalStateException("Não foi possível consolidar jornadas PDE", ex);
+        }
+    }
+
+    /** Carrega as jornadas mais recentes usando a conexão informada. */
+    private List<FunnelAnalyticsSessionJourneyDto> loadSessionJourneyDtos(Connection connection, String productSlug, int limit)
+            throws SQLException, IOException {
         String sql = """
                 SELECT
                   COALESCE(e.session_id, e.event_id) AS resolved_session_id,
@@ -422,10 +437,9 @@ public class AccessService {
                 WHERE e.product_slug = ?
                 ORDER BY recent.last_event_at DESC, e.occurred_at ASC, e.id ASC
                 """;
-        try (Connection connection = openConnection();
-                PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, productSlug);
-            statement.setInt(2, safeLimit);
+            statement.setInt(2, limit);
             statement.setString(3, productSlug);
             try (ResultSet resultSet = statement.executeQuery()) {
                 Map<String, SessionJourneyBuilder> builders = new LinkedHashMap<>();
@@ -434,14 +448,10 @@ public class AccessService {
                     SessionJourneyBuilder builder = builders.computeIfAbsent(sessionId, SessionJourneyBuilder::new);
                     builder.add(toSessionJourneyEvent(resultSet));
                 }
-                List<FunnelAnalyticsSessionJourneyDto> sessions = builders.values().stream()
+                return builders.values().stream()
                         .map(SessionJourneyBuilder::toDto)
                         .toList();
-                return new FunnelAnalyticsJourneyResponse(productSlug, sessions.size(), sessions);
             }
-        } catch (SQLException | IOException ex) {
-            log.error("Falha ao consolidar jornadas PDE; productSlug={}, limit={}", productSlug, safeLimit, ex);
-            throw new IllegalStateException("Não foi possível consolidar jornadas PDE", ex);
         }
     }
 
@@ -726,7 +736,7 @@ public class AccessService {
     /** Retorna métricas vazias quando o backend está em modo local sem banco analítico. */
     private FunnelAnalyticsSummaryResponse emptyFunnelAnalytics(String productSlug) {
         return new FunnelAnalyticsSummaryResponse(
-                productSlug, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of(), List.of());
+                productSlug, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of(), List.of(), List.of(), List.of());
     }
 
     /** Converte uma linha JDBC em evento normalizado de jornada. */
@@ -823,6 +833,58 @@ public class AccessService {
                             resultSet.getLong("subscription_clicked"),
                             resultSet.getLong("checkout_started"),
                             resultSet.getLong("subscription_approved")));
+                }
+                return metrics;
+            }
+        }
+    }
+
+    /** Lê desempenho por origem, campanha e criativo para cruzar mídia com comportamento real no PDE. */
+    private List<FunnelAnalyticsTrafficSourceMetricDto> loadTrafficSourceMetrics(Connection connection, String productSlug)
+            throws SQLException {
+        String sql = """
+                SELECT
+                  COALESCE(NULLIF(utm_source, ''), 'sem-origem') AS resolved_utm_source,
+                  COALESCE(NULLIF(utm_campaign, ''), 'sem-campanha') AS resolved_utm_campaign,
+                  COALESCE(NULLIF(utm_content, ''), 'sem-criativo') AS resolved_utm_content,
+                  COUNT(DISTINCT session_id) AS sessions,
+                  SUM(CASE WHEN event_type = 'PED_ENTRY' THEN 1 ELSE 0 END) AS pde_entries,
+                  SUM(CASE WHEN event_type IN ('PRESENCE_MAP_CHOICE_SELECTED', 'DIAGNOSTIC_CHOICE_SELECTED') THEN 1 ELSE 0 END)
+                    AS first_interaction_clicks,
+                  SUM(CASE WHEN event_type = 'LOGIN_STARTED' THEN 1 ELSE 0 END) AS login_started,
+                  SUM(CASE WHEN event_type = 'PAYWALL_VIEWED' THEN 1 ELSE 0 END) AS paywall_viewed,
+                  SUM(CASE WHEN event_type = 'CHECKOUT_STARTED' THEN 1 ELSE 0 END) AS checkout_started,
+                  SUM(CASE WHEN event_type = 'SUBSCRIPTION_APPROVED' THEN 1 ELSE 0 END) AS subscription_approved,
+                  COALESCE(SUM(visible_ms), 0) AS total_visible_ms,
+                  MAX(occurred_at) AS last_event_at
+                FROM pde_funnel_event
+                WHERE product_slug = ?
+                GROUP BY
+                  COALESCE(NULLIF(utm_source, ''), 'sem-origem'),
+                  COALESCE(NULLIF(utm_campaign, ''), 'sem-campanha'),
+                  COALESCE(NULLIF(utm_content, ''), 'sem-criativo')
+                ORDER BY sessions DESC, last_event_at DESC
+                LIMIT 20
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, productSlug);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<FunnelAnalyticsTrafficSourceMetricDto> metrics = new java.util.ArrayList<>();
+                while (resultSet.next()) {
+                    Timestamp lastEventAt = resultSet.getTimestamp("last_event_at");
+                    metrics.add(new FunnelAnalyticsTrafficSourceMetricDto(
+                            resultSet.getString("resolved_utm_source"),
+                            resultSet.getString("resolved_utm_campaign"),
+                            resultSet.getString("resolved_utm_content"),
+                            resultSet.getLong("sessions"),
+                            resultSet.getLong("pde_entries"),
+                            resultSet.getLong("first_interaction_clicks"),
+                            resultSet.getLong("login_started"),
+                            resultSet.getLong("paywall_viewed"),
+                            resultSet.getLong("checkout_started"),
+                            resultSet.getLong("subscription_approved"),
+                            resultSet.getLong("total_visible_ms"),
+                            lastEventAt == null ? null : lastEventAt.toInstant().toString()));
                 }
                 return metrics;
             }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: como esta a perfomance atual do PDE Musa ?

Modelo: {"titulo":"PDE Musa: topo bom, conversão travada","comentario":"**Diagnóstico atual:** o PDE Musa está comprando tráfego barato e com boa curiosidade, mas ainda não está convertendo em ação comercial.\n\n**Evidências principais**\n- Campanha ativa: `MUSA Canario Real 2026-07-20 - Trafego Clube MUSA`, experimento 67, status `ACTIVE`.\n- Meta Ads atual: R$24,77 gastos, 4.122 impressões, 222 cliques no link, CTR 5,63%, CPC R$0,11 e 162 landing page views.\n- PDE/Clube Musa: 140 visitantes únicos, 146 sessões, 143 entradas no PDE e 144 page views.\n- Conversão interna: 0 login iniciado, 0 login concluído, 0 paywall visto, 0 checkout iniciado e 0 compra aprovada.\n- Versão atual medida: `musa-pde-entry-v3`.\n\n**Leitura de marketing**\n\nO anúncio está funcionando para atrair atenção. CTR de 5,63% e CPC de R$0,11 são bons sinais de topo de funil. O problema não parece ser público ou criativo neste momento.\n\nO gargalo está na primeira ação dentro do PDE. A pessoa entra, visualiza a tela, mas não avança para diagnóstico/login. Ou seja: o tráfego chega com curiosidade, mas a tela inicial ainda não transforma essa curiosidade em compromisso.\n\n**Causa mais provável**\n\nA promessa do anúncio gera interesse em “presença elegante”, mas a tela pede um passo intermediário pouco irresistível antes de capturar e-mail. O botão/diagnóstico gratuito não está gerando cliques registrados. Isso mata o funil antes de paywall e checkout.\n\n**Alternativas avaliadas**\n\n1. **Escalar campanha atual**  \nBenefício: tráfego barato. Risco: aumenta gasto sem vendas. Não recomendo agora.\n\n2. **Pausar tudo**  \nBenefício: evita desperdício. Risco: perde um criativo com sinal forte de clique. Não é o melhor, porque o topo está bom.\n\n3. **Manter orçamento baixo e corrigir primeira dobra/CTA**  \nMelhor opção. Preserva aprendizado barato e ataca o gargalo real: transformar visita em diagnóstico, login e paywall.\n\n**Recomendação acionável**\n\n- Não escalar orçamento ainda.\n- Manter campanha ativa em orçamento baixo por enquanto.\n- Alterar a primeira dobra para um CTA mais direto, tipo: **“Ver o que está enfraquecendo minha presença”**.\n- Mostrar o resultado prometido antes do e-mail: “em 30 segundos você recebe seu primeiro ajuste”.\n- Reduzir fricção: tornar o diagnóstico visual e imediato, com 2 ou 3 opções grandes, sem parecer formulário.\n- Após clique no diagnóstico, pedir e-mail como continuação natural: “Para salvar seu Mapa de Presença, informe seu e-mail”.\n- Só avaliar venda depois de pelo menos 30 a 50 eventos de `LOGIN_STARTED` ou `DIAGNOSTIC_CHOICE_SELECTED`.\n\n**Conclusão**\n\nPerformance atual: **boa aquisição, conversão interna zerada**. O PDE Musa ainda não validou venda, mas validou que existe interesse barato no tema. A próxima melhoria deve ser na entrada do Clube Musa, não no anúncio.","sugestaoMelhoriaAmbiente":"O trabalho seria melhor com um painel único ligando Meta Ads, eventos PDE e jornada por sessão em tempo real, para ver por criativo qual sessão clicou, quanto tempo ficou e onde abandonou."}

Última mensagem do usuário:
Implementa:
O trabalho seria melhor com um painel único ligando Meta Ads, eventos PDE e jornada por sessão em tempo real, para ver por criativo qual sessão clicou, quanto tempo ficou e onde abandonou.

**Resumo das alterações:**
{"titulo":"Painel PDE implementado","comentario":"Implementei o painel único no monitor pós-deploy do experimento.\n\n**O que ficou pronto**\n- PDE agora retorna analytics por origem/campanha/criativo via UTM.\n- Monitor pós-deploy agora exibe bloco **Criativos e UTMs**.\n- Monitor também exibe **Jornadas recentes por sessão**, com tempo visível, scroll, última ação e ponto de abandono.\n- Backend administrativo cruza esses dados com Meta Ads e mantém a recomendação executiva do experimento.\n- Registro adicionado em `docs/registros/experimentos.md`.\n\n**Impacto de marketing**\nAgora dá para ver, no mesmo painel, qual criativo trouxe sessão útil e onde a visitante abandonou: primeira dobra, CTA, e-mail, paywall ou checkout.\n\n**Validação feita**\n- `mvn -q -Dtest=AccessServiceTest test` passou.\n- `mvn -q -Dtest=PostDeployMonitorServiceTest test` passou.\n- `npm run build` do frontend passou.\n\nNão criei PR, conforme orientação.","sugestaoMelhoriaAmbiente":"O frontend estava sem dependências instaladas; precisei rodar `npm install`, que apontou vulnerabilidades no pacote atual. Um ambiente já provisionado com dependências e auditoria resolvida aceleraria a validação.","orientacaoProximaAcao":"Para publicar isso, peça explicitamente a criação do PR e depois execute o fluxo normal de revisão/deploy."}