### PR TITLE
AI Hub: {"titulo":"Marketing Hub ajustado","comentario":"Implementei a estratégia híbrida de vídeo para venda.\n\n**O que mudou:**\n\n- `LANDING_HERO` com Luma agora é tratado como **hero comercial de 30s**.\n- Se vier duração curta legada, menor que 25s,…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.LandingPage;
 import com.marketinghub.experiment.video.ExperimentVideoAsset;
 import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
+import com.marketinghub.experiment.video.ExperimentVideoSlot;
 import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.experiment.video.dto.CreateExperimentVideoAssetRequest;
 import com.marketinghub.experiment.video.dto.ExperimentVideoAssetDto;
@@ -52,6 +53,8 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class ExperimentVideoAssetService {
+    private static final int LANDING_HERO_LUMA_TARGET_SECONDS = 30;
+
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
             .findAndAddModules()
             .build();
@@ -385,6 +388,7 @@ public class ExperimentVideoAssetService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "planned video asset script is required");
         }
         String providerName = Optional.ofNullable(trimToNull(videoAsset.getProvider())).orElse("LUMA_RAY_3_2");
+        Integer targetDurationSeconds = resolvePlannedRenderTargetDurationSeconds(videoAsset, providerName);
         Long experimentId = videoAsset.getExperiment() != null ? videoAsset.getExperiment().getId() : null;
         String title = "Vídeo planejado #%d - experimento %d".formatted(videoAsset.getId(), experimentId);
 
