### PR TITLE
AI Hub: {"titulo":"Reativação pronta","comentario":"Implementei no Marketing Hub a funcionalidade correta para **retornar um experimento à atividade com motivo registrado**.\n\nO que ficou pronto:\n\n- Novo endpoint: `POST /api/experiments/{id}/reactivate…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -196,6 +196,18 @@ public class Experiment {
     @Column(length = 32)
     private ExperimentStatus status;
 
+    /** Último motivo registrado para mudança administrativa de status. */
+    @Column(name = "last_status_change_reason", length = 1024)
+    private String lastStatusChangeReason;
+
+    /** Última ação administrativa que mudou o status do experimento. */
+    @Column(name = "last_status_change_action", length = 64)
+    private String lastStatusChangeAction;
+
+    /** Momento da última mudança administrativa de status. */
+    @Column(name = "last_status_changed_at")
+    private Instant lastStatusChangedAt;
+
     @Enumerated(EnumType.STRING)
     private ExperimentPlatform platform;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatusChange.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatusChange.java
@@ -1,0 +1,73 @@
+package com.marketinghub.experiment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Registra uma mudança auditável de status de um experimento comercial.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentStatusChange {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    /** Status anterior do experimento antes da ação administrativa. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", length = 32)
+    private ExperimentStatus previousStatus;
+
+    /** Novo status aplicado ao experimento pela ação administrativa. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "new_status", length = 32, nullable = false)
+    private ExperimentStatus newStatus;
+
+    /** Tipo de ação que originou a mudança de status. */
+    @Column(name = "action", length = 64, nullable = false)
+    private String action;
+
+    /** Motivo informado pelo usuário para justificar a mudança de status. */
+    @Column(name = "reason", length = 1024, nullable = false)
+    private String reason;
+
+    /** Origem operacional que executou a ação no sistema. */
+    @Column(name = "changed_by", length = 191, nullable = false)
+    private String changedBy;
+
+    /** Momento em que a mudança foi registrada pelo backend. */
+    @Column(name = "changed_at", nullable = false)
+    private Instant changedAt;
+
+    /** Garante data e origem padrão antes de persistir o histórico. */
+    @PrePersist
+    void applyDefaults() {
+        if (changedAt == null) {
+            changedAt = Instant.now();
+        }
+        if (changedBy == null || changedBy.isBlank()) {
+            changedBy = "SYSTEM";
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -86,6 +86,9 @@ public class ExperimentDto {
     private Instant creativeGenerationStartedAt;
     private Instant creativeGenerationFinishedAt;
     private String creativeGenerationError;
+    private String lastStatusChangeReason;
+    private String lastStatusChangeAction;
+    private Instant lastStatusChangedAt;
     private String primaryVariable;
     private String primaryMetric;
     private boolean creativeApproved;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ReactivateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ReactivateExperimentRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.experiment.dto;
+
+/**
+ * Contrato usado pela tela para reativar um experimento com justificativa auditável.
+ */
+public record ReactivateExperimentRequest(String reason) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -12,6 +12,7 @@ import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.experiment.*;
 import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
+import com.marketinghub.experiment.dto.ReactivateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.funnel.ExperimentFunnelStandbyService;
 import com.marketinghub.facebookads.FacebookCampaignStopReason;
@@ -20,6 +21,7 @@ import com.marketinghub.gerasalespage.v1.GeraSalesPagePublicationAudit;
 import com.marketinghub.gerasalespage.v1.GeraSalesPageStageCode;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentStatusChangeRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
@@ -63,6 +65,7 @@ public class ExperimentService {
     private static final String MUSA_PDE_CANONICAL_HOST = "clubemusa.com.br";
 
     private final ExperimentRepository repository;
+    private final ExperimentStatusChangeRepository statusChangeRepository;
     private final ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository;
     private final MarketNicheRepository nicheRepository;
     private final com.marketinghub.repository.jpa.hypothesis.HypothesisRepository hypothesisRepository;
@@ -90,7 +93,9 @@ public class ExperimentService {
     private final ProductAiExperimentPreparationService productAiExperimentPreparationService;
     private final ExperimentFunnelStandbyService experimentFunnelStandbyService;
 
+    /** Inicializa o serviço com repositórios, integrações e validadores usados pelos experimentos. */
     public ExperimentService(ExperimentRepository repository,
+                             ExperimentStatusChangeRepository statusChangeRepository,
                              ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository,
                              MarketNicheRepository nicheRepository,
                              com.marketinghub.repository.jpa.hypothesis.HypothesisRepository hypothesisRepository,
@@ -118,6 +123,7 @@ public class ExperimentService {
                              ProductAiExperimentPreparationService productAiExperimentPreparationService,
                              ExperimentFunnelStandbyService experimentFunnelStandbyService) {
         this.repository = repository;
+        this.statusChangeRepository = statusChangeRepository;
         this.promiseGenerationRequestRepository = promiseGenerationRequestRepository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
@@ -578,6 +584,60 @@ public class ExperimentService {
             );
         }
         return exp;
+    }
+
+    /**
+     * Reativa um experimento parado registrando motivo de negócio e histórico auditável.
+     */
+    @Transactional
+    public Experiment reactivate(Long id, ReactivateExperimentRequest request) {
+        String reason = normalizeStatusChangeReason(request != null ? request.reason() : null);
+        Experiment exp = repository.findById(id).orElseThrow();
+        ExperimentStatus previousStatus = exp.getStatus();
+        if (!canReactivate(previousStatus)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "experiment status does not allow reactivation");
+        }
+        validateRunningStatusTransition(exp);
+        exp.setStatus(ExperimentStatus.RUNNING);
+        exp.setLastStatusChangeAction("REACTIVATE");
+        exp.setLastStatusChangeReason(reason);
+        exp.setLastStatusChangedAt(Instant.now());
+        statusChangeRepository.save(ExperimentStatusChange.builder()
+                .experiment(exp)
+                .previousStatus(previousStatus)
+                .newStatus(ExperimentStatus.RUNNING)
+                .action("REACTIVATE")
+                .reason(reason)
+                .changedBy("ADMIN_UI")
+                .changedAt(exp.getLastStatusChangedAt())
+                .build());
+        return exp;
+    }
+
+    /** Verifica se o status atual representa um experimento parado que pode voltar à atividade. */
+    private boolean canReactivate(ExperimentStatus status) {
+        return status == ExperimentStatus.PAUSED
+                || status == ExperimentStatus.STANDBY
+                || status == ExperimentStatus.USER_STOPPED
+                || status == ExperimentStatus.INCONCLUSIVE
+                || status == ExperimentStatus.FAILED;
+    }
+
+    /** Normaliza e valida o motivo informado para mudança auditável de status. */
+    private String normalizeStatusChangeReason(String reason) {
+        if (!StringUtils.hasText(reason)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "reason required");
+        }
+        String normalized = reason.trim();
+        if (normalized.length() < 10) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "reason must have at least 10 characters");
+        }
+        if (normalized.length() > 1024) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "reason must have at most 1024 characters");
+        }
+        return normalized;
     }
 
     /** Valida as evidências mínimas antes de aceitar experimento como em execução. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.dto.ExperimentSessionDurationSummaryDto;
 import com.marketinghub.experiment.dto.ExperimentSessionDurationVariantDto;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.experiment.dto.ReactivateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateSelectedSampleEmailRequest;
 import com.marketinghub.experiment.funnel.ExperimentFunnelService;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
@@ -148,6 +149,14 @@ public class ExperimentController {
             @PathVariable Long id,
             @RequestParam com.marketinghub.experiment.ExperimentStatus status) {
         return mapper.toDto(service.updateStatus(id, status));
+    }
+
+    /** Reativa um experimento parado registrando o motivo informado pelo usuário. */
+    @PostMapping("/{id}/reactivate")
+    public ExperimentDto reactivate(
+            @PathVariable Long id,
+            @RequestBody ReactivateExperimentRequest request) {
+        return mapper.toDto(service.reactivate(id, request));
     }
 
     /** Atualiza os campos editáveis de um experimento existente. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentStatusChangeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentStatusChangeRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.experiment;
+
+import com.marketinghub.experiment.ExperimentStatusChange;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Persiste o histórico auditável de mudanças de status dos experimentos.
+ */
+public interface ExperimentStatusChangeRepository extends JpaRepository<ExperimentStatusChange, Long> {
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-22-experiment-reactivation-audit.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-22-experiment-reactivation-audit.yaml
@@ -1,0 +1,89 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-22-experiment-reactivation-audit
+      author: codex
+      preConditions:
+        - dbms:
+            type: mysql
+      changes:
+        - addColumn:
+            tableName: experiment
+            columns:
+              - column:
+                  name: last_status_change_reason
+                  type: varchar(1024)
+              - column:
+                  name: last_status_change_action
+                  type: varchar(64)
+              - column:
+                  name: last_status_changed_at
+                  type: datetime
+        - createTable:
+            tableName: experiment_status_change
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: previous_status
+                  type: varchar(32)
+              - column:
+                  name: new_status
+                  type: varchar(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: action
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: reason
+                  type: varchar(1024)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: changed_by
+                  type: varchar(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: changed_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: experiment_status_change
+            baseColumnNames: experiment_id
+            constraintName: fk_experiment_status_change_experiment
+            referencedTableName: experiment
+            referencedColumnNames: id
+        - createIndex:
+            tableName: experiment_status_change
+            indexName: idx_experiment_status_change_experiment_changed
+            columns:
+              - column:
+                  name: experiment_id
+              - column:
+                  name: changed_at
+      rollback:
+        - dropTable:
+            tableName: experiment_status_change
+        - dropColumn:
+            tableName: experiment
+            columnName: last_status_change_reason
+        - dropColumn:
+            tableName: experiment
+            columnName: last_status_change_action
+        - dropColumn:
+            tableName: experiment
+            columnName: last_status_changed_at

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-22-experiment-reactivation-audit.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-16-experiment-type-pde-membership-subscription.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment;
 
 import com.marketinghub.repository.jpa.creative.label.AngleRepository;
 import com.marketinghub.repository.jpa.experiment.MetricPresetRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentStatusChangeRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
@@ -67,6 +68,8 @@ class ExperimentServiceTest {
     com.marketinghub.repository.jpa.experiment.MetricPresetRepository metricPresetRepository;
     @Autowired
     ExperimentRepository experimentRepository;
+    @Autowired
+    ExperimentStatusChangeRepository experimentStatusChangeRepository;
     @Autowired
     JourneyTemplateRepository journeyTemplateRepository;
     @Autowired
@@ -808,6 +811,79 @@ class ExperimentServiceTest {
         assertThat(stored.getStopCompletedAt()).isNull();
         assertThat(stored.getStopLastError()).isNull();
         assertThat(stored.getStopReason()).isEqualTo(FacebookCampaignStopReason.ADMIN_EXPERIMENT_PAUSED);
+    }
+
+    @Test
+    void reactivateStoppedExperimentRegistersReasonAndHistory() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Reactivation").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("ARX").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("HRX")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150_REACTIVATE")
+                .name("Lean-Startup 150 Reactivate")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("ExpReactivate");
+        req.setHypothesis("H");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150_REACTIVATE");
+        req.setDailyBudget(new BigDecimal("25"));
+        req.setJourneyTemplateId(createJourneyTemplate().getId());
+        req.setLeadPortalFlowId(createLeadPortalFlow(niche));
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        Experiment experiment = service.create(req);
+        experiment.setStatus(ExperimentStatus.USER_STOPPED);
+        experimentRepository.save(experiment);
+
+        FacebookAccount facebookAccount = facebookAccountRepository.save(FacebookAccount.builder()
+                .name("Conta Facebook Reactivation")
+                .adAccountId("act_reactivation")
+                .build());
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("campaign-reactivation");
+        campaign.setExternalId("meta-reactivation");
+        campaign.setAdAccountId("act_reactivation");
+        campaign.setExperiment(experiment);
+        campaign.setFacebookAccount(facebookAccount);
+        campaign.setName("Campanha para reativar");
+        campaign.setObjective("OUTCOME_LEADS");
+        campaign.setStatus(FacebookAdStatus.PAUSED);
+        campaign.setBudgetMode(BudgetMode.CAMPAIGN);
+        facebookAdsCampaignRepository.save(campaign);
+
+        Experiment reactivated = service.reactivate(
+                experiment.getId(),
+                new com.marketinghub.experiment.dto.ReactivateExperimentRequest(
+                        "Retomar ciclo controlado para validar a nova entrada do PDE Musa."));
+
+        assertThat(reactivated.getStatus()).isEqualTo(ExperimentStatus.RUNNING);
+        assertThat(reactivated.getLastStatusChangeAction()).isEqualTo("REACTIVATE");
+        assertThat(reactivated.getLastStatusChangeReason()).contains("Retomar ciclo controlado");
+        assertThat(reactivated.getLastStatusChangedAt()).isNotNull();
+        assertThat(experimentStatusChangeRepository.findAll())
+                .anySatisfy(change -> {
+                    assertThat(change.getExperiment().getId()).isEqualTo(experiment.getId());
+                    assertThat(change.getPreviousStatus()).isEqualTo(ExperimentStatus.USER_STOPPED);
+                    assertThat(change.getNewStatus()).isEqualTo(ExperimentStatus.RUNNING);
+                    assertThat(change.getAction()).isEqualTo("REACTIVATE");
+                });
+        reactivated.setStatus(ExperimentStatus.USER_STOPPED);
+        experimentRepository.save(reactivated);
     }
 
     @Test

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -165,6 +165,9 @@ export interface Experiment {
   creativeGenerationStartedAt?: string | null;
   creativeGenerationFinishedAt?: string | null;
   creativeGenerationError?: string | null;
+  lastStatusChangeReason?: string | null;
+  lastStatusChangeAction?: string | null;
+  lastStatusChangedAt?: string | null;
   primaryVariable?: string | null;
   primaryMetric?: string | null;
   createdAt: string;

--- a/frontend/src/api/experiment/useUpdateExperimentStatus.ts
+++ b/frontend/src/api/experiment/useUpdateExperimentStatus.ts
@@ -7,12 +7,33 @@ interface UpdateExperimentStatusInput {
   status: string;
 }
 
+interface ReactivateExperimentInput {
+  id: string;
+  reason: string;
+}
+
 export function useUpdateExperimentStatus() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ id, status }: UpdateExperimentStatusInput) => {
       const { data } = await axios.patch<Experiment>(`/api/experiments/${id}/status`, null, {
         params: { status },
+      });
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["experiment", variables.id] });
+      queryClient.invalidateQueries({ queryKey: ["experiments"] });
+    },
+  });
+}
+
+export function useReactivateExperiment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, reason }: ReactivateExperimentInput) => {
+      const { data } = await axios.post<Experiment>(`/api/experiments/${id}/reactivate`, {
+        reason,
       });
       return data;
     },

