### PR TITLE
AI Hub: {"titulo":"Link QA no card","comentario":"Implementei a funcionalidade no Marketing Hub.\n\nO que ficou pronto:\n\n- No card do produto em **Cadastro de Produtos**, agora aparece o botão **Preview/QA sem métricas** quando o produto tem URL pública…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -248,55 +248,86 @@ public class ProductService {
         }
     }
 
-    /** Monta o modelo inicial AIDA para medir o questionário como mecanismo comercial do PDE. */
+    /** Monta o funil experiencial por estágios para medir a jornada comercial do PDE. */
     private ObjectNode buildDefaultPdePersuasiveJourney(Product product) {
         ObjectNode journey = objectMapper.createObjectNode();
-        journey.put("version", "aida-interactive-v1");
-        journey.put("framework", "AIDA");
+        journey.put("version", "commercial-stages-v1");
+        journey.put("framework", "Funil experiencial PDE");
+        journey.put("psychologicalModel", "AIDA como apoio, não como eixo principal de leitura");
         journey.put("name", "Jornada Persuasiva Interativa do PDE");
-        journey.put("objective", "Medir se o questionário aumenta consciência, desejo e avanço para login/paywall sem contaminar versões de experiência.");
+        journey.put("objective", "Medir em qual estágio comercial a pessoa ganha ou perde confiança, desejo e disposição de pagar.");
         journey.put("productSlug", valueOrFallback(product.getSlug()));
         journey.put("commercialPromise", valueOrFallback(product.getPromise()));
         ArrayNode steps = journey.putArray("steps");
-        addPersuasiveJourneyStep(steps, "attention", "Atenção", "login_hero",
-                "Capturar atenção com promessa clara e reconhecimento imediato da dor.",
-                "A pessoa entende que o produto fala diretamente com a dificuldade dela.",
-                "page_view e tempo visível na primeira dobra",
-                "Se muita gente abandona aqui, revisar promessa, hero, carregamento e clareza do primeiro CTA.");
-        addPersuasiveJourneyStep(steps, "interest", "Interesse", "interactive_diagnostic",
-                "Levar a usuária a interagir e revelar contexto próprio dentro do questionário.",
-                "A pessoa troca passividade por microcompromisso e passa a aprender sobre a própria dor.",
-                "eventos de seção e início do diagnóstico",
-                "Se há pouca interação, reduzir fricção da primeira pergunta e tornar a recompensa do diagnóstico mais concreta.");
-        addPersuasiveJourneyStep(steps, "desire", "Desejo", "free_diagnostic_preview",
-                "Entregar diagnóstico parcial que prove valor e aumente desejo pela continuidade.",
-                "A pessoa percebe personalização e imagina o resultado prometido aplicado à rotina dela.",
-                "tempo visível no diagnóstico, clique para continuar e captura de e-mail",
-                "Se o desejo não avança, fortalecer prova, especificidade do plano e contraste antes/depois.");
-        addPersuasiveJourneyStep(steps, "action", "Ação", "subscription_paywall",
-                "Converter intenção em login, paywall, checkout e compra.",
-                "A pessoa entende a próxima ação e vê motivo suficiente para liberar a experiência completa.",
-                "login, paywall, checkout e compra",
-                "Se o gargalo está aqui, revisar preço, oferta, garantia, checkout e continuidade entre diagnóstico e pagamento.");
+        addPersuasiveJourneyStep(steps, 1, "promise_contact", "Contato com a promessa", "Atenção",
+                "Anúncio e primeira dobra apresentam dor, promessa e motivo para clicar/entrar.",
+                "A pessoa deixa de ignorar o anúncio e aceita conhecer a promessa do produto.",
+                new String[] {"login_hero"},
+                new String[] {"PAGE_VIEW", "PAGE_VISIBLE_TIME"},
+                "impressões, CTR, CPC, page_view e tempo visível na primeira dobra",
+                "Se quebra aqui, revisar promessa, criativo, público, carregamento e clareza do primeiro CTA.");
+        addPersuasiveJourneyStep(steps, 2, "diagnostic_value", "Envolvimento diagnóstico", "Interesse + Desejo",
+                "Questionário e plano de 7 dias transformam curiosidade em valor percebido personalizado.",
+                "A pessoa troca passividade por microcompromisso e recebe um plano aplicável à própria rotina.",
+                new String[] {"interactive_diagnostic", "free_diagnostic_preview"},
+                new String[] {"PRESENCE_MAP_CHOICE_SELECTED", "DIAGNOSTIC_CHOICE_SELECTED", "SECTION_VIEW"},
+                "início/conclusão do questionário, visualização do plano e tempo no diagnóstico",
+                "Se quebra aqui, reduzir fricção das perguntas e tornar a recompensa do plano mais concreta.");
+        addPersuasiveJourneyStep(steps, 3, "continuity_commitment", "Compromisso de continuidade", "Desejo + Ação",
+                "Login, cadastro, salvar plano ou iniciar missão transformam valor percebido em intenção real.",
+                "A pessoa aceita deixar um sinal de identidade para continuar a jornada.",
+                new String[] {"login_panel", "guided_journey"},
+                new String[] {"LOGIN_STARTED", "LOGIN_COMPLETED", "FIRST_USE", "MISSION_OPEN"},
+                "login iniciado/concluído, plano salvo, primeira missão aberta e primeiro uso",
+                "Se quebra aqui, simplificar cadastro, reforçar continuidade do plano e explicar por que salvar a jornada.");
+        addPersuasiveJourneyStep(steps, 4, "commercial_conversion", "Conversão comercial", "Ação",
+                "Paywall, checkout e compra convertem intenção em receita.",
+                "A pessoa entende que a parte paga libera a continuidade de maior valor.",
+                new String[] {"subscription_paywall"},
+                new String[] {"PAYWALL_VIEWED", "SUBSCRIPTION_CLICKED", "CHECKOUT_STARTED", "SUBSCRIPTION_APPROVED"},
+                "paywall visto, clique de assinatura, checkout iniciado e compra aprovada",
+                "Se quebra aqui, revisar preço, oferta, garantia, prova, checkout e transição entre plano gratuito e acesso pago.");
+        addPersuasiveJourneyStep(steps, 5, "post_purchase_validation", "Validação pós-compra", "Retenção",
+                "Acesso liberado, uso inicial e missões concluídas confirmam que a promessa vendida está sendo aplicada.",
+                "A pessoa percebe progresso prático e reduz risco de arrependimento ou abandono.",
+                new String[] {"member_journey", "materials_library"},
+                new String[] {"ACCESS_RELEASED", "FIRST_USE", "MISSION_COMPLETED", "MATERIAL_OPEN"},
+                "acesso liberado, primeiro uso, missão concluída e abertura de materiais",
+                "Se quebra aqui, melhorar onboarding, missão do Dia 1, clareza dos materiais e acompanhamento inicial.");
         return journey;
     }
 
     /** Adiciona uma etapa comercial rastreável à jornada persuasiva padrão. */
     private void addPersuasiveJourneyStep(
             ArrayNode steps,
+            int stageNumber,
             String stage,
-            String aidaLabel,
-            String trackedSectionId,
+            String stageName,
+            String psychologicalRole,
             String commercialFunction,
             String userShift,
+            String[] trackedSectionIds,
+            String[] eventNames,
             String primaryMetric,
             String optimizationRule) {
         ObjectNode step = steps.addObject();
+        step.put("stageNumber", stageNumber);
         step.put("stage", stage);
-        step.put("aidaLabel", aidaLabel);
-        step.put("trackedSectionId", trackedSectionId);
+        step.put("stageName", stageName);
+        step.put("psychologicalRole", psychologicalRole);
         step.put("commercialFunction", commercialFunction);
         step.put("userShift", userShift);
+        ArrayNode sections = step.putArray("trackedSectionIds");
+        for (String trackedSectionId : trackedSectionIds) {
+            sections.add(trackedSectionId);
+        }
+        if (trackedSectionIds.length > 0) {
+            step.put("trackedSectionId", trackedSectionIds[0]);
+        }
+        ArrayNode events = step.putArray("eventNames");
+        for (String eventName : eventNames) {
+            events.add(eventName);
+        }
         step.put("primaryMetric", primaryMetric);
         step.put("optimizationRule", optimizationRule);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -1,7 +1,10 @@
 package com.marketinghub.product.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.product.Product;
@@ -55,6 +58,24 @@ public class ProductService {
     public Product updateProduct(Long id, CreateProductRequest request) {
         Product product = getProduct(id);
         applyRequest(product, request);
+        return repository.save(product);
+    }
+
+    /** Insere a jornada persuasiva interativa padrão no contrato PDE do produto. */
+    @Transactional
+    public Product applyDefaultPdePersuasiveJourney(Long id) {
+        Product product = getProduct(id);
+        ObjectNode contract = readPdeExperienceContract(product);
+        if (!contract.hasNonNull("slug") && product.getSlug() != null && !product.getSlug().isBlank()) {
+            contract.put("slug", product.getSlug().trim());
+        }
+        contract.set("persuasiveJourney", buildDefaultPdePersuasiveJourney(product));
+        try {
+            product.setPdeExperienceJson(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(contract));
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Não foi possível atualizar a jornada persuasiva PDE", ex);
+        }
         return repository.save(product);
     }
 
@@ -184,6 +205,19 @@ public class ProductService {
         return product.getPdeExperienceJson().trim();
     }
 
+    /** Lê a jornada persuasiva interativa publicada no contrato PDE do produto. */
+    @Transactional(readOnly = true)
+    public JsonNode getPublicPdePersuasiveJourney(String productCode) {
+        Product product = findProductByCode(productCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Produto não encontrado"));
+        ObjectNode contract = readPdeExperienceContract(product);
+        JsonNode journey = contract.get("persuasiveJourney");
+        if (journey == null || journey.isNull() || journey.isMissingNode()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Jornada persuasiva PDE não cadastrada");
+        }
+        return journey;
+    }
+
     /** Valida que o contrato PDE informado é JSON antes de persistir no cadastro comercial. */
     private String validatePdeExperienceJson(String rawJson) {
         if (rawJson == null || rawJson.isBlank()) {
@@ -195,6 +229,76 @@ public class ProductService {
         } catch (JsonProcessingException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Contrato JSON da experiência PDE inválido", ex);
         }
+    }
+
+    /** Converte o contrato PDE salvo em objeto JSON editável. */
+    private ObjectNode readPdeExperienceContract(Product product) {
+        String rawJson = product.getPdeExperienceJson();
+        if (rawJson == null || rawJson.isBlank()) {
+            return objectMapper.createObjectNode();
+        }
+        try {
+            JsonNode parsed = objectMapper.readTree(rawJson);
+            if (!parsed.isObject()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Contrato JSON da experiência PDE deve ser um objeto");
+            }
+            return (ObjectNode) parsed;
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Contrato JSON da experiência PDE inválido", ex);
+        }
+    }
+
+    /** Monta o modelo inicial AIDA para medir o questionário como mecanismo comercial do PDE. */
+    private ObjectNode buildDefaultPdePersuasiveJourney(Product product) {
+        ObjectNode journey = objectMapper.createObjectNode();
+        journey.put("version", "aida-interactive-v1");
+        journey.put("framework", "AIDA");
+        journey.put("name", "Jornada Persuasiva Interativa do PDE");
+        journey.put("objective", "Medir se o questionário aumenta consciência, desejo e avanço para login/paywall sem contaminar versões de experiência.");
+        journey.put("productSlug", valueOrFallback(product.getSlug()));
+        journey.put("commercialPromise", valueOrFallback(product.getPromise()));
+        ArrayNode steps = journey.putArray("steps");
+        addPersuasiveJourneyStep(steps, "attention", "Atenção", "login_hero",
+                "Capturar atenção com promessa clara e reconhecimento imediato da dor.",
+                "A pessoa entende que o produto fala diretamente com a dificuldade dela.",
+                "page_view e tempo visível na primeira dobra",
+                "Se muita gente abandona aqui, revisar promessa, hero, carregamento e clareza do primeiro CTA.");
+        addPersuasiveJourneyStep(steps, "interest", "Interesse", "interactive_diagnostic",
+                "Levar a usuária a interagir e revelar contexto próprio dentro do questionário.",
+                "A pessoa troca passividade por microcompromisso e passa a aprender sobre a própria dor.",
+                "eventos de seção e início do diagnóstico",
+                "Se há pouca interação, reduzir fricção da primeira pergunta e tornar a recompensa do diagnóstico mais concreta.");
+        addPersuasiveJourneyStep(steps, "desire", "Desejo", "free_diagnostic_preview",
+                "Entregar diagnóstico parcial que prove valor e aumente desejo pela continuidade.",
+                "A pessoa percebe personalização e imagina o resultado prometido aplicado à rotina dela.",
+                "tempo visível no diagnóstico, clique para continuar e captura de e-mail",
+                "Se o desejo não avança, fortalecer prova, especificidade do plano e contraste antes/depois.");
+        addPersuasiveJourneyStep(steps, "action", "Ação", "subscription_paywall",
+                "Converter intenção em login, paywall, checkout e compra.",
+                "A pessoa entende a próxima ação e vê motivo suficiente para liberar a experiência completa.",
+                "login, paywall, checkout e compra",
+                "Se o gargalo está aqui, revisar preço, oferta, garantia, checkout e continuidade entre diagnóstico e pagamento.");
+        return journey;
+    }
+
+    /** Adiciona uma etapa comercial rastreável à jornada persuasiva padrão. */
+    private void addPersuasiveJourneyStep(
+            ArrayNode steps,
+            String stage,
+            String aidaLabel,
+            String trackedSectionId,
+            String commercialFunction,
+            String userShift,
+            String primaryMetric,
+            String optimizationRule) {
+        ObjectNode step = steps.addObject();
+        step.put("stage", stage);
+        step.put("aidaLabel", aidaLabel);
+        step.put("trackedSectionId", trackedSectionId);
+        step.put("commercialFunction", commercialFunction);
+        step.put("userShift", userShift);
+        step.put("primaryMetric", primaryMetric);
+        step.put("optimizationRule", optimizationRule);
     }
 
     /** Busca o produto por slug público ou por identificador interno numérico. */

--- a/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
@@ -4,6 +4,7 @@ import com.marketinghub.product.dto.CreateProductRequest;
 import com.marketinghub.product.dto.ProductDto;
 import com.marketinghub.product.mapper.ProductMapper;
 import com.marketinghub.product.service.ProductService;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.springframework.http.HttpHeaders;
@@ -45,6 +46,12 @@ public class ProductController {
         return mapper.toDto(service.updateProduct(id, request));
     }
 
+    /** Insere a jornada persuasiva interativa padrão no contrato PDE do produto. */
+    @PostMapping("/{id}/pde-persuasive-journey/default")
+    public ProductDto applyDefaultPdePersuasiveJourney(@PathVariable Long id) {
+        return mapper.toDto(service.applyDefaultPdePersuasiveJourney(id));
+    }
+
     /** Lista os produtos comerciais cadastrados no Marketing Hub. */
     @GetMapping
     public List<ProductDto> list() {
@@ -84,5 +91,13 @@ public class ProductController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(service.getPublicPdeExperienceJson(productCode));
+    }
+
+    /** Retorna a jornada persuasiva interativa cadastrada no contrato PDE do produto. */
+    @GetMapping(
+            value = "/public/{productCode}/pde-persuasive-journey",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public JsonNode getPublicPdePersuasiveJourney(@PathVariable String productCode) {
+        return service.getPublicPdePersuasiveJourney(productCode);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -181,7 +181,7 @@ class ProductServiceTest {
         assertThat(json).isEqualTo("{\"slug\":\"metodo-musa-7-dias\"}");
     }
 
-    /** Deve inserir a jornada persuasiva AIDA no contrato PDE preservando dados existentes. */
+    /** Deve inserir a jornada persuasiva por estágios comerciais no contrato PDE preservando dados existentes. */
     @Test
     void applyDefaultPdePersuasiveJourney() {
         ProductRepository productRepository = mock(ProductRepository.class);
@@ -202,8 +202,10 @@ class ProductServiceTest {
 
         assertThat(updated.getPdeExperienceJson()).contains("\"experienceVersion\" : \"musa-pde-entry-v4-video-hero\"");
         assertThat(updated.getPdeExperienceJson()).contains("\"persuasiveJourney\"");
-        assertThat(updated.getPdeExperienceJson()).contains("\"framework\" : \"AIDA\"");
-        assertThat(updated.getPdeExperienceJson()).contains("\"trackedSectionId\" : \"interactive_diagnostic\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"framework\" : \"Funil experiencial PDE\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"stageName\" : \"Envolvimento diagnóstico\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"stageName\" : \"Validação pós-compra\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"trackedSectionIds\" : [ \"interactive_diagnostic\", \"free_diagnostic_preview\" ]");
         assertThat(updated.getPdeExperienceJson()).contains("\"trackedSectionId\" : \"subscription_paywall\"");
     }
 
@@ -216,14 +218,14 @@ class ProductServiceTest {
         ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
         Product product = Product.builder()
                 .slug("metodo-musa-7-dias")
-                .pdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"AIDA\",\"steps\":[]}}")
+                .pdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"Funil experiencial PDE\",\"steps\":[]}}")
                 .build();
 
         when(productRepository.findBySlug("metodo-musa-7-dias")).thenReturn(Optional.of(product));
 
         var journey = service.getPublicPdePersuasiveJourney("metodo-musa-7-dias");
 
-        assertThat(journey.get("framework").asText()).isEqualTo("AIDA");
+        assertThat(journey.get("framework").asText()).isEqualTo("Funil experiencial PDE");
         assertThat(journey.get("steps").isArray()).isTrue();
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -181,6 +181,52 @@ class ProductServiceTest {
         assertThat(json).isEqualTo("{\"slug\":\"metodo-musa-7-dias\"}");
     }
 
+    /** Deve inserir a jornada persuasiva AIDA no contrato PDE preservando dados existentes. */
+    @Test
+    void applyDefaultPdePersuasiveJourney() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
+        Product product = Product.builder()
+                .id(1L)
+                .slug("metodo-musa-7-dias")
+                .promise("Presença elegante em 7 dias")
+                .pdeExperienceJson("{\"slug\":\"metodo-musa-7-dias\",\"experienceVersion\":\"musa-pde-entry-v4-video-hero\"}")
+                .build();
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(productRepository.save(product)).thenReturn(product);
+
+        Product updated = service.applyDefaultPdePersuasiveJourney(1L);
+
+        assertThat(updated.getPdeExperienceJson()).contains("\"experienceVersion\" : \"musa-pde-entry-v4-video-hero\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"persuasiveJourney\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"framework\" : \"AIDA\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"trackedSectionId\" : \"interactive_diagnostic\"");
+        assertThat(updated.getPdeExperienceJson()).contains("\"trackedSectionId\" : \"subscription_paywall\"");
+    }
+
+    /** Deve ler a jornada persuasiva publicada no contrato PDE do produto. */
+    @Test
+    void getPublicPdePersuasiveJourney() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        InstagramAccountRepository accountRepository = mock(InstagramAccountRepository.class);
+        MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
+        ProductService service = new ProductService(productRepository, accountRepository, marketNicheRepository, objectMapper);
+        Product product = Product.builder()
+                .slug("metodo-musa-7-dias")
+                .pdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"AIDA\",\"steps\":[]}}")
+                .build();
+
+        when(productRepository.findBySlug("metodo-musa-7-dias")).thenReturn(Optional.of(product));
+
+        var journey = service.getPublicPdePersuasiveJourney("metodo-musa-7-dias");
+
+        assertThat(journey.get("framework").asText()).isEqualTo("AIDA");
+        assertThat(journey.get("steps").isArray()).isTrue();
+    }
+
     /** Deve rejeitar contrato PDE que não seja JSON válido antes de salvar o produto. */
     @Test
     void updateProductRejectsInvalidPdeExperienceJson() {

--- a/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
@@ -129,7 +129,7 @@ class ProductControllerTest {
         ProductDto response = new ProductDto();
         response.setId(1L);
         response.setName("Método MUSA");
-        response.setPdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"AIDA\"}}");
+        response.setPdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"Funil experiencial PDE\"}}");
 
         when(service.applyDefaultPdePersuasiveJourney(1L)).thenReturn(product);
         when(mapper.toDto(product)).thenReturn(response);
@@ -137,19 +137,19 @@ class ProductControllerTest {
         mockMvc.perform(post("/api/products/{id}/pde-persuasive-journey/default", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.pdeExperienceJson").value("{\"persuasiveJourney\":{\"framework\":\"AIDA\"}}"));
+                .andExpect(jsonPath("$.pdeExperienceJson").value("{\"persuasiveJourney\":{\"framework\":\"Funil experiencial PDE\"}}"));
     }
 
     /** Deve expor a jornada persuasiva PDE como contrato JSON público. */
     @Test
     void getPublicPdePersuasiveJourney() throws Exception {
-        var journey = objectMapper.readTree("{\"framework\":\"AIDA\",\"steps\":[]}");
+        var journey = objectMapper.readTree("{\"framework\":\"Funil experiencial PDE\",\"steps\":[]}");
 
         when(service.getPublicPdePersuasiveJourney("metodo-musa-7-dias")).thenReturn(journey);
 
         mockMvc.perform(get("/api/products/public/{productCode}/pde-persuasive-journey", "metodo-musa-7-dias"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.framework").value("AIDA"));
+                .andExpect(jsonPath("$.framework").value("Funil experiencial PDE"));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -119,5 +120,36 @@ class ProductControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.slug").value("metodo-musa-7-dias"));
+    }
+
+    /** Deve acionar a inserção da jornada persuasiva interativa no produto. */
+    @Test
+    void applyDefaultPdePersuasiveJourney() throws Exception {
+        Product product = Product.builder().id(1L).name("Método MUSA").build();
+        ProductDto response = new ProductDto();
+        response.setId(1L);
+        response.setName("Método MUSA");
+        response.setPdeExperienceJson("{\"persuasiveJourney\":{\"framework\":\"AIDA\"}}");
+
+        when(service.applyDefaultPdePersuasiveJourney(1L)).thenReturn(product);
+        when(mapper.toDto(product)).thenReturn(response);
+
+        mockMvc.perform(post("/api/products/{id}/pde-persuasive-journey/default", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.pdeExperienceJson").value("{\"persuasiveJourney\":{\"framework\":\"AIDA\"}}"));
+    }
+
+    /** Deve expor a jornada persuasiva PDE como contrato JSON público. */
+    @Test
+    void getPublicPdePersuasiveJourney() throws Exception {
+        var journey = objectMapper.readTree("{\"framework\":\"AIDA\",\"steps\":[]}");
+
+        when(service.getPublicPdePersuasiveJourney("metodo-musa-7-dias")).thenReturn(journey);
+
+        mockMvc.perform(get("/api/products/public/{productCode}/pde-persuasive-journey", "metodo-musa-7-dias"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.framework").value("AIDA"));
     }
 }

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -170,6 +170,20 @@ Regras obrigatórias:
 
 O objetivo comercial é transformar o anúncio em entrada de relacionamento, permitir que a lead veja valor dentro do sistema e vender o acesso quando ela quiser continuar nas partes de maior valor.
 
+### Jornada Persuasiva Interativa do PDE
+
+A Jornada Persuasiva Interativa do PDE deve ser lida como **funil experiencial por estágios comerciais**, não como AIDA simples.
+
+O modelo AIDA pode ser usado como apoio psicológico dentro de cada estágio, mas a unidade principal de análise deve ser o avanço comercial real do consumidor:
+
+1. **Contato com a promessa**: anúncio e primeira dobra fazem a pessoa reconhecer a dor/promessa e aceitar entrar.
+2. **Envolvimento diagnóstico**: questionário e plano/amostra gratuita aumentam informação, valor percebido e desejo pela continuidade.
+3. **Compromisso de continuidade**: login, cadastro, plano salvo, primeira missão ou ação equivalente transformam interesse em intenção mensurável.
+4. **Conversão comercial**: paywall, clique de assinatura, checkout e compra transformam intenção em receita.
+5. **Validação pós-compra**: acesso liberado, primeiro uso, missão concluída e materiais abertos confirmam que a promessa vendida começou a ser aplicada.
+
+O contrato `persuasiveJourney` publicado pelo Marketing Hub deve declarar esses estágios de forma versionada, com função comercial, mudança esperada no usuário, seções/eventos rastreados, métrica principal e regra de otimização quando o estágio quebrar. O relatório do experimento deve usar essa jornada para responder em qual estágio a pessoa perdeu confiança, desejo ou disposição de pagar.
+
 ### Analytics obrigatório para campanhas PDE
 
 Toda aplicação PDE usada como destino de campanha deve registrar eventos próprios no backend PDE antes de escalar tráfego pago. A medição mínima deve permitir reconstruir o funil por produto, campanha, origem e dispositivo.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6016,3 +6016,10 @@
 - foi feito: criado smoke test público com Playwright para abrir a URL publicada, confirmar JavaScript carregado, headline comercial visível e bloco `Diagnóstico de Presença` renderizado.
 - foi feito: o workflow de homologação e produção do PDE passou a executar essa validação depois do deploy, além do health HTTP do backend.
 - impacto comercial esperado: evitar liberar tráfego pago para página que responde `200`, mas está branca, com asset JavaScript quebrado ou sem a primeira dobra comercial visível.
+
+## 2026-07-22 — PED/MUSA: jornada persuasiva interativa no Marketing Hub
+
+- foi decidido tratar o questionário do PDE como mecanismo comercial mensurável, não como formulário isolado.
+- foi feito: o cadastro de produtos passou a inserir e exibir uma `Jornada Persuasiva Interativa do PDE` no contrato do produto, usando AIDA como primeira leitura operacional.
+- foi feito: a aba de analytics do experimento passou a cruzar a jornada cadastrada com seções rastreadas do PDE, mostrando sessões, tempo visível, métrica primária e regra de otimização por etapa.
+- impacto comercial esperado: identificar se o gargalo está em atenção, interesse, desejo ou ação, orientando ajustes de promessa, pergunta inicial, diagnóstico parcial, login, paywall e checkout com base em evidência comportamental.

--- a/docs/swagger/product-swagger.yaml
+++ b/docs/swagger/product-swagger.yaml
@@ -112,10 +112,13 @@ components:
       properties:
         version:
           type: string
-          example: aida-interactive-v1
+          example: commercial-stages-v1
         framework:
           type: string
-          example: AIDA
+          example: Funil experiencial PDE
+        psychologicalModel:
+          type: string
+          example: AIDA como apoio, não como eixo principal de leitura
         name:
           type: string
           example: Jornada Persuasiva Interativa do PDE
@@ -133,15 +136,40 @@ components:
     PdePersuasiveJourneyStep:
       type: object
       properties:
+        stageNumber:
+          type: integer
+          example: 2
         stage:
           type: string
-          example: interest
+          example: diagnostic_value
+        stageName:
+          type: string
+          example: Envolvimento diagnóstico
         aidaLabel:
           type: string
           example: Interesse
+          deprecated: true
+        psychologicalRole:
+          type: string
+          example: Interesse + Desejo
         trackedSectionId:
           type: string
           example: interactive_diagnostic
+          deprecated: true
+        trackedSectionIds:
+          type: array
+          items:
+            type: string
+          example:
+            - interactive_diagnostic
+            - free_diagnostic_preview
+        eventNames:
+          type: array
+          items:
+            type: string
+          example:
+            - DIAGNOSTIC_CHOICE_SELECTED
+            - SECTION_VIEW
         commercialFunction:
           type: string
         userShift:

--- a/docs/swagger/product-swagger.yaml
+++ b/docs/swagger/product-swagger.yaml
@@ -4,6 +4,29 @@ info:
   version: 1.0.0
   description: Endpoints públicos e administrativos do cadastro comercial de produtos.
 paths:
+  /api/products/{id}/pde-persuasive-journey/default:
+    post:
+      tags:
+        - Products
+      summary: Insere a jornada persuasiva interativa padrão no contrato PDE do produto.
+      operationId: applyDefaultPdePersuasiveJourney
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          example: 1
+      responses:
+        "200":
+          description: Produto atualizado com persuasiveJourney no campo pdeExperienceJson.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Product"
+        "404":
+          description: Produto não encontrado.
   /api/products/public/{productCode}/marketing-definition.md:
     get:
       tags:
@@ -26,6 +49,28 @@ paths:
                 type: string
         "404":
           description: Produto não encontrado.
+  /api/products/public/{productCode}/pde-persuasive-journey:
+    get:
+      tags:
+        - Products
+      summary: Retorna a jornada persuasiva interativa cadastrada no contrato PDE do produto.
+      operationId: getPublicPdePersuasiveJourney
+      parameters:
+        - name: productCode
+          in: path
+          required: true
+          schema:
+            type: string
+          example: metodo-musa-7-dias
+      responses:
+        "200":
+          description: Jornada persuasiva versionada usada para interpretar o questionário do PDE no funil comercial.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PdePersuasiveJourney"
+        "404":
+          description: Produto não encontrado ou jornada persuasiva não cadastrada.
   /api/products/public/{productCode}/marketing-definition:
     get:
       tags:
@@ -48,3 +93,60 @@ paths:
                 type: string
         "404":
           description: Produto não encontrado.
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        name:
+          type: string
+        pdeExperienceJson:
+          type: string
+    PdePersuasiveJourney:
+      type: object
+      properties:
+        version:
+          type: string
+          example: aida-interactive-v1
+        framework:
+          type: string
+          example: AIDA
+        name:
+          type: string
+          example: Jornada Persuasiva Interativa do PDE
+        objective:
+          type: string
+        productSlug:
+          type: string
+          example: metodo-musa-7-dias
+        commercialPromise:
+          type: string
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/PdePersuasiveJourneyStep"
+    PdePersuasiveJourneyStep:
+      type: object
+      properties:
+        stage:
+          type: string
+          example: interest
+        aidaLabel:
+          type: string
+          example: Interesse
+        trackedSectionId:
+          type: string
+          example: interactive_diagnostic
+        commercialFunction:
+          type: string
+        userShift:
+          type: string
+        primaryMetric:
+          type: string
+        optimizationRule:
+          type: string

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -163,6 +163,19 @@
   color: var(--product-primary, #7a2444);
 }
 
+.product-catalog-card__action-button--qa {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+  color: #334155;
+}
+
+.product-catalog-card__action-button--qa:hover,
+.product-catalog-card__action-button--qa:focus {
+  background: #e2e8f0;
+  border-color: #94a3b8;
+  color: #172033;
+}
+
 .product-catalog-card__panel {
   border: 1px solid
     color-mix(

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -120,6 +120,11 @@
     box-shadow 0.15s ease;
 }
 
+.product-catalog-card__action-button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
 .product-catalog-card__action-button:hover,
 .product-catalog-card__action-button:focus {
   text-decoration: none;

--- a/frontend/src/api/product/pdePersuasiveJourney.ts
+++ b/frontend/src/api/product/pdePersuasiveJourney.ts
@@ -1,7 +1,12 @@
 export interface PdePersuasiveJourneyStep {
+  stageNumber?: number;
   stage: string;
+  stageName?: string;
   aidaLabel?: string;
+  psychologicalRole?: string;
   trackedSectionId?: string;
+  trackedSectionIds?: string[];
+  eventNames?: string[];
   commercialFunction?: string;
   userShift?: string;
   primaryMetric?: string;
@@ -11,6 +16,7 @@ export interface PdePersuasiveJourneyStep {
 export interface PdePersuasiveJourney {
   version?: string;
   framework?: string;
+  psychologicalModel?: string;
   name?: string;
   objective?: string;
   productSlug?: string;

--- a/frontend/src/api/product/pdePersuasiveJourney.ts
+++ b/frontend/src/api/product/pdePersuasiveJourney.ts
@@ -1,0 +1,33 @@
+export interface PdePersuasiveJourneyStep {
+  stage: string;
+  aidaLabel?: string;
+  trackedSectionId?: string;
+  commercialFunction?: string;
+  userShift?: string;
+  primaryMetric?: string;
+  optimizationRule?: string;
+}
+
+export interface PdePersuasiveJourney {
+  version?: string;
+  framework?: string;
+  name?: string;
+  objective?: string;
+  productSlug?: string;
+  commercialPromise?: string;
+  steps?: PdePersuasiveJourneyStep[];
+}
+
+export function parsePdePersuasiveJourney(
+  pdeExperienceJson?: string | null,
+): PdePersuasiveJourney | null {
+  if (!pdeExperienceJson?.trim()) return null;
+  try {
+    const parsed = JSON.parse(pdeExperienceJson);
+    const journey = parsed?.persuasiveJourney;
+    if (!journey || typeof journey !== "object") return null;
+    return journey as PdePersuasiveJourney;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/api/product/useApplyDefaultPdePersuasiveJourney.ts
+++ b/frontend/src/api/product/useApplyDefaultPdePersuasiveJourney.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Product } from "./useProducts";
+
+export function useApplyDefaultPdePersuasiveJourney() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (productId: number) => {
+      const { data } = await axios.post<Product>(
+        `/api/products/${productId}/pde-persuasive-journey/default`,
+      );
+      return data;
+    },
+    onSuccess: (product) => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+      queryClient.invalidateQueries({
+        queryKey: ["product", String(product.id)],
+      });
+      queryClient.invalidateQueries({ queryKey: ["product", product.id] });
+    },
+  });
+}

--- a/frontend/src/api/product/usePdePersuasiveJourney.ts
+++ b/frontend/src/api/product/usePdePersuasiveJourney.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { PdePersuasiveJourney } from "./pdePersuasiveJourney";
+
+export function usePdePersuasiveJourney(productSlug = "metodo-musa-7-dias") {
+  return useQuery<PdePersuasiveJourney>({
+    queryKey: ["products", productSlug, "pde-persuasive-journey"],
+    queryFn: async () => {
+      const { data } = await axios.get<PdePersuasiveJourney>(
+        `/api/products/public/${productSlug}/pde-persuasive-journey`,
+      );
+      return data;
+    },
+    retry: false,
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import ExperimentLandingAnalyticsTab from "./ExperimentLandingAnalyticsTab";
+
+vi.mock("axios");
+
+describe("ExperimentLandingAnalyticsTab", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the persuasive journey with analytics evidence by tracked section", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/experiments/67/funnel/analytics") {
+        return Promise.resolve({
+          data: {
+            totalEvents: 4,
+            totalSessions: 2,
+            pageViews: 2,
+            sectionViewEvents: 2,
+            totalVisibleMs: 18000,
+            averageVisibleMsPerSession: 9000,
+            deviceBreakdown: [],
+            mobileOperatingSystemBreakdown: [],
+            screenSizeBreakdown: [],
+            sessions: [
+              {
+                sessionId: "s1",
+                eventCount: 2,
+                pageViews: 1,
+                sectionViewEvents: 1,
+                totalVisibleMs: 12000,
+                topSections: [
+                  {
+                    sectionId: "interactive_diagnostic",
+                    visibleMs: 12000,
+                    events: 1,
+                  },
+                ],
+              },
+              {
+                sessionId: "s2",
+                eventCount: 2,
+                pageViews: 1,
+                sectionViewEvents: 1,
+                totalVisibleMs: 6000,
+                topSections: [],
+              },
+            ],
+          },
+        });
+      }
+      if (
+        url === "/api/products/public/metodo-musa-7-dias/pde-persuasive-journey"
+      ) {
+        return Promise.resolve({
+          data: {
+            version: "aida-interactive-v1",
+            framework: "AIDA",
+            steps: [
+              {
+                stage: "interest",
+                aidaLabel: "Interesse",
+                trackedSectionId: "interactive_diagnostic",
+                commercialFunction:
+                  "Levar a usuária a interagir com o diagnóstico.",
+                primaryMetric: "início do diagnóstico",
+                optimizationRule: "reduzir fricção da primeira pergunta",
+              },
+            ],
+          },
+        });
+      }
+      return Promise.reject(new Error(`URL inesperada: ${url}`));
+    });
+    const client = new QueryClient();
+
+    render(
+      <QueryClientProvider client={client}>
+        <ExperimentLandingAnalyticsTab experimentId="67" />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText(/Jornada persuasiva interativa/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/Interesse/i)).toBeTruthy();
+    expect(
+      screen.getAllByText(/interactive_diagnostic/i).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(/50.0% do tráfego/i)).toBeTruthy();
+    expect(
+      screen.getByText(/reduzir fricção da primeira pergunta/i),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.test.tsx
@@ -42,6 +42,11 @@ describe("ExperimentLandingAnalyticsTab", () => {
                     visibleMs: 12000,
                     events: 1,
                   },
+                  {
+                    sectionId: "free_diagnostic_preview",
+                    visibleMs: 3000,
+                    events: 1,
+                  },
                 ],
               },
               {
@@ -61,17 +66,23 @@ describe("ExperimentLandingAnalyticsTab", () => {
       ) {
         return Promise.resolve({
           data: {
-            version: "aida-interactive-v1",
-            framework: "AIDA",
+            version: "commercial-stages-v1",
+            framework: "Funil experiencial PDE",
             steps: [
               {
-                stage: "interest",
-                aidaLabel: "Interesse",
-                trackedSectionId: "interactive_diagnostic",
+                stageNumber: 2,
+                stage: "diagnostic_value",
+                stageName: "Envolvimento diagnóstico",
+                psychologicalRole: "Interesse + Desejo",
+                trackedSectionIds: [
+                  "interactive_diagnostic",
+                  "free_diagnostic_preview",
+                ],
                 commercialFunction:
-                  "Levar a usuária a interagir com o diagnóstico.",
-                primaryMetric: "início do diagnóstico",
-                optimizationRule: "reduzir fricção da primeira pergunta",
+                  "Questionário e plano de 7 dias aumentam valor percebido.",
+                primaryMetric: "questionário concluído e plano visualizado",
+                optimizationRule:
+                  "reduzir fricção da primeira pergunta e tornar o plano mais concreto",
               },
             ],
           },
@@ -90,13 +101,14 @@ describe("ExperimentLandingAnalyticsTab", () => {
     expect(
       await screen.findByText(/Jornada persuasiva interativa/i),
     ).toBeTruthy();
-    expect(screen.getByText(/Interesse/i)).toBeTruthy();
+    expect(
+      screen.getByText(/Estágio 2: Envolvimento diagnóstico/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/Interesse \+ Desejo/i)).toBeTruthy();
     expect(
       screen.getAllByText(/interactive_diagnostic/i).length,
     ).toBeGreaterThan(0);
     expect(screen.getByText(/50.0% do tráfego/i)).toBeTruthy();
-    expect(
-      screen.getByText(/reduzir fricção da primeira pergunta/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/tornar o plano mais concreto/i)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
@@ -58,6 +58,24 @@ function alertVariant(severity?: string | null) {
   return "info";
 }
 
+function getJourneyStepLabel(step: {
+  stageNumber?: number;
+  stageName?: string;
+  aidaLabel?: string;
+  stage?: string;
+}) {
+  const name = step.stageName || step.aidaLabel || step.stage || "Etapa";
+  return step.stageNumber ? `Estágio ${step.stageNumber}: ${name}` : name;
+}
+
+function getJourneyTrackedSections(step: {
+  trackedSectionIds?: string[];
+  trackedSectionId?: string;
+}) {
+  if (step.trackedSectionIds?.length) return step.trackedSectionIds;
+  return step.trackedSectionId ? [step.trackedSectionId] : [];
+}
+
 export default function ExperimentLandingAnalyticsTab({
   experimentId,
 }: ExperimentLandingAnalyticsTabProps) {
@@ -233,20 +251,43 @@ export default function ExperimentLandingAnalyticsTab({
                   <Workflow size={18} /> Jornada persuasiva interativa
                 </h5>
                 <p className="text-muted small mb-0">
-                  Leitura comercial do questionário do PDE por etapa AIDA,
+                  Leitura comercial por estágio do funil experiencial PDE,
                   usando a jornada cadastrada no produto.
                 </p>
               </div>
               <span className="badge text-bg-light border">
-                {persuasiveJourney.framework || "AIDA"} ·{" "}
+                {persuasiveJourney.framework || "Funil experiencial PDE"} ·{" "}
                 {persuasiveJourney.version || "sem versão"}
               </span>
             </div>
             <div className="row g-3">
               {persuasiveJourney.steps.map((step) => {
-                const stats = step.trackedSectionId
-                  ? sectionStats.get(step.trackedSectionId)
-                  : undefined;
+                const trackedSections = getJourneyTrackedSections(step);
+                const uniqueSessions = new Set<string>();
+                let visibleMs = 0;
+                let events = 0;
+                for (const session of sessions) {
+                  let matchedSession = false;
+                  for (const section of session.topSections) {
+                    if (!trackedSections.includes(section.sectionId)) {
+                      continue;
+                    }
+                    matchedSession = true;
+                    visibleMs += section.visibleMs;
+                    events += section.events;
+                  }
+                  if (matchedSession) {
+                    uniqueSessions.add(session.sessionId);
+                  }
+                }
+                const stats =
+                  trackedSections.length === 1
+                    ? sectionStats.get(trackedSections[0])
+                    : {
+                        sessions: uniqueSessions.size,
+                        visibleMs,
+                        events,
+                      };
                 const sessionRate =
                   data?.totalSessions && stats?.sessions
                     ? (stats.sessions / data.totalSessions) * 100
@@ -254,15 +295,22 @@ export default function ExperimentLandingAnalyticsTab({
                 return (
                   <div
                     className="col-12 col-lg-6"
-                    key={`${step.stage}-${step.trackedSectionId}`}
+                    key={`${step.stage}-${trackedSections.join("-")}`}
                   >
                     <div className="border rounded-3 p-3 h-100">
                       <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-                        <strong>{step.aidaLabel || step.stage}</strong>
+                        <strong>{getJourneyStepLabel(step)}</strong>
                         <span className="badge text-bg-light border">
-                          {step.trackedSectionId || "sem seção"}
+                          {trackedSections.length
+                            ? trackedSections.join(", ")
+                            : "sem seção"}
                         </span>
                       </div>
+                      {step.psychologicalRole ? (
+                        <p className="text-muted small mb-2">
+                          Apoio psicológico: {step.psychologicalRole}
+                        </p>
+                      ) : null}
                       <p className="mb-2">
                         {step.commercialFunction || "Função não cadastrada."}
                       </p>

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
@@ -8,8 +8,10 @@ import {
   Tablet,
   Timer,
   Users,
+  Workflow,
 } from "lucide-react";
 import { useExperimentLandingAnalytics } from "../../api/experiment/useExperimentLandingAnalytics";
+import { usePdePersuasiveJourney } from "../../api/product/usePdePersuasiveJourney";
 
 interface ExperimentLandingAnalyticsTabProps {
   experimentId: string;
@@ -46,7 +48,11 @@ function shortUrl(value?: string | null) {
 }
 
 function alertVariant(severity?: string | null) {
-  if (severity === "success" || severity === "danger" || severity === "warning") {
+  if (
+    severity === "success" ||
+    severity === "danger" ||
+    severity === "warning"
+  ) {
     return severity;
   }
   return "info";
@@ -57,6 +63,7 @@ export default function ExperimentLandingAnalyticsTab({
 }: ExperimentLandingAnalyticsTabProps) {
   const { data, isLoading, isError } =
     useExperimentLandingAnalytics(experimentId);
+  const { data: persuasiveJourney } = usePdePersuasiveJourney();
 
   if (isLoading) {
     return (
@@ -82,6 +89,27 @@ export default function ExperimentLandingAnalyticsTab({
     data?.mobileOperatingSystemBreakdown ?? [];
   const screenSizeBreakdown = data?.screenSizeBreakdown ?? [];
   const loadMetrics = data?.loadMetrics;
+  const sectionStats = new Map<
+    string,
+    { sessions: number; visibleMs: number; events: number }
+  >();
+  for (const session of sessions) {
+    const countedSections = new Set<string>();
+    for (const section of session.topSections) {
+      const current = sectionStats.get(section.sectionId) ?? {
+        sessions: 0,
+        visibleMs: 0,
+        events: 0,
+      };
+      current.visibleMs += section.visibleMs;
+      current.events += section.events;
+      if (!countedSections.has(section.sectionId)) {
+        current.sessions += 1;
+        countedSections.add(section.sectionId);
+      }
+      sectionStats.set(section.sectionId, current);
+    }
+  }
   const deviceIcons = {
     mobile: Smartphone,
     desktop: Monitor,
@@ -114,13 +142,17 @@ export default function ExperimentLandingAnalyticsTab({
     },
     {
       label: "Carregamento médio",
-      value: loadMetrics?.events ? formatDuration(loadMetrics.averageLoadDurationMs) : "—",
+      value: loadMetrics?.events
+        ? formatDuration(loadMetrics.averageLoadDurationMs)
+        : "—",
       icon: Clock,
       hint: "Média técnica até o evento load completo da landing.",
     },
     {
       label: "P95 carregamento",
-      value: loadMetrics?.events ? formatDuration(loadMetrics.p95LoadDurationMs) : "—",
+      value: loadMetrics?.events
+        ? formatDuration(loadMetrics.p95LoadDurationMs)
+        : "—",
       icon: Activity,
       hint: "Tempo dos piores carregamentos capturados para detectar lentidão.",
     },
@@ -169,7 +201,6 @@ export default function ExperimentLandingAnalyticsTab({
         })}
       </div>
 
-
       {loadMetrics ? (
         <div
           className={`alert alert-${alertVariant(loadMetrics.diagnosisSeverity)} mb-0`}
@@ -184,10 +215,80 @@ export default function ExperimentLandingAnalyticsTab({
               Recomendação: {loadMetrics.recommendation}
             </span>
             <span className="small text-muted">
-              Engajamento inicial: {loadMetrics.initialEngagementRate.toFixed(2)}%
-              · Sessões sem seção visível: {loadMetrics.sessionsWithoutSectionEvents}
-              · Navegador in-app: {loadMetrics.inAppBrowserPercentage.toFixed(2)}%
+              Engajamento inicial:{" "}
+              {loadMetrics.initialEngagementRate.toFixed(2)}% · Sessões sem
+              seção visível: {loadMetrics.sessionsWithoutSectionEvents}·
+              Navegador in-app: {loadMetrics.inAppBrowserPercentage.toFixed(2)}%
             </span>
+          </div>
+        </div>
+      ) : null}
+
+      {persuasiveJourney?.steps?.length ? (
+        <div className="card">
+          <div className="card-body">
+            <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+              <div>
+                <h5 className="card-title mb-1 d-flex align-items-center gap-2">
+                  <Workflow size={18} /> Jornada persuasiva interativa
+                </h5>
+                <p className="text-muted small mb-0">
+                  Leitura comercial do questionário do PDE por etapa AIDA,
+                  usando a jornada cadastrada no produto.
+                </p>
+              </div>
+              <span className="badge text-bg-light border">
+                {persuasiveJourney.framework || "AIDA"} ·{" "}
+                {persuasiveJourney.version || "sem versão"}
+              </span>
+            </div>
+            <div className="row g-3">
+              {persuasiveJourney.steps.map((step) => {
+                const stats = step.trackedSectionId
+                  ? sectionStats.get(step.trackedSectionId)
+                  : undefined;
+                const sessionRate =
+                  data?.totalSessions && stats?.sessions
+                    ? (stats.sessions / data.totalSessions) * 100
+                    : 0;
+                return (
+                  <div
+                    className="col-12 col-lg-6"
+                    key={`${step.stage}-${step.trackedSectionId}`}
+                  >
+                    <div className="border rounded-3 p-3 h-100">
+                      <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+                        <strong>{step.aidaLabel || step.stage}</strong>
+                        <span className="badge text-bg-light border">
+                          {step.trackedSectionId || "sem seção"}
+                        </span>
+                      </div>
+                      <p className="mb-2">
+                        {step.commercialFunction || "Função não cadastrada."}
+                      </p>
+                      <div className="d-flex flex-wrap gap-2 small mb-2">
+                        <span className="badge text-bg-primary">
+                          {stats?.sessions ?? 0} sessões
+                        </span>
+                        <span className="badge text-bg-light border">
+                          {sessionRate.toFixed(1)}% do tráfego
+                        </span>
+                        <span className="badge text-bg-light border">
+                          {formatDuration(stats?.visibleMs)}
+                        </span>
+                      </div>
+                      <p className="text-muted small mb-1">
+                        Métrica: {step.primaryMetric || "não cadastrada"}
+                      </p>
+                      <p className="text-muted small mb-0">
+                        Ação se quebrar:{" "}
+                        {step.optimizationRule || "revisar esta etapa."}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
       ) : null}

--- a/frontend/src/pages/product/ProductListPage.test.tsx
+++ b/frontend/src/pages/product/ProductListPage.test.tsx
@@ -1,4 +1,11 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
@@ -143,5 +150,82 @@ describe("ProductListPage", () => {
       "https://clubemusa.com.br/?mh_preview=qa&pde_analytics=off&utm_source=internal&utm_medium=qa&utm_campaign=metodo-musa-7-dias_preview_qa&utm_content=product_card",
     );
     expect(previewLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("shows the PDE persuasive journey registered in the product contract", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          slug: "metodo-musa-7-dias",
+          name: "Método MUSA - Presença Elegante em 7 Dias",
+          pdeExperienceJson: JSON.stringify({
+            persuasiveJourney: {
+              version: "aida-interactive-v1",
+              framework: "AIDA",
+              steps: [
+                {
+                  stage: "interest",
+                  aidaLabel: "Interesse",
+                  trackedSectionId: "interactive_diagnostic",
+                  commercialFunction:
+                    "Levar a usuária a interagir com o diagnóstico.",
+                },
+              ],
+            },
+          }),
+        },
+      ],
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <ProductListPage />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Jornada persuasiva PDE/i)).toBeTruthy();
+    expect(screen.getByText(/AIDA · aida-interactive-v1/i)).toBeTruthy();
+    expect(screen.getByText(/Levar a usuária a interagir/i)).toBeTruthy();
+    expect(screen.getByText(/seção: interactive_diagnostic/i)).toBeTruthy();
+  });
+
+  it("calls backend to insert the default PDE persuasive journey", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          slug: "metodo-musa-7-dias",
+          name: "Método MUSA - Presença Elegante em 7 Dias",
+        },
+      ],
+    });
+    (axios.post as any).mockResolvedValue({
+      data: {
+        id: 1,
+        slug: "metodo-musa-7-dias",
+        name: "Método MUSA - Presença Elegante em 7 Dias",
+      },
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <ProductListPage />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Inserir jornada PDE/i }),
+    );
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        "/api/products/1/pde-persuasive-journey/default",
+      );
+    });
   });
 });

--- a/frontend/src/pages/product/ProductListPage.test.tsx
+++ b/frontend/src/pages/product/ProductListPage.test.tsx
@@ -113,4 +113,35 @@ describe("ProductListPage", () => {
       "/api/products/public/metodo-musa-7-dias/marketing-definition.md",
     );
   });
+
+  it("shows preview QA link that suppresses commercial metrics", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          slug: "metodo-musa-7-dias",
+          name: "Método MUSA - Presença Elegante em 7 Dias",
+          publicUrl: "https://clubemusa.com.br",
+        },
+      ],
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <ProductListPage />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+
+    const previewLink = await screen.findByRole("link", {
+      name: /Preview\/QA sem métricas/i,
+    });
+
+    expect(previewLink).toHaveAttribute(
+      "href",
+      "https://clubemusa.com.br/?mh_preview=qa&pde_analytics=off&utm_source=internal&utm_medium=qa&utm_campaign=metodo-musa-7-dias_preview_qa&utm_content=product_card",
+    );
+    expect(previewLink).toHaveAttribute("target", "_blank");
+  });
 });

--- a/frontend/src/pages/product/ProductListPage.test.tsx
+++ b/frontend/src/pages/product/ProductListPage.test.tsx
@@ -161,15 +161,20 @@ describe("ProductListPage", () => {
           name: "Método MUSA - Presença Elegante em 7 Dias",
           pdeExperienceJson: JSON.stringify({
             persuasiveJourney: {
-              version: "aida-interactive-v1",
-              framework: "AIDA",
+              version: "commercial-stages-v1",
+              framework: "Funil experiencial PDE",
               steps: [
                 {
-                  stage: "interest",
-                  aidaLabel: "Interesse",
-                  trackedSectionId: "interactive_diagnostic",
+                  stageNumber: 2,
+                  stage: "diagnostic_value",
+                  stageName: "Envolvimento diagnóstico",
+                  psychologicalRole: "Interesse + Desejo",
+                  trackedSectionIds: [
+                    "interactive_diagnostic",
+                    "free_diagnostic_preview",
+                  ],
                   commercialFunction:
-                    "Levar a usuária a interagir com o diagnóstico.",
+                    "Questionário e plano de 7 dias aumentam valor percebido.",
                 },
               ],
             },
@@ -186,10 +191,19 @@ describe("ProductListPage", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByText(/Jornada persuasiva PDE/i)).toBeTruthy();
-    expect(screen.getByText(/AIDA · aida-interactive-v1/i)).toBeTruthy();
-    expect(screen.getByText(/Levar a usuária a interagir/i)).toBeTruthy();
-    expect(screen.getByText(/seção: interactive_diagnostic/i)).toBeTruthy();
+    expect(await screen.findByText(/Jornada comercial PDE/i)).toBeTruthy();
+    expect(
+      screen.getByText(/Funil experiencial PDE · commercial-stages-v1/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Estágio 2: Envolvimento diagnóstico/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/Questionário e plano de 7 dias/i)).toBeTruthy();
+    expect(
+      screen.getByText(
+        /seções: interactive_diagnostic, free_diagnostic_preview/i,
+      ),
+    ).toBeTruthy();
   });
 
   it("calls backend to insert the default PDE persuasive journey", async () => {

--- a/frontend/src/pages/product/ProductListPage.tsx
+++ b/frontend/src/pages/product/ProductListPage.tsx
@@ -146,6 +146,24 @@ function buildIdentityColors(product: {
   return [...colors, ...supportColors];
 }
 
+function getJourneyStepLabel(step: {
+  stageNumber?: number;
+  stageName?: string;
+  aidaLabel?: string;
+  stage?: string;
+}) {
+  const name = step.stageName || step.aidaLabel || step.stage || "Etapa";
+  return step.stageNumber ? `Estágio ${step.stageNumber}: ${name}` : name;
+}
+
+function getJourneyTrackedSections(step: {
+  trackedSectionIds?: string[];
+  trackedSectionId?: string;
+}) {
+  if (step.trackedSectionIds?.length) return step.trackedSectionIds;
+  return step.trackedSectionId ? [step.trackedSectionId] : [];
+}
+
 export default function ProductListPage() {
   const { data, isLoading } = useProducts();
   const applyDefaultJourney = useApplyDefaultPdePersuasiveJourney();
@@ -368,27 +386,35 @@ export default function ProductListPage() {
                       </p>
                       {persuasiveJourney && (
                         <>
-                          <h3 className="h6 mt-3">Jornada persuasiva PDE</h3>
+                          <h3 className="h6 mt-3">Jornada comercial PDE</h3>
                           <p className="small text-muted mb-2">
-                            {persuasiveJourney.framework || "AIDA"} ·{" "}
-                            {persuasiveJourney.version || "sem versão"}
+                            {persuasiveJourney.framework ||
+                              "Funil experiencial PDE"}{" "}
+                            · {persuasiveJourney.version || "sem versão"}
                           </p>
                           <ol className="product-catalog-card__journey">
-                            {persuasiveJourneySteps.map((step) => (
-                              <li
-                                key={`${step.stage}-${step.trackedSectionId}`}
-                              >
-                                <strong>{step.aidaLabel || step.stage}</strong>
-                                {step.commercialFunction
-                                  ? `: ${step.commercialFunction}`
-                                  : ""}
-                                {step.trackedSectionId ? (
-                                  <small className="d-block text-muted">
-                                    seção: {step.trackedSectionId}
-                                  </small>
-                                ) : null}
-                              </li>
-                            ))}
+                            {persuasiveJourneySteps.map((step) => {
+                              const trackedSections =
+                                getJourneyTrackedSections(step);
+                              return (
+                                <li key={`${step.stage}-${trackedSections[0]}`}>
+                                  <strong>{getJourneyStepLabel(step)}</strong>
+                                  {step.psychologicalRole ? (
+                                    <small className="d-block text-muted">
+                                      apoio: {step.psychologicalRole}
+                                    </small>
+                                  ) : null}
+                                  {step.commercialFunction
+                                    ? `: ${step.commercialFunction}`
+                                    : ""}
+                                  {trackedSections.length ? (
+                                    <small className="d-block text-muted">
+                                      seções: {trackedSections.join(", ")}
+                                    </small>
+                                  ) : null}
+                                </li>
+                              );
+                            })}
                           </ol>
                         </>
                       )}

--- a/frontend/src/pages/product/ProductListPage.tsx
+++ b/frontend/src/pages/product/ProductListPage.tsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
 import type { CSSProperties } from "react";
-import { Eye, Pencil, Video } from "lucide-react";
+import { Eye, Loader2, Pencil, Video, Workflow } from "lucide-react";
+import { parsePdePersuasiveJourney } from "../../api/product/pdePersuasiveJourney";
+import { useApplyDefaultPdePersuasiveJourney } from "../../api/product/useApplyDefaultPdePersuasiveJourney";
 import { useProducts } from "../../api/product/useProducts";
 import PageTitle from "../../components/PageTitle";
 
@@ -24,6 +26,22 @@ function isMusaProduct(product: { slug?: string; name?: string }) {
     slug === "metodo-musa-7-dias" ||
     name.includes("método musa") ||
     name.includes("metodo musa")
+  );
+}
+
+function isPdeProduct(product: {
+  slug?: string;
+  name?: string;
+  productType?: string;
+  pdeExperienceJson?: string;
+}) {
+  const slug = product.slug?.toLowerCase() ?? "";
+  const type = product.productType?.toLowerCase() ?? "";
+  return (
+    slug.includes("pde") ||
+    type.includes("pde") ||
+    Boolean(product.pdeExperienceJson?.trim()) ||
+    isMusaProduct(product)
   );
 }
 
@@ -130,6 +148,7 @@ function buildIdentityColors(product: {
 
 export default function ProductListPage() {
   const { data, isLoading } = useProducts();
+  const applyDefaultJourney = useApplyDefaultPdePersuasiveJourney();
   const products = Array.isArray(data) ? data : [];
   if (isLoading) return <p>Carregando...</p>;
   return (
@@ -158,6 +177,14 @@ export default function ProductListPage() {
         {products.map((product) => {
           const colors = buildIdentityColors(product);
           const previewQaUrl = buildPreviewQaUrl(product);
+          const persuasiveJourney = parsePdePersuasiveJourney(
+            product.pdeExperienceJson,
+          );
+          const showPdeJourneyAction = isPdeProduct(product);
+          const persuasiveJourneySteps = persuasiveJourney?.steps ?? [];
+          const isApplyingJourney =
+            applyDefaultJourney.isPending &&
+            applyDefaultJourney.variables === product.id;
           const registeredColorCount = colors.filter(
             (color) => color.source === "Cadastrada",
           ).length;
@@ -303,6 +330,27 @@ export default function ProductListPage() {
                           Preview/QA sem métricas
                         </a>
                       )}
+                      {showPdeJourneyAction && (
+                        <button
+                          type="button"
+                          className="product-catalog-card__action-button product-catalog-card__action-button--secondary"
+                          disabled={isApplyingJourney}
+                          onClick={() => applyDefaultJourney.mutate(product.id)}
+                        >
+                          {isApplyingJourney ? (
+                            <Loader2
+                              size={16}
+                              aria-hidden="true"
+                              className="product-editor__button-icon spinning"
+                            />
+                          ) : (
+                            <Workflow size={16} aria-hidden="true" />
+                          )}
+                          {persuasiveJourney
+                            ? "Atualizar jornada PDE"
+                            : "Inserir jornada PDE"}
+                        </button>
+                      )}
                     </div>
                     {!product.slug && (
                       <p className="product-catalog-card__description-links">
@@ -318,6 +366,32 @@ export default function ProductListPage() {
                           product.storytelling ||
                           "Não informada"}
                       </p>
+                      {persuasiveJourney && (
+                        <>
+                          <h3 className="h6 mt-3">Jornada persuasiva PDE</h3>
+                          <p className="small text-muted mb-2">
+                            {persuasiveJourney.framework || "AIDA"} ·{" "}
+                            {persuasiveJourney.version || "sem versão"}
+                          </p>
+                          <ol className="product-catalog-card__journey">
+                            {persuasiveJourneySteps.map((step) => (
+                              <li
+                                key={`${step.stage}-${step.trackedSectionId}`}
+                              >
+                                <strong>{step.aidaLabel || step.stage}</strong>
+                                {step.commercialFunction
+                                  ? `: ${step.commercialFunction}`
+                                  : ""}
+                                {step.trackedSectionId ? (
+                                  <small className="d-block text-muted">
+                                    seção: {step.trackedSectionId}
+                                  </small>
+                                ) : null}
+                              </li>
+                            ))}
+                          </ol>
+                        </>
+                      )}
                       {product.sevenDayJourney && (
                         <>
                           <h3 className="h6 mt-3">Jornada de 7 dias</h3>

--- a/frontend/src/pages/product/ProductListPage.tsx
+++ b/frontend/src/pages/product/ProductListPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { CSSProperties } from "react";
-import { Pencil, Video } from "lucide-react";
+import { Eye, Pencil, Video } from "lucide-react";
 import { useProducts } from "../../api/product/useProducts";
 import PageTitle from "../../components/PageTitle";
 
@@ -29,6 +29,25 @@ function isMusaProduct(product: { slug?: string; name?: string }) {
 
 function cleanJourneyItem(value: string) {
   return value.replace(/^- /, "").replace(/\*\*/g, "");
+}
+
+function buildPreviewQaUrl(product: { publicUrl?: string; slug?: string }) {
+  if (!product.publicUrl) return "";
+  try {
+    const url = new URL(product.publicUrl);
+    url.searchParams.set("mh_preview", "qa");
+    url.searchParams.set("pde_analytics", "off");
+    url.searchParams.set("utm_source", "internal");
+    url.searchParams.set("utm_medium", "qa");
+    url.searchParams.set(
+      "utm_campaign",
+      `${product.slug || "produto"}_preview_qa`,
+    );
+    url.searchParams.set("utm_content", "product_card");
+    return url.toString();
+  } catch {
+    return "";
+  }
 }
 
 function extractHexColor(value: string) {
@@ -138,6 +157,7 @@ export default function ProductListPage() {
         )}
         {products.map((product) => {
           const colors = buildIdentityColors(product);
+          const previewQaUrl = buildPreviewQaUrl(product);
           const registeredColorCount = colors.filter(
             (color) => color.source === "Cadastrada",
           ).length;
@@ -272,6 +292,17 @@ export default function ProductListPage() {
                         <Video size={16} aria-hidden="true" />
                         Vídeos de venda
                       </Link>
+                      {previewQaUrl && (
+                        <a
+                          className="product-catalog-card__action-button product-catalog-card__action-button--qa"
+                          href={previewQaUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <Eye size={16} aria-hidden="true" />
+                          Preview/QA sem métricas
+                        </a>
+                      )}
                     </div>
                     {!product.slug && (
                       <p className="product-catalog-card__description-links">

--- a/pde-platform/frontend/src/App.tsx
+++ b/pde-platform/frontend/src/App.tsx
@@ -484,6 +484,11 @@ function readCampaignParams() {
   };
 }
 
+function isCommercialAnalyticsSuppressed() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('mh_preview') === 'qa' || params.get('pde_analytics') === 'off';
+}
+
 function resolveUrlHost(url: string) {
   try {
     return new URL(url).hostname;
@@ -996,6 +1001,9 @@ function App() {
   }
 
   async function trackEvent(eventType: string, options: TrackingOptions = {}) {
+    if (isCommercialAnalyticsSuppressed()) {
+      return;
+    }
     try {
       await fetch('/api/pde/access/events', {
         method: 'POST',
@@ -1008,6 +1016,9 @@ function App() {
   }
 
   function sendTrackingBeacon(eventType: string, options: TrackingOptions = {}) {
+    if (isCommercialAnalyticsSuppressed()) {
+      return;
+    }
     const payload = JSON.stringify(buildTrackingPayload(eventType, options));
     if (navigator.sendBeacon) {
       navigator.sendBeacon('/api/pde/access/events', new Blob([payload], { type: 'application/json' }));

--- a/pde-platform/frontend/tests/musa-entry.visual.spec.ts
+++ b/pde-platform/frontend/tests/musa-entry.visual.spec.ts
@@ -66,3 +66,24 @@ test('carrega a entrada visual do Clube MUSA', async ({ page }) => {
     fullPage: true,
   });
 });
+
+test('modo Preview QA nao envia eventos comerciais', async ({ page }) => {
+  let trackedEvents = 0;
+  await page.route('/api/pde/access/events', async (route) => {
+    trackedEvents += 1;
+    await route.fulfill({ json: { status: 'RECORDED' } });
+  });
+
+  await page.goto('/?mh_preview=qa&pde_analytics=off&utm_source=internal&utm_medium=qa&utm_campaign=metodo-musa-7-dias_preview_qa&utm_content=product_card');
+
+  await expect(
+    page.getByRole('heading', {
+      name: /Sua imagem comunica a mulher/i,
+      level: 1,
+    }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Trabalho ou reunião' }).click();
+  await page.waitForTimeout(250);
+
+  expect(trackedEvents).toBe(0);
+});


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: vamos criar um novo experimento para testar essa versão atual em produção do PDE Musa ou melhor continuar o experimento atual ?

Modelo: {"titulo":"Continue o experimento atual","comentario":"Minha recomendação: **não criar um novo experimento agora**. Continue o **Experimento 67**, mas trate a versão atual do PDE Musa como uma **nova versão/ciclo mensurável dentro do experimento atual**.\n\nEvidências principais:\n\n- Meta Ads está trazendo tráfego barato: **303 cliques**, **CTR 5,35%**, **CPC R$0,11**, gasto **R$32,34**.\n- O PDE recebeu **203 sessões**, **196 entradas** e **187 visitantes únicos**.\n- O gargalo ainda está antes da venda: **0 login**, **0 paywall**, **0 checkout**, **0 compra**.\n- A versão `musa-pde-entry-v3` teve **100 entradas** e só **5 interações iniciais**.\n- Produção está respondendo, mas o deploy produtivo ainda aparece sem `experienceVersion` no status; já a homologação mostra `musa-pde-entry-v4-video-hero`.\n\nAlternativas avaliadas:\n\n1. **Criar novo experimento agora**  \n   Benefício: separação limpa.  \n   Risco: fragmenta aprendizado com pouco volume e pode parecer que mudamos hipótese quando o problema real ainda é o primeiro microcompromisso.  \n   Aderência: média.\n\n2. **Continuar o experimento atual sem separar versão**  \n   Benefício: simples.  \n   Risco: mistura tráfego antigo, tela branca corrigida e novas versões do PDE.  \n   Aderência: baixa.\n\n3. **Continuar o Experimento 67, mas medir por versão/ciclo**  \n   Benefício: mantém histórico, evita criar experimento artificial e permite comparar `sem-versao`, `v3` e próxima versão em produção.  \n   Risco: precisa garantir que a versão comercial esteja marcada corretamente nos eventos.  \n   Aderência: melhor.\n\nDecisão: **seguir pela alternativa 3**.\n\nPróximo movimento recomendado:\n\n- Não mexer em público nem em promessa principal agora.\n- Garantir que a versão atual em produção esteja marcada com `experienceVersion` explícita.\n- Rodar mais um ciclo curto no Experimento 67 com limite controlado, olhando principalmente: clique no diagnóstico, geração do plano, preenchimento de e-mail, login, paywall e checkout.\n- Só criar um novo experimento se mudarmos uma aposta estrutural: outro público, outra promessa, outro mecanismo, outra oferta/preço ou outro formato de criativo dominante.\n\nResumo prático: **o Experimento 67 ainda é o lugar certo para aprender. O que precisa mudar agora não é o número do experimento; é a leitura por versão do PDE e o volume mínimo depois da correção da entrada.**","sugestaoMelhoriaAmbiente":""}

Usuário: vamos ativa novamente esse experimento então. faça isso mude o estado dele. Mas vamos fazer pelo sistema para que fique registrado. Se o Mkt Hub não tiver essa opção vamos criar essa funcionalidade de retorno a atividade dizendo o motivvo.

Modelo: {"titulo":"Reativação pronta","comentario":"Implementei no Marketing Hub a funcionalidade correta para **retornar um experimento à atividade com motivo registrado**.\n\nO que ficou pronto:\n\n- Novo endpoint: `POST /api/experiments/{id}/reactivate`.\n- O experimento volta para `RUNNING` somente se estiver em estado reativável, como `USER_STOPPED`, `PAUSED`, `STANDBY`, `INCONCLUSIVE` ou `FAILED`.\n- O motivo informado fica salvo no experimento e também em histórico auditável append-only (`experiment_status_change`).\n- A tela de experimentos agora mostra o botão **Retornar à atividade** para experimentos parados.\n- Para o Experimento 67, o modal já sugere o motivo correto: retomar o ciclo para medir a versão atual do PDE Musa em produção sem criar novo experimento.\n\nTambém confirmei em produção que o Experimento 67 está atualmente como `USER_STOPPED`, então ele é o caso certo para essa ação.\n\nValidações executadas:\n\n- Backend: `ExperimentServiceTest` passou com 28 testes.\n- Front-end: `ExperimentListPage.test.tsx` passou com 6 testes.\n- Typecheck front-end passou.\n- Changelog Liquibase validado com include relativo e sem `TIMESTAMP NOT NULL` problemático.\n\nNão criei PR e não publiquei alteração, seguindo sua regra. A produção ainda não foi alterada; o estado do Experimento 67 só poderá ser mudado pelo sistema depois que essa funcionalidade for publicada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Quando quiser avançar, peça o PR/deploy dessa mudança. Depois do deploy, use o botão “Retornar à atividade” no Experimento 67 para registrar o motivo e reativar pelo sistema."}

Usuário: eu preciso de um link para ir para a página do PDE Musa sem contaminar as métricass

Modelo: {"titulo":"Link do PDE Musa","comentario":"Use este link para acessar sem contaminar as métricas de campanha paga:\n\n**https://clubemusa.com.br/?utm_source=internal&utm_medium=qa&utm_campaign=experimento_67_revisao_manual&utm_content=codex_mkt**\n\nEsse acesso ainda pode aparecer como sessão no analytics, mas fica separado como tráfego **internal / qa**, sem misturar com Meta Ads, criativos ou aquisição real.\n\nA URL pública canônica do PDE, segundo a definição do produto, é:\n\n**https://clubemusa.com.br**","sugestaoMelhoriaAmbiente":"Seria melhor ter no próprio Marketing Hub um modo de preview/QA que exclua automaticamente sessões internas das métricas comerciais."}

Última mensagem do usuário:
Sobre essa situação :
"Seria melhor ter no próprio Marketing Hub um modo de preview/QA que exclua automaticamente sessões internas das métricas comerciais."

Coloque o link para esse modo no card do produto na tela de cadastro de produtos.

**Resumo das alterações:**
{"titulo":"Link QA no card","comentario":"Implementei a funcionalidade no Marketing Hub.\n\nO que ficou pronto:\n\n- No card do produto em **Cadastro de Produtos**, agora aparece o botão **Preview/QA sem métricas** quando o produto tem URL pública.\n- Para o Método MUSA, o link gerado fica no padrão:\n\n`https://clubemusa.com.br/?mh_preview=qa&pde_analytics=off&utm_source=internal&utm_medium=qa&utm_campaign=metodo-musa-7-dias_preview_qa&utm_content=product_card`\n\n- O frontend do PDE agora reconhece `mh_preview=qa` ou `pde_analytics=off` e **não envia eventos comerciais** para `/api/pde/access/events`.\n- Isso resolve a causa-raiz: não é só separar por UTM; o modo QA realmente impede contaminação de sessão, clique e microconversão comercial.\n\nValidações executadas:\n\n- `ProductListPage.test.tsx`: 5 testes passaram.\n- `frontend` typecheck passou.\n- `pde-platform/frontend` build passou.\n- Playwright do PDE passou com 4 testes, incluindo o novo teste que confirma que o modo Preview/QA não registra eventos comerciais.\n\nNão criei PR e não publiquei alteração.","sugestaoMelhoriaAmbiente":"Manter as dependências Node e o Chromium do Playwright pré-instalados no workspace reduziria o tempo de validação em mudanças de frontend.","orientacaoProximaAcao":"Quando quiser publicar essa funcionalidade, peça o PR/deploy. Depois do deploy, o link aparecerá no card do produto e poderá ser usado para revisar o PDE Musa sem contaminar métricas comerciais."}