@@ -395,7 +399,7 @@ public class ExperimentVideoAssetService {
         profileRequest.setPersonaStyle(trimToNull(request.personaStyle()));
         profileRequest.setVoiceStyle(trimToNull(request.voiceStyle()));
         profileRequest.setLanguage(Optional.ofNullable(trimToNull(request.language())).orElse("pt-BR"));
-        profileRequest.setTargetDurationSeconds(videoAsset.getDurationSeconds());
+        profileRequest.setTargetDurationSeconds(targetDurationSeconds);
         profileRequest.setLandingPageId(landingPageId);
         SalesVideoProfileDto profile = salesVideoService.createProfile(product.getId(), profileRequest);
 
@@ -409,7 +413,7 @@ public class ExperimentVideoAssetService {
         renderRequest.setProviderFamily(SalesVideoProviderFamily.EXTERNAL_VIDEO_MODULE);
         renderRequest.setProviderName(providerName);
         renderRequest.setExecutionMode(request.executionMode());
-        renderRequest.setMetadataJson(buildPlannedRenderMetadata(videoAsset, request));
+        renderRequest.setMetadataJson(buildPlannedRenderMetadata(videoAsset, targetDurationSeconds, request));
         SalesVideoJobDto job = salesVideoService.requestRender(profile.getId(), renderRequest);
 
         videoAsset.setSalesVideoProfile(resolveProfile(profile.getId()));
@@ -417,6 +421,7 @@ public class ExperimentVideoAssetService {
         videoAsset.setProvider(providerName);
         videoAsset.setModel(Optional.ofNullable(trimToNull(videoAsset.getModel())).orElse(providerName));
         videoAsset.setStatus(ExperimentVideoStatus.GENERATING);
+        videoAsset.setDurationSeconds(targetDurationSeconds);
         videoAsset.setReviewStatus(ExperimentVideoReviewStatus.PENDING);
         if (request.requiredForRelease() != null) {
             videoAsset.setRequiredForRelease(request.requiredForRelease());
@@ -431,6 +436,23 @@ public class ExperimentVideoAssetService {
             videoAsset.setCost(estimatedCost);
         }
         return videoAsset;
+    }
+
+    /** Normaliza a duração comercial do render planejado conforme o papel do vídeo no funil. */
+    private Integer resolvePlannedRenderTargetDurationSeconds(ExperimentVideoAsset videoAsset, String providerName) {
+        Integer plannedDurationSeconds = videoAsset.getDurationSeconds();
+        boolean lumaHero = videoAsset.getSlot() == ExperimentVideoSlot.LANDING_HERO
+                && isLumaProvider(providerName);
+        if (lumaHero && (plannedDurationSeconds == null || plannedDurationSeconds < 25)) {
+            return LANDING_HERO_LUMA_TARGET_SECONDS;
+        }
+        return plannedDurationSeconds;
+    }
+
+    /** Identifica providers Luma para aplicar a estratégia comercial de hero premium. */
+    private boolean isLumaProvider(String providerName) {
+        String normalizedProviderName = Optional.ofNullable(trimToNull(providerName)).orElse("").toUpperCase();
+        return normalizedProviderName.contains("LUMA") || normalizedProviderName.contains("RAY_3_2");
     }
 
     /** Identifica ativos planejados ou falhados que podem receber novo job sem duplicar o ativo. */
@@ -497,6 +519,7 @@ public class ExperimentVideoAssetService {
 
     /** Monta metadados estruturados para renderizar um ativo planejado existente. */
     private String buildPlannedRenderMetadata(ExperimentVideoAsset videoAsset,
+                                              Integer targetDurationSeconds,
                                               RequestPlannedExperimentVideoRenderRequest request) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put("artifactType", "experiment.plannedVideoRenderRequest.v1");
@@ -505,7 +528,8 @@ public class ExperimentVideoAssetService {
         metadata.put("slot", videoAsset.getSlot());
         metadata.put("provider", trimToNull(videoAsset.getProvider()));
         metadata.put("model", trimToNull(videoAsset.getModel()));
-        metadata.put("durationSeconds", videoAsset.getDurationSeconds());
+        metadata.put("durationSeconds", targetDurationSeconds);
+        metadata.put("commercialStrategy", buildCommercialStrategyMetadata(videoAsset));
         metadata.put("aspectRatio", trimToNull(videoAsset.getAspectRatio()));
         metadata.put("objective", trimToNull(videoAsset.getObjective()));
         metadata.put("primaryMetric", trimToNull(videoAsset.getPrimaryMetric()));
@@ -520,6 +544,31 @@ public class ExperimentVideoAssetService {
                     "planned video metadata serialization failed",
                     ex);
         }
+    }
+
+    /** Descreve nos metadados como o ativo deve ser usado para maximizar venda no funil. */
+    private Map<String, Object> buildCommercialStrategyMetadata(ExperimentVideoAsset videoAsset) {
+        Map<String, Object> strategy = new LinkedHashMap<>();
+        boolean landingHero = videoAsset.getSlot() == ExperimentVideoSlot.LANDING_HERO;
+        boolean luma = isLumaProvider(videoAsset.getProvider());
+        if (landingHero && luma) {
+            strategy.put("funnelRole", "LANDING_HERO");
+            strategy.put("recommendedUse", "hero principal da landing para atravessar dor, mecanismo, desejo e CTA");
+            strategy.put("recommendedPrimaryDurationSeconds", LANDING_HERO_LUMA_TARGET_SECONDS);
+            strategy.put("recommendedPaidTrafficDerivativeSeconds", List.of(10, 15));
+            strategy.put("approvalRule", "aprovar um hero principal e usar os demais como variacoes ou base para cortes curtos");
+            strategy.put("salesJourney", "desconhecimento -> relevancia -> mecanismo -> desejo -> compra");
+        } else if (videoAsset.getSlot() == ExperimentVideoSlot.AD) {
+            strategy.put("funnelRole", "PAID_TRAFFIC_HOOK");
+            strategy.put("recommendedUse", "criativo curto para captar atencao e levar para a landing");
+            strategy.put("recommendedPrimaryDurationSeconds", 15);
+            strategy.put("salesJourney", "desconhecimento -> relevancia");
+        } else {
+            strategy.put("funnelRole", videoAsset.getSlot() != null ? videoAsset.getSlot().name() : "EXPERIMENT_VIDEO");
+            strategy.put("recommendedUse", "apoio de funil conforme contexto do experimento");
+            strategy.put("salesJourney", "reduzir incerteza e esforco percebido");
+        }
+        return strategy;
     }
 
     /** Resolve o custo em USD informado ou calculado pela tabela oficial do provider. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -26,6 +26,8 @@ import com.marketinghub.salesvideo.SalesVideoExecutionMode;
 import com.marketinghub.salesvideo.SalesVideoJob;
 import com.marketinghub.salesvideo.SalesVideoProfile;
 import com.marketinghub.salesvideo.SalesVideoStatus;
+import com.marketinghub.salesvideo.dto.CreateSalesVideoProfileRequest;
+import com.marketinghub.salesvideo.dto.RequestVideoRenderRequest;
 import com.marketinghub.salesvideo.dto.SalesVideoJobDto;
 import com.marketinghub.salesvideo.dto.SalesVideoProfileDto;
 import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
@@ -255,11 +257,23 @@ class ExperimentVideoAssetServiceTest {
         assertThat(result.get(0).id()).isEqualTo(5L);
         assertThat(result.get(0).status()).isEqualTo(ExperimentVideoStatus.GENERATING);
         assertThat(result.get(0).provider()).isEqualTo("LUMA_RAY_3_2");
+        assertThat(result.get(0).durationSeconds()).isEqualTo(30);
         assertThat(result.get(0).salesVideoProfileId()).isEqualTo(12L);
         assertThat(result.get(0).salesVideoJobId()).isEqualTo(20431L);
+        ArgumentCaptor<CreateSalesVideoProfileRequest> profileRequest =
+                ArgumentCaptor.forClass(CreateSalesVideoProfileRequest.class);
+        verify(salesVideoService).createProfile(any(), profileRequest.capture());
+        assertThat(profileRequest.getValue().getTargetDurationSeconds()).isEqualTo(30);
+        ArgumentCaptor<RequestVideoRenderRequest> renderRequest = ArgumentCaptor.forClass(RequestVideoRenderRequest.class);
+        verify(salesVideoService).requestRender(any(), renderRequest.capture());
+        assertThat(renderRequest.getValue().getMetadataJson())
+                .contains("\"durationSeconds\":30")
+                .contains("\"funnelRole\":\"LANDING_HERO\"")
+                .contains("\"recommendedPaidTrafficDerivativeSeconds\":[10,15]");
         ArgumentCaptor<ExperimentVideoAsset> savedAsset = ArgumentCaptor.forClass(ExperimentVideoAsset.class);
         verify(repository).save(savedAsset.capture());
         assertThat(savedAsset.getValue().getId()).isEqualTo(5L);
+        assertThat(savedAsset.getValue().getDurationSeconds()).isEqualTo(30);
     }
 
     /** Permite reprocessar o mesmo ativo quando o job anterior falhou no executor de vídeo. */
@@ -322,6 +336,7 @@ class ExperimentVideoAssetServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).id()).isEqualTo(5L);
         assertThat(result.get(0).status()).isEqualTo(ExperimentVideoStatus.GENERATING);
+        assertThat(result.get(0).durationSeconds()).isEqualTo(30);
         assertThat(result.get(0).salesVideoProfileId()).isEqualTo(13L);
         assertThat(result.get(0).salesVideoJobId()).isEqualTo(20435L);
     }

