### PR TITLE
AI Hub: {"titulo":"Controle no Hub pronto","comentario":"Implementei o controle de homologação → produção dentro do Marketing Hub.\n\n**O que mudou**\n\n- O painel pós-deploy agora compara homologação e produção por commit, saúde pública, compose, URLs e …

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/PostDeployMonitorService.java
@@ -9,6 +9,9 @@ import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeDeployEnvironmentDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeDeployServiceDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeExperienceVersionDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployRequestDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployResponseDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdePromotionControlDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSessionJourneyDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeSummaryDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployPdeTrafficSourceDto;
@@ -16,6 +19,7 @@ import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
 import com.marketinghub.experiment.monitoring.pde.PdeDeployStatus;
 import com.marketinghub.experiment.monitoring.pde.PdeDeployStatusClient;
+import com.marketinghub.experiment.monitoring.pde.PdeProductionDeploymentClient;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
 import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
@@ -46,6 +50,7 @@ public class PostDeployMonitorService {
     private final ExperimentFacebookApiLogService apiLogService;
     private final PdeAnalyticsClient pdeAnalyticsClient;
     private final PdeDeployStatusClient pdeDeployStatusClient;
+    private final PdeProductionDeploymentClient pdeProductionDeploymentClient;
 
     /** Inicializa o agregador com as fontes persistidas do Hub e o cliente do PDE. */
     public PostDeployMonitorService(
@@ -53,12 +58,14 @@ public class PostDeployMonitorService {
             ExperimentCampaignMetricRepository campaignMetricRepository,
             ExperimentFacebookApiLogService apiLogService,
             PdeAnalyticsClient pdeAnalyticsClient,
-            PdeDeployStatusClient pdeDeployStatusClient) {
+            PdeDeployStatusClient pdeDeployStatusClient,
+            PdeProductionDeploymentClient pdeProductionDeploymentClient) {
         this.experimentRepository = experimentRepository;
         this.campaignMetricRepository = campaignMetricRepository;
         this.apiLogService = apiLogService;
         this.pdeAnalyticsClient = pdeAnalyticsClient;
         this.pdeDeployStatusClient = pdeDeployStatusClient;
+        this.pdeProductionDeploymentClient = pdeProductionDeploymentClient;
     }
 
     /** Monta o painel pós-deploy para o experimento e produto PDE informados. */
@@ -70,8 +77,9 @@ public class PostDeployMonitorService {
         PostDeployMetaAdsSummaryDto metaAds = toMetaAdsSummary(metric);
         PostDeployPdeSummaryDto pde = fetchPdeSummary(resolvedProductSlug);
         List<PostDeployPdeDeployEnvironmentDto> pdeDeployments = fetchPdeDeployments();
+        PostDeployPdePromotionControlDto pdePromotionControl = buildPromotionControl(pdeDeployments);
         PostDeployFacebookLogSummaryDto logs = summarizeLogs(experimentId);
-        List<String> alerts = buildAlerts(metaAds, pde, pdeDeployments, logs);
+        List<String> alerts = buildAlerts(metaAds, pde, pdeDeployments, pdePromotionControl, logs);
         PostDeployMonitorDecision decision = decide(metaAds, pde, logs);
         return new PostDeployMonitorResponseDto(
                 experimentId,
@@ -82,9 +90,49 @@ public class PostDeployMonitorService {
                 recommendation(decision, pde),
                 metaAds,
                 pde,
+                pdePromotionControl,
                 pdeDeployments,
                 logs,
                 alerts);
+    }
+
+    /** Solicita produção apenas quando homologação está saudável e produção está defasada. */
+    public PostDeployPdeProductionDeployResponseDto requestProductionDeploy(
+            Long experimentId,
+            PostDeployPdeProductionDeployRequestDto request) {
+        experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experimento %d não encontrado".formatted(experimentId)));
+        List<PostDeployPdeDeployEnvironmentDto> pdeDeployments = fetchPdeDeployments();
+        PostDeployPdePromotionControlDto control = buildPromotionControl(pdeDeployments);
+        if (!control.productionDeployAvailable()) {
+            return new PostDeployPdeProductionDeployResponseDto(
+                    false,
+                    "BLOCKED",
+                    control.recommendation(),
+                    control.targetEnvironment(),
+                    control.workflowFile(),
+                    control.sourceCommitSha(),
+                    Instant.now());
+        }
+        String requestedBy = request != null && StringUtils.hasText(request.requestedBy())
+                ? request.requestedBy().trim()
+                : "marketing-hub";
+        String requestedCommit = request != null && StringUtils.hasText(request.sourceCommitSha())
+                ? request.sourceCommitSha().trim()
+                : control.sourceCommitSha();
+        if (StringUtils.hasText(control.sourceCommitSha())
+                && StringUtils.hasText(requestedCommit)
+                && !control.sourceCommitSha().equals(requestedCommit)) {
+            return new PostDeployPdeProductionDeployResponseDto(
+                    false,
+                    "BLOCKED",
+                    "A homologação mudou desde que a tela foi carregada. Atualize o painel antes de publicar produção.",
+                    control.targetEnvironment(),
+                    control.workflowFile(),
+                    control.sourceCommitSha(),
+                    Instant.now());
+        }
+        return pdeProductionDeploymentClient.dispatchProductionDeploy(experimentId, requestedBy, control.sourceCommitSha());
     }
 
     /** Resolve o produto PDE padrão quando a tela não informa um slug específico. */
@@ -217,6 +265,110 @@ public class PostDeployMonitorService {
                         service.targetPort(),
                         service.role()))
                 .toList();
+    }
+
+    /** Calcula o estado de promoção homologação-produção a partir dos deploys reais. */
+    private PostDeployPdePromotionControlDto buildPromotionControl(
+            List<PostDeployPdeDeployEnvironmentDto> pdeDeployments) {
+        PostDeployPdeDeployEnvironmentDto homolog = findDeployment(pdeDeployments, "homolog");
+        PostDeployPdeDeployEnvironmentDto production = findDeployment(pdeDeployments, "production");
+        boolean homologAvailable = isDeploymentHealthy(homolog);
+        boolean productionAvailable = isDeploymentHealthy(production);
+        String homologCommit = homolog != null ? homolog.commitSha() : null;
+        String productionCommit = production != null ? production.commitSha() : null;
+        boolean hasComparableCommits = isKnownCommit(homologCommit) && isKnownCommit(productionCommit);
+        boolean productionBehind = homologAvailable
+                && hasComparableCommits
+                && !homologCommit.equals(productionCommit);
+        boolean productionUpToDate = homologAvailable
+                && productionAvailable
+                && hasComparableCommits
+                && homologCommit.equals(productionCommit);
+        boolean githubConfigured = pdeProductionDeploymentClient.isConfigured();
+        boolean deployAvailable = productionBehind && githubConfigured;
+        boolean deployBlocked = !deployAvailable;
+        String workflowFile = "pde-platform-metodo-musa-ci.yml";
+        return new PostDeployPdePromotionControlDto(
+                homologAvailable,
+                productionAvailable,
+                productionBehind,
+                productionUpToDate,
+                deployAvailable,
+                deployBlocked,
+                promotionStatusLabel(homologAvailable, productionBehind, productionUpToDate, githubConfigured),
+                promotionRecommendation(homologAvailable, productionBehind, productionUpToDate, githubConfigured),
+                homologCommit,
+                productionCommit,
+                "production",
+                workflowFile);
+    }
+
+    /** Busca um deploy por nome de ambiente sem depender de caixa alta/baixa. */
+    private PostDeployPdeDeployEnvironmentDto findDeployment(
+            List<PostDeployPdeDeployEnvironmentDto> deployments,
+            String environment) {
+        if (deployments == null) {
+            return null;
+        }
+        return deployments.stream()
+                .filter(deployment -> environment.equalsIgnoreCase(deployment.environment()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Confirma que backend e frontend públicos do ambiente estão respondendo. */
+    private boolean isDeploymentHealthy(PostDeployPdeDeployEnvironmentDto deployment) {
+        return deployment != null
+                && deployment.available()
+                && deployment.backendReachable()
+                && deployment.frontendReachable();
+    }
+
+    /** Verifica se o commit pode ser usado para comparar homologação e produção. */
+    private boolean isKnownCommit(String commitSha) {
+        return StringUtils.hasText(commitSha) && !"unknown".equalsIgnoreCase(commitSha);
+    }
+
+    /** Define o rótulo executivo do controle de promoção do PDE. */
+    private String promotionStatusLabel(
+            boolean homologAvailable,
+            boolean productionBehind,
+            boolean productionUpToDate,
+            boolean githubConfigured) {
+        if (!homologAvailable) {
+            return "Homologação não validada";
+        }
+        if (productionUpToDate) {
+            return "Produção atualizada";
+        }
+        if (productionBehind && githubConfigured) {
+            return "Produção pronta para publicar";
+        }
+        if (productionBehind) {
+            return "Produção pendente sem token";
+        }
+        return "Aguardando comparação";
+    }
+
+    /** Define a recomendação operacional para publicar ou bloquear produção. */
+    private String promotionRecommendation(
+            boolean homologAvailable,
+            boolean productionBehind,
+            boolean productionUpToDate,
+            boolean githubConfigured) {
+        if (!homologAvailable) {
+            return "Valide homologação com backend e frontend online antes de liberar produção.";
+        }
+        if (productionUpToDate) {
+            return "Produção já está no mesmo commit da homologação. Não há deploy pendente.";
+        }
+        if (productionBehind && githubConfigured) {
+            return "Homologação está saudável e produção está defasada. Pode solicitar deploy produtivo pelo Marketing Hub.";
+        }
+        if (productionBehind) {
+            return "Produção está defasada, mas o backend não possui token do GitHub Actions para acionar o workflow.";
+        }
+        return "Não há evidência suficiente para liberar produção. Atualize o painel e confirme os commits dos ambientes.";
     }
 
     /** Converte o contrato do PDE em métricas comerciais específicas do painel. */
@@ -382,6 +534,7 @@ public class PostDeployMonitorService {
     private List<String> buildAlerts(PostDeployMetaAdsSummaryDto metaAds,
                                      PostDeployPdeSummaryDto pde,
                                      List<PostDeployPdeDeployEnvironmentDto> pdeDeployments,
+                                     PostDeployPdePromotionControlDto promotionControl,
                                      PostDeployFacebookLogSummaryDto logs) {
         List<String> alerts = new ArrayList<>();
         if (!pde.available()) {
@@ -396,6 +549,9 @@ public class PostDeployMonitorService {
         }
         if (logs.errorLogs() > 0) {
             alerts.add("Há erros recentes nos logs da API Meta Ads.");
+        }
+        if (promotionControl.productionBehind()) {
+            alerts.add("Homologação e produção estão em commits diferentes; não liberar tráfego sem publicar ou decidir manter produção antiga.");
         }
         if (spendAtLeast(metaAds, ZERO_INTERACTION_SPEND_THRESHOLD) && pde.available() && firstInteractionCount(pde) == 0) {
             alerts.add("Gasto atingiu o limite de atenção sem clique no Mapa/Diagnóstico.");

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployMonitorResponseDto.java
@@ -13,6 +13,7 @@ public record PostDeployMonitorResponseDto(
         String recommendation,
         PostDeployMetaAdsSummaryDto metaAds,
         PostDeployPdeSummaryDto pde,
+        PostDeployPdePromotionControlDto pdePromotionControl,
         List<PostDeployPdeDeployEnvironmentDto> pdeDeployments,
         PostDeployFacebookLogSummaryDto logs,
         List<String> alerts

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeProductionDeployRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeProductionDeployRequestDto.java
@@ -1,0 +1,7 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+/** Recebe a confirmação administrativa para publicar o PDE em produção. */
+public record PostDeployPdeProductionDeployRequestDto(
+        String requestedBy,
+        String sourceCommitSha
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeProductionDeployResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdeProductionDeployResponseDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+import java.time.Instant;
+
+/** Retorna o resultado da solicitação de deploy de produção do PDE. */
+public record PostDeployPdeProductionDeployResponseDto(
+        boolean accepted,
+        String status,
+        String message,
+        String targetEnvironment,
+        String workflowFile,
+        String sourceCommitSha,
+        Instant requestedAt
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdePromotionControlDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/dto/PostDeployPdePromotionControlDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.experiment.monitoring.dto;
+
+/** Resume a decisão operacional para promover um PDE de homologação para produção. */
+public record PostDeployPdePromotionControlDto(
+        boolean homologAvailable,
+        boolean productionAvailable,
+        boolean productionBehind,
+        boolean productionUpToDate,
+        boolean productionDeployAvailable,
+        boolean productionDeployBlocked,
+        String statusLabel,
+        String recommendation,
+        String sourceCommitSha,
+        String productionCommitSha,
+        String targetEnvironment,
+        String workflowFile
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/GithubActionsPdeProductionDeploymentClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/GithubActionsPdeProductionDeploymentClient.java
@@ -1,0 +1,127 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployResponseDto;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/** Solicita ao GitHub Actions o deploy produtivo do PDE sem usar SSH direto no servidor. */
+@Component
+@Slf4j
+public class GithubActionsPdeProductionDeploymentClient implements PdeProductionDeploymentClient {
+
+    private final String token;
+    private final String repository;
+    private final String workflowFile;
+    private final String ref;
+    private final RestClient restClient;
+
+    /** Inicializa o cliente com repositório, workflow e token administrativo configuráveis. */
+    public GithubActionsPdeProductionDeploymentClient(
+            @Value("${integrations.pde-platform.github-actions.token:${GITHUB_TOKEN:}}") String token,
+            @Value("${integrations.pde-platform.github-actions.repository:paulofor/marketing-hub}") String repository,
+            @Value("${integrations.pde-platform.github-actions.workflow-file:pde-platform-metodo-musa-ci.yml}") String workflowFile,
+            @Value("${integrations.pde-platform.github-actions.ref:main}") String ref) {
+        this.token = token;
+        this.repository = repository;
+        this.workflowFile = workflowFile;
+        this.ref = ref;
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory();
+        requestFactory.setReadTimeout(Duration.ofSeconds(10));
+        this.restClient = RestClient.builder()
+                .baseUrl("https://api.github.com")
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    /** Informa se o token e os identificadores do workflow estão presentes. */
+    @Override
+    public boolean isConfigured() {
+        return StringUtils.hasText(token)
+                && StringUtils.hasText(repository)
+                && StringUtils.hasText(repositoryOwner())
+                && StringUtils.hasText(repositoryName())
+                && StringUtils.hasText(workflowFile)
+                && StringUtils.hasText(ref);
+    }
+
+    /** Dispara o workflow com target_environment=production e registra contexto operacional. */
+    @Override
+    public PostDeployPdeProductionDeployResponseDto dispatchProductionDeploy(
+            Long experimentId,
+            String requestedBy,
+            String sourceCommitSha) {
+        if (!isConfigured()) {
+            return new PostDeployPdeProductionDeployResponseDto(
+                    false,
+                    "NOT_CONFIGURED",
+                    "Token ou workflow do GitHub Actions não configurado no backend.",
+                    "production",
+                    workflowFile,
+                    sourceCommitSha,
+                    Instant.now());
+        }
+        try {
+            restClient.post()
+                    .uri(
+                            "/repos/{owner}/{repo}/actions/workflows/{workflowFile}/dispatches",
+                            repositoryOwner(),
+                            repositoryName(),
+                            workflowFile)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .header(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of(
+                            "ref", ref,
+                            "inputs", Map.of("target_environment", "production")))
+                    .retrieve()
+                    .toBodilessEntity();
+            log.info(
+                    "Deploy produtivo PDE solicitado pelo Marketing Hub; experimentId={}, requestedBy={}, sourceCommitSha={}, workflowFile={}, ref={}",
+                    experimentId,
+                    requestedBy,
+                    sourceCommitSha,
+                    workflowFile,
+                    ref);
+            return new PostDeployPdeProductionDeployResponseDto(
+                    true,
+                    "DISPATCHED",
+                    "Workflow de produção solicitado. Acompanhe o painel até produção mostrar o mesmo commit da homologação.",
+                    "production",
+                    workflowFile,
+                    sourceCommitSha,
+                    Instant.now());
+        } catch (Exception ex) {
+            log.error(
+                    "Falha ao solicitar deploy produtivo PDE; experimentId={}, requestedBy={}, sourceCommitSha={}, repository={}, workflowFile={}, ref={}",
+                    experimentId,
+                    requestedBy,
+                    sourceCommitSha,
+                    repository,
+                    workflowFile,
+                    ref,
+                    ex);
+            throw new IllegalStateException("Não foi possível solicitar o deploy produtivo do PDE", ex);
+        }
+    }
+
+    /** Extrai o owner do repositório GitHub configurado. */
+    private String repositoryOwner() {
+        return repository.split("/", 2)[0];
+    }
+
+    /** Extrai o nome do repositório GitHub configurado. */
+    private String repositoryName() {
+        String[] parts = repository.split("/", 2);
+        return parts.length > 1 ? parts[1] : "";
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeProductionDeploymentClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeProductionDeploymentClient.java
@@ -1,0 +1,16 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployResponseDto;
+
+/** Cliente responsável por solicitar deploy produtivo do PDE no pipeline oficial. */
+public interface PdeProductionDeploymentClient {
+
+    /** Informa se existe configuração suficiente para acionar o deploy pelo Marketing Hub. */
+    boolean isConfigured();
+
+    /** Dispara a publicação produtiva usando o workflow canônico do PDE. */
+    PostDeployPdeProductionDeployResponseDto dispatchProductionDeploy(
+            Long experimentId,
+            String requestedBy,
+            String sourceCommitSha);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/PostDeployMonitorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/PostDeployMonitorController.java
@@ -2,8 +2,12 @@ package com.marketinghub.experiment.web;
 
 import com.marketinghub.experiment.monitoring.PostDeployMonitorService;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorResponseDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployRequestDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployResponseDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +30,13 @@ public class PostDeployMonitorController {
             @PathVariable Long experimentId,
             @RequestParam(name = "productSlug", required = false) String productSlug) {
         return service.summarize(experimentId, productSlug);
+    }
+
+    /** Solicita o deploy produtivo do PDE quando a homologação está validada. */
+    @PostMapping("/pde/production-deploy")
+    public PostDeployPdeProductionDeployResponseDto requestProductionDeploy(
+            @PathVariable Long experimentId,
+            @RequestBody(required = false) PostDeployPdeProductionDeployRequestDto request) {
+        return service.requestProductionDeploy(experimentId, request);
     }
 }

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -106,6 +106,10 @@ integrations.fashion-chat.read-timeout=${FASHION_CHAT_READ_TIMEOUT:PT0S}
 integrations.pde-platform.base-url=${PDE_PLATFORM_BASE_URL:https://clubemusa.com.br}
 integrations.pde-platform.deploy-status.homolog-url=${PDE_PLATFORM_HOMOLOG_DEPLOY_STATUS_URL:http://191.252.102.54:8097}
 integrations.pde-platform.deploy-status.production-url=${PDE_PLATFORM_PRODUCTION_DEPLOY_STATUS_URL:http://191.252.102.54:8096}
+integrations.pde-platform.github-actions.token=${PDE_PLATFORM_GITHUB_ACTIONS_TOKEN:${GITHUB_TOKEN:}}
+integrations.pde-platform.github-actions.repository=${PDE_PLATFORM_GITHUB_ACTIONS_REPOSITORY:paulofor/marketing-hub}
+integrations.pde-platform.github-actions.workflow-file=${PDE_PLATFORM_GITHUB_ACTIONS_WORKFLOW_FILE:pde-platform-metodo-musa-ci.yml}
+integrations.pde-platform.github-actions.ref=${PDE_PLATFORM_GITHUB_ACTIONS_REF:main}
 
 # Lead portal asset storage (Cloudflare R2)
 lead-portal.storage.bucket=${LEAD_PORTAL_STORAGE_BUCKET:leadportal}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/PostDeployMonitorServiceTest.java
@@ -1,15 +1,20 @@
 package com.marketinghub.experiment.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployRequestDto;
+import com.marketinghub.experiment.monitoring.dto.PostDeployPdeProductionDeployResponseDto;
 import com.marketinghub.experiment.monitoring.dto.PostDeployMonitorDecision;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
 import com.marketinghub.experiment.monitoring.pde.PdeDeployStatus;
 import com.marketinghub.experiment.monitoring.pde.PdeDeployStatusClient;
+import com.marketinghub.experiment.monitoring.pde.PdeProductionDeploymentClient;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
 import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
@@ -45,6 +50,9 @@ class PostDeployMonitorServiceTest {
     @Mock
     private PdeDeployStatusClient pdeDeployStatusClient;
 
+    @Mock
+    private PdeProductionDeploymentClient pdeProductionDeploymentClient;
+
     private PostDeployMonitorService service;
 
     /** Monta o serviço com dependências controladas para cenários comerciais. */
@@ -55,8 +63,10 @@ class PostDeployMonitorServiceTest {
                 campaignMetricRepository,
                 apiLogService,
                 pdeAnalyticsClient,
-                pdeDeployStatusClient);
+                pdeDeployStatusClient,
+                pdeProductionDeploymentClient);
         when(pdeDeployStatusClient.fetchStatuses()).thenReturn(List.of(availableDeployStatus()));
+        when(pdeProductionDeploymentClient.isConfigured()).thenReturn(false);
     }
 
     /** Recomenda pausa quando há gasto relevante sem primeira interação no PDE. */
@@ -225,6 +235,72 @@ class PostDeployMonitorServiceTest {
         assertThat(response.logs().totalLogs()).isEqualTo(1);
     }
 
+    /** Libera o comando de produção quando homologação está saudável e produção está defasada. */
+    @Test
+    void exposesProductionDeployActionWhenHomologIsAhead() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(campaignMetricRepository.findByExperiment(experiment)).thenReturn(Optional.of(metric("8.00", null)));
+        when(apiLogService.findLogs(67L, 50)).thenReturn(List.of());
+        when(pdeProductionDeploymentClient.isConfigured()).thenReturn(true);
+        when(pdeDeployStatusClient.fetchStatuses()).thenReturn(List.of(
+                deployStatus("homolog", "commit-homolog", true, true),
+                deployStatus("production", "commit-production", true, true)));
+        when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias")).thenReturn(emptyPdeSummary());
+
+        var response = service.summarize(67L, null);
+
+        assertThat(response.pdePromotionControl().productionBehind()).isTrue();
+        assertThat(response.pdePromotionControl().productionDeployAvailable()).isTrue();
+        assertThat(response.alerts()).anyMatch(alert -> alert.contains("commits diferentes"));
+    }
+
+    /** Dispara o workflow produtivo quando o controle de promoção está liberado. */
+    @Test
+    void dispatchesProductionDeployWhenPromotionIsAvailable() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(pdeProductionDeploymentClient.isConfigured()).thenReturn(true);
+        when(pdeDeployStatusClient.fetchStatuses()).thenReturn(List.of(
+                deployStatus("homolog", "commit-homolog", true, true),
+                deployStatus("production", "commit-production", true, true)));
+        when(pdeProductionDeploymentClient.dispatchProductionDeploy(eq(67L), eq("Paulo"), eq("commit-homolog")))
+                .thenReturn(new PostDeployPdeProductionDeployResponseDto(
+                        true,
+                        "DISPATCHED",
+                        "ok",
+                        "production",
+                        "pde-platform-metodo-musa-ci.yml",
+                        "commit-homolog",
+                        Instant.parse("2026-07-21T02:10:00Z")));
+
+        var response = service.requestProductionDeploy(
+                67L,
+                new PostDeployPdeProductionDeployRequestDto("Paulo", "commit-homolog"));
+
+        assertThat(response.accepted()).isTrue();
+        assertThat(response.status()).isEqualTo("DISPATCHED");
+        verify(pdeProductionDeploymentClient).dispatchProductionDeploy(67L, "Paulo", "commit-homolog");
+    }
+
+    /** Bloqueia produção quando a homologação não está saudável. */
+    @Test
+    void blocksProductionDeployWhenHomologIsNotHealthy() {
+        Experiment experiment = Experiment.builder().id(67L).build();
+        when(experimentRepository.findById(67L)).thenReturn(Optional.of(experiment));
+        when(pdeDeployStatusClient.fetchStatuses()).thenReturn(List.of(
+                deployStatus("homolog", "commit-homolog", false, true),
+                deployStatus("production", "commit-production", true, true)));
+
+        var response = service.requestProductionDeploy(
+                67L,
+                new PostDeployPdeProductionDeployRequestDto("Paulo", "commit-homolog"));
+
+        assertThat(response.accepted()).isFalse();
+        assertThat(response.status()).isEqualTo("BLOCKED");
+        assertThat(response.message()).contains("Valide homologação");
+    }
+
     /** Cria uma métrica Meta Ads mínima para os cenários do painel. */
     private ExperimentCampaignMetric metric(String spend, String lastError) {
         Experiment experiment = Experiment.builder().id(67L).build();
@@ -267,6 +343,25 @@ class PostDeployMonitorServiceTest {
                         5177,
                         80,
                         "frontend")));
+    }
+
+    /** Cria status de deploy parametrizado para comparar homologação e produção. */
+    private PdeDeployStatus deployStatus(String environment, String commitSha, boolean frontendReachable, boolean backendReachable) {
+        return new PdeDeployStatus(
+                environment,
+                backendReachable,
+                backendReachable ? "AVAILABLE" : "UNAVAILABLE",
+                null,
+                "production".equals(environment) ? "docker-compose.deploy.yml" : "docker-compose.homolog.yml",
+                commitSha,
+                commitSha,
+                "musa-pde-entry-v4-video-hero",
+                "production".equals(environment) ? "https://clubemusa.com.br" : "http://191.252.102.54:5177",
+                "production".equals(environment) ? "http://191.252.102.54:8096" : "http://191.252.102.54:8097",
+                frontendReachable,
+                backendReachable,
+                Instant.parse("2026-07-21T02:00:00Z"),
+                List.of());
     }
 
     /** Cria um resumo PDE sem conversão para cenários focados no status de deploy. */

--- a/docs/canonical/pde-platform-canon.v1.md
+++ b/docs/canonical/pde-platform-canon.v1.md
@@ -246,6 +246,24 @@ O pipeline de deploy deve executar o smoke test público depois da publicação 
 
 Um PDE não pode ser considerado pronto para tráfego se o smoke test público falhar, mesmo quando o status HTTP estiver 200. O objetivo é bloquear recorrência de tela branca, assets misturados entre ambientes, bundle JavaScript quebrado ou primeira dobra errada antes de gastar mídia.
 
+### Controle de homologação e produção pelo Marketing Hub
+
+O Marketing Hub deve ser o painel operacional de decisão para promover um PDE de homologação para produção.
+
+GitHub Actions verde não é prova suficiente de publicação produtiva. Antes de liberar tráfego pago ou considerar uma correção publicada, o painel pós-deploy do Marketing Hub deve confirmar:
+
+- homologação com backend e frontend públicos respondendo;
+- produção com backend e frontend públicos respondendo;
+- commit/tag de imagem da homologação;
+- commit/tag de imagem da produção;
+- compose usado por ambiente;
+- URLs e portas declaradas;
+- versão comercial da experiência PDE publicada.
+
+Quando a homologação estiver saudável e produção estiver em commit diferente, o Marketing Hub deve exibir produção como defasada e liberar uma ação administrativa explícita para solicitar o workflow produtivo canônico com `target_environment=production`. Essa ação não pode usar SSH direto no servidor; deve acionar o pipeline versionado do repositório.
+
+Se o backend do Marketing Hub não possuir token/configuração para acionar o GitHub Actions, o painel deve mostrar a produção como pendente sem token e orientar configuração operacional, sem fingir que a publicação foi solicitada.
+
 ## Contrato mínimo de produto
 
 Cada produto PDE deve ter, no mínimo:

--- a/docs/operations/musa-pde-version-start-2026-07-22.md
+++ b/docs/operations/musa-pde-version-start-2026-07-22.md
@@ -1,0 +1,49 @@
+# Marco de inicio real da versao MUSA PDE
+
+## Inicio real
+
+- Produto: Consultora MUSA / PDE Platform
+- Ambiente: producao
+- URL: `https://clubemusa.com.br`
+- Inicio real considerado: `2026-07-22 18:35:34 UTC`
+- Commit em producao: `f7095a41727e9965daa26865dc508943572b0f4a`
+- Deploy tecnico confirmado em: `2026-07-22T18:19:55Z`
+- Imagem/tag: `f7095a41727e9965daa26865dc508943572b0f4a`
+
+## Criterio usado
+
+Este horario marca o inicio real da versao porque houve confirmacao manual de teste funcional pelo usuario em producao apos a correcao do fluxo de espera do plano da Consultora MUSA.
+
+Para analise de marketing, metricas anteriores a `2026-07-22 18:35:34 UTC` devem ser tratadas como periodo contaminado por falha operacional do funil. A partir desse horario, os dados podem ser usados como base inicial da versao corrigida.
+
+## Evidencias operacionais
+
+- Backend de producao reportou `environment=production`.
+- `commitSha` e `imageTag` em producao estavam em `f7095a41727e9965daa26865dc508943572b0f4a`.
+- Servicos publicados na mesma tag:
+  - `pde-platform-backend`
+  - `pde-platform-frontend`
+  - `pde-ai-worker`
+- Schema de IA pronto:
+  - `aiGuidanceTableExists=true`
+  - `aiGuidanceAccessTokenLength=120`
+  - `aiGuidanceAccessTokenReady=true`
+- Confirmacao do usuario: teste real em producao funcionou apos o deploy da correcao do wait.
+
+## Uso recomendado em relatorios
+
+- Separar qualquer analise de conversao em dois blocos:
+  - antes de `2026-07-22 18:35:34 UTC`: diagnostico operacional, nao performance comercial limpa;
+  - depois de `2026-07-22 18:35:34 UTC`: primeira janela valida da versao corrigida.
+- Medir principalmente:
+  - visitantes na pagina;
+  - envios de diagnostico;
+  - diagnosticos concluidos;
+  - tempo medio ate plano pronto;
+  - cliques no proximo passo/oferta;
+  - abandono durante o estado de espera;
+  - conversao final em compra, quando conectada ao checkout.
+
+## Observacao
+
+No momento da validacao, o status de deploy ainda apontava um alerta operacional antigo de `HTTP_5XX` em `/api/actuator/health` visto em `2026-07-22T18:21:46Z`. Esse alerta deve ser monitorado, mas nao invalida o marco de inicio real enquanto o fluxo publico de diagnostico permanecer funcional.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6023,3 +6023,11 @@
 - foi feito: o cadastro de produtos passou a inserir e exibir uma `Jornada Persuasiva Interativa do PDE` no contrato do produto, usando AIDA como primeira leitura operacional.
 - foi feito: a aba de analytics do experimento passou a cruzar a jornada cadastrada com seções rastreadas do PDE, mostrando sessões, tempo visível, métrica primária e regra de otimização por etapa.
 - impacto comercial esperado: identificar se o gargalo está em atenção, interesse, desejo ou ação, orientando ajustes de promessa, pergunta inicial, diagnóstico parcial, login, paywall e checkout com base em evidência comportamental.
+
+## 2026-07-22 — PED/MUSA: controle de produção pelo Marketing Hub
+
+- causa-raiz operacional: o GitHub Actions publicava homologação no fluxo normal e produção apenas por execução manual, mas a decisão ficava fora do Marketing Hub; isso gerou confusão entre workflow verde, homologação publicada e produção ainda antiga.
+- foi feito: o painel pós-deploy passou a comparar homologação e produção por saúde pública, commit, compose, URLs e containers, destacando quando produção está defasada em relação à homologação.
+- foi feito: adicionada ação administrativa no Marketing Hub para solicitar deploy produtivo pelo workflow canônico do PDE com `target_environment=production`, sem SSH direto no servidor.
+- bloqueio seguro: se homologação não estiver saudável, se os commits mudarem entre leitura e clique ou se o backend não tiver token/configuração do GitHub Actions, o Hub bloqueia a promoção e mostra a causa.
+- impacto comercial esperado: reduzir atraso entre correção homologada e funil real corrigido, evitando perda de leads por versão antiga em produção.

--- a/docs/swagger/experiment-post-deploy-monitor-swagger.yaml
+++ b/docs/swagger/experiment-post-deploy-monitor-swagger.yaml
@@ -1,0 +1,188 @@
+openapi: 3.0.3
+info:
+  title: Experiment Post Deploy Monitor API
+  version: "1.0"
+  description: Contratos administrativos para monitorar PDEs e controlar promoção de homologação para produção.
+paths:
+  /api/experiments/{experimentId}/post-deploy-monitor:
+    get:
+      summary: Resume monitoramento pós-deploy do experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: productSlug
+          in: query
+          required: false
+          schema:
+            type: string
+            default: metodo-musa-7-dias
+      responses:
+        "200":
+          description: Painel consolidado com mídia, analytics PDE, deploys e controle de promoção.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PostDeployMonitorResponse"
+  /api/experiments/{experimentId}/post-deploy-monitor/pde/production-deploy:
+    post:
+      summary: Solicita deploy produtivo do PDE pelo workflow canônico
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostDeployPdeProductionDeployRequest"
+      responses:
+        "200":
+          description: Solicitação aceita ou bloqueada com causa objetiva.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PostDeployPdeProductionDeployResponse"
+components:
+  schemas:
+    PostDeployMonitorResponse:
+      type: object
+      required:
+        - experimentId
+        - productSlug
+        - generatedAt
+        - pdePromotionControl
+        - pdeDeployments
+        - alerts
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+        productSlug:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        decision:
+          type: string
+        decisionLabel:
+          type: string
+        recommendation:
+          type: string
+        pdePromotionControl:
+          $ref: "#/components/schemas/PostDeployPdePromotionControl"
+        pdeDeployments:
+          type: array
+          items:
+            $ref: "#/components/schemas/PostDeployPdeDeployEnvironment"
+        alerts:
+          type: array
+          items:
+            type: string
+    PostDeployPdePromotionControl:
+      type: object
+      required:
+        - homologAvailable
+        - productionAvailable
+        - productionBehind
+        - productionUpToDate
+        - productionDeployAvailable
+        - productionDeployBlocked
+        - statusLabel
+        - recommendation
+        - targetEnvironment
+        - workflowFile
+      properties:
+        homologAvailable:
+          type: boolean
+        productionAvailable:
+          type: boolean
+        productionBehind:
+          type: boolean
+        productionUpToDate:
+          type: boolean
+        productionDeployAvailable:
+          type: boolean
+        productionDeployBlocked:
+          type: boolean
+        statusLabel:
+          type: string
+        recommendation:
+          type: string
+        sourceCommitSha:
+          type: string
+          nullable: true
+        productionCommitSha:
+          type: string
+          nullable: true
+        targetEnvironment:
+          type: string
+          example: production
+        workflowFile:
+          type: string
+          example: pde-platform-metodo-musa-ci.yml
+    PostDeployPdeDeployEnvironment:
+      type: object
+      properties:
+        environment:
+          type: string
+        available:
+          type: boolean
+        commitSha:
+          type: string
+          nullable: true
+        imageTag:
+          type: string
+          nullable: true
+        composeFile:
+          type: string
+          nullable: true
+        frontendReachable:
+          type: boolean
+        backendReachable:
+          type: boolean
+    PostDeployPdeProductionDeployRequest:
+      type: object
+      properties:
+        requestedBy:
+          type: string
+        sourceCommitSha:
+          type: string
+          nullable: true
+    PostDeployPdeProductionDeployResponse:
+      type: object
+      required:
+        - accepted
+        - status
+        - message
+        - targetEnvironment
+        - workflowFile
+        - requestedAt
+      properties:
+        accepted:
+          type: boolean
+        status:
+          type: string
+          enum:
+            - DISPATCHED
+            - BLOCKED
+            - NOT_CONFIGURED
+        message:
+          type: string
+        targetEnvironment:
+          type: string
+        workflowFile:
+          type: string
+        sourceCommitSha:
+          type: string
+          nullable: true
+        requestedAt:
+          type: string
+          format: date-time

--- a/frontend/src/api/experiment/usePostDeployMonitor.ts
+++ b/frontend/src/api/experiment/usePostDeployMonitor.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { toast } from "react-toastify";
 
 export type PostDeployMonitorDecision =
   | "WAITING_DATA"
@@ -117,6 +118,31 @@ export interface PostDeployPdeDeployEnvironment {
   services: PostDeployPdeDeployService[];
 }
 
+export interface PostDeployPdePromotionControl {
+  homologAvailable: boolean;
+  productionAvailable: boolean;
+  productionBehind: boolean;
+  productionUpToDate: boolean;
+  productionDeployAvailable: boolean;
+  productionDeployBlocked: boolean;
+  statusLabel: string;
+  recommendation: string;
+  sourceCommitSha?: string | null;
+  productionCommitSha?: string | null;
+  targetEnvironment: string;
+  workflowFile: string;
+}
+
+export interface PostDeployPdeProductionDeployResponse {
+  accepted: boolean;
+  status: string;
+  message: string;
+  targetEnvironment: string;
+  workflowFile: string;
+  sourceCommitSha?: string | null;
+  requestedAt: string;
+}
+
 export interface PostDeployPdeDeployService {
   name: string;
   containerName: string;
@@ -142,6 +168,7 @@ export interface PostDeployMonitorResponse {
   recommendation: string;
   metaAds: PostDeployMetaAdsSummary;
   pde: PostDeployPdeSummary;
+  pdePromotionControl: PostDeployPdePromotionControl;
   pdeDeployments: PostDeployPdeDeployEnvironment[];
   logs: PostDeployFacebookLogSummary;
   alerts: string[];
@@ -161,6 +188,32 @@ export function usePostDeployMonitor(
         { params: { productSlug } },
       );
       return data;
+    },
+  });
+}
+
+export function useRequestPdeProductionDeploy(experimentId?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (variables: { requestedBy?: string; sourceCommitSha?: string | null }) => {
+      const { data } = await axios.post<PostDeployPdeProductionDeployResponse>(
+        `/api/experiments/${experimentId}/post-deploy-monitor/pde/production-deploy`,
+        variables,
+      );
+      return data;
+    },
+    onSuccess: (response) => {
+      if (response.accepted) {
+        toast.success(response.message);
+      } else {
+        toast.warn(response.message);
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["experiment", experimentId, "post-deploy-monitor"],
+      });
+    },
+    onError: () => {
+      toast.error("Não foi possível solicitar o deploy de produção agora.");
     },
   });
 }

--- a/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentPostDeployMonitorTab.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   usePostDeployMonitor,
+  useRequestPdeProductionDeploy,
   type PostDeployMonitorDecision,
 } from "../../api/experiment/usePostDeployMonitor";
 
@@ -106,8 +107,10 @@ export default function ExperimentPostDeployMonitorTab({
   experimentId,
 }: ExperimentPostDeployMonitorTabProps) {
   const monitorQuery = usePostDeployMonitor(experimentId);
+  const requestProductionDeploy = useRequestPdeProductionDeploy(experimentId);
   const monitor = monitorQuery.data;
   const pdeDeployments = monitor?.pdeDeployments ?? [];
+  const promotionControl = monitor?.pdePromotionControl;
   const trafficSources = monitor?.pde.trafficSources ?? [];
   const recentJourneys = monitor?.pde.recentJourneys ?? [];
 
@@ -312,6 +315,56 @@ export default function ExperimentPostDeployMonitorTab({
                 </p>
               </div>
             </div>
+            {promotionControl ? (
+              <div className="alert alert-light border d-flex flex-column flex-xl-row align-items-xl-center justify-content-between gap-3 mb-3">
+                <div>
+                  <div className="fw-semibold">
+                    Controle homologação → produção:{" "}
+                    {promotionControl.statusLabel}
+                  </div>
+                  <div className="small text-muted">
+                    {promotionControl.recommendation}
+                  </div>
+                  <div className="small mt-1">
+                    Homolog:{" "}
+                    <span className="font-monospace">
+                      {shortCommit(promotionControl.sourceCommitSha)}
+                    </span>{" "}
+                    · Produção:{" "}
+                    <span className="font-monospace">
+                      {shortCommit(promotionControl.productionCommitSha)}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={
+                    !promotionControl.productionDeployAvailable ||
+                    requestProductionDeploy.isPending
+                  }
+                  onClick={() =>
+                    requestProductionDeploy.mutate({
+                      requestedBy: "Marketing Hub",
+                      sourceCommitSha: promotionControl.sourceCommitSha,
+                    })
+                  }
+                >
+                  {requestProductionDeploy.isPending ? (
+                    <>
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        role="status"
+                        aria-hidden="true"
+                      />
+                      Solicitando produção...
+                    </>
+                  ) : (
+                    "Publicar produção"
+                  )}
+                </button>
+              </div>
+            ) : null}
             <div className="table-responsive">
               <table className="table table-sm align-middle mb-0">
                 <thead>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: fiz deploy mas erro continua

Modelo: {"titulo":"Erro é schema do PDE","comentario":"A causa-raiz foi confirmada: o erro continua porque o backend publicado ainda falha ao salvar o diagnóstico público da Consultora MUSA.\n\nEvidências:\n- A tela mostra erro ao clicar em `Enviar diagnóstico`.\n- O POST em `https://clubemusa.com.br/api/pde/public/presence-diagnostic` retorna `500`.\n- O log real do backend mostra: `Data too long for column 'access_token'`.\n- O diagnóstico público usa token no formato `public-presence-diagnostic:<uuid>`, maior que a coluna atual em produção.\n\nCorreção deixada pronta na worktree:\n- Reforcei a migração do backend PDE para criar/ajustar `pde_ai_guidance_request` com `access_token VARCHAR(120)`.\n- O serviço de IA agora valida/repara o schema antes de gravar orientação, evitando depender só da migração de startup.\n- Adicionei testes cobrindo tabela ausente e coluna curta após startup.\n\nValidação:\n- `mvn test` no `pde-platform/backend`: **41 testes passaram**.\n- `mvn spotless:check` não rodou porque esse módulo não tem plugin Spotless configurado.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Agora precisa publicar essa correção por PR/deploy. O erro atual em produção só vai sumir quando uma imagem nova contendo essa mudança for implantada e a migração ajustar a coluna no banco."}

Usuário: baixa tudo para o seu ambiente e testa tudo so entrega quando tiver certeza que esta funcionando, pode gravar dados no MySql não tem problema.

Modelo: {"titulo":"Correção pronta","comentario":"Identifiquei e corrigi uma causa real do erro que continuava após deploy.\n\n**Causa confirmada**\n\nO backend publicado está retornando alvo inválido para sincronização de métricas do Facebook Ads:\n\n```json\n{\"total\":1,\"blankCampaignIds\":1,\"sample\":[{\"campaignId\":\"\",\"experimentId\":3,\"lastSyncedAt\":null}]}\n```\n\nIsso fazia o worker tentar registrar erro em uma rota sem `campaignId`, gerando o 404 observado em log: `/api/facebook-campaigns/metrics-error`.\n\n**Correção aplicada na worktree**\n\n- Backend: `findMetricsSyncTargets` agora não devolve campanhas com `id` nulo ou vazio.\n- Facebook Ads Worker: adicionada barreira defensiva para ignorar alvo de métricas sem `campaignId` caso dado legado escape.\n- Teste: adicionado teste garantindo que alvo sem campanha não entra no ciclo de métricas.\n\n**Validação executada**\n\n- `facebook-ads-worker`: `mvn -q test` passou.\n- `backend/ads-service`: `mvn -q test` passou.\n- `git diff --check` passou.\n\nNão criei PR e não publiquei nada. As mudanças estão prontas na branch/worktree.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para o erro parar em produção, execute o fluxo de PR/deploy dos módulos `backend/ads-service` e `facebook-ads-worker`. Após deploy, o endpoint não deve mais alimentar o worker com `campaignId` vazio."}

Usuário: o errro continua. Vc tem chave para o servidor ?

Modelo: {"titulo":"Erro é deploy antigo","comentario":"Não vou usar SSH para corrigir direto no servidor. Pelo modo definido, a correção precisa ir por PR/deploy versionado.\n\n**Causa confirmada agora**\n\n- Reproduzi em produção: `POST https://clubemusa.com.br/api/pde/public/presence-diagnostic` retorna `500`.\n- Banco PDE em produção ainda está com `pde_ai_guidance_request.access_token = varchar(36)`.\n- O token público usa formato `public-presence-diagnostic:<uuid>`, maior que 36.\n- Log do backend confirma: `Data too long for column 'access_token'`.\n- Deploy atual está na imagem/commit `582e0fc...`, mas o repositório atual está em `acaf657...` e contém o reparo que amplia a coluna para `varchar(120)`.\n\n**Conclusão**\n\nO erro continua porque produção não está rodando a versão que contém a correção. Não é problema da tela, nem ainda do worker/OpenAI. O funil quebra antes, ao tentar gravar o diagnóstico no MySQL.\n\n**Validação feita**\n\n- Backend PDE local: testes passaram.\n- Worker PDE AI: testes passaram.\n- Smoke local do diagnóstico público: passou, criando e consultando a solicitação corretamente.\n\n**Impacto comercial**\n\nA lead chega no momento de maior intenção, responde o diagnóstico e recebe erro. Isso destrói a promessa da Consultora MUSA e perde conversão antes do checkout.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Precisa publicar a imagem atual da branch/repositório. Depois do deploy, validar que `/api/pde/deploy/status` mostra o commit novo e que `pde_ai_guidance_request.access_token` virou `varchar(120)`."}

Usuário: veja o github pq ele não publicou ?

Modelo: {"titulo":"Produziu homolog, não produção","comentario":"O GitHub publicou, mas **não publicou em produção**.\n\n**Causa confirmada**\n\n- O PR `#4461` foi mergeado na `main` em `22/07/2026 17:07 UTC`.\n- O workflow `CI - PDE Platform Metodo MUSA` rodou com sucesso.\n- Porém o job **Deploy production to Metodo MUSA host** ficou `skipped`.\n- O job que rodou foi **Deploy homolog to Metodo MUSA host**.\n\n**Evidência de produção**\n\nProdução ainda está na imagem antiga:\n\n```json\n\"commitSha\": \"582e0fc07776c2aa11b4ebd24e84c4d0f46b51a8\"\n```\n\nA correção mergeada está em:\n\n```json\n\"commitSha\": \"acaf6579183415186845f236409d1f280ad6c10b\"\n```\n\n**Por que aconteceu**\n\nO workflow do PDE só publica produção quando é executado manualmente com:\n\n```text\ntarget_environment = production\n```\n\nNo push/merge normal da `main`, ele publica homologação por padrão. Por isso ficou verde no GitHub, mas `clubemusa.com.br` continuou antigo.\n\n**Alternativas avaliadas**\n\n1. Rodar o workflow manual para `production`: melhor agora, baixo risco, usa o pipeline correto.\n2. Mudar o workflow para publicar produção automaticamente em todo merge: resolve recorrência, mas aumenta risco comercial.\n3. Criar uma regra com aprovação manual obrigatória para produção: melhor causa-raiz estrutural, mas exige ajuste no workflow.\n\n**Melhor próxima ação agora**\n\nExecutar manualmente o workflow `CI - PDE Platform Metodo MUSA` com `target_environment=production`. Depois validar se `/api/pde/deploy/status` mostra `acaf657...`.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize explicitamente se você quer que eu dispare o workflow de produção pelo GitHub Actions. Isso é deploy real em produção."}

Usuário: Execute sua orientação : 
Autorize explicitamente se você quer que eu dispare o workflow de produção pelo GitHub Actions. Isso é deploy real em produção.

Modelo: {"titulo":"Produção corrigida","comentario":"Deploy de produção executado com sucesso pelo GitHub Actions.\n\n**Resultado confirmado**\n\n- Workflow: `CI - PDE Platform Metodo MUSA`\n- Run: `29944299709`\n- Commit publicado: `acaf6579183415186845f236409d1f280ad6c10b`\n- Produção agora mostra esse commit em `/api/pde/deploy/status`\n- Schema corrigido em produção: `pde_ai_guidance_request.access_token = 120`\n- `aiGuidanceAccessTokenReady=true`\n- O smoke público do workflow passou.\n\n**Teste real no funil**\n\nExecutei o POST em produção no endpoint que quebrava:\n\n`/api/pde/public/presence-diagnostic`\n\nResultado: não retorna mais `500`. Criou diagnóstico e depois completou com IA:\n\n- `requestId`: `140840c9-2556-4b59-b559-96414bfb5f4c`\n- status inicial: `PENDING`\n- status final: `COMPLETED`\n- retornou headline, resumo, sinais, plano de 7 dias e modelo usado.\n\n**Conclusão**\n\nO erro original foi resolvido em produção. A visitante agora consegue enviar o diagnóstico e receber o plano, que é o ponto crítico de conversão da Consultora MUSA.","sugestaoMelhoriaAmbiente":"Criar no próprio GitHub Actions uma proteção visual mais clara para diferenciar deploy de homologação e deploy de produção, com resumo automático do commit publicado e status do schema após o deploy."}

Usuário: solicitei nesse instante meu plano, acompanhe nos logs

Modelo: {"titulo":"Plano concluído","comentario":"Acompanhei o fluxo em produção e o seu plano foi gerado com sucesso.\n\n**Status confirmado**\n\n- `requestId`: `e93b44bf-fc09-42ef-ac2a-830cf4d9a040`\n- Status no banco: `COMPLETED`\n- Criado em: `2026-07-22 17:59:22 UTC`\n- Finalizado em: `2026-07-22 17:59:53 UTC`\n- Modelo: `gpt-5.5`\n- `service_tier`: `flex`\n- Erro: nenhum\n\n**Resultado entregue pelo endpoint da tela**\n\nHeadline retornada:\n\n`Sua presença pede acabamento, não excesso.`\n\n**Fila e falhas**\n\n- Solicitações pendentes: `0`\n- Falhas operacionais PDE registradas: `0`\n- Erros antigos de `Data too long for column 'access_token'` pararam após o deploy das `17:55 UTC`.\n\nConclusão: o fluxo crítico voltou a funcionar. Do ponto de vista comercial, a visitante já consegue pedir o diagnóstico e receber o plano, que era o ponto de conversão quebrado.","sugestaoMelhoriaAmbiente":""}

Usuário: a tela continua em wait

Modelo: {"titulo":"Wait da tela corrigido","comentario":"A causa-raiz agora ficou clara: o plano foi gerado, mas a tela parou de consultar cedo demais.\n\n**Evidência**\n\n- Seu pedido `e93b44bf-fc09-42ef-ac2a-830cf4d9a040` está `COMPLETED` em produção.\n- Criado: `17:59:22 UTC`.\n- Finalizado: `17:59:53 UTC`.\n- Tempo real: cerca de **31 segundos**.\n- O front atual só aguardava cerca de **20 segundos** e, ao estourar esse tempo, deixava o estado como `PENDING`. Por isso o botão continuava em `Montando seu plano...` mesmo com o plano pronto no backend.\n\n**Alternativas avaliadas**\n\n1. Apenas pedir para atualizar a página: baixo esforço, mas não resolve recorrência.\n2. Reduzir tempo da IA: instável, porque `flex` pode variar.\n3. Corrigir o polling do front: melhor opção, porque acompanha o tempo real do backend e evita travamento comercial.\n\n**Correção aplicada na worktree**\n\n- Aumentei o polling do diagnóstico público para até aproximadamente **2min40s**.\n- Se ainda assim não concluir, a tela não fica presa em `PENDING`; volta para estado acionável com mensagem de erro.\n- Adicionei teste simulando IA demorando mais que o limite antigo e confirmando que o plano aparece depois.\n\n**Validação**\n\n- `npm run build`: passou.\n- `npm run test:visual -- tests/musa-entry.visual.spec.ts --project=chromium-desktop`: passou, 3 testes.\n- `git diff --check`: passou.\n- Confirmei em produção que o endpoint do seu `requestId` retorna `COMPLETED` com o plano.\n\nNão criei PR e não publiquei nada. A correção está pronta na branch/worktree.","sugestaoMelhoriaAmbiente":"Deixar o navegador do Playwright pré-cacheado no ambiente evitaria a etapa extra de instalação antes dos testes visuais.","orientacaoProximaAcao":"Para a tela real parar de travar em produção, precisa publicar essa alteração do frontend por PR/deploy. Até lá, o backend gera o plano, mas a versão atual da tela ainda pode parar de consultar antes da IA concluir."}

Usuário: acompanha o github para ver se esta indo para homologação ou produção a versão nova

Modelo: {"titulo":"Foi para homologação","comentario":"Acompanhei o GitHub até o fim.\n\n**Resultado confirmado**\n\n- Commit novo: `f7095a41727e9965daa26865dc508943572b0f4a`\n- Workflow: `CI - PDE Platform Metodo MUSA`\n- Run: `29945548574`\n- Status geral: **success**\n- Backend tests: **passou**\n- Frontend build: **passou**\n- Imagens Docker: **geradas e publicadas**\n- Deploy homolog: **passou**\n- Smoke público homolog: **passou**\n- Deploy production: **skipped**\n\n**Ambiente que recebeu a versão nova**\n\nHomologação recebeu a versão nova:\n\n```text\nhttp://191.252.102.54:5177\ncommitSha = f7095a41727e9965daa26865dc508943572b0f4a\n```\n\nProdução ainda está na versão anterior:\n\n```text\nhttps://clubemusa.com.br\ncommitSha = acaf6579183415186845f236409d1f280ad6c10b\n```\n\n**Conclusão**\n\nA correção do `wait` ainda **não chegou em produção**. Ela foi publicada em **homologação** e validada pelo pipeline. Por isso a tela real em `clubemusa.com.br` ainda pode continuar com o comportamento antigo.\n\n**Alternativas agora**\n\n1. Publicar produção manualmente: melhor ação imediata, baixo risco porque homolog já passou.\n2. Testar manualmente em homolog antes: mais conservador, mas atrasa a correção no funil real.\n3. Alterar o workflow para produção automática: resolve recorrência, mas exige cuidado para não publicar mudanças comerciais sem validação.\n\nMinha recomendação: publicar produção agora via workflow manual com `target_environment=production`.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize explicitamente se você quer que eu dispare agora o workflow de produção para publicar o commit `f7095a41727e9965daa26865dc508943572b0f4a` em `clubemusa.com.br`."}

Usuário: coloca em produção.

Modelo: Aguardando resposta do modelo... (Em execução)

Última mensagem do usuário:
temos que melhorar esse fluxo de homologaçaõ e produção. Fazer esse controle pelo Marketing Hub

**Resumo das alterações:**
{"titulo":"Controle no Hub pronto","comentario":"Implementei o controle de homologação → produção dentro do Marketing Hub.\n\n**O que mudou**\n\n- O painel pós-deploy agora compara homologação e produção por commit, saúde pública, compose, URLs e containers.\n- Se homologação estiver saudável e produção estiver atrasada, o Hub mostra produção como defasada.\n- Adicionei o botão **Publicar produção**, que solicita o workflow oficial do GitHub Actions com `target_environment=production`.\n- O botão fica bloqueado se homologação não estiver saudável, se o commit mudar entre leitura e clique, ou se faltar token/configuração do GitHub Actions.\n- Atualizei o cânone do PDE, registro de experimentos e Swagger do novo contrato.\n\n**Validação**\n\n- `mvn -q -Dtest=PostDeployMonitorServiceTest test`: passou.\n- `mvn -q test` no backend: passou.\n- `npm run typecheck`: passou.\n- `npm run build`: passou.\n- `git diff --check`: passou.\n- `spotless:check` restrito aos arquivos Java alterados: passou.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para isso funcionar em produção, precisa abrir PR/deploy dessas mudanças e configurar no backend produtivo um token com permissão para disparar GitHub Actions via `PDE_PLATFORM_GITHUB_ACTIONS_TOKEN`."}