### PR TITLE
AI Hub: {"titulo":"Action travou no deploy","comentario":"A Action atual **falhou por timeout** no workflow `Build & Deploy containers`.\n\n**Causa confirmada:** o job não travou em testes nem build. Ele ficou 30 minutos no passo `docker load backend (/tm…

### DIFF
--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -228,6 +228,7 @@ jobs:
   deploy-app:
     name: Deploy backend + frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     needs: [detect-changes, backend-image, frontend-image]
     if: always() && needs.detect-changes.outputs.app_deploy == 'true'
     steps:
@@ -335,7 +336,7 @@ jobs:
           SSH_OPTS: -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o TCPKeepAlive=yes
         run: |
           ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} "chmod +x ${DEPLOY_DIR}/bin/apply.sh"
-          timeout 30m ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} \
+          timeout -k 30s 18m ssh ${SSH_OPTS} ${VPS_USER}@${APP_VPS_IP} \
             "IMAGE_TAG=${GIT_SHA} BACKEND_TAR=/tmp/backend-image.tar FRONTEND_TAR=/tmp/frontend-image.tar BACKEND_IMAGE=${BACKEND_IMAGE} FRONTEND_IMAGE=${FRONTEND_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} /bin/bash ${DEPLOY_DIR}/bin/apply.sh"
 
   deploy-video-management:

--- a/deploy/bin/apply.sh
+++ b/deploy/bin/apply.sh
@@ -9,6 +9,10 @@ BACKEND_IMAGE=${BACKEND_IMAGE:-marketinghub-backend}
 FRONTEND_IMAGE=${FRONTEND_IMAGE:-marketinghub-frontend}
 VIDEO_IMAGE=${VIDEO_IMAGE:-marketinghub-video-management}
 IMAGE_TAG=${IMAGE_TAG:-latest}