--- a/docs/canonical/avatar-sales-video-canonical-rules.md
+++ b/docs/canonical/avatar-sales-video-canonical-rules.md
@@ -144,6 +144,8 @@ Um vídeo só pode ir para `PUBLISHED` se:
 - Vídeo hero de venda para PDE/funil público deve ser tratado como peça comercial completa, não como clipe técnico isolado.
 - Quando o perfil pedir duração alvo maior que a duração nativa do provider, o fluxo deve gerar cenas/montagem suficiente para completar **Dor -> Resultado -> Mecanismo -> CTA**.
 - Para o Método MUSA, o provider recomendado para hero premium é `LUMA_RAY_3_2`; `KLING_3_0` deve ser usado como alternativa de teste; `VEO` deve ficar restrito a teaser curto ou cena isolada dentro de montagem.
+- Para `LANDING_HERO` com Luma, durações planejadas menores que 25s devem ser tratadas como legado/limite de provider antigo e normalizadas para alvo comercial de 30s no render. Cortes de 10-15s devem existir como derivados para mídia paga, não como substitutos do hero principal da landing.
+- A aprovação comercial deve escolher um hero principal para a landing e classificar os demais vídeos prontos como variações de teste, retargeting ou base para derivados curtos.
 - Todo render final deve registrar duração real auditada em `metadataJson.duration_seconds`.
 - Render com duração menor que o mínimo comercial do perfil não pode ficar como `VIDEO_READY`.
 - A experiência principal da usuária deve priorizar streaming adaptativo via `streamPlaybackUrl` HLS/DASH. MP4 bruto deve ser fallback, auditoria ou contingência.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6047,3 +6047,11 @@
 - foi feito: criado fluxo para solicitar render dos vídeos planejados preservando os IDs dos ativos, criando profile/script/job no módulo SalesVideo e marcando os ativos como `GENERATING`.
 - foi feito: a aba Vídeo do experimento passou a oferecer a ação `Renderizar planejados`, com execução em modo `TEST` e provider/model vindos do ativo planejado.
 - impacto comercial esperado: destravar o hero de vídeo do MUSA sem perder rastreabilidade de criativo, custo, job e aprendizado por clipe.
+
+## 2026-07-23 — PED/MUSA: estratégia híbrida de vídeos para venda
+
+- decisão comercial: o vídeo hero da landing deve ser uma peça de venda completa de aproximadamente 30s, atravessando dor, mecanismo, desejo e CTA; vídeos de 10-15s devem ser derivados para mídia paga e não substitutos do hero.
+- causa-raiz tratada: durações curtas em assets `LANDING_HERO` com Luma podem vir de limite legado do provider VEO; o backend agora normaliza esse caso para alvo comercial de 30s ao solicitar render planejado.
+- foi feito: os metadados do render planejado passaram a registrar `commercialStrategy`, com papel no funil, uso recomendado, duração hero e derivados curtos recomendados.
+- foi feito: a aba Vídeo passou a mostrar um painel de estratégia com contagem de hero pronto, hero aprovado e cortes curtos, além de classificar cada asset por papel no funil e uso recomendado.
+- impacto comercial esperado: aprovar um hero principal para conversão na landing e usar os demais vídeos como variações/retargeting/base de cortes, aumentando clareza de decisão e evitando otimização apenas por clipe curto.

--- a/docs/swagger/experiment-video-assets-swagger.yaml
+++ b/docs/swagger/experiment-video-assets-swagger.yaml
@@ -82,6 +82,7 @@ paths:
   /api/experiments/{experimentId}/video-assets/planned-render-requests:
     post:
       summary: Solicita render dos vídeos planejados preservando os ativos existentes
+      description: Para ativos `LANDING_HERO` com Luma, o backend normaliza duração curta legada para hero comercial de 30s e registra metadados de estratégia híbrida, recomendando derivados de 10-15s para mídia paga.
       parameters:
         - name: experimentId
           in: path

