### PR TITLE
AI Hub: {"titulo":"Correção aplicada","comentario":"Atualizei o PDE frontend para alinhar o contrato público e os testes com o CTA novo: `Ver meu primeiro passo`.\n\n**Arquivos alterados**\n\n- `pde-platform/frontend/public/pde-health-contract.json`\n- `p…

### DIFF
--- a/pde-platform/frontend/public/pde-health-contract.json
+++ b/pde-platform/frontend/public/pde-health-contract.json
@@ -4,7 +4,7 @@
   "requiredTexts": [
     "Sua imagem comunica a mulher que você quer ser vista como?",
     "Diagnóstico de Presença",
-    "Enviar diagnóstico"
+    "Ver meu primeiro passo"
   ],
   "forbiddenTexts": [
     "Application error",

--- a/pde-platform/frontend/tests/musa-entry.visual.spec.ts
+++ b/pde-platform/frontend/tests/musa-entry.visual.spec.ts
@@ -47,14 +47,14 @@ test('carrega a entrada visual do Clube MUSA', async ({ page }) => {
     }),
   ).toBeVisible();
   await expect(page.getByText('Diagnóstico de Presença')).toBeVisible();
-  await expect(page.getByRole('button', { name: /Enviar diagnóstico/i })).toBeDisabled();
+  await expect(page.getByRole('button', { name: /Ver meu primeiro passo/i })).toBeDisabled();
   await page.getByRole('button', { name: 'Trabalho ou reunião' }).click();
   await page.getByRole('button', { name: 'Falta acabamento' }).click();
   await page.getByRole('button', { name: 'Elegância discreta' }).click();
   await page.getByRole('button', { name: 'Pouco tempo' }).click();
   await page.getByRole('button', { name: 'Cabelo e pele' }).click();
-  await expect(page.getByRole('button', { name: /Enviar diagnóstico/i })).toBeEnabled();
-  await page.getByRole('button', { name: /Enviar diagnóstico/i }).click();
+  await expect(page.getByRole('button', { name: /Ver meu primeiro passo/i })).toBeEnabled();
+  await page.getByRole('button', { name: /Ver meu primeiro passo/i }).click();
   await expect(page.getByRole('heading', { name: /Seu plano começa reduzindo ruído visual/i })).toBeVisible();
   await expect(page.getByText(/Quer saber exatamente como executar esse plano/i)).toBeVisible();
   await page.getByPlaceholder('seuemail@exemplo.com').fill('teste+diagnostico@sandbox.local');
@@ -119,7 +119,7 @@ test('continua aguardando diagnostico publico quando IA demora mais que 20 segun
   await page.getByRole('button', { name: 'Elegância discreta' }).click();
   await page.getByRole('button', { name: 'Pouco tempo' }).click();
   await page.getByRole('button', { name: 'Roupa que já tenho' }).click();
-  await page.getByRole('button', { name: /Enviar diagnóstico/i }).click();
+  await page.getByRole('button', { name: /Ver meu primeiro passo/i }).click();
 
   await expect(page.getByRole('button', { name: /Montando seu plano/i })).toBeVisible();
   await expect(page.getByRole('heading', { name: /Seu plano chegou sem travar a tela/i })).toBeVisible();

--- a/pde-platform/frontend/tests/public-health.spec.ts
+++ b/pde-platform/frontend/tests/public-health.spec.ts
@@ -13,7 +13,7 @@ const defaultContract: Required<PublicHealthContract> = {
   requiredTexts: [
     'Sua imagem comunica a mulher que você quer ser vista como?',
     'Diagnóstico de Presença',
-    'Enviar diagnóstico',
+    'Ver meu primeiro passo',
   ],
   forbiddenTexts: [
     'Application error',


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: deu erro no github verifique

Modelo: {"titulo":"Erro confirmado no GitHub","comentario":"Verifiquei o GitHub Actions.\n\n**Falha encontrada**\n\nO workflow que falhou foi **CI - PDE Platform Metodo MUSA**, na `main`, após o merge do PR #4469 em **23/07/2026 02:45 UTC**.\n\nA falha não foi de build, backend, frontend ou imagem Docker. O erro aconteceu no deploy de homologação, no passo **Validate homolog public rendering**.\n\n**Causa-raiz provável**\n\nA página pública do PDE passou a renderizar o CTA:\n\n`Ver meu primeiro passo`\n\nMas o teste de saúde pública ainda espera o texto antigo:\n\n`Enviar diagnóstico`\n\nEvidências no repositório:\n\n- `pde-platform/frontend/src/App.tsx` usa `Ver meu primeiro passo`\n- `pde-platform/frontend/tests/public-health.spec.ts` ainda espera `Enviar diagnóstico`\n- `pde-platform/frontend/public/pde-health-contract.json` ainda exige `Enviar diagnóstico`\n- `pde-platform/frontend/tests/musa-entry.visual.spec.ts` também ainda procura `Enviar diagnóstico`\n\n**Avaliação das alternativas**\n\n1. Voltar o CTA para `Enviar diagnóstico`  \n   Benefício: passa no teste atual.  \n   Risco: piora a copy comercial, porque o CTA novo é mais orientado a benefício e menos burocrático.\n\n2. Atualizar os testes e contrato público para `Ver meu primeiro passo`  \n   Benefício: mantém a melhoria de conversão e corrige a causa real: contrato de teste desatualizado.  \n   Risco: baixo, desde que os testes visuais também sejam atualizados.\n\n3. Aceitar ambos os textos no teste  \n   Benefício: reduz quebra por mudança de copy.  \n   Risco: enfraquece o teste e pode esconder regressão comercial.\n\n**Recomendação**\n\nA melhor opção é **atualizar o contrato e os testes para o CTA novo `Ver meu primeiro passo`**. Do ponto de vista de marketing, o CTA novo é melhor porque vende avanço imediato, não uma ação técnica de envio.\n\nNão alterei arquivos e não criei PR, porque você pediu apenas para verificar.","sugestaoMelhoriaAmbiente":"O ambiente seria melhor se o token do GitHub CLI tivesse o escopo read:org, pois o gh auth status acusa essa permissão ausente. Mesmo assim, foi possível consultar runs, PR e logs necessários para diagnosticar a falha."}

Última mensagem do usuário:
execute sua recomendação

**Resumo das alterações:**
{"titulo":"Correção aplicada","comentario":"Atualizei o PDE frontend para alinhar o contrato público e os testes com o CTA novo: `Ver meu primeiro passo`.\n\n**Arquivos alterados**\n\n- `pde-platform/frontend/public/pde-health-contract.json`\n- `pde-platform/frontend/tests/public-health.spec.ts`\n- `pde-platform/frontend/tests/musa-entry.visual.spec.ts`\n\n**Validações executadas**\n\n- `npm run build` passou.\n- `npm run test:public-health` passou: 2 testes OK, desktop e mobile.\n- `npx playwright test tests/musa-entry.visual.spec.ts --config=playwright.config.ts` passou: 6 testes OK.\n\nA causa-raiz ficou corrigida: a experiência pública, o contrato de health e os testes agora validam a mesma promessa comercial. Não criei PR.","sugestaoMelhoriaAmbiente":"Seria melhor o ambiente já vir com o Chromium gerenciado do Playwright instalado no cache local; precisei instalar com `npx playwright install chromium` antes de rodar os testes."}