### PR TITLE
AI Hub: {"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/RequestPlannedExperimentVideoRenderRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/RequestPlannedExperimentVideoRenderRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.experiment.video.dto;
+
+import com.marketinghub.salesvideo.SalesVideoExecutionMode;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Solicitação administrativa para renderizar vídeos planejados já vinculados ao experimento.
+ */
+public record RequestPlannedExperimentVideoRenderRequest(
+        @NotBlank String requestedBy,
+        SalesVideoExecutionMode executionMode,
+        String personaName,
+        String personaStyle,
+        String voiceStyle,
+        String language,
+        Boolean requiredForRelease
+) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
 import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
 import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.RequestPlannedExperimentVideoRenderRequest;
 import com.marketinghub.experiment.video.dto.RequestExperimentVeoVideoRequest;
 import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
 import com.marketinghub.media.Asset;
@@ -196,6 +197,29 @@ public class ExperimentVideoAssetService {
         return toDto(repository.save(videoAsset));
     }
 
+    /** Cria jobs de render para ativos planejados e preserva o vínculo original do experimento. */
+    @Transactional
+    public List<ExperimentVideoAssetDto> requestPlannedRenders(
+            Long experimentId,
+            RequestPlannedExperimentVideoRenderRequest request) {
+        Experiment experiment = ensureExperiment(experimentId);
+        Product product = resolveOrCreateProduct(experiment);
+        Long landingPageId = resolveLandingPageId(experimentId);
+        List<ExperimentVideoAsset> plannedAssets = repository.findByExperimentIdOrderByCreatedAtDesc(experimentId)
+                .stream()
+                .filter(videoAsset -> videoAsset.getStatus() == ExperimentVideoStatus.PLANNED)
+                .filter(videoAsset -> videoAsset.getSalesVideoJob() == null)
+                .toList();
+        if (plannedAssets.isEmpty()) {
+            return List.of();
+        }
+        return plannedAssets.stream()
+                .map(videoAsset -> requestRenderForPlannedAsset(videoAsset, product, landingPageId, request))
+                .map(repository::save)
+                .map(this::toDto)
+                .toList();
+    }
+
     /** Atualiza um vídeo de experimento sem perder os campos não enviados. */
     @Transactional
     public ExperimentVideoAssetDto update(Long experimentId, Long videoAssetId, UpdateExperimentVideoAssetRequest request) {
@@ -351,6 +375,64 @@ public class ExperimentVideoAssetService {
                 .orElse(null);
     }
 
+    /** Solicita render no módulo SalesVideo usando o roteiro e prompt já planejados no ativo. */
+    private ExperimentVideoAsset requestRenderForPlannedAsset(ExperimentVideoAsset videoAsset,
+                                                              Product product,
+                                                              Long landingPageId,
+                                                              RequestPlannedExperimentVideoRenderRequest request) {
+        String scriptText = trimToNull(videoAsset.getScript());
+        if (scriptText == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "planned video asset script is required");
+        }
+        String providerName = Optional.ofNullable(trimToNull(videoAsset.getProvider())).orElse("LUMA_RAY_3_2");
+        Long experimentId = videoAsset.getExperiment() != null ? videoAsset.getExperiment().getId() : null;
+        String title = "Vídeo planejado #%d - experimento %d".formatted(videoAsset.getId(), experimentId);
+
+        CreateSalesVideoProfileRequest profileRequest = new CreateSalesVideoProfileRequest();
+        profileRequest.setVideoKind(SalesVideoKind.HERO);
+        profileRequest.setTitle(title);
+        profileRequest.setPersonaName(trimToNull(request.personaName()));
+        profileRequest.setPersonaStyle(trimToNull(request.personaStyle()));
+        profileRequest.setVoiceStyle(trimToNull(request.voiceStyle()));
+        profileRequest.setLanguage(Optional.ofNullable(trimToNull(request.language())).orElse("pt-BR"));
+        profileRequest.setTargetDurationSeconds(videoAsset.getDurationSeconds());
+        profileRequest.setLandingPageId(landingPageId);
+        SalesVideoProfileDto profile = salesVideoService.createProfile(product.getId(), profileRequest);
+
+        ApproveSalesVideoScriptRequest scriptRequest = new ApproveSalesVideoScriptRequest();
+        scriptRequest.setScriptText(scriptText);
+        scriptRequest.setApprovedBy(request.requestedBy().trim());
+        salesVideoService.approveScript(profile.getId(), scriptRequest);
+
+        RequestVideoRenderRequest renderRequest = new RequestVideoRenderRequest();
+        renderRequest.setRequestedBy(request.requestedBy().trim());
+        renderRequest.setProviderFamily(SalesVideoProviderFamily.EXTERNAL_VIDEO_MODULE);
+        renderRequest.setProviderName(providerName);
+        renderRequest.setExecutionMode(request.executionMode());
+        renderRequest.setMetadataJson(buildPlannedRenderMetadata(videoAsset, request));
+        SalesVideoJobDto job = salesVideoService.requestRender(profile.getId(), renderRequest);
+
+        videoAsset.setSalesVideoProfile(resolveProfile(profile.getId()));
+        videoAsset.setSalesVideoJob(resolveJob(job.getId()));
+        videoAsset.setProvider(providerName);
+        videoAsset.setModel(Optional.ofNullable(trimToNull(videoAsset.getModel())).orElse(providerName));
+        videoAsset.setStatus(ExperimentVideoStatus.GENERATING);
+        videoAsset.setReviewStatus(ExperimentVideoReviewStatus.PENDING);
+        if (request.requiredForRelease() != null) {
+            videoAsset.setRequiredForRelease(request.requiredForRelease());
+        }
+        BigDecimal estimatedCost = resolveCost(
+                videoAsset.getCost(),
+                videoAsset.getProvider(),
+                videoAsset.getModel(),
+                videoAsset.getDurationSeconds(),
+                null);
+        if (estimatedCost != null) {
+            videoAsset.setCost(estimatedCost);
+        }
+        return videoAsset;
+    }
+
     /** Monta um resumo auditável do prompt enviado ao fluxo VEO. */
     private String buildVeoPromptSnapshot(RequestExperimentVeoVideoRequest request) {
         return """
@@ -398,6 +480,33 @@ public class ExperimentVideoAssetService {
             return OBJECT_MAPPER.writeValueAsString(metadata);
         } catch (JsonProcessingException ex) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "video metadata serialization failed", ex);
+        }
+    }
+
+    /** Monta metadados estruturados para renderizar um ativo planejado existente. */
+    private String buildPlannedRenderMetadata(ExperimentVideoAsset videoAsset,
+                                              RequestPlannedExperimentVideoRenderRequest request) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("artifactType", "experiment.plannedVideoRenderRequest.v1");
+        metadata.put("experimentId", videoAsset.getExperiment() != null ? videoAsset.getExperiment().getId() : null);
+        metadata.put("experimentVideoAssetId", videoAsset.getId());
+        metadata.put("slot", videoAsset.getSlot());
+        metadata.put("provider", trimToNull(videoAsset.getProvider()));
+        metadata.put("model", trimToNull(videoAsset.getModel()));
+        metadata.put("durationSeconds", videoAsset.getDurationSeconds());
+        metadata.put("aspectRatio", trimToNull(videoAsset.getAspectRatio()));
+        metadata.put("objective", trimToNull(videoAsset.getObjective()));
+        metadata.put("primaryMetric", trimToNull(videoAsset.getPrimaryMetric()));
+        metadata.put("prompt", trimToNull(videoAsset.getPrompt()));
+        metadata.put("scriptText", trimToNull(videoAsset.getScript()));
+        metadata.put("requestedBy", request.requestedBy().trim());
+        try {
+            return OBJECT_MAPPER.writeValueAsString(metadata);
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "planned video metadata serialization failed",
+                    ex);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/web/ExperimentVideoAssetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/web/ExperimentVideoAssetController.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.video.web;
 
 import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
 import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.RequestPlannedExperimentVideoRenderRequest;
 import com.marketinghub.experiment.video.dto.RequestExperimentVeoVideoRequest;
 import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
 import com.marketinghub.experiment.video.service.ExperimentVideoAssetService;
@@ -46,6 +47,14 @@ public class ExperimentVideoAssetController {
     public ExperimentVideoAssetDto requestVeoRender(@PathVariable Long experimentId,
                                                     @Valid @RequestBody RequestExperimentVeoVideoRequest request) {
         return service.requestVeoRender(experimentId, request);
+    }
+
+    /** Cria jobs de render para vídeos planejados sem perder o vínculo dos ativos existentes. */
+    @PostMapping("/planned-render-requests")
+    public List<ExperimentVideoAssetDto> requestPlannedRenders(
+            @PathVariable Long experimentId,
+            @Valid @RequestBody RequestPlannedExperimentVideoRenderRequest request) {
+        return service.requestPlannedRenders(experimentId, request);
     }
 
     /** Atualiza status, revisão e vínculos de um vídeo comercial do experimento. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -8,6 +8,7 @@ import com.marketinghub.experiment.video.ExperimentVideoSlot;
 import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
 import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
+import com.marketinghub.experiment.video.dto.RequestPlannedExperimentVideoRenderRequest;
 import com.marketinghub.experiment.video.dto.RequestExperimentVeoVideoRequest;
 import com.marketinghub.experiment.video.dto.UpdateExperimentVideoAssetRequest;
 import com.marketinghub.niche.MarketNiche;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
@@ -41,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 /**
  * Valida o registro de vídeos como ativos comerciais vinculados ao experimento.
@@ -190,6 +193,72 @@ class ExperimentVideoAssetServiceTest {
         assertThat(dto.requiredForRelease()).isTrue();
         assertThat(dto.cost()).isEqualByComparingTo("12.0000");
         assertThat(dto.prompt()).contains("gpt-image-2", "Retrato vertical de consultora brasileira elegante");
+    }
+
+    /** Garante que ativos planejados viram jobs de render sem criar ativos duplicados. */
+    @Test
+    void shouldRequestRenderForExistingPlannedVideoAssets() {
+        MarketNiche niche = MarketNiche.builder().id(31L).name("Beleza").build();
+        Experiment experiment = Experiment.builder()
+                .id(68L)
+                .niche(niche)
+                .name("Metodo MUSA")
+                .singlePain("Imagem sem presenca")
+                .funnelPromise("Parecer mais elegante em 7 dias")
+                .build();
+        Product product = Product.builder().id(3L).marketNiche(niche).build();
+        SalesVideoProfile profile = SalesVideoProfile.builder().id(12L).product(product).build();
+        SalesVideoJob job = SalesVideoJob.builder().id(20431L).profile(profile).build();
+        ExperimentVideoAsset plannedAsset = ExperimentVideoAsset.builder()
+                .id(5L)
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.LANDING_HERO)
+                .objective("Aumentar clique no diagnostico")
+                .primaryMetric("diagnostico iniciado")
+                .script("Clipe 1 - Dor do espelho.")
+                .prompt("Video vertical 9:16, 8 segundos, estilo editorial realista.")
+                .provider("LUMA_RAY_3_2")
+                .model("luma-ray-3.2")
+                .durationSeconds(8)
+                .aspectRatio("9:16")
+                .status(ExperimentVideoStatus.PLANNED)
+                .reviewStatus(ExperimentVideoReviewStatus.PENDING)
+                .requiredForRelease(true)
+                .build();
+        SalesVideoProfileDto profileDto = new SalesVideoProfileDto();
+        profileDto.setId(12L);
+        SalesVideoJobDto jobDto = new SalesVideoJobDto();
+        jobDto.setId(20431L);
+        given(experimentRepository.findById(68L)).willReturn(Optional.of(experiment));
+        given(productRepository.findFirstByMarketNiche_IdOrderByCreatedAtDesc(31L)).willReturn(Optional.of(product));
+        given(landingPageRepository.findByExperimentId(68L)).willReturn(List.of());
+        given(repository.findByExperimentIdOrderByCreatedAtDesc(68L)).willReturn(List.of(plannedAsset));
+        given(salesVideoService.createProfile(any(), any())).willReturn(profileDto);
+        given(salesVideoService.requestRender(any(), any())).willReturn(jobDto);
+        given(profileRepository.findById(12L)).willReturn(Optional.of(profile));
+        given(jobRepository.findById(20431L)).willReturn(Optional.of(job));
+        given(repository.save(any(ExperimentVideoAsset.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        List<ExperimentVideoAssetDto> result = service.requestPlannedRenders(
+                68L,
+                new RequestPlannedExperimentVideoRenderRequest(
+                        "time@marketinghub.io",
+                        SalesVideoExecutionMode.TEST,
+                        null,
+                        "editorial premium acessivel",
+                        "natural",
+                        "pt-BR",
+                        true));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(5L);
+        assertThat(result.get(0).status()).isEqualTo(ExperimentVideoStatus.GENERATING);
+        assertThat(result.get(0).provider()).isEqualTo("LUMA_RAY_3_2");
+        assertThat(result.get(0).salesVideoProfileId()).isEqualTo(12L);
+        assertThat(result.get(0).salesVideoJobId()).isEqualTo(20431L);
+        ArgumentCaptor<ExperimentVideoAsset> savedAsset = ArgumentCaptor.forClass(ExperimentVideoAsset.class);
+        verify(repository).save(savedAsset.capture());
+        assertThat(savedAsset.getValue().getId()).isEqualTo(5L);
     }
 
     /** Garante que a landing de outro experimento não pode contaminar o aprendizado do funil atual. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6040,3 +6040,10 @@
 - foi feito: adicionada ação administrativa no Marketing Hub para solicitar deploy produtivo pelo workflow canônico do PDE com `target_environment=production`, sem SSH direto no servidor.
 - bloqueio seguro: se homologação não estiver saudável, se os commits mudarem entre leitura e clique ou se o backend não tiver token/configuração do GitHub Actions, o Hub bloqueia a promoção e mostra a causa.
 - impacto comercial esperado: reduzir atraso entre correção homologada e funil real corrigido, evitando perda de leads por versão antiga em produção.
+
+## 2026-07-23 — PED/MUSA: vídeos planejados viram jobs de render
+
+- causa-raiz confirmada: o experimento 68 tinha 4 vídeos `LANDING_HERO` planejados para Luma Ray 3.2, mas nenhum `sales_video_job_id`; o endpoint existente de VEO criava um novo ativo em vez de anexar render ao ativo planejado.
+- foi feito: criado fluxo para solicitar render dos vídeos planejados preservando os IDs dos ativos, criando profile/script/job no módulo SalesVideo e marcando os ativos como `GENERATING`.
+- foi feito: a aba Vídeo do experimento passou a oferecer a ação `Renderizar planejados`, com execução em modo `TEST` e provider/model vindos do ativo planejado.
+- impacto comercial esperado: destravar o hero de vídeo do MUSA sem perder rastreabilidade de criativo, custo, job e aprendizado por clipe.

--- a/docs/swagger/experiment-video-assets-swagger.yaml
+++ b/docs/swagger/experiment-video-assets-swagger.yaml
@@ -79,6 +79,25 @@ paths:
       responses:
         "200":
           description: Job VEO criado e vinculado ao experimento
+  /api/experiments/{experimentId}/video-assets/planned-render-requests:
+    post:
+      summary: Solicita render dos vídeos planejados preservando os ativos existentes
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestPlannedExperimentVideoRenderRequest"
+      responses:
+        "200":
+          description: Jobs criados e vinculados aos ativos planejados
 components:
   schemas:
     CreateExperimentVideoAssetRequest:
@@ -204,5 +223,26 @@ components:
           enum: [TEST, PRODUCTION]
         requestedBy:
           type: string
+        requiredForRelease:
+          type: boolean
+    RequestPlannedExperimentVideoRenderRequest:
+      type: object
+      required:
+        - requestedBy
+      properties:
+        requestedBy:
+          type: string
+        executionMode:
+          type: string
+          enum: [TEST, PRODUCTION]
+        personaName:
+          type: string
+        personaStyle:
+          type: string
+        voiceStyle:
+          type: string
+        language:
+          type: string
+          example: pt-BR
         requiredForRelease:
           type: boolean

--- a/frontend/src/api/experiment/useRequestPlannedExperimentVideoRenders.ts
+++ b/frontend/src/api/experiment/useRequestPlannedExperimentVideoRenders.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import {
+  ExperimentVideoAsset,
+  SalesVideoExecutionMode,
+} from "./useExperimentVideoAssets";
+
+export interface RequestPlannedExperimentVideoRendersPayload {
+  requestedBy: string;
+  executionMode?: SalesVideoExecutionMode;
+  personaName?: string;
+  personaStyle?: string;
+  voiceStyle?: string;
+  language?: string;
+  requiredForRelease?: boolean;
+}
+
+export function useRequestPlannedExperimentVideoRenders(
+  experimentId?: string | number,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: RequestPlannedExperimentVideoRendersPayload) => {
+      if (!experimentId) {
+        throw new Error("Experimento inválido para renderização de vídeos");
+      }
+      const { data } = await axios.post<ExperimentVideoAsset[]>(
+        `/api/experiments/${experimentId}/video-assets/planned-render-requests`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["experiment-video-assets", experimentId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["experiment-video-assets", "all"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["experiment", String(experimentId)],
+      });
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentVideoTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentVideoTab.tsx
@@ -10,6 +10,7 @@ import {
   SalesVideoExecutionMode,
   useExperimentVideoAssets,
 } from "../../api/experiment/useExperimentVideoAssets";
+import { useRequestPlannedExperimentVideoRenders } from "../../api/experiment/useRequestPlannedExperimentVideoRenders";
 import { useRequestExperimentVeoVideo } from "../../api/experiment/useRequestExperimentVeoVideo";
 import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 import { useTenantContext } from "../../utils/tenantContext";
@@ -117,6 +118,9 @@ export default function ExperimentVideoTab({
   );
   const geraSalesPagePublications = useGeraSalesPagePublications(experiment.id);
   const requestVeoVideo = useRequestExperimentVeoVideo(experiment.id);
+  const requestPlannedRenders = useRequestPlannedExperimentVideoRenders(
+    experiment.id,
+  );
   const [formState, setFormState] = useState({
     slot: "LANDING_HERO" as ExperimentVideoSlot,
     title: `Vídeo VEO - Experimento ${experiment.id}`,
@@ -143,6 +147,13 @@ export default function ExperimentVideoTab({
   });
 
   const sortedAssets = useMemo(() => videoAssets ?? [], [videoAssets]);
+  const plannedAssetsWithoutJob = useMemo(
+    () =>
+      sortedAssets.filter(
+        (asset) => asset.status === "PLANNED" && !asset.salesVideoJobId,
+      ),
+    [sortedAssets],
+  );
   const landingHeroAsset = useMemo(
     () =>
       sortedAssets.find(
@@ -184,6 +195,38 @@ export default function ExperimentVideoTab({
     formState.scriptText.trim().length > 0 &&
     tenantContext.userEmail.trim().length > 0 &&
     !requestVeoVideo.isPending;
+  const canRequestPlannedRenders =
+    !alterationLocked &&
+    plannedAssetsWithoutJob.length > 0 &&
+    tenantContext.userEmail.trim().length > 0 &&
+    !requestPlannedRenders.isPending;
+
+  const handleRequestPlannedRenders = async () => {
+    try {
+      const updatedAssets = await requestPlannedRenders.mutateAsync({
+        requestedBy: tenantContext.userEmail,
+        executionMode: "TEST",
+        personaStyle: "editorial, realista e premium acessivel",
+        voiceStyle: "natural, direta e comercial",
+        language: "pt-BR",
+        requiredForRelease: true,
+      });
+      if (updatedAssets.length === 0) {
+        toast.info("Nenhum vídeo planejado sem job para renderizar.");
+        return;
+      }
+      toast.success(
+        `${updatedAssets.length} vídeo(s) planejado(s) enviados para render.`,
+      );
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.message ??
+          error.response?.data?.detail ??
+          "Não foi possível solicitar os renders planejados.")
+        : "Não foi possível solicitar os renders planejados.";
+      toast.error(message);
+    }
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -352,9 +395,21 @@ export default function ExperimentVideoTab({
                 página.
               </p>
             </div>
-            <span className="badge text-bg-secondary">
-              {sortedAssets.length} ativo(s)
-            </span>
+            <div className="d-flex align-items-center gap-2 flex-wrap">
+              <button
+                type="button"
+                className="btn btn-sm btn-primary"
+                disabled={!canRequestPlannedRenders}
+                onClick={handleRequestPlannedRenders}
+              >
+                {requestPlannedRenders.isPending
+                  ? "Solicitando..."
+                  : "Renderizar planejados"}
+              </button>
+              <span className="badge text-bg-secondary">
+                {sortedAssets.length} ativo(s)
+              </span>
+            </div>
           </div>
           <div className="table-responsive mt-3">
             <table className="table table-sm align-middle">


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: vejo apenas videos planejados tem algum problema ?

Modelo: {"titulo":"Vídeos só planejados","comentario":"Sim, há um problema **se a expectativa era já ter vídeos renderizados**.\n\nPelo backend e banco real, o experimento 68 tem 4 vídeos `LANDING_HERO`, todos com:\n\n- `status=PLANNED`\n- `reviewStatus=PENDING`\n- `salesVideoJobId=null`\n- `assetId=null`\n- `assetUrl=null`\n- `cost=null`\n\nOu seja: o sistema registrou o **plano criativo dos 4 clipes**, mas ainda **não criou job de renderização** nem gerou arquivo de vídeo.\n\n**Conclusão:** não parece falha do renderizador neste ponto. O render simplesmente não foi disparado/vinculado. Também confirmei que não há `sales_video_job` criado depois de `23/07/2026 17:20 UTC` para esse fluxo.\n\n**Impacto comercial:** enquanto estiver assim, a landing mostra “Vídeo ainda não disponível” e a campanha não deveria ser liberada como funil com vídeo obrigatório. Para vender melhor, esse hero precisa virar vídeo real com `READY + APPROVED + assetUrl`.\n\n**Alternativas avaliadas:**\n\n1. Manter como planejado por enquanto: serve só como planejamento criativo. Baixo esforço, mas não ajuda a conversão agora.\n2. Solicitar cada vídeo manualmente pelo formulário atual: rápido, mas a tela está orientada a VEO, enquanto a estratégia documentada para MUSA recomenda Luma Ray 3.2 como principal.\n3. Melhor caminho: transformar os 4 assets planejados Luma em jobs reais de renderização, preservando vínculo, custo, asset e aprovação. É o caminho mais aderente ao objetivo de venda e rastreabilidade.\n\nMinha recomendação: tratar isso como **pendência operacional do funil**, não como erro visual da tela.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs diretos do video-management-service; isso permitiria confirmar status do worker Luma com mais precisão quando houver jobs criados.","orientacaoProximaAcao":"Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados."}

Última mensagem do usuário:
Execute sua orientação : 
Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados.

**Resumo das alterações:**
{"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned-render-requests`.\n- Ele pega assets `PLANNED` sem `salesVideoJobId`, cria `profile + script + job` no SalesVideo e atualiza o próprio asset para `GENERATING`.\n- Frontend ganhou a ação **Renderizar planejados** na aba Vídeo do experimento.\n- Swagger e registro de experimentos foram atualizados.\n\n**Validação:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou com 7 testes.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n\n**Importante:** ainda não criei PR e não publiquei nada. Os 4 vídeos do experimento 68 continuam sem render em produção até essa mudança passar por PR/deploy e a ação ser executada no Marketing Hub.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar essa mudança; depois do deploy, use a ação Renderizar planejados na aba Vídeo do experimento 68 para criar os 4 jobs Luma vinculados aos assets existentes."}