### PR TITLE
AI Hub: {"titulo":"Renderização falhou na Luma","comentario":"Acompanhei o deploy no GitHub até concluir com sucesso e executei a renderização dos vídeos do experimento 68 pelo contrato do Marketing Hub.\n\n**Resultado operacional:**\n\n- O deploy do PR `…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
@@ -1,10 +1,14 @@
 package com.marketinghub.experiment.video.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.marketinghub.experiment.video.ExperimentVideoAsset;
 import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.dto.JobCompletionRequest;
+import com.marketinghub.salesvideo.dto.JobFailureRequest;
 import com.marketinghub.salesvideo.service.SalesVideoCompletedRenderAssetSync;
 import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
 import java.math.BigDecimal;
@@ -17,6 +21,8 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRenderAssetSync {
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+
     private final ExperimentVideoAssetRepository repository;
     private final SalesVideoProductionCostCalculator costCalculator;
 
@@ -52,6 +58,22 @@ public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRe
         repository.saveAll(videoAssets);
     }
 
+    /** Propaga falha definitiva de render para os videos de experimento vinculados ao job. */
+    @Override
+    public void syncFailedRender(SalesVideoJob job, JobFailureRequest request) {
+        if (job == null || job.getId() == null) {
+            return;
+        }
+        List<ExperimentVideoAsset> videoAssets = repository.findBySalesVideoJobId(job.getId());
+        if (videoAssets.isEmpty()) {
+            return;
+        }
+        for (ExperimentVideoAsset videoAsset : videoAssets) {
+            applyFailedRender(videoAsset, job, request);
+        }
+        repository.saveAll(videoAssets);
+    }
+
     /** Aplica os campos auditaveis do render concluido em um ativo de experimento. */
     private void applyCompletedRender(ExperimentVideoAsset videoAsset,
                                       SalesVideoJob job,
@@ -74,4 +96,40 @@ public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRe
         videoAsset.setResponseJson(request.getMetadataJson());
         videoAsset.setStatus(ExperimentVideoStatus.READY);
     }
+
+    /** Registra a causa da falha no ativo para a tela não permanecer como gerando. */
+    private void applyFailedRender(ExperimentVideoAsset videoAsset,
+                                   SalesVideoJob job,
+                                   JobFailureRequest request) {
+        videoAsset.setStatus(ExperimentVideoStatus.FAILED);
+        videoAsset.setResponseJson(failureSnapshot(job, request));
+    }
+
+    /** Monta um JSON simples com a causa operacional da falha do render. */
+    private String failureSnapshot(SalesVideoJob job, JobFailureRequest request) {
+        String message = request != null ? request.getMessage() : null;
+        String failureCode = request != null && request.getFailureCode() != null
+                ? request.getFailureCode()
+                : job.getFailureCode();
+        String failureDetail = request != null && request.getFailureDetail() != null
+                ? request.getFailureDetail()
+                : job.getFailureDetail();
+        try {
+            return OBJECT_MAPPER.writeValueAsString(new FailureSnapshot(
+                    "VIDEO_FAILED",
+                    job.getId(),
+                    failureCode,
+                    message,
+                    failureDetail));
+        } catch (JsonProcessingException ex) {
+            return "{\"status\":\"VIDEO_FAILED\",\"jobId\":%d}".formatted(job.getId());
+        }
+    }
+
+    /** Snapshot persistido para explicar a falha operacional na tela do experimento. */
+    private record FailureSnapshot(String status,
+                                   Long jobId,
+                                   String failureCode,
+                                   String message,
+                                   String failureDetail) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -28,6 +28,7 @@ import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoKind;
 import com.marketinghub.salesvideo.SalesVideoProfile;
 import com.marketinghub.salesvideo.SalesVideoProviderFamily;
+import com.marketinghub.salesvideo.SalesVideoStatus;
 import com.marketinghub.salesvideo.dto.ApproveSalesVideoScriptRequest;
 import com.marketinghub.salesvideo.dto.CreateSalesVideoProfileRequest;
 import com.marketinghub.salesvideo.dto.RequestVideoRenderRequest;
@@ -207,8 +208,7 @@ public class ExperimentVideoAssetService {
         Long landingPageId = resolveLandingPageId(experimentId);
         List<ExperimentVideoAsset> plannedAssets = repository.findByExperimentIdOrderByCreatedAtDesc(experimentId)
                 .stream()
-                .filter(videoAsset -> videoAsset.getStatus() == ExperimentVideoStatus.PLANNED)
-                .filter(videoAsset -> videoAsset.getSalesVideoJob() == null)
+                .filter(this::requiresRenderJob)
                 .toList();
         if (plannedAssets.isEmpty()) {
             return List.of();
@@ -431,6 +431,18 @@ public class ExperimentVideoAssetService {
             videoAsset.setCost(estimatedCost);
         }
         return videoAsset;
+    }
+
+    /** Identifica ativos planejados ou falhados que podem receber novo job sem duplicar o ativo. */
+    private boolean requiresRenderJob(ExperimentVideoAsset videoAsset) {
+        if (videoAsset.getStatus() == ExperimentVideoStatus.PLANNED && videoAsset.getSalesVideoJob() == null) {
+            return true;
+        }
+        SalesVideoJob currentJob = videoAsset.getSalesVideoJob();
+        return currentJob != null
+                && currentJob.getStatus() == SalesVideoStatus.VIDEO_FAILED
+                && (videoAsset.getStatus() == ExperimentVideoStatus.GENERATING
+                        || videoAsset.getStatus() == ExperimentVideoStatus.FAILED);
     }
 
     /** Monta um resumo auditável do prompt enviado ao fluxo VEO. */

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoCompletedRenderAssetSync.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoCompletedRenderAssetSync.java
@@ -2,6 +2,7 @@ package com.marketinghub.salesvideo.service;
 
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.dto.JobCompletionRequest;
+import com.marketinghub.salesvideo.dto.JobFailureRequest;
 
 /**
  * Sincroniza dominios externos interessados quando um render de SalesVideo e concluido.
@@ -12,4 +13,7 @@ public interface SalesVideoCompletedRenderAssetSync {
                              JobCompletionRequest request,
                              Integer durationSeconds,
                              String resolution);
+
+    /** Propaga falhas finais de render para ativos comerciais associados ao job. */
+    void syncFailedRender(SalesVideoJob job, JobFailureRequest request);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
@@ -203,6 +203,7 @@ public class SalesVideoJobService {
         }
         jobRepository.save(job);
         syncExperimentVideoAsset(job, request, durationSeconds);
+        syncFailedExperimentVideoAsset(job, completionFailureRequest(request));
         maybeUpdateProfileStatus(job, finalStatus);
         registerEvent(job, SalesVideoJobEventType.COMPLETED, previous, finalStatus,
                 completionMessage(request, durationValidation), completionDetails(request, durationValidation));
@@ -220,6 +221,7 @@ public class SalesVideoJobService {
         job.setFailureDetail(request.getFailureDetail());
         job.setFinishedAt(Instant.now());
         jobRepository.save(job);
+        syncFailedExperimentVideoAsset(job, request);
         maybeUpdateProfileStatus(job, newStatus);
         registerEvent(job, SalesVideoJobEventType.FAILED, previous, newStatus,
                 request.getMessage(), request.getFailureDetail());
@@ -309,6 +311,25 @@ public class SalesVideoJobService {
                 request,
                 durationSeconds,
                 resolveResolution(request));
+    }
+
+    /** Notifica a porta de sincronizacao quando um render vinculado falha definitivamente. */
+    private void syncFailedExperimentVideoAsset(SalesVideoJob job, JobFailureRequest request) {
+        if (job.getId() == null || job.getJobType() != SalesVideoJobType.RENDER
+                || job.getStatus() != SalesVideoStatus.VIDEO_FAILED) {
+            return;
+        }
+        completedRenderAssetSync.syncFailedRender(job, request);
+    }
+
+    /** Converte uma conclusao bloqueada em payload de falha para sincronizacao externa. */
+    private JobFailureRequest completionFailureRequest(JobCompletionRequest request) {
+        JobFailureRequest failureRequest = new JobFailureRequest();
+        failureRequest.setStatus(SalesVideoStatus.VIDEO_FAILED);
+        failureRequest.setFailureCode(SHORT_DURATION_FAILURE_CODE);
+        failureRequest.setFailureDetail(request.getDetailsJson());
+        failureRequest.setMessage(request.getMessage());
+        return failureRequest;
     }
 
     /** Extrai a duração auditada do metadata do worker quando disponível. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -25,6 +25,7 @@ import com.marketinghub.salesvideo.LandingVideoSlot;
 import com.marketinghub.salesvideo.SalesVideoExecutionMode;
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoProfile;
+import com.marketinghub.salesvideo.SalesVideoStatus;
 import com.marketinghub.salesvideo.dto.SalesVideoJobDto;
 import com.marketinghub.salesvideo.dto.SalesVideoProfileDto;
 import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
@@ -259,6 +260,70 @@ class ExperimentVideoAssetServiceTest {
         ArgumentCaptor<ExperimentVideoAsset> savedAsset = ArgumentCaptor.forClass(ExperimentVideoAsset.class);
         verify(repository).save(savedAsset.capture());
         assertThat(savedAsset.getValue().getId()).isEqualTo(5L);
+    }
+
+    /** Permite reprocessar o mesmo ativo quando o job anterior falhou no executor de vídeo. */
+    @Test
+    void shouldRequestNewRenderForAssetWithFailedSalesVideoJob() {
+        MarketNiche niche = MarketNiche.builder().id(31L).name("Beleza").build();
+        Experiment experiment = Experiment.builder().id(68L).niche(niche).name("Metodo MUSA").build();
+        Product product = Product.builder().id(3L).marketNiche(niche).build();
+        SalesVideoProfile oldProfile = SalesVideoProfile.builder().id(12L).product(product).build();
+        SalesVideoJob failedJob = SalesVideoJob.builder()
+                .id(20431L)
+                .profile(oldProfile)
+                .status(SalesVideoStatus.VIDEO_FAILED)
+                .build();
+        SalesVideoProfile newProfile = SalesVideoProfile.builder().id(13L).product(product).build();
+        SalesVideoJob newJob = SalesVideoJob.builder().id(20435L).profile(newProfile).build();
+        ExperimentVideoAsset asset = ExperimentVideoAsset.builder()
+                .id(5L)
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.LANDING_HERO)
+                .objective("Aumentar clique no diagnostico")
+                .primaryMetric("diagnostico iniciado")
+                .script("Clipe 1 - Dor do espelho.")
+                .prompt("Video vertical 9:16, 8 segundos, estilo editorial realista.")
+                .provider("LUMA_RAY_3_2")
+                .model("luma-ray-3.2")
+                .durationSeconds(8)
+                .aspectRatio("9:16")
+                .status(ExperimentVideoStatus.GENERATING)
+                .reviewStatus(ExperimentVideoReviewStatus.PENDING)
+                .salesVideoProfile(oldProfile)
+                .salesVideoJob(failedJob)
+                .requiredForRelease(true)
+                .build();
+        SalesVideoProfileDto profileDto = new SalesVideoProfileDto();
+        profileDto.setId(13L);
+        SalesVideoJobDto jobDto = new SalesVideoJobDto();
+        jobDto.setId(20435L);
+        given(experimentRepository.findById(68L)).willReturn(Optional.of(experiment));
+        given(productRepository.findFirstByMarketNiche_IdOrderByCreatedAtDesc(31L)).willReturn(Optional.of(product));
+        given(landingPageRepository.findByExperimentId(68L)).willReturn(List.of());
+        given(repository.findByExperimentIdOrderByCreatedAtDesc(68L)).willReturn(List.of(asset));
+        given(salesVideoService.createProfile(any(), any())).willReturn(profileDto);
+        given(salesVideoService.requestRender(any(), any())).willReturn(jobDto);
+        given(profileRepository.findById(13L)).willReturn(Optional.of(newProfile));
+        given(jobRepository.findById(20435L)).willReturn(Optional.of(newJob));
+        given(repository.save(any(ExperimentVideoAsset.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        List<ExperimentVideoAssetDto> result = service.requestPlannedRenders(
+                68L,
+                new RequestPlannedExperimentVideoRenderRequest(
+                        "time@marketinghub.io",
+                        SalesVideoExecutionMode.TEST,
+                        null,
+                        "editorial premium acessivel",
+                        "natural",
+                        "pt-BR",
+                        true));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(5L);
+        assertThat(result.get(0).status()).isEqualTo(ExperimentVideoStatus.GENERATING);
+        assertThat(result.get(0).salesVideoProfileId()).isEqualTo(13L);
+        assertThat(result.get(0).salesVideoJobId()).isEqualTo(20435L);
     }
 
     /** Garante que a landing de outro experimento não pode contaminar o aprendizado do funil atual. */

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
@@ -8,6 +8,7 @@ import com.marketinghub.salesvideo.SalesVideoProfile;
 import com.marketinghub.salesvideo.SalesVideoProviderFamily;
 import com.marketinghub.salesvideo.SalesVideoStatus;
 import com.marketinghub.salesvideo.dto.JobCompletionRequest;
+import com.marketinghub.salesvideo.dto.JobFailureRequest;
 import com.marketinghub.salesvideo.dto.SalesVideoJobDto;
 import com.marketinghub.repository.jpa.salesvideo.SalesVideoJobEventRepository;
 import com.marketinghub.repository.jpa.salesvideo.SalesVideoJobRepository;
@@ -142,6 +143,9 @@ class SalesVideoJobServiceTest {
                 org.mockito.Mockito.any(),
                 org.mockito.Mockito.any(),
                 org.mockito.Mockito.any());
+        verify(completedRenderAssetSync).syncFailedRender(
+                org.mockito.Mockito.eq(job),
+                org.mockito.Mockito.any(JobFailureRequest.class));
     }
 
     /** Aceita render quando a duração auditada atende a tolerância comercial do perfil. */
@@ -176,5 +180,27 @@ class SalesVideoJobServiceTest {
                 org.mockito.Mockito.eq(request),
                 org.mockito.Mockito.eq(28),
                 org.mockito.Mockito.eq("720p"));
+    }
+
+    /** Propaga falha de render para ativos comerciais vinculados ao job. */
+    @Test
+    void shouldSyncFailedRenderWithExperimentVideoAssets() {
+        SalesVideoJob job = SalesVideoJob.builder()
+                .id(20431L)
+                .jobType(SalesVideoJobType.RENDER)
+                .providerFamily(SalesVideoProviderFamily.EXTERNAL_VIDEO_MODULE)
+                .status(SalesVideoStatus.VIDEO_PROCESSING)
+                .build();
+        JobFailureRequest request = new JobFailureRequest();
+        request.setStatus(SalesVideoStatus.VIDEO_FAILED);
+        request.setFailureCode("VIDEO_MODULE_ERROR");
+        request.setFailureDetail("404 Not Found from POST https://agents.lumalabs.ai/v1/generations");
+        given(jobRepository.findById(20431L)).willReturn(Optional.of(job));
+        given(jobRepository.save(job)).willReturn(job);
+
+        SalesVideoJobDto result = service.fail(20431L, request);
+
+        assertThat(result.getStatus()).isEqualTo(SalesVideoStatus.VIDEO_FAILED);
+        verify(completedRenderAssetSync).syncFailedRender(job, request);
     }
 }

--- a/video-management-service/README.md
+++ b/video-management-service/README.md
@@ -45,6 +45,7 @@ Para acompanhar os logs dos jobs, mantenha `video.jobs.polling-enabled=true` e v
 | `video.providers.veo.model` | Modelo VEO usado para gerar vídeo. | `veo-3.1-generate-preview` |
 | `video.providers.veo.duration-seconds` | Duração numérica enviada ao VEO. | `8` |
 | `video.providers.luma.enabled` | Habilita o adapter direto Luma Ray 3.2. | `false` |
+| `video.providers.luma.base-url` | Host oficial da Luma Agents API. | `https://agents.lumalabs.ai` |
 | `video.providers.luma.api-key` | Chave Luma Agents usada pelo adapter Luma. | `${LUMA_AGENTS_API_KEY}` / `${VIDEO_PROVIDERS_LUMA_API_KEY}` |
 | `video.providers.luma.api-key-file` | Arquivo montado com a chave Luma. | `${LUMA_API_KEY_FILE}` |
 | `video.providers.luma.scene-count` | Quantidade de cenas Ray 3.2 para montagem do hero. | `3` |

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/config/VideoManagementProperties.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/config/VideoManagementProperties.java
@@ -86,7 +86,7 @@ public class VideoManagementProperties {
          * Base URL oficial da Luma Agents API.
          */
         @NotNull
-        private URI baseUrl = URI.create("https://api.lumalabs.ai");
+        private URI baseUrl = URI.create("https://agents.lumalabs.ai");
 
         /**
          * Chave da Luma Agents API usada apenas pelo módulo executor de vídeo.

--- a/video-management-service/src/main/resources/application.yml
+++ b/video-management-service/src/main/resources/application.yml
@@ -20,7 +20,7 @@ video:
         - LUMA_RAY_3_2
         - LUMA
         - RAY_3_2
-      base-url: https://api.lumalabs.ai
+      base-url: https://agents.lumalabs.ai
       api-key: ${LUMA_AGENTS_API_KEY:${VIDEO_PROVIDERS_LUMA_API_KEY:}}
       api-key-file: ${LUMA_API_KEY_FILE:}
       model: ray-3.2

--- a/video-management-service/src/test/java/com/marketinghub/videomanagement/service/provider/LumaRayVideoProviderTest.java
+++ b/video-management-service/src/test/java/com/marketinghub/videomanagement/service/provider/LumaRayVideoProviderTest.java
@@ -93,6 +93,15 @@ class LumaRayVideoProviderTest {
                 .hasMessageContaining("LUMA_AGENTS_API_KEY");
     }
 
+    /** Mantem o host oficial da Luma Agents como padrao para evitar chamadas ao contrato legado. */
+    @Test
+    void shouldUseOfficialLumaAgentsBaseUrlByDefault() {
+        VideoManagementProperties properties = new VideoManagementProperties();
+
+        assertThat(properties.getProviders().getLuma().getBaseUrl())
+                .isEqualTo(URI.create("https://agents.lumalabs.ai"));
+    }
+
     /** Cria uma resposta JSON para a Luma Agents API simulada. */
     private MockResponse json(String body) {
         return new MockResponse()


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: vejo apenas videos planejados tem algum problema ?

Modelo: {"titulo":"Vídeos só planejados","comentario":"Sim, há um problema **se a expectativa era já ter vídeos renderizados**.\n\nPelo backend e banco real, o experimento 68 tem 4 vídeos `LANDING_HERO`, todos com:\n\n- `status=PLANNED`\n- `reviewStatus=PENDING`\n- `salesVideoJobId=null`\n- `assetId=null`\n- `assetUrl=null`\n- `cost=null`\n\nOu seja: o sistema registrou o **plano criativo dos 4 clipes**, mas ainda **não criou job de renderização** nem gerou arquivo de vídeo.\n\n**Conclusão:** não parece falha do renderizador neste ponto. O render simplesmente não foi disparado/vinculado. Também confirmei que não há `sales_video_job` criado depois de `23/07/2026 17:20 UTC` para esse fluxo.\n\n**Impacto comercial:** enquanto estiver assim, a landing mostra “Vídeo ainda não disponível” e a campanha não deveria ser liberada como funil com vídeo obrigatório. Para vender melhor, esse hero precisa virar vídeo real com `READY + APPROVED + assetUrl`.\n\n**Alternativas avaliadas:**\n\n1. Manter como planejado por enquanto: serve só como planejamento criativo. Baixo esforço, mas não ajuda a conversão agora.\n2. Solicitar cada vídeo manualmente pelo formulário atual: rápido, mas a tela está orientada a VEO, enquanto a estratégia documentada para MUSA recomenda Luma Ray 3.2 como principal.\n3. Melhor caminho: transformar os 4 assets planejados Luma em jobs reais de renderização, preservando vínculo, custo, asset e aprovação. É o caminho mais aderente ao objetivo de venda e rastreabilidade.\n\nMinha recomendação: tratar isso como **pendência operacional do funil**, não como erro visual da tela.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs diretos do video-management-service; isso permitiria confirmar status do worker Luma com mais precisão quando houver jobs criados.","orientacaoProximaAcao":"Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados."}

Usuário: Execute sua orientação : 
Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados.

Modelo: {"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned-render-requests`.\n- Ele pega assets `PLANNED` sem `salesVideoJobId`, cria `profile + script + job` no SalesVideo e atualiza o próprio asset para `GENERATING`.\n- Frontend ganhou a ação **Renderizar planejados** na aba Vídeo do experimento.\n- Swagger e registro de experimentos foram atualizados.\n\n**Validação:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou com 7 testes.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n\n**Importante:** ainda não criei PR e não publiquei nada. Os 4 vídeos do experimento 68 continuam sem render em produção até essa mudança passar por PR/deploy e a ação ser executada no Marketing Hub.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar essa mudança; depois do deploy, use a ação Renderizar planejados na aba Vídeo do experimento 68 para criar os 4 jobs Luma vinculados aos assets existentes."}

Última mensagem do usuário:
esta fazendo o deploy, acompanhe pelo github e depois Execute a Renderização dos Videos do experimento 68 pelo Marketing Hub veja se vai funcioanr corretamente ajuste o que for necessario.

**Resumo das alterações:**
{"titulo":"Renderização falhou na Luma","comentario":"Acompanhei o deploy no GitHub até concluir com sucesso e executei a renderização dos vídeos do experimento 68 pelo contrato do Marketing Hub.\n\n**Resultado operacional:**\n\n- O deploy do PR `#4480` terminou com sucesso.\n- A chamada `POST /api/experiments/68/video-assets/planned-render-requests` funcionou.\n- Os 4 assets saíram de `PLANNED` para `GENERATING`.\n- Foram criados os jobs `20431`, `20432`, `20433` e `20434`.\n\n**Problema encontrado:**\n\nOs 4 jobs falharam imediatamente no executor de vídeo com:\n\n`404 Not Found from POST https://api.lumalabs.ai/v1/generations`\n\nA causa-raiz é integração desatualizada com a Luma. A documentação atual da Luma Agents usa o host:\n\n`https://agents.lumalabs.ai/v1/generations`\n\nReferências consultadas:\n\n- https://docs.agents.lumalabs.ai/\n- https://docs.agents.lumalabs.ai/guides/videos/generation/\n\n**Ajustes deixados prontos na branch/worktree:**\n\n- Corrigi o host padrão da Luma no `video-management-service` para `https://agents.lumalabs.ai`.\n- Atualizei o teste do provider Luma para proteger esse contrato.\n- Corrigi o backend para sincronizar falha de render no asset do experimento, evitando a tela ficar presa em `GENERATING` quando o job já está `VIDEO_FAILED`.\n- Ajustei o endpoint de renderização planejada para permitir reprocessar o mesmo asset quando o job anterior falhou, sem duplicar vídeos.\n\n**Validação:**\n\n- `video-management-service`: `LumaRayVideoProviderTest` passou com 3 testes.\n- Backend: `SalesVideoJobServiceTest` + `ExperimentVideoAssetServiceTest` passaram com 13 testes.\n\n**Estado atual em produção:**\n\n- Os assets `5`, `6`, `7`, `8` do experimento 68 ainda estão `GENERATING`.\n- Os jobs vinculados `20431` a `20434` estão `VIDEO_FAILED`.\n- A renderização correta ainda depende de publicar estes novos ajustes.\n\nNão criei PR, conforme sua regra.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.","orientacaoProximaAcao":"Peça o PR/deploy destes ajustes. Depois do deploy, execute novamente `Renderizar planejados` no experimento 68; o sistema agora conseguirá reprocessar os mesmos 4 assets com jobs falhados."}