--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -363,4 +363,70 @@ describe("ExperimentListPage", () => {
     ).toBeNull();
   });
 
+  it("reactivates a stopped experiment with a registered reason", async () => {
+    const experiments = [
+      {
+        id: "67",
+        nicheId: 10,
+        hypothesisId: "hypothesis-67",
+        name: "MUSA-H001-E005",
+        hypothesis: "Método MUSA",
+        cost: 32.34,
+        startDate: "2026-07-21",
+        endDate: null,
+        creativeApproved: true,
+        status: "USER_STOPPED",
+        platform: "FACEBOOK",
+        stage: "AD",
+        createdAt: "2026-07-21T00:00:00Z",
+        updatedAt: "2026-07-22T00:16:31Z",
+      },
+    ];
+
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/experiments")
+        return Promise.resolve({ data: experiments });
+      if (url === "/api/niches") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 10,
+              name: "Mulheres urbanas",
+              description: "",
+              demandVolume: "",
+              promises: "",
+              offers: "",
+              baseSegmentation: "",
+              interests: "",
+              demographicFilters: "",
+              extraTips: "",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: null });
+    });
+    (axios.post as any).mockResolvedValueOnce({
+      data: { ...experiments[0], status: "RUNNING" },
+    });
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Retornar à atividade" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Retornar experimento à atividade" }),
+    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Reativar" }));
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/experiments/67/reactivate",
+      {
+        reason:
+          "Retomar o Experimento 67 para medir a versão atual do PDE Musa em produção como novo ciclo dentro do mesmo aprendizado.",
+      },
+    );
+  });
+
 });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -1,7 +1,10 @@
 import { Link } from "react-router-dom";
 import { useExperiments } from "../../api/experiment/useExperiments";
 import { useNiches } from "../../api/niche/useNiches";