+IMAGE_LOAD_TIMEOUT=${IMAGE_LOAD_TIMEOUT:-12m}
+COMPOSE_RECREATE_TIMEOUT=${COMPOSE_RECREATE_TIMEOUT:-8m}
+BACKEND_HEALTH_URL=${BACKEND_HEALTH_URL:-http://localhost:8000/ops-mh-observability-v2/health}
+FRONTEND_HEALTH_URL=${FRONTEND_HEALTH_URL:-http://localhost:5173/}
 
 log() {
   printf '[%s] [apply.sh] %s\n' "$(date -Is)" "$*"
@@ -44,6 +48,51 @@ run_with_heartbeat() {
   return "${status}"
 }
 
+dump_app_diagnostics() {
+  log "Diagnóstico docker compose ps"
+  docker compose ps backend frontend || true
+
+  log "Últimas linhas do backend"
+  docker logs --tail 120 marketinghub-backend 2>&1 || true
+
+  log "Últimas linhas do frontend"
+  docker logs --tail 80 marketinghub-frontend 2>&1 || true
+}
+
+run_with_timeout_and_diagnostics() {
+  local description="$1"
+  local duration="$2"
+  shift 2
+
+  if ! run_with_heartbeat "${description}" timeout "${duration}" "$@"; then
+    log "Comando falhou ou excedeu o limite ${duration}: ${description}"
+    dump_app_diagnostics
+    return 1
+  fi
+}
+
+wait_http() {
+  local name="$1"
+  local url="$2"
+  local attempts="${3:-24}"
+  local interval="${4:-5}"
+
+  log "Validando ${name} em ${url}"
+  for attempt in $(seq 1 "${attempts}"); do
+    if curl -fsS --max-time 5 "${url}" >/dev/null; then
+      log "${name} respondeu com sucesso"
+      return 0
+    fi
+
+    log "Aguardando ${name} responder (${attempt}/${attempts})"
+    sleep "${interval}"
+  done
+
+  log "${name} não respondeu em ${url}"
+  dump_app_diagnostics
+  return 1
+}
+
 mkdir -p "${DEPLOY_DIR}"
 cd "${DEPLOY_DIR}"
 
@@ -51,19 +100,19 @@ log "Preparando diretórios persistentes em ${DEPLOY_DIR}"
 mkdir -p volumes/backend/uploads volumes/backend/logs
 
 if [[ -f "${BACKEND_TAR}" ]]; then
-  run_with_heartbeat "docker load backend (${BACKEND_TAR})" docker load -i "${BACKEND_TAR}"
+  run_with_timeout_and_diagnostics "docker load backend (${BACKEND_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${BACKEND_TAR}"
 else
   log "Arquivo de imagem backend não encontrado em ${BACKEND_TAR}; mantendo imagem local atual."
 fi
 
 if [[ -f "${FRONTEND_TAR}" ]]; then
-  run_with_heartbeat "docker load frontend (${FRONTEND_TAR})" docker load -i "${FRONTEND_TAR}"
+  run_with_timeout_and_diagnostics "docker load frontend (${FRONTEND_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${FRONTEND_TAR}"
 else
   log "Arquivo de imagem frontend não encontrado em ${FRONTEND_TAR}; mantendo imagem local atual."
 fi
 
 if [[ -f "${VIDEO_TAR}" ]]; then
-  run_with_heartbeat "docker load video-management (${VIDEO_TAR})" docker load -i "${VIDEO_TAR}"
+  run_with_timeout_and_diagnostics "docker load video-management (${VIDEO_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${VIDEO_TAR}"
 else
   log "Arquivo de imagem video-management não encontrado em ${VIDEO_TAR}; mantendo imagem local atual."
 fi
@@ -125,10 +174,14 @@ fi
 remove_conflicting_container "backend" "marketinghub-backend"
 remove_conflicting_container "frontend" "marketinghub-frontend"
 
-run_with_heartbeat \
+run_with_timeout_and_diagnostics \
   "recriar somente backend/frontend" \
+  "${COMPOSE_RECREATE_TIMEOUT}" \
   env BACKEND_IMAGE_TAG=latest FRONTEND_IMAGE_TAG=latest VIDEO_MGMT_IMAGE_TAG=latest \
   docker compose up -d --force-recreate --remove-orphans backend frontend
+
+wait_http "backend" "${BACKEND_HEALTH_URL}"
+wait_http "frontend" "${FRONTEND_HEALTH_URL}" 12 5
 
 cleanup_previous_tags "${BACKEND_IMAGE}" "latest"
 cleanup_previous_tags "${FRONTEND_IMAGE}" "latest"

--- a/deploy/bin/apply.sh
+++ b/deploy/bin/apply.sh
@@ -10,6 +10,7 @@ FRONTEND_IMAGE=${FRONTEND_IMAGE:-marketinghub-frontend}
 VIDEO_IMAGE=${VIDEO_IMAGE:-marketinghub-video-management}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 IMAGE_LOAD_TIMEOUT=${IMAGE_LOAD_TIMEOUT:-12m}
+COMMAND_TIMEOUT_KILL_AFTER=${COMMAND_TIMEOUT_KILL_AFTER:-30s}
 COMPOSE_RECREATE_TIMEOUT=${COMPOSE_RECREATE_TIMEOUT:-8m}
 BACKEND_HEALTH_URL=${BACKEND_HEALTH_URL:-http://localhost:8000/ops-mh-observability-v2/health}
 FRONTEND_HEALTH_URL=${FRONTEND_HEALTH_URL:-http://localhost:5173/}
@@ -49,6 +50,12 @@ run_with_heartbeat() {
 }
 
 dump_app_diagnostics() {
+  log "Diagnóstico de disco"
+  df -h "${DEPLOY_DIR}" /tmp || true
+
+  log "Diagnóstico docker system df"
+  docker system df || true
+
   log "Diagnóstico docker compose ps"
   docker compose ps backend frontend || true
 
@@ -64,11 +71,22 @@ run_with_timeout_and_diagnostics() {
   local duration="$2"
   shift 2
 
-  if ! run_with_heartbeat "${description}" timeout "${duration}" "$@"; then
+  if ! run_with_heartbeat "${description}" timeout -k "${COMMAND_TIMEOUT_KILL_AFTER}" "${duration}" "$@"; then
     log "Comando falhou ou excedeu o limite ${duration}: ${description}"
     dump_app_diagnostics
     return 1
   fi
+}
+
+prepare_image_load() {
+  local name="$1"
+  local tar_path="$2"
+
+  log "Preparando carga da imagem ${name}"
+  ls -lh "${tar_path}" || true
+  df -h "${DEPLOY_DIR}" /tmp || true
+  docker system df || true
+  docker image prune -f >/dev/null 2>&1 || true
 }
 
 wait_http() {
@@ -100,18 +118,21 @@ log "Preparando diretórios persistentes em ${DEPLOY_DIR}"
 mkdir -p volumes/backend/uploads volumes/backend/logs
 
 if [[ -f "${BACKEND_TAR}" ]]; then
+  prepare_image_load "backend" "${BACKEND_TAR}"
   run_with_timeout_and_diagnostics "docker load backend (${BACKEND_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${BACKEND_TAR}"
 else
   log "Arquivo de imagem backend não encontrado em ${BACKEND_TAR}; mantendo imagem local atual."
 fi
 
 if [[ -f "${FRONTEND_TAR}" ]]; then
+  prepare_image_load "frontend" "${FRONTEND_TAR}"
   run_with_timeout_and_diagnostics "docker load frontend (${FRONTEND_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${FRONTEND_TAR}"
 else
   log "Arquivo de imagem frontend não encontrado em ${FRONTEND_TAR}; mantendo imagem local atual."
 fi
 
 if [[ -f "${VIDEO_TAR}" ]]; then
+  prepare_image_load "video-management" "${VIDEO_TAR}"
   run_with_timeout_and_diagnostics "docker load video-management (${VIDEO_TAR})" "${IMAGE_LOAD_TIMEOUT}" docker load -i "${VIDEO_TAR}"
 else
   log "Arquivo de imagem video-management não encontrado em ${VIDEO_TAR}; mantendo imagem local atual."


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: ja teve alguem preenchendo as perguntas e recebendo o diagnostico depois da versão correta subir para produção do PDE Musa ?

Modelo: {"titulo":"Ainda não houve diagnóstico válido","comentario":"Não. Pela evidência disponível, **não apareceu ninguém preenchendo as perguntas e recebendo diagnóstico depois da versão correta subir para produção do PDE Musa**.\n\n**Corte usado:** `2026-07-22 18:35:34 UTC`, registrado em `docs/operations/musa-pde-version-start-2026-07-22.md` como início comercial limpo da versão corrigida.\n\n**O que encontrei:**\n- Eventos do funil após esse horário: **0**.\n- Liberações/acessos após esse horário: **0**.\n- Pedidos de diagnóstico/IA após esse horário: **0**.\n- Logs do `pde-platform-backend` após esse horário: **0 linhas relevantes**.\n\n**Importante:** antes do corte existiram interações: o banco mostra **12 envios de diagnóstico** e **7 diagnósticos de IA concluídos**, mas o último diagnóstico concluído foi às `2026-07-22 18:24:28 UTC`, ou seja, **antes** do marco correto. Para análise de marketing, esses dados ainda entram como período contaminado por falha operacional, não como validação real da versão corrigida.\n\n**Conclusão de negócio:** ainda não temos prova de mercado pós-correção. O próximo sinal que precisamos ver é pelo menos: visitante novo → envio do diagnóstico → IA concluída → usuário vê resultado/continua para próximo passo.","sugestaoMelhoriaAmbiente":""}

Usuário: veja se a campanha esta ativa e se esta tudo ok com o experimento.

Modelo: {"titulo":"Campanha não está ativa","comentario":"**Conclusão:** não está tudo ok para considerar o experimento rodando.\n\nO PDE MUSA em produção está tecnicamente publicado e respondendo, mas a **campanha não está ativa de fato**:\n\n- Experimento `66 / MUSA-H001-E004`: status `USER_STOPPED`.\n- Campanha Meta `120250345328870326`: `PAUSED`.\n- Ad set aparece configurado como `ACTIVE`, mas o status efetivo é `CAMPAIGN_PAUSED`.\n- Insights de hoje na Meta: sem dados retornados.\n- Logs do Facebook Ads Worker após `2026-07-22 18:35:34 UTC`: 0 linhas.\n- Eventos do PDE após o corte correto: 0.\n- Diagnósticos/IA após o corte correto: 0.\n- Liberações/acessos após o corte correto: 0.\n\n**O que está ok:**\n\n- `https://clubemusa.com.br/healthz` respondeu `UP`.\n- Deploy de produção está na tag correta `f7095a41727e9965daa26865dc508943572b0f4a`.\n- Backend PDE indica schema de IA pronto.\n- Página/produto ainda expõe a versão `musa-pde-entry-v3`.\n\n**Ponto de atenção:** o monitor pós-deploy do Marketing Hub ainda marcou `TECHNICAL_ATTENTION`, principalmente porque a integração consolidada de analytics PDE pelo backend principal não está entregando o resumo completo, embora o endpoint direto do PDE esteja respondendo. Isso não impede a página de funcionar, mas atrapalha decisão automática pelo painel.\n\n**Orientação de marketing:** antes de avaliar performance, reativar de forma controlada: campanha + experimento, confirmar sincronização de métricas e observar os primeiros eventos pós-corte. No estado atual, o experimento não está recebendo tráfego pago válido.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Se a intenção for retomar o teste, reative o experimento/campanha pelo fluxo do Marketing Hub/Meta e depois peça nova verificação após alguns minutos de entrega."}

Usuário: veja pq o action atual do github esta demorando tanto para terminar ajuste se for necessário.

Modelo: Aguardando resposta do modelo... (Em execução)

Última mensagem do usuário:
Execute sua orientação : 
Se a intenção for retomar o teste, reative o experimento/campanha pelo fluxo do Marketing Hub/Meta e depois peça nova verificação após alguns minutos de entrega.

**Resumo das alterações:**
{"titulo":"Action travou no deploy","comentario":"A Action atual **falhou por timeout** no workflow `Build & Deploy containers`.\n\n**Causa confirmada:** o job não travou em testes nem build. Ele ficou 30 minutos no passo `docker load backend (/tmp/backend-image.tar)` e terminou com `exit code 124` às `2026-07-22 19:24:16 UTC`.\n\n**Estado do produto:** backend e frontend públicos responderam durante a análise:\n- Backend: `UP`, banco MySQL `UP`.\n- Frontend: `200 OK`.\n\n**Ajuste deixado pronto na worktree:** alterei `deploy/bin/apply.sh` para:\n- aplicar timeout também no `docker load` das imagens;\n- aplicar timeout no `docker compose up`;\n- imprimir diagnóstico de containers/logs quando travar;\n- validar backend e frontend após recriar o stack.\n\nValidação feita: `bash -n deploy/bin/apply.sh` passou.\n\n**Alternativas avaliadas:**\n1. Só aguardar: baixo esforço, mas mantém deploy cego e pode travar de novo.\n2. Aumentar timeout: mascara o problema e piora tempo de reação.\n3. Falhar rápido com diagnóstico e healthcheck: melhor equilíbrio, porque protege produção e mostra a causa real no próximo run.\n\nEscolhi a alternativa 3.","sugestaoMelhoriaAmbiente":"Acesso seguro via MCP aos estados do Docker no VPS permitiria confirmar uso de disco, I/O e estado do daemon sem depender apenas dos logs do GitHub Actions.","orientacaoProximaAcao":"Para publicar essa correção, peça o PR. Depois do merge, rerode o deploy para que o próximo erro venha com diagnóstico útil em vez de esperar 30 minutos."}