--- a/frontend/src/pages/experiment/ExperimentVideoTab.css
+++ b/frontend/src/pages/experiment/ExperimentVideoTab.css
@@ -79,7 +79,37 @@
   text-align: center;
 }
 
+.experiment-video-strategy-panel {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.experiment-video-strategy-panel__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.experiment-video-strategy-panel__metrics span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 999px;
+  background: var(--bs-body-bg);
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
 @media (max-width: 767.98px) {
+  .experiment-video-strategy-panel {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .experiment-video-preview-card__sales-page {
     min-height: 28rem;
   }

--- a/frontend/src/pages/experiment/ExperimentVideoTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentVideoTab.tsx
@@ -108,6 +108,46 @@ function getAspectRatioStyle(asset: ExperimentVideoAsset) {
   return { aspectRatio: normalizedRatio };
 }
 
+function getCommercialVideoRole(asset: ExperimentVideoAsset) {
+  const duration = asset.durationSeconds ?? 0;
+  const provider = `${asset.provider ?? ""} ${asset.model ?? ""}`.toUpperCase();
+  const isLuma = provider.includes("LUMA") || provider.includes("RAY");
+
+  if (asset.slot === "LANDING_HERO" && isLuma && duration >= 25) {
+    return "Hero de venda";
+  }
+  if (asset.slot === "LANDING_HERO" && duration > 0 && duration < 25) {
+    return "Cena curta";
+  }
+  if (asset.slot === "AD" || (duration >= 10 && duration <= 15)) {
+    return "Hook de mídia";
+  }
+  if (asset.slot === "FORM_EXPLAINER") {
+    return "Redução de dúvida";
+  }
+  if (asset.slot === "PRE_CHECKOUT") {
+    return "Pré-checkout";
+  }
+  return "Apoio de funil";
+}
+
+function getCommercialVideoUse(asset: ExperimentVideoAsset) {
+  const role = getCommercialVideoRole(asset);
+  if (role === "Hero de venda") {
+    return "Landing";
+  }
+  if (role === "Cena curta" || role === "Hook de mídia") {
+    return "Ads/Reels";
+  }
+  if (role === "Redução de dúvida") {
+    return "Formulário";
+  }
+  if (role === "Pré-checkout") {
+    return "Checkout";
+  }
+  return "Teste";
+}
+
 export default function ExperimentVideoTab({
   experiment,
   alterationLocked = false,
@@ -147,6 +187,28 @@ export default function ExperimentVideoTab({
   });
 
   const sortedAssets = useMemo(() => videoAssets ?? [], [videoAssets]);
+  const readyHeroAssets = useMemo(
+    () =>
+      sortedAssets.filter(
+        (asset) =>
+          asset.slot === "LANDING_HERO" &&
+          asset.status === "READY" &&
+          Boolean(asset.assetUrl) &&
+          getCommercialVideoRole(asset) === "Hero de venda",
+      ),
+    [sortedAssets],
+  );
+  const approvedHeroAssets = useMemo(
+    () => readyHeroAssets.filter((asset) => asset.reviewStatus === "APPROVED"),
+    [readyHeroAssets],
+  );
+  const shortTrafficAssets = useMemo(
+    () =>
+      sortedAssets.filter((asset) =>
+        ["Cena curta", "Hook de mídia"].includes(getCommercialVideoRole(asset)),
+      ),
+    [sortedAssets],
+  );
   const plannedAssetsWithoutJob = useMemo(
     () =>
       sortedAssets.filter(
@@ -412,11 +474,26 @@ export default function ExperimentVideoTab({
             </div>
           </div>
           <div className="table-responsive mt-3">
+            <div className="alert alert-light border experiment-video-strategy-panel mb-3">
+              <div>
+                <div className="fw-semibold">Estratégia recomendada</div>
+                <div className="small text-muted">
+                  Hero de 30s na landing; cortes de 10-15s para tráfego pago.
+                </div>
+              </div>
+              <div className="experiment-video-strategy-panel__metrics">
+                <span>Hero pronto: {readyHeroAssets.length}</span>
+                <span>Hero aprovado: {approvedHeroAssets.length}</span>
+                <span>Cortes curtos: {shortTrafficAssets.length}</span>
+              </div>
+            </div>
             <table className="table table-sm align-middle">
               <thead>
                 <tr>
                   <th>ID</th>
                   <th>Slot</th>
+                  <th>Papel no funil</th>
+                  <th>Uso</th>
                   <th>Status</th>
                   <th>Revisão</th>
                   <th>Provider</th>
@@ -430,13 +507,13 @@ export default function ExperimentVideoTab({
               <tbody>
                 {isLoading ? (
                   <tr>
-                    <td colSpan={10} className="text-muted">
+                    <td colSpan={12} className="text-muted">
                       Carregando vídeos...
                     </td>
                   </tr>
                 ) : sortedAssets.length === 0 ? (
                   <tr>
-                    <td colSpan={10} className="text-muted">
+                    <td colSpan={12} className="text-muted">
                       Nenhum vídeo registrado para este experimento.
                     </td>
                   </tr>
@@ -445,6 +522,8 @@ export default function ExperimentVideoTab({
                     <tr key={asset.id}>
                       <td>{asset.id}</td>
                       <td>{asset.slot}</td>
+                      <td>{getCommercialVideoRole(asset)}</td>
+                      <td>{getCommercialVideoUse(asset)}</td>
                       <td>
                         <span className="badge text-bg-info">
                           {asset.status}
@@ -493,7 +572,11 @@ export default function ExperimentVideoTab({
 
       <form className="card" onSubmit={handleSubmit}>
         <div className="card-body">
-          <h5 className="card-title mb-3">Solicitar vídeo VEO</h5>
+          <h5 className="card-title mb-1">Solicitar vídeo VEO</h5>
+          <p className="text-muted small mb-3">
+            Use como teaser/cena curta. Para hero principal, priorize Luma nos
+            vídeos planejados.
+          </p>
           <div className="row g-3">
             <div className="col-md-3">
               <label className="form-label">Slot</label>


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Itens opcionais selecionados pelo usuário para complementar o prompt:
Leia e use como base o documento em : /docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md

Histórico da conversa:
Usuário: vejo apenas videos planejados tem algum problema ?

Modelo: {"titulo":"Vídeos só planejados","comentario":"Sim, há um problema **se a expectativa era já ter vídeos renderizados**.\n\nPelo backend e banco real, o experimento 68 tem 4 vídeos `LANDING_HERO`, todos com:\n\n- `status=PLANNED`\n- `reviewStatus=PENDING`\n- `salesVideoJobId=null`\n- `assetId=null`\n- `assetUrl=null`\n- `cost=null`\n\nOu seja: o sistema registrou o **plano criativo dos 4 clipes**, mas ainda **não criou job de renderização** nem gerou arquivo de vídeo.\n\n**Conclusão:** não parece falha do renderizador neste ponto. O render simplesmente não foi disparado/vinculado. Também confirmei que não há `sales_video_job` criado depois de `23/07/2026 17:20 UTC` para esse fluxo.\n\n**Impacto comercial:** enquanto estiver assim, a landing mostra “Vídeo ainda não disponível” e a campanha não deveria ser liberada como funil com vídeo obrigatório. Para vender melhor, esse hero precisa virar vídeo real com `READY + APPROVED + assetUrl`.\n\n**Alternativas avaliadas:**\n\n1. Manter como planejado por enquanto: serve só como planejamento criativo. Baixo esforço, mas não ajuda a conversão agora.\n2. Solicitar cada vídeo manualmente pelo formulário atual: rápido, mas a tela está orientada a VEO, enquanto a estratégia documentada para MUSA recomenda Luma Ray 3.2 como principal.\n3. Melhor caminho: transformar os 4 assets planejados Luma em jobs reais de renderização, preservando vínculo, custo, asset e aprovação. É o caminho mais aderente ao objetivo de venda e rastreabilidade.\n\nMinha recomendação: tratar isso como **pendência operacional do funil**, não como erro visual da tela.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs diretos do video-management-service; isso permitiria confirmar status do worker Luma com mais precisão quando houver jobs criados.","orientacaoProximaAcao":"Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados."}

Usuário: Execute sua orientação : 
Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados.

Modelo: {"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned-render-requests`.\n- Ele pega assets `PLANNED` sem `salesVideoJobId`, cria `profile + script + job` no SalesVideo e atualiza o próprio asset para `GENERATING`.\n- Frontend ganhou a ação **Renderizar planejados** na aba Vídeo do experimento.\n- Swagger e registro de experimentos foram atualizados.\n\n**Validação:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou com 7 testes.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n\n**Importante:** ainda não criei PR e não publiquei nada. Os 4 vídeos do experimento 68 continuam sem render em produção até essa mudança passar por PR/deploy e a ação ser executada no Marketing Hub.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar essa mudança; depois do deploy, use a ação Renderizar planejados na aba Vídeo do experimento 68 para criar os 4 jobs Luma vinculados aos assets existentes."}

Usuário: esta fazendo o deploy, acompanhe pelo github e depois Execute a Renderização dos Videos do experimento 68 pelo Marketing Hub veja se vai funcioanr corretamente ajuste o que for necessario.

Modelo: {"titulo":"Renderização falhou na Luma","comentario":"Acompanhei o deploy no GitHub até concluir com sucesso e executei a renderização dos vídeos do experimento 68 pelo contrato do Marketing Hub.\n\n**Resultado operacional:**\n\n- O deploy do PR `#4480` terminou com sucesso.\n- A chamada `POST /api/experiments/68/video-assets/planned-render-requests` funcionou.\n- Os 4 assets saíram de `PLANNED` para `GENERATING`.\n- Foram criados os jobs `20431`, `20432`, `20433` e `20434`.\n\n**Problema encontrado:**\n\nOs 4 jobs falharam imediatamente no executor de vídeo com:\n\n`404 Not Found from POST https://api.lumalabs.ai/v1/generations`\n\nA causa-raiz é integração desatualizada com a Luma. A documentação atual da Luma Agents usa o host:\n\n`https://agents.lumalabs.ai/v1/generations`\n\nReferências consultadas:\n\n- https://docs.agents.lumalabs.ai/\n- https://docs.agents.lumalabs.ai/guides/videos/generation/\n\n**Ajustes deixados prontos na branch/worktree:**\n\n- Corrigi o host padrão da Luma no `video-management-service` para `https://agents.lumalabs.ai`.\n- Atualizei o teste do provider Luma para proteger esse contrato.\n- Corrigi o backend para sincronizar falha de render no asset do experimento, evitando a tela ficar presa em `GENERATING` quando o job já está `VIDEO_FAILED`.\n- Ajustei o endpoint de renderização planejada para permitir reprocessar o mesmo asset quando o job anterior falhou, sem duplicar vídeos.\n\n**Validação:**\n\n- `video-management-service`: `LumaRayVideoProviderTest` passou com 3 testes.\n- Backend: `SalesVideoJobServiceTest` + `ExperimentVideoAssetServiceTest` passaram com 13 testes.\n\n**Estado atual em produção:**\n\n- Os assets `5`, `6`, `7`, `8` do experimento 68 ainda estão `GENERATING`.\n- Os jobs vinculados `20431` a `20434` estão `VIDEO_FAILED`.\n- A renderização correta ainda depende de publicar estes novos ajustes.\n\nNão criei PR, conforme sua regra.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.","orientacaoProximaAcao":"Peça o PR/deploy destes ajustes. Depois do deploy, execute novamente `Renderizar planejados` no experimento 68; o sistema agora conseguirá reprocessar os mesmos 4 assets com jobs falhados."}

Usuário: implemente:
O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.

Modelo: {"titulo":"Logs do vídeo no MCP","comentario":"Implementei a melhoria para o MCP consultar logs do `video-management-service`.\n\n**O que ficou pronto:**\n\n- `java_module_logs` agora aceita o módulo `video-management-service`.\n- Default configurado: `http://177.153.62.107:8095/actuator/logfile`.\n- `video-management-service` agora grava log em `/app/logs/video-management-service.log`.\n- O Actuator do vídeo agora expõe `/actuator/logfile`.\n- `deploy/docker-compose.yml` persiste os logs do vídeo em volume.\n- README e contrato operacional do MCP foram atualizados.\n- Teste novo garante que o MCP lê logs do `video-management-service`.\n\n**Validação executada:**\n\n- `mcp-server`: `mvn -q test` passou.\n- `video-management-service`: `mvn -q test` passou.\n- `docker compose -f deploy/docker-compose.yml config` passou, com apenas aviso já existente de `version` obsoleto.\n- `git diff --check` sem problemas.\n\nNão criei PR e não publiquei nada. A mudança está pronta na worktree para passar pelo fluxo normal de PR/deploy.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy desta alteração. Depois do deploy, poderemos chamar `java_module_logs` com `module=video-management-service` para acompanhar a nova renderização dos vídeos do experimento 68 com logs reais do executor."}

Usuário: verifique se o github action terminou e tente novamente produzir os videos pelo marketing hub se tiver problemas novamente faça o ajuste, teste no seu ambiente antes de entregar.

Modelo: {"titulo":"Render ainda bloqueado","comentario":"Acompanhei o GitHub Action: o deploy terminou com sucesso.\n\nDepois executei novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub.\n\n**Resultado:**\n\n- A chamada funcionou com `executionMode=TEST`.\n- Foram criados novos jobs: `20435`, `20436`, `20437`, `20438`.\n- A falha antiga de URL Luma legada **não voltou**.\n- A Luma chegou a gerar URLs de MP4, mas o worker falhou ao baixar os arquivos S3:\n\n`400 Bad Request from GET https://ai-lumalabs-vespa-production.s3.amazonaws.com/...mp4`\n\n**Causa-raiz:** o download do MP4 da Luma precisa preservar a URL presignada exatamente como recebida. A documentação atual da Luma diz que o resultado vem em `output[].url` como URL presignada e deve ser baixado imediatamente para storage próprio: https://docs.agents.lumalabs.ai/guides/videos/generation/ e https://docs.agents.lumalabs.ai/guides/error-handling/\n\n**Ajuste implementado na branch/worktree:**\n\n- Separei o cliente de download do cliente autenticado da API Luma.\n- O download agora usa `URI.create(videoUrl)` para preservar query string/assinatura da URL presignada.\n- O teste agora garante que:\n  - chamadas para API Luma continuam com `Authorization: Bearer`;\n  - download S3 não recebe `Authorization`;\n  - query presignada `X-Amz-*` não é perdida.\n\n**Validação local:**\n\n- `mvn test -Dtest=LumaRayVideoProviderTest`: passou.\n- `mvn test` no `video-management-service`: passou com 21 testes.\n\n**Estado atual em produção:** os 4 assets do experimento 68 estão `FAILED` porque a correção ainda não foi publicada. Não criei PR.","sugestaoMelhoriaAmbiente":"Adicionar `video-management-service` à tool MCP `java_module_logs`; hoje o MCP ainda não lista esse módulo, então a investigação dependeu de banco/eventos e não do log direto do worker.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste. Depois do deploy, execute novamente a ação Renderizar planejados no experimento 68 para criar novos jobs e validar o download correto dos MP4s."}

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: CODEX_TURN_STALLED

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: {"titulo":"Deploy de vídeo travou","comentario":"O GitHub Action **ainda não terminou**.\n\n**O que aconteceu:**\n\n- Reexecutei o workflow `Build & Deploy containers` do run `30039506257`.\n- A imagem do `video-management-service` foi construída com sucesso.\n- Os testes do serviço passaram no GitHub Action.\n- O deploy ficou preso por mais de 20 minutos em `Upload image to VIDEO VPS`.\n\n**Causa provável:** o workflow usa `scp` para enviar `video-management-image.tar` ao VPS. Esse upload não tem retomada parcial nem timeout efetivo, então pode ficar travado em transferência pesada.\n\n**Ajuste que deixei pronto na worktree:**\n\n- Troquei o upload do vídeo de `scp` para `rsync -az --partial --append-verify`.\n- Adicionei `timeout` para evitar GitHub Action preso indefinidamente.\n- Validei com `actionlint` e `git diff --check`: passou.\n\n**Alternativas avaliadas:**\n\n1. Tentar renderizar agora: alto risco de usar o worker antigo e repetir a falha de download do MP4.\n2. Esperar indefinidamente o deploy atual: baixo valor, porque o job já está preso no upload.\n3. Melhor caminho: publicar o ajuste do workflow, deixar o deploy rodar com upload resiliente e só depois executar a renderização do experimento 68.\n\nAinda **não tentei gerar os vídeos novamente**, porque o deploy do worker corrigido não foi concluído. Também **não criei PR**, conforme sua regra.","sugestaoMelhoriaAmbiente":"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste do workflow. Depois que esse deploy concluir, eu executo novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub e acompanho o resultado."}

Usuário: vc não tem ? Mas vc tem chave do github
"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado."

Modelo: {"titulo":"Acesso GitHub limitado","comentario":"Você tem razão em questionar.\n\nEu tenho **algum acesso ao GitHub**, mas ao testar agora o `gh` neste ambiente ele falhou com:\n\n`the token in GITHUB_TOKEN is missing required scope 'read:org'`\n\nEntão a frase correta seria:\n\n**Eu não tenho, neste momento, acesso confiável via CLI aos logs do GitHub Action em tempo real.**\n\nAlém disso, mesmo com acesso ao GitHub, há uma limitação prática: o GitHub Actions normalmente mostra logs por blocos já emitidos. Se o passo está travado dentro de um `scp` sem imprimir progresso, o log pode ficar parado sem provar se está transferindo devagar ou congelado.\n\nO ajuste que propus continua válido: trocar `scp` por `rsync` com progresso parcial e timeout melhora o deploy porque transforma um travamento silencioso em execução observável e recuperável.\n\nResumo objetivo:\n\n- Sim, existe chave/credencial GitHub no ambiente.\n- Não, ela não está funcionando plenamente via `gh` agora por falta de escopo.\n- Mesmo com acesso, o passo atual pode não emitir progresso útil se o comando não logar nada.\n- A melhoria correta é tornar o workflow mais observável e resiliente.","sugestaoMelhoriaAmbiente":"Conceder ao token GitHub usado no ambiente escopos suficientes para consultar Actions/logs do repositório via `gh`, incluindo permissões compatíveis com organização privada quando aplicável.","orientacaoProximaAcao":"Se quiser que eu acompanhe Actions diretamente por CLI, ajuste/autorizе o token GitHub do ambiente com os escopos necessários. Caso contrário, posso continuar trabalhando com os dados disponíveis e deixar o workflow mais robusto no repositório."}

Usuário: agora terminou verifique se gerou conseguimos gerar os videos

Modelo: {"titulo":"Vídeos gerados","comentario":"Sim, conseguimos gerar os vídeos do experimento 68.\n\n**Resultado confirmado:**\n\n- Deploy do GitHub Action terminou com sucesso.\n- Executei a renderização pelo Marketing Hub.\n- Foram criados os jobs `20439`, `20440`, `20441`, `20442`.\n- Os 4 jobs finalizaram como `VIDEO_READY`.\n- Os 4 assets do experimento 68 agora estão `READY`, com `assetUrl` público e `asset_id` preenchido.\n- Validei os arquivos com `ffprobe`: todos são MP4 H.264, vertical `720x1280`, duração aproximada de `30s`.\n\n**Ponto de atenção comercial:**\n\nOs vídeos estavam planejados como clipes curtos de `8s`, mas o fluxo Luma atual monta 3 cenas de 10s, gerando vídeos finais de cerca de `30s`. Tecnicamente funcionou; para tráfego, eu trataria isso como material válido para revisão, mas avaliaria se o hero precisa de uma versão mais curta para primeira dobra e anúncios.\n\n**Estado atual:** os vídeos ainda estão com `review_status=PENDING`. Ou seja, existem e estão prontos tecnicamente, mas ainda precisam de aprovação/revisão antes de serem usados como ativo final de campanha.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Revise os 4 vídeos na aba Vídeo do experimento 68 e aprove os melhores. Se quiser manter a estratégia original de clipes rápidos, peça para eu ajustar o fluxo Luma para gerar versão curta alinhada ao planejamento de 8s."}

Usuário: deo onde vem esse planejamento de 8 minutos ? acho que isso era uma limigtação do antigo provedor de videos o veo. Analise o que vc considera melhora para vendas.

Modelo: {"titulo":"Melhor vídeo para vender","comentario":"Você está certo: **não existe planejamento de 8 minutos** e, no experimento 68, também **não encontrei planejamento real de 8 segundos nos assets**.\n\nA origem do “8s” vem do catálogo legado do frontend para **VEO**, onde ele aparece como provider de **teasers curtos/cenas isoladas**. Já a estratégia atual do sistema coloca **Luma Ray 3.2** como provider principal para hero premium, com montagem de vídeo final perto de **30s**.\n\n**Evidência do experimento 68:**\n\n- Os 4 assets estão `READY`.\n- Provider real: `LUMA_RAY_3_2`.\n- Duração gravada: `30s` cada.\n- Cada vídeo foi montado com `3 cenas x 10s`.\n- O planejamento salvo nos assets contém apenas ângulo/caption, não duração de 8s.\n\n**Minha leitura para vendas:**\n\nO melhor não é voltar para 8s como regra geral. Para uma landing de produto novo como MUSA, o vídeo precisa atravessar a estrada: dor → relevância → mecanismo → desejo → CTA. Em 8s, normalmente só dá para gerar atenção, não desejo suficiente.\n\n**Alternativas avaliadas:**\n\n1. **Usar só vídeos de 8s**  \nBom para anúncio e hook rápido, mas fraco para explicar mecanismo e valor. Risco: muita curiosidade e pouca conversão.\n\n2. **Usar só vídeos de 30s**  \nMelhor para landing/hero, porque permite mostrar dor, transformação e mecanismo. Risco: longo demais para tráfego frio se os primeiros 3 segundos não forem fortes.\n\n3. **Melhor caminho: estratégia híbrida**  \nManter vídeo de 30s para a landing e gerar cortes/variações curtas de 10-15s para anúncios. Isso atende venda e aquisição: anúncio captura atenção; landing aprofunda desejo.\n\n**Recomendação objetiva:**\n\n- Para a **landing do experimento 68**: use o melhor vídeo de 30s, desde que o primeiro impacto visual seja forte nos 3 primeiros segundos.\n- Para **Meta Ads/Reels/Stories**: criar versões curtas de 10-15s com foco em uma única promessa.\n- Não usar os 4 vídeos de 30s como se fossem todos equivalentes; escolha um como hero principal e use os outros como variações de teste ou retargeting.\n\n**Prioridade comercial dos ângulos:**\n\n1. `Dor do espelho`: melhor para tráfego frio, porque começa pela dor reconhecível.\n2. `Presença sem luxo`: bom para promessa aspiracional sem parecer inacessível.\n3. `Microações de 7 dias`: bom para explicar mecanismo e reduzir esforço percebido.\n4. `Plano MUSA personalizado`: melhor para CTA/retargeting, não como primeira abordagem.\n\nConclusão: o ajuste ideal para vender mais não é “voltar para 8s”. É transformar o módulo em uma lógica de **vídeo hero de 30s + derivados curtos para tráfego**, com aprovação comercial baseada no papel de cada vídeo no funil.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
Ajuste o Marketing Hub para seguir essa recomendação sua

**Resumo das alterações:**
{"titulo":"Marketing Hub ajustado","comentario":"Implementei a estratégia híbrida de vídeo para venda.\n\n**O que mudou:**\n\n- `LANDING_HERO` com Luma agora é tratado como **hero comercial de 30s**.\n- Se vier duração curta legada, menor que 25s, o backend normaliza para 30s no render planejado.\n- O job passa a gravar `commercialStrategy` nos metadados: papel no funil, uso recomendado, hero 30s e derivados 10-15s para mídia paga.\n- A aba Vídeo agora mostra:\n  - hero pronto;\n  - hero aprovado;\n  - cortes curtos;\n  - papel de cada vídeo no funil;\n  - uso recomendado: Landing, Ads/Reels, Formulário, Checkout ou Teste.\n- O formulário VEO ficou sinalizado como uso de teaser/cena curta, não como caminho principal para hero.\n- Atualizei o documento canônico e o registro do experimento para evitar voltar à regra antiga do VEO.\n\n**Validação executada:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou.\n- Spotless restrito aos arquivos Java alterados passou.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar esta mudança no Marketing Hub. Depois do deploy, a aba Vídeo do experimento 68 já deve orientar a escolha do hero principal e separar os demais vídeos como variações/cortes para tráfego."}