-import { useUpdateExperimentStatus } from "../../api/experiment/useUpdateExperimentStatus";
+import {
+  useReactivateExperiment,
+  useUpdateExperimentStatus,
+} from "../../api/experiment/useUpdateExperimentStatus";
 import { useCloseExperimentPipelineJobs } from "../../api/experiment/useCloseExperimentPipelineJobs";
 import { useLatestPromiseOptionsDraft } from "../../api/experiment/useGeneratePromiseOptions";
 import PageTitle from "../../components/PageTitle";
@@ -12,6 +15,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
 const PAGE_SIZE = 25;
+const REACTIVATABLE_STATUSES = new Set([
+  "PAUSED",
+  "STANDBY",
+  "USER_STOPPED",
+  "INCONCLUSIVE",
+  "FAILED",
+]);
 
 function parseDate(date?: string | null) {
   if (!date) return 0;
@@ -65,6 +75,7 @@ export default function ExperimentListPage() {
   const { data, isLoading } = useExperiments();
   const { data: niches } = useNiches();
   const updateStatus = useUpdateExperimentStatus();
+  const reactivateExperiment = useReactivateExperiment();
   const closePipelineJobs = useCloseExperimentPipelineJobs();
   const queryClient = useQueryClient();
   const latestPromiseOptionsDraft = useLatestPromiseOptionsDraft();
@@ -78,6 +89,10 @@ export default function ExperimentListPage() {
   const [retryingExperimentId, setRetryingExperimentId] = useState<
     string | null
   >(null);
+  const [reactivationExperimentId, setReactivationExperimentId] = useState<
+    string | null
+  >(null);
+  const [reactivationReason, setReactivationReason] = useState("");
   const retryRelease = useMutation({
     mutationFn: async (experimentId: string) => {
       const { data } = await axios.post(
@@ -206,6 +221,26 @@ export default function ExperimentListPage() {
     }
   }
 
+  async function handleReactivate() {
+    if (!reactivationExperimentId) return;
+    const reason = reactivationReason.trim();
+    if (reason.length < 10) {
+      toast.error("Informe um motivo com pelo menos 10 caracteres.");
+      return;
+    }
+    try {
+      await reactivateExperiment.mutateAsync({
+        id: reactivationExperimentId,
+        reason,
+      });
+      toast.success("Experimento reativado com motivo registrado.");
+      setReactivationExperimentId(null);
+      setReactivationReason("");
+    } catch {
+      toast.error("Não foi possível reativar o experimento.");
+    }
+  }
+
   if (isLoading) return <p>Carregando...</p>;
 
   return (
@@ -291,6 +326,7 @@ export default function ExperimentListPage() {
           <tbody>
             {paginated.map((e) => {
               const canStop = e.status === "RUNNING";
+              const canReactivate = REACTIVATABLE_STATUSES.has(e.status);
               const isStopping = stoppingExperimentId === String(e.id);
               const isRetrying = retryingExperimentId === String(e.id);
               return (
@@ -363,6 +399,22 @@ export default function ExperimentListPage() {
                         Parada do usuário
                       </button>
                     )}
+                    {canReactivate && (
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-success ms-1"
+                        onClick={() => {
+                          setReactivationExperimentId(String(e.id));
+                          setReactivationReason(
+                            e.id === "67"
+                              ? "Retomar o Experimento 67 para medir a versão atual do PDE Musa em produção como novo ciclo dentro do mesmo aprendizado."
+                              : "",
+                          );
+                        }}
+                      >
+                        Retornar à atividade
+                      </button>
+                    )}
                     {e.status === "FAILED" && (
                       <button
                         type="button"
@@ -390,6 +442,69 @@ export default function ExperimentListPage() {
       {sorted.length === 0 && (
         <div className="alert alert-light border" role="status">
           Nenhum experimento encontrado para os filtros selecionados.
+        </div>
+      )}
+      {reactivationExperimentId && (
+        <div className="modal d-block" tabIndex={-1} role="dialog">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h2 className="modal-title h5">Retornar experimento à atividade</h2>
+                <button
+                  type="button"
+                  className="btn-close"
+                  aria-label="Fechar"
+                  onClick={() => {
+                    setReactivationExperimentId(null);
+                    setReactivationReason("");
+                  }}
+                />
+              </div>
+              <div className="modal-body">
+                <label className="form-label" htmlFor="reactivation-reason">
+                  Motivo do retorno
+                </label>
+                <textarea
+                  id="reactivation-reason"
+                  className="form-control"
+                  rows={4}
+                  maxLength={1024}
+                  value={reactivationReason}
+                  onChange={(event) => setReactivationReason(event.target.value)}
+                />
+                <div className="form-text">
+                  Esse motivo fica registrado no histórico do experimento.
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={() => {
+                    setReactivationExperimentId(null);
+                    setReactivationReason("");
+                  }}
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  disabled={reactivateExperiment.isPending}
+                  onClick={handleReactivate}
+                >
+                  {reactivateExperiment.isPending && (
+                    <span
+                      className="spinner-border spinner-border-sm me-1"
+                      role="status"
+                      aria-hidden="true"
+                    />
+                  )}
+                  Reativar
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
       {totalPages > 1 && (


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: vamos criar um novo experimento para testar essa versão atual em produção do PDE Musa ou melhor continuar o experimento atual ?

Modelo: {"titulo":"Continue o experimento atual","comentario":"Minha recomendação: **não criar um novo experimento agora**. Continue o **Experimento 67**, mas trate a versão atual do PDE Musa como uma **nova versão/ciclo mensurável dentro do experimento atual**.\n\nEvidências principais:\n\n- Meta Ads está trazendo tráfego barato: **303 cliques**, **CTR 5,35%**, **CPC R$0,11**, gasto **R$32,34**.\n- O PDE recebeu **203 sessões**, **196 entradas** e **187 visitantes únicos**.\n- O gargalo ainda está antes da venda: **0 login**, **0 paywall**, **0 checkout**, **0 compra**.\n- A versão `musa-pde-entry-v3` teve **100 entradas** e só **5 interações iniciais**.\n- Produção está respondendo, mas o deploy produtivo ainda aparece sem `experienceVersion` no status; já a homologação mostra `musa-pde-entry-v4-video-hero`.\n\nAlternativas avaliadas:\n\n1. **Criar novo experimento agora**  \n   Benefício: separação limpa.  \n   Risco: fragmenta aprendizado com pouco volume e pode parecer que mudamos hipótese quando o problema real ainda é o primeiro microcompromisso.  \n   Aderência: média.\n\n2. **Continuar o experimento atual sem separar versão**  \n   Benefício: simples.  \n   Risco: mistura tráfego antigo, tela branca corrigida e novas versões do PDE.  \n   Aderência: baixa.\n\n3. **Continuar o Experimento 67, mas medir por versão/ciclo**  \n   Benefício: mantém histórico, evita criar experimento artificial e permite comparar `sem-versao`, `v3` e próxima versão em produção.  \n   Risco: precisa garantir que a versão comercial esteja marcada corretamente nos eventos.  \n   Aderência: melhor.\n\nDecisão: **seguir pela alternativa 3**.\n\nPróximo movimento recomendado:\n\n- Não mexer em público nem em promessa principal agora.\n- Garantir que a versão atual em produção esteja marcada com `experienceVersion` explícita.\n- Rodar mais um ciclo curto no Experimento 67 com limite controlado, olhando principalmente: clique no diagnóstico, geração do plano, preenchimento de e-mail, login, paywall e checkout.\n- Só criar um novo experimento se mudarmos uma aposta estrutural: outro público, outra promessa, outro mecanismo, outra oferta/preço ou outro formato de criativo dominante.\n\nResumo prático: **o Experimento 67 ainda é o lugar certo para aprender. O que precisa mudar agora não é o número do experimento; é a leitura por versão do PDE e o volume mínimo depois da correção da entrada.**","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
vamos ativa novamente esse experimento então. faça isso mude o estado dele. Mas vamos fazer pelo sistema para que fique registrado. Se o Mkt Hub não tiver essa opção vamos criar essa funcionalidade de retorno a atividade dizendo o motivvo.

**Resumo das alterações:**
{"titulo":"Reativação pronta","comentario":"Implementei no Marketing Hub a funcionalidade correta para **retornar um experimento à atividade com motivo registrado**.\n\nO que ficou pronto:\n\n- Novo endpoint: `POST /api/experiments/{id}/reactivate`.\n- O experimento volta para `RUNNING` somente se estiver em estado reativável, como `USER_STOPPED`, `PAUSED`, `STANDBY`, `INCONCLUSIVE` ou `FAILED`.\n- O motivo informado fica salvo no experimento e também em histórico auditável append-only (`experiment_status_change`).\n- A tela de experimentos agora mostra o botão **Retornar à atividade** para experimentos parados.\n- Para o Experimento 67, o modal já sugere o motivo correto: retomar o ciclo para medir a versão atual do PDE Musa em produção sem criar novo experimento.\n\nTambém confirmei em produção que o Experimento 67 está atualmente como `USER_STOPPED`, então ele é o caso certo para essa ação.\n\nValidações executadas:\n\n- Backend: `ExperimentServiceTest` passou com 28 testes.\n- Front-end: `ExperimentListPage.test.tsx` passou com 6 testes.\n- Typecheck front-end passou.\n- Changelog Liquibase validado com include relativo e sem `TIMESTAMP NOT NULL` problemático.\n\nNão criei PR e não publiquei alteração, seguindo sua regra. A produção ainda não foi alterada; o estado do Experimento 67 só poderá ser mudado pelo sistema depois que essa funcionalidade for publicada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Quando quiser avançar, peça o PR/deploy dessa mudança. Depois do deploy, use o botão “Retornar à atividade” no Experimento 67 para registrar o motivo e reativar pelo sistema."}