### PR TITLE
AI Hub: {"titulo":"Erro do GitHub corrigido","comentario":"Verifiquei o GitHub Action com erro: o workflow `Build & Deploy containers` falhou no backend, no teste `ExperimentServiceTest.updateStatusPreservesReleaseTimestampForBaseline`.\n\n**Causa-raiz:**…

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -665,6 +665,7 @@ class ExperimentServiceTest {
         assertThat(result).extracting(Experiment::getId).containsExactly(expApproved.getId());
     }
 
+    /** Garante que pausa administrativa preserva o timestamp persistido de liberação para Facebook. */
     @Test
     void updateStatusPreservesReleaseTimestampForBaseline() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Status").build());
@@ -702,12 +703,13 @@ class ExperimentServiceTest {
 
         Experiment released = service.releaseForFacebook(experiment.getId());
         assertThat(released.getFacebookReleaseRequestedAt()).isNotNull();
-        var releaseTimestamp = released.getFacebookReleaseRequestedAt();
+        var releaseTimestamp = Instant.parse("2026-07-23T12:00:00Z");
+        released.setFacebookReleaseRequestedAt(releaseTimestamp);
+        experimentRepository.saveAndFlush(released);
 
         Experiment paused = service.updateStatus(experiment.getId(), ExperimentStatus.PAUSED);
         assertThat(paused.getFacebookReleaseRequestedAt()).isNotNull();
-        assertThat(paused.getFacebookReleaseRequestedAt().toEpochMilli())
-                .isEqualTo(releaseTimestamp.toEpochMilli());
+        assertThat(paused.getFacebookReleaseRequestedAt()).isEqualTo(releaseTimestamp);
     }
 
     @Test


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Histórico da conversa:
Usuário: vejo apenas videos planejados tem algum problema ?

Modelo: {"titulo":"Vídeos só planejados","comentario":"Sim, há um problema **se a expectativa era já ter vídeos renderizados**.\n\nPelo backend e banco real, o experimento 68 tem 4 vídeos `LANDING_HERO`, todos com:\n\n- `status=PLANNED`\n- `reviewStatus=PENDING`\n- `salesVideoJobId=null`\n- `assetId=null`\n- `assetUrl=null`\n- `cost=null`\n\nOu seja: o sistema registrou o **plano criativo dos 4 clipes**, mas ainda **não criou job de renderização** nem gerou arquivo de vídeo.\n\n**Conclusão:** não parece falha do renderizador neste ponto. O render simplesmente não foi disparado/vinculado. Também confirmei que não há `sales_video_job` criado depois de `23/07/2026 17:20 UTC` para esse fluxo.\n\n**Impacto comercial:** enquanto estiver assim, a landing mostra “Vídeo ainda não disponível” e a campanha não deveria ser liberada como funil com vídeo obrigatório. Para vender melhor, esse hero precisa virar vídeo real com `READY + APPROVED + assetUrl`.\n\n**Alternativas avaliadas:**\n\n1. Manter como planejado por enquanto: serve só como planejamento criativo. Baixo esforço, mas não ajuda a conversão agora.\n2. Solicitar cada vídeo manualmente pelo formulário atual: rápido, mas a tela está orientada a VEO, enquanto a estratégia documentada para MUSA recomenda Luma Ray 3.2 como principal.\n3. Melhor caminho: transformar os 4 assets planejados Luma em jobs reais de renderização, preservando vínculo, custo, asset e aprovação. É o caminho mais aderente ao objetivo de venda e rastreabilidade.\n\nMinha recomendação: tratar isso como **pendência operacional do funil**, não como erro visual da tela.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs diretos do video-management-service; isso permitiria confirmar status do worker Luma com mais precisão quando houver jobs criados.","orientacaoProximaAcao":"Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados."}

Usuário: Execute sua orientação : 
Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados.

Modelo: {"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned-render-requests`.\n- Ele pega assets `PLANNED` sem `salesVideoJobId`, cria `profile + script + job` no SalesVideo e atualiza o próprio asset para `GENERATING`.\n- Frontend ganhou a ação **Renderizar planejados** na aba Vídeo do experimento.\n- Swagger e registro de experimentos foram atualizados.\n\n**Validação:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou com 7 testes.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n\n**Importante:** ainda não criei PR e não publiquei nada. Os 4 vídeos do experimento 68 continuam sem render em produção até essa mudança passar por PR/deploy e a ação ser executada no Marketing Hub.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar essa mudança; depois do deploy, use a ação Renderizar planejados na aba Vídeo do experimento 68 para criar os 4 jobs Luma vinculados aos assets existentes."}

Usuário: esta fazendo o deploy, acompanhe pelo github e depois Execute a Renderização dos Videos do experimento 68 pelo Marketing Hub veja se vai funcioanr corretamente ajuste o que for necessario.

Modelo: {"titulo":"Renderização falhou na Luma","comentario":"Acompanhei o deploy no GitHub até concluir com sucesso e executei a renderização dos vídeos do experimento 68 pelo contrato do Marketing Hub.\n\n**Resultado operacional:**\n\n- O deploy do PR `#4480` terminou com sucesso.\n- A chamada `POST /api/experiments/68/video-assets/planned-render-requests` funcionou.\n- Os 4 assets saíram de `PLANNED` para `GENERATING`.\n- Foram criados os jobs `20431`, `20432`, `20433` e `20434`.\n\n**Problema encontrado:**\n\nOs 4 jobs falharam imediatamente no executor de vídeo com:\n\n`404 Not Found from POST https://api.lumalabs.ai/v1/generations`\n\nA causa-raiz é integração desatualizada com a Luma. A documentação atual da Luma Agents usa o host:\n\n`https://agents.lumalabs.ai/v1/generations`\n\nReferências consultadas:\n\n- https://docs.agents.lumalabs.ai/\n- https://docs.agents.lumalabs.ai/guides/videos/generation/\n\n**Ajustes deixados prontos na branch/worktree:**\n\n- Corrigi o host padrão da Luma no `video-management-service` para `https://agents.lumalabs.ai`.\n- Atualizei o teste do provider Luma para proteger esse contrato.\n- Corrigi o backend para sincronizar falha de render no asset do experimento, evitando a tela ficar presa em `GENERATING` quando o job já está `VIDEO_FAILED`.\n- Ajustei o endpoint de renderização planejada para permitir reprocessar o mesmo asset quando o job anterior falhou, sem duplicar vídeos.\n\n**Validação:**\n\n- `video-management-service`: `LumaRayVideoProviderTest` passou com 3 testes.\n- Backend: `SalesVideoJobServiceTest` + `ExperimentVideoAssetServiceTest` passaram com 13 testes.\n\n**Estado atual em produção:**\n\n- Os assets `5`, `6`, `7`, `8` do experimento 68 ainda estão `GENERATING`.\n- Os jobs vinculados `20431` a `20434` estão `VIDEO_FAILED`.\n- A renderização correta ainda depende de publicar estes novos ajustes.\n\nNão criei PR, conforme sua regra.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.","orientacaoProximaAcao":"Peça o PR/deploy destes ajustes. Depois do deploy, execute novamente `Renderizar planejados` no experimento 68; o sistema agora conseguirá reprocessar os mesmos 4 assets com jobs falhados."}

Usuário: implemente:
O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.

Modelo: {"titulo":"Logs do vídeo no MCP","comentario":"Implementei a melhoria para o MCP consultar logs do `video-management-service`.\n\n**O que ficou pronto:**\n\n- `java_module_logs` agora aceita o módulo `video-management-service`.\n- Default configurado: `http://177.153.62.107:8095/actuator/logfile`.\n- `video-management-service` agora grava log em `/app/logs/video-management-service.log`.\n- O Actuator do vídeo agora expõe `/actuator/logfile`.\n- `deploy/docker-compose.yml` persiste os logs do vídeo em volume.\n- README e contrato operacional do MCP foram atualizados.\n- Teste novo garante que o MCP lê logs do `video-management-service`.\n\n**Validação executada:**\n\n- `mcp-server`: `mvn -q test` passou.\n- `video-management-service`: `mvn -q test` passou.\n- `docker compose -f deploy/docker-compose.yml config` passou, com apenas aviso já existente de `version` obsoleto.\n- `git diff --check` sem problemas.\n\nNão criei PR e não publiquei nada. A mudança está pronta na worktree para passar pelo fluxo normal de PR/deploy.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy desta alteração. Depois do deploy, poderemos chamar `java_module_logs` com `module=video-management-service` para acompanhar a nova renderização dos vídeos do experimento 68 com logs reais do executor."}

Usuário: verifique se o github action terminou e tente novamente produzir os videos pelo marketing hub se tiver problemas novamente faça o ajuste, teste no seu ambiente antes de entregar.

Modelo: {"titulo":"Render ainda bloqueado","comentario":"Acompanhei o GitHub Action: o deploy terminou com sucesso.\n\nDepois executei novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub.\n\n**Resultado:**\n\n- A chamada funcionou com `executionMode=TEST`.\n- Foram criados novos jobs: `20435`, `20436`, `20437`, `20438`.\n- A falha antiga de URL Luma legada **não voltou**.\n- A Luma chegou a gerar URLs de MP4, mas o worker falhou ao baixar os arquivos S3:\n\n`400 Bad Request from GET https://ai-lumalabs-vespa-production.s3.amazonaws.com/...mp4`\n\n**Causa-raiz:** o download do MP4 da Luma precisa preservar a URL presignada exatamente como recebida. A documentação atual da Luma diz que o resultado vem em `output[].url` como URL presignada e deve ser baixado imediatamente para storage próprio: https://docs.agents.lumalabs.ai/guides/videos/generation/ e https://docs.agents.lumalabs.ai/guides/error-handling/\n\n**Ajuste implementado na branch/worktree:**\n\n- Separei o cliente de download do cliente autenticado da API Luma.\n- O download agora usa `URI.create(videoUrl)` para preservar query string/assinatura da URL presignada.\n- O teste agora garante que:\n  - chamadas para API Luma continuam com `Authorization: Bearer`;\n  - download S3 não recebe `Authorization`;\n  - query presignada `X-Amz-*` não é perdida.\n\n**Validação local:**\n\n- `mvn test -Dtest=LumaRayVideoProviderTest`: passou.\n- `mvn test` no `video-management-service`: passou com 21 testes.\n\n**Estado atual em produção:** os 4 assets do experimento 68 estão `FAILED` porque a correção ainda não foi publicada. Não criei PR.","sugestaoMelhoriaAmbiente":"Adicionar `video-management-service` à tool MCP `java_module_logs`; hoje o MCP ainda não lista esse módulo, então a investigação dependeu de banco/eventos e não do log direto do worker.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste. Depois do deploy, execute novamente a ação Renderizar planejados no experimento 68 para criar novos jobs e validar o download correto dos MP4s."}

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: CODEX_TURN_STALLED

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: {"titulo":"Deploy de vídeo travou","comentario":"O GitHub Action **ainda não terminou**.\n\n**O que aconteceu:**\n\n- Reexecutei o workflow `Build & Deploy containers` do run `30039506257`.\n- A imagem do `video-management-service` foi construída com sucesso.\n- Os testes do serviço passaram no GitHub Action.\n- O deploy ficou preso por mais de 20 minutos em `Upload image to VIDEO VPS`.\n\n**Causa provável:** o workflow usa `scp` para enviar `video-management-image.tar` ao VPS. Esse upload não tem retomada parcial nem timeout efetivo, então pode ficar travado em transferência pesada.\n\n**Ajuste que deixei pronto na worktree:**\n\n- Troquei o upload do vídeo de `scp` para `rsync -az --partial --append-verify`.\n- Adicionei `timeout` para evitar GitHub Action preso indefinidamente.\n- Validei com `actionlint` e `git diff --check`: passou.\n\n**Alternativas avaliadas:**\n\n1. Tentar renderizar agora: alto risco de usar o worker antigo e repetir a falha de download do MP4.\n2. Esperar indefinidamente o deploy atual: baixo valor, porque o job já está preso no upload.\n3. Melhor caminho: publicar o ajuste do workflow, deixar o deploy rodar com upload resiliente e só depois executar a renderização do experimento 68.\n\nAinda **não tentei gerar os vídeos novamente**, porque o deploy do worker corrigido não foi concluído. Também **não criei PR**, conforme sua regra.","sugestaoMelhoriaAmbiente":"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste do workflow. Depois que esse deploy concluir, eu executo novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub e acompanho o resultado."}

Usuário: vc não tem ? Mas vc tem chave do github
"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado."

Modelo: {"titulo":"Acesso GitHub limitado","comentario":"Você tem razão em questionar.\n\nEu tenho **algum acesso ao GitHub**, mas ao testar agora o `gh` neste ambiente ele falhou com:\n\n`the token in GITHUB_TOKEN is missing required scope 'read:org'`\n\nEntão a frase correta seria:\n\n**Eu não tenho, neste momento, acesso confiável via CLI aos logs do GitHub Action em tempo real.**\n\nAlém disso, mesmo com acesso ao GitHub, há uma limitação prática: o GitHub Actions normalmente mostra logs por blocos já emitidos. Se o passo está travado dentro de um `scp` sem imprimir progresso, o log pode ficar parado sem provar se está transferindo devagar ou congelado.\n\nO ajuste que propus continua válido: trocar `scp` por `rsync` com progresso parcial e timeout melhora o deploy porque transforma um travamento silencioso em execução observável e recuperável.\n\nResumo objetivo:\n\n- Sim, existe chave/credencial GitHub no ambiente.\n- Não, ela não está funcionando plenamente via `gh` agora por falta de escopo.\n- Mesmo com acesso, o passo atual pode não emitir progresso útil se o comando não logar nada.\n- A melhoria correta é tornar o workflow mais observável e resiliente.","sugestaoMelhoriaAmbiente":"Conceder ao token GitHub usado no ambiente escopos suficientes para consultar Actions/logs do repositório via `gh`, incluindo permissões compatíveis com organização privada quando aplicável.","orientacaoProximaAcao":"Se quiser que eu acompanhe Actions diretamente por CLI, ajuste/autorizе o token GitHub do ambiente com os escopos necessários. Caso contrário, posso continuar trabalhando com os dados disponíveis e deixar o workflow mais robusto no repositório."}

Usuário: agora terminou verifique se gerou conseguimos gerar os videos

Modelo: {"titulo":"Vídeos gerados","comentario":"Sim, conseguimos gerar os vídeos do experimento 68.\n\n**Resultado confirmado:**\n\n- Deploy do GitHub Action terminou com sucesso.\n- Executei a renderização pelo Marketing Hub.\n- Foram criados os jobs `20439`, `20440`, `20441`, `20442`.\n- Os 4 jobs finalizaram como `VIDEO_READY`.\n- Os 4 assets do experimento 68 agora estão `READY`, com `assetUrl` público e `asset_id` preenchido.\n- Validei os arquivos com `ffprobe`: todos são MP4 H.264, vertical `720x1280`, duração aproximada de `30s`.\n\n**Ponto de atenção comercial:**\n\nOs vídeos estavam planejados como clipes curtos de `8s`, mas o fluxo Luma atual monta 3 cenas de 10s, gerando vídeos finais de cerca de `30s`. Tecnicamente funcionou; para tráfego, eu trataria isso como material válido para revisão, mas avaliaria se o hero precisa de uma versão mais curta para primeira dobra e anúncios.\n\n**Estado atual:** os vídeos ainda estão com `review_status=PENDING`. Ou seja, existem e estão prontos tecnicamente, mas ainda precisam de aprovação/revisão antes de serem usados como ativo final de campanha.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Revise os 4 vídeos na aba Vídeo do experimento 68 e aprove os melhores. Se quiser manter a estratégia original de clipes rápidos, peça para eu ajustar o fluxo Luma para gerar versão curta alinhada ao planejamento de 8s."}

Usuário: deo onde vem esse planejamento de 8 minutos ? acho que isso era uma limigtação do antigo provedor de videos o veo. Analise o que vc considera melhora para vendas.

Modelo: {"titulo":"Melhor vídeo para vender","comentario":"Você está certo: **não existe planejamento de 8 minutos** e, no experimento 68, também **não encontrei planejamento real de 8 segundos nos assets**.\n\nA origem do “8s” vem do catálogo legado do frontend para **VEO**, onde ele aparece como provider de **teasers curtos/cenas isoladas**. Já a estratégia atual do sistema coloca **Luma Ray 3.2** como provider principal para hero premium, com montagem de vídeo final perto de **30s**.\n\n**Evidência do experimento 68:**\n\n- Os 4 assets estão `READY`.\n- Provider real: `LUMA_RAY_3_2`.\n- Duração gravada: `30s` cada.\n- Cada vídeo foi montado com `3 cenas x 10s`.\n- O planejamento salvo nos assets contém apenas ângulo/caption, não duração de 8s.\n\n**Minha leitura para vendas:**\n\nO melhor não é voltar para 8s como regra geral. Para uma landing de produto novo como MUSA, o vídeo precisa atravessar a estrada: dor → relevância → mecanismo → desejo → CTA. Em 8s, normalmente só dá para gerar atenção, não desejo suficiente.\n\n**Alternativas avaliadas:**\n\n1. **Usar só vídeos de 8s**  \nBom para anúncio e hook rápido, mas fraco para explicar mecanismo e valor. Risco: muita curiosidade e pouca conversão.\n\n2. **Usar só vídeos de 30s**  \nMelhor para landing/hero, porque permite mostrar dor, transformação e mecanismo. Risco: longo demais para tráfego frio se os primeiros 3 segundos não forem fortes.\n\n3. **Melhor caminho: estratégia híbrida**  \nManter vídeo de 30s para a landing e gerar cortes/variações curtas de 10-15s para anúncios. Isso atende venda e aquisição: anúncio captura atenção; landing aprofunda desejo.\n\n**Recomendação objetiva:**\n\n- Para a **landing do experimento 68**: use o melhor vídeo de 30s, desde que o primeiro impacto visual seja forte nos 3 primeiros segundos.\n- Para **Meta Ads/Reels/Stories**: criar versões curtas de 10-15s com foco em uma única promessa.\n- Não usar os 4 vídeos de 30s como se fossem todos equivalentes; escolha um como hero principal e use os outros como variações de teste ou retargeting.\n\n**Prioridade comercial dos ângulos:**\n\n1. `Dor do espelho`: melhor para tráfego frio, porque começa pela dor reconhecível.\n2. `Presença sem luxo`: bom para promessa aspiracional sem parecer inacessível.\n3. `Microações de 7 dias`: bom para explicar mecanismo e reduzir esforço percebido.\n4. `Plano MUSA personalizado`: melhor para CTA/retargeting, não como primeira abordagem.\n\nConclusão: o ajuste ideal para vender mais não é “voltar para 8s”. É transformar o módulo em uma lógica de **vídeo hero de 30s + derivados curtos para tráfego**, com aprovação comercial baseada no papel de cada vídeo no funil.","sugestaoMelhoriaAmbiente":""}

Usuário: Ajuste o Marketing Hub para seguir essa recomendação sua


Modelo: {"titulo":"Marketing Hub ajustado","comentario":"Implementei a estratégia híbrida de vídeo para venda.\n\n**O que mudou:**\n\n- `LANDING_HERO` com Luma agora é tratado como **hero comercial de 30s**.\n- Se vier duração curta legada, menor que 25s, o backend normaliza para 30s no render planejado.\n- O job passa a gravar `commercialStrategy` nos metadados: papel no funil, uso recomendado, hero 30s e derivados 10-15s para mídia paga.\n- A aba Vídeo agora mostra:\n  - hero pronto;\n  - hero aprovado;\n  - cortes curtos;\n  - papel de cada vídeo no funil;\n  - uso recomendado: Landing, Ads/Reels, Formulário, Checkout ou Teste.\n- O formulário VEO ficou sinalizado como uso de teaser/cena curta, não como caminho principal para hero.\n- Atualizei o documento canônico e o registro do experimento para evitar voltar à regra antiga do VEO.\n\n**Validação executada:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou.\n- Spotless restrito aos arquivos Java alterados passou.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar esta mudança no Marketing Hub. Depois do deploy, a aba Vídeo do experimento 68 já deve orientar a escolha do hero principal e separar os demais vídeos como variações/cortes para tráfego."}

Última mensagem do usuário:
deu erro no github verifique e ajuste

**Resumo das alterações:**
{"titulo":"Erro do GitHub corrigido","comentario":"Verifiquei o GitHub Action com erro: o workflow `Build & Deploy containers` falhou no backend, no teste `ExperimentServiceTest.updateStatusPreservesReleaseTimestampForBaseline`.\n\n**Causa-raiz:** o teste comparava o timestamp logo após `Instant.now()` em memória. No próximo passo, o valor era recarregado do banco H2 com pequena diferença de precisão, gerando falha intermitente de `1ms`. Não era falha comercial do fluxo de vídeos.\n\n**Ajuste feito:**\n\n- Corrigi o teste para usar um timestamp fixo e persistido.\n- A regra validada continua a mesma: ao pausar um experimento, o Marketing Hub deve preservar o timestamp de liberação para Facebook, sem recriá-lo.\n\n**Alternativas avaliadas:**\n\n1. Aumentar tolerância de tempo no teste: rápido, mas mascararia regressão real.\n2. Alterar a regra no service: risco desnecessário, porque a regra de negócio estava correta.\n3. Melhor caminho: fixar o timestamp persistido no teste e validar preservação real. Foi o que implementei.\n\n**Validação:**\n\n- Teste específico que falhou no GitHub: passou.\n- Classe completa `ExperimentServiceTest`: passou com 28 testes.\n- Suíte completa do backend `mvn -q test`: passou; 244 relatórios Surefire sem failures/errors.\n- `git diff --check`: passou.\n\n**Observação:** `mvn spotless:check` global falhou por violações preexistentes em milhares de arquivos, começando por `GeraSalesPageStageServiceTest.java`, fora do arquivo alterado. Não apliquei formatação global para não gerar um diff enorme e não relacionado.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"Configurar Spotless com ratchet ou checagem apenas de arquivos alterados evitaria que violações antigas bloqueassem validações pequenas e focadas.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste para o GitHub Action rodar novamente com a correção."}