### PR TITLE
AI Hub: {"titulo":"Tela de vídeos ajustada","comentario":"Implementei a mudança: vídeos agora são gerenciados pela tela do produto `/products/4/sales-videos`, não mais pela aba do experimento.\n\n**O que ficou pronto:**\n\n- Refiz a tela de vídeos do prod…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/salesvideo/SalesVideoJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/salesvideo/SalesVideoJobRepository.java
@@ -20,6 +20,9 @@ public interface SalesVideoJobRepository extends JpaRepository<SalesVideoJob, Lo
     /** Lista jobs de um perfil de vídeo do mais recente para o mais antigo. */
     List<SalesVideoJob> findByProfileIdOrderByRequestedAtDesc(Long profileId);
 
+    /** Lista jobs de todos os perfis de vídeo de um produto do mais recente para o mais antigo. */
+    List<SalesVideoJob> findByProfileProductIdAndTenantIdOrderByRequestedAtDesc(Long productId, String tenantId);
+
     /** Busca o job mais recente de um perfil de vídeo. */
     Optional<SalesVideoJob> findFirstByProfileIdOrderByRequestedAtDesc(Long profileId);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/controller/SalesVideoController.java
@@ -137,6 +137,12 @@ public class SalesVideoController {
         return salesVideoService.listJobsByProfile(profileId);
     }
 
+    /** Lista jobs administrativos de todos os perfis de um produto. */
+    @GetMapping("/api/products/{productId}/sales-videos/jobs")
+    public List<SalesVideoJobDto> listJobsByProduct(@PathVariable Long productId) {
+        return salesVideoService.listJobsByProduct(productId);
+    }
+
     /** Consulta um job administrativo. */
     @GetMapping("/api/sales-videos/jobs/{jobId}")
     public SalesVideoJobDto getAdminJob(@PathVariable Long jobId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoJobService.java
@@ -138,6 +138,16 @@ public class SalesVideoJobService {
                 .toList();
     }
 
+    /** Lista todos os jobs de vídeo de um produto para gestão e totalização de custo. */
+    @Transactional(readOnly = true)
+    public List<SalesVideoJobDto> listJobsByProduct(Long productId) {
+        String tenantId = TenantContextHolder.requireTenant();
+        return jobRepository.findByProfileProductIdAndTenantIdOrderByRequestedAtDesc(productId, tenantId)
+                .stream()
+                .map(SalesVideoMapper::toDto)
+                .toList();
+    }
+
     @Transactional
     public SalesVideoJobDto claimJob(Long jobId, JobClaimRequest request) {
         SalesVideoJob job = loadJob(jobId);

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/service/SalesVideoService.java
@@ -125,6 +125,11 @@ public class SalesVideoService {
         return jobService.listJobsByProfile(profileId);
     }
 
+    /** Lista todos os jobs de vídeo de um produto. */
+    public List<SalesVideoJobDto> listJobsByProduct(Long productId) {
+        return jobService.listJobsByProduct(productId);
+    }
+
     /** Consulta um job pelo identificador. */
     public SalesVideoJobDto getJob(Long jobId) {
         return jobService.getJob(jobId);

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/SalesVideoJobServiceTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.marketinghub.salesvideo.exception.VideoModuleException;
+import com.marketinghub.salesvideo.tenant.TenantContext;
+import com.marketinghub.salesvideo.tenant.TenantContextHolder;
 
 import java.time.Instant;
 import java.util.List;
@@ -99,6 +101,42 @@ class SalesVideoJobServiceTest {
                 .extracting(SalesVideoJobDto::getId)
                 .isEqualTo(55L);
         assertThat(result.get(0).getStatus()).isEqualTo(SalesVideoStatus.VIDEO_REQUESTED);
+    }
+
+    /** Garante que a tela de produto lista todos os jobs do produto no tenant atual. */
+    @Test
+    void shouldListJobsByProduct() {
+        long productId = 4L;
+        TenantContextHolder.set(new TenantContext("tenant-a", "seller@example.com", false));
+        SalesVideoProfile profile = SalesVideoProfile.builder()
+                .id(10L)
+                .tenantId("tenant-a")
+                .build();
+        SalesVideoJob job = SalesVideoJob.builder()
+                .id(56L)
+                .profile(profile)
+                .tenantId("tenant-a")
+                .jobType(SalesVideoJobType.RENDER)
+                .providerFamily(SalesVideoProviderFamily.EXTERNAL_VIDEO_MODULE)
+                .status(SalesVideoStatus.VIDEO_READY)
+                .requestedAt(Instant.parse("2024-01-01T10:15:30Z"))
+                .metadataJson("{\"cost_usd\":12.34}")
+                .build();
+        given(jobRepository.findByProfileProductIdAndTenantIdOrderByRequestedAtDesc(productId, "tenant-a"))
+                .willReturn(List.of(job));
+
+        try {
+            List<SalesVideoJobDto> result = service.listJobsByProduct(productId);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .first()
+                    .extracting(SalesVideoJobDto::getId)
+                    .isEqualTo(56L);
+            assertThat(result.get(0).getMetadataJson()).contains("cost_usd");
+        } finally {
+            TenantContextHolder.clear();
+        }
     }
 
     /** Garante erro de negocio quando o perfil solicitado nao existe. */

--- a/docs/canonical/avatar-sales-video-canonical-rules.md
+++ b/docs/canonical/avatar-sales-video-canonical-rules.md
@@ -141,6 +141,9 @@ Um vídeo só pode ir para `PUBLISHED` se:
 
 ## 6.1 Vídeo hero comercial, providers e streaming
 
+- A localização única de criação, geração, pós-produção, custo e gerenciamento de vídeos comerciais é a tela do produto: `/products/{productId}/sales-videos`.
+- Experimentos não devem criar, renderizar ou pós-produzir vídeos diretamente. A aba de vídeo do experimento deve atuar apenas como revisão/consulta dos ativos historicamente vinculados ou consumidos pela campanha, direcionando qualquer nova operação para a central de vídeos do produto.
+- O custo de vídeo deve ser auditável por job de produção e exibido na central do produto tanto individualmente quanto como total do produto. Quando o provider ainda não devolver custo conhecido, a UI deve evidenciar ausência de custo em vez de estimar valor não auditado.
 - Vídeo hero de venda para PDE/funil público deve ser tratado como peça comercial completa, não como clipe técnico isolado.
 - Quando o perfil pedir duração alvo maior que a duração nativa do provider, o fluxo deve gerar cenas/montagem suficiente para completar **Dor -> Resultado -> Mecanismo -> CTA**.
 - Para o Método MUSA, o provider recomendado para hero premium é `LUMA_RAY_3_2`; `KLING_3_0` deve ser usado como alternativa de teste; `VEO` deve ficar restrito a teaser curto ou cena isolada dentro de montagem.

--- a/frontend/src/api/salesVideo/types.ts
+++ b/frontend/src/api/salesVideo/types.ts
@@ -13,7 +13,8 @@ export type SalesVideoStatus =
   | "ARCHIVED";
 export type SalesVideoProviderFamily = "OPENAI" | "EXTERNAL_VIDEO_MODULE";
 export type SalesVideoExecutionMode = "TEST" | "PRODUCTION";
-export type SalesVideoJobType = "SCRIPT" | "STORYBOARD" | "RENDER" | "PUBLISH" | "RETRY";
+export type SalesVideoJobType =
+  "SCRIPT" | "STORYBOARD" | "RENDER" | "POST_PRODUCTION" | "PUBLISH" | "RETRY";
 export type SalesVideoRetryReason =
   | "MANUAL_INTERVENTION"
   | "PROVIDER_FAILURE"
@@ -21,7 +22,8 @@ export type SalesVideoRetryReason =
   | "QUALITY_ASSURANCE"
   | "AUTO_RECOVERY"
   | "OTHER";
-export type SalesVideoScriptStatus = "DRAFT" | "READY_FOR_REVIEW" | "APPROVED" | "ARCHIVED";
+export type SalesVideoScriptStatus =
+  "DRAFT" | "READY_FOR_REVIEW" | "APPROVED" | "ARCHIVED";
 export type SalesVideoScriptSource = "MANUAL" | "OPENAI";
 
 export interface SalesVideoScript {
@@ -70,6 +72,7 @@ export interface SalesVideoJob {
   posterAssetId?: number | null;
   vttAssetId?: number | null;
   metadataJson?: string | null;
+  auditSnapshotJson?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
 }
@@ -226,13 +229,8 @@ export interface LandingVideoSlotHistory {
   notes?: string | null;
 }
 
-
 export type SalesVideoConversionEventType =
-  | "VIEW"
-  | "LEAD"
-  | "QUALIFIED_LEAD"
-  | "CHECKOUT_STARTED"
-  | "PURCHASE";
+  "VIEW" | "LEAD" | "QUALIFIED_LEAD" | "CHECKOUT_STARTED" | "PURCHASE";
 
 export interface SalesVideoCommercialPlaybook {
   id: number;

--- a/frontend/src/api/salesVideo/useProductSalesVideoJobs.ts
+++ b/frontend/src/api/salesVideo/useProductSalesVideoJobs.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { SalesVideoJob } from "./types";
+
+export function useProductSalesVideoJobs(productId?: string | number) {
+  return useQuery({
+    queryKey: ["product-sales-video-jobs", productId],
+    enabled: Boolean(productId),
+    queryFn: async () => {
+      const { data } = await axios.get<SalesVideoJob[]>(
+        `/api/products/${productId}/sales-videos/jobs`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentVideoTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentVideoTab.tsx
@@ -1,71 +1,17 @@
-import { FormEvent, useMemo, useState } from "react";
-import axios from "axios";
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { toast } from "react-toastify";
 import { useGeraSalesPagePublications } from "../../api/experiment/useGeraSalesPagePublications";
 import type { Experiment } from "../../api/experiment/useExperiments";
 import {
   ExperimentVideoAsset,
-  ExperimentVideoSlot,
-  SalesVideoExecutionMode,
   useExperimentVideoAssets,
 } from "../../api/experiment/useExperimentVideoAssets";
-import { useRequestPlannedExperimentVideoRenders } from "../../api/experiment/useRequestPlannedExperimentVideoRenders";
-import { useRequestExperimentVideoPostProduction } from "../../api/experiment/useRequestExperimentVideoPostProduction";
-import { useRequestExperimentVeoVideo } from "../../api/experiment/useRequestExperimentVeoVideo";
 import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
-import { useTenantContext } from "../../utils/tenantContext";
 import "./ExperimentVideoTab.css";
 
 interface ExperimentVideoTabProps {
   experiment: Experiment;
   alterationLocked?: boolean;
-}
-
-const VIDEO_SLOT_OPTIONS: ExperimentVideoSlot[] = [
-  "AD",
-  "LANDING_HERO",
-  "FORM_EXPLAINER",
-  "PRE_CHECKOUT",
-];
-
-const EXECUTION_MODE_OPTIONS: SalesVideoExecutionMode[] = [
-  "TEST",
-  "PRODUCTION",
-];
-
-function buildInitialScript(experiment: Experiment) {
-  const sections = [
-    experiment.funnelPromise ? `Promessa: ${experiment.funnelPromise}` : null,
-    experiment.singlePain ? `Dor: ${experiment.singlePain}` : null,
-    experiment.primaryCta ? `CTA: ${experiment.primaryCta}` : null,
-    experiment.adCopy ? `Copy do anúncio:\n${experiment.adCopy}` : null,
-    experiment.landingPageCopy
-      ? `Copy da página:\n${experiment.landingPageCopy}`
-      : null,
-  ].filter(Boolean);
-  return sections.join("\n\n").slice(0, 6000);
-}
-
-function buildInitialCharacterImagePrompt(experiment: Experiment) {
-  const promise = experiment.funnelPromise ?? "presenca elegante e intencional";
-  const pain =
-    experiment.singlePain ??
-    "sentir que a imagem comunica menos valor do que deveria";
-  return [
-    "Retrato vertical realista para personagem de video hero do Metodo MUSA 7 Dias.",
-    "Mulher brasileira adulta, elegante, acessivel e confiavel, com presenca sofisticada sem ostentacao.",
-    "Expressao acolhedora e segura, roupa neutra bem ajustada, beleza natural, fundo claro editorial.",
-    `Contexto comercial: promessa de ${promise}.`,
-    `Dor central que o video deve refletir sem dramatizar: ${pain}.`,
-    "Estilo: premium acessivel, luz suave, enquadramento 9:16, pronta para referencia no VEO.",
-  ].join("\n");
-}
-
-function parseOptionalNumber(value: string) {
-  if (!value.trim()) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function formatDate(value?: string | null) {
@@ -159,42 +105,10 @@ export default function ExperimentVideoTab({
   experiment,
   alterationLocked = false,
 }: ExperimentVideoTabProps) {
-  const tenantContext = useTenantContext();
   const { data: videoAssets, isLoading } = useExperimentVideoAssets(
     experiment.id,
   );
   const geraSalesPagePublications = useGeraSalesPagePublications(experiment.id);
-  const requestVeoVideo = useRequestExperimentVeoVideo(experiment.id);
-  const requestPlannedRenders = useRequestPlannedExperimentVideoRenders(
-    experiment.id,
-  );
-  const requestPostProduction = useRequestExperimentVideoPostProduction(
-    experiment.id,
-  );
-  const [formState, setFormState] = useState({
-    slot: "LANDING_HERO" as ExperimentVideoSlot,
-    title: `Vídeo VEO - Experimento ${experiment.id}`,
-    objective:
-      "Aumentar conversão da página de venda e destravar campanha com vídeo obrigatório.",
-    primaryMetric: "CTR, tempo na página e conversão para checkout/lead.",
-    personaName: "",
-    personaStyle: "consultiva, direta e comercial",
-    voiceStyle: "natural, confiante e com urgência moderada",
-    language: "pt-BR",
-    targetDurationSeconds: "30",
-    scriptText: buildInitialScript(experiment),
-    hookText: experiment.funnelPromise ?? "",
-    ctaText: experiment.primaryCta ?? "Quero acessar agora",
-    captionText: "",
-    characterImagePrompt: buildInitialCharacterImagePrompt(experiment),
-    characterImageModel: "gpt-image-2",
-    characterImageJobId: "",
-    characterImageAssetId: "",
-    characterImageReferenceUrl: "",
-    providerName: "VEO",
-    executionMode: "TEST" as SalesVideoExecutionMode,
-    requiredForRelease: true,
-  });
 
   const sortedAssets = useMemo(() => videoAssets ?? [], [videoAssets]);
   const readyHeroAssets = useMemo(
@@ -222,30 +136,10 @@ export default function ExperimentVideoTab({
       ),
     [sortedAssets],
   );
-  const postProductionCandidates = useMemo(
-    () =>
-      sortedAssets.filter((asset) => {
-        if (
-          asset.provider === "MUSA_POST_PRODUCTION" &&
-          asset.status === "FAILED"
-        ) {
-          return true;
-        }
-        return readyHeroAssets.includes(asset);
-      }),
-    [readyHeroAssets, sortedAssets],
-  );
   const shortTrafficAssets = useMemo(
     () =>
       sortedAssets.filter((asset) =>
         ["Cena curta", "Hook de mídia"].includes(getCommercialVideoRole(asset)),
-      ),
-    [sortedAssets],
-  );
-  const plannedAssetsWithoutJob = useMemo(
-    () =>
-      sortedAssets.filter(
-        (asset) => asset.status === "PLANNED" && !asset.salesVideoJobId,
       ),
     [sortedAssets],
   );
@@ -282,129 +176,7 @@ export default function ExperimentVideoTab({
   const salesPagePreviewUrl = buildExperimentTestUrl(
     latestSalesPagePublication?.salesPageUrl,
   );
-  const canSubmit =
-    !alterationLocked &&
-    formState.title.trim().length > 0 &&
-    formState.objective.trim().length > 0 &&
-    formState.primaryMetric.trim().length > 0 &&
-    formState.scriptText.trim().length > 0 &&
-    tenantContext.userEmail.trim().length > 0 &&
-    !requestVeoVideo.isPending;
-  const canRequestPlannedRenders =
-    !alterationLocked &&
-    plannedAssetsWithoutJob.length > 0 &&
-    tenantContext.userEmail.trim().length > 0 &&
-    !requestPlannedRenders.isPending;
-  const canRequestPostProduction =
-    !alterationLocked &&
-    postProductionCandidates.length > 0 &&
-    tenantContext.userEmail.trim().length > 0 &&
-    !requestPostProduction.isPending;
-
-  const handleRequestPlannedRenders = async () => {
-    try {
-      const updatedAssets = await requestPlannedRenders.mutateAsync({
-        requestedBy: tenantContext.userEmail,
-        executionMode: "TEST",
-        personaStyle: "editorial, realista e premium acessivel",
-        voiceStyle: "natural, direta e comercial",
-        language: "pt-BR",
-        requiredForRelease: true,
-      });
-      if (updatedAssets.length === 0) {
-        toast.info("Nenhum vídeo planejado sem job para renderizar.");
-        return;
-      }
-      toast.success(
-        `${updatedAssets.length} vídeo(s) planejado(s) enviados para render.`,
-      );
-    } catch (error) {
-      const message = axios.isAxiosError(error)
-        ? (error.response?.data?.message ??
-          error.response?.data?.detail ??
-          "Não foi possível solicitar os renders planejados.")
-        : "Não foi possível solicitar os renders planejados.";
-      toast.error(message);
-    }
-  };
-
-  const handleRequestPostProduction = async () => {
-    try {
-      const updatedAssets = await requestPostProduction.mutateAsync({
-        requestedBy: tenantContext.userEmail,
-        executionMode: "TEST",
-        outputVariant: "LANDING_HERO_FINAL",
-        createShortDerivatives: true,
-      });
-      if (updatedAssets.length === 0) {
-        toast.info("Nenhum vídeo pronto aguardando pós-produção.");
-        return;
-      }
-      toast.success(
-        `${updatedAssets.length} vídeo(s) enviado(s) para pós-produção.`,
-      );
-    } catch (error) {
-      const message = axios.isAxiosError(error)
-        ? (error.response?.data?.message ??
-          error.response?.data?.detail ??
-          "Não foi possível solicitar a pós-produção.")
-        : "Não foi possível solicitar a pós-produção.";
-      toast.error(message);
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const targetDurationSeconds = parseOptionalNumber(
-      formState.targetDurationSeconds,
-    );
-    if (
-      formState.targetDurationSeconds.trim() &&
-      targetDurationSeconds === undefined
-    ) {
-      toast.error("Duração alvo inválida");
-      return;
-    }
-    try {
-      const created = await requestVeoVideo.mutateAsync({
-        slot: formState.slot,
-        title: formState.title.trim(),
-        objective: formState.objective.trim(),
-        primaryMetric: formState.primaryMetric.trim(),
-        personaName: formState.personaName.trim() || undefined,
-        personaStyle: formState.personaStyle.trim() || undefined,
-        voiceStyle: formState.voiceStyle.trim() || undefined,
-        language: formState.language.trim() || undefined,
-        targetDurationSeconds,
-        scriptText: formState.scriptText.trim(),
-        hookText: formState.hookText.trim() || undefined,
-        ctaText: formState.ctaText.trim() || undefined,
-        captionText: formState.captionText.trim() || undefined,
-        characterImagePrompt:
-          formState.characterImagePrompt.trim() || undefined,
-        characterImageModel: formState.characterImageModel.trim() || undefined,
-        characterImageJobId: formState.characterImageJobId.trim() || undefined,
-        characterImageAssetId:
-          parseOptionalNumber(formState.characterImageAssetId) ?? undefined,
-        characterImageReferenceUrl:
-          formState.characterImageReferenceUrl.trim() || undefined,
-        providerName: formState.providerName.trim() || "VEO",
-        executionMode: formState.executionMode,
-        requestedBy: tenantContext.userEmail,
-        requiredForRelease: formState.requiredForRelease,
-      });
-      toast.success(
-        `Vídeo solicitado. Profile #${created.salesVideoProfileId} · Job #${created.salesVideoJobId}`,
-      );
-    } catch (error) {
-      const message = axios.isAxiosError(error)
-        ? (error.response?.data?.message ??
-          error.response?.data?.detail ??
-          "Não foi possível solicitar o vídeo VEO.")
-        : "Não foi possível solicitar o vídeo VEO.";
-      toast.error(message);
-    }
-  };
+  const productVideoUrl = "/products/4/sales-videos";
 
   return (
     <div className="d-flex flex-column gap-3">
@@ -521,26 +293,9 @@ export default function ExperimentVideoTab({
               </p>
             </div>
             <div className="d-flex align-items-center gap-2 flex-wrap">
-              <button
-                type="button"
-                className="btn btn-sm btn-primary"
-                disabled={!canRequestPlannedRenders}
-                onClick={handleRequestPlannedRenders}
-              >
-                {requestPlannedRenders.isPending
-                  ? "Solicitando..."
-                  : "Renderizar planejados"}
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-outline-primary"
-                disabled={!canRequestPostProduction}
-                onClick={handleRequestPostProduction}
-              >
-                {requestPostProduction.isPending
-                  ? "Finalizando..."
-                  : "Finalizar para venda"}
-              </button>
+              <Link className="btn btn-sm btn-primary" to={productVideoUrl}>
+                Gerenciar no produto
+              </Link>
               <span className="badge text-bg-secondary">
                 {sortedAssets.length} ativo(s)
               </span>
@@ -551,9 +306,9 @@ export default function ExperimentVideoTab({
               <div>
                 <div className="fw-semibold">Estratégia recomendada</div>
                 <div className="small text-muted">
-                  Hero de 30s na landing; cortes de 10-15s para tráfego pago.
-                  Finalize os vídeos brutos com voz off, legenda e trilha antes
-                  de aprovar para campanha.
+                  A criação e pós-produção de vídeos agora ficam na tela do
+                  produto. Esta aba mantém apenas revisão do que o experimento
+                  está usando ou herdou historicamente.
                 </div>
               </div>
               <div className="experiment-video-strategy-panel__metrics">
@@ -561,6 +316,7 @@ export default function ExperimentVideoTab({
                 <span>Hero aprovado: {approvedHeroAssets.length}</span>
                 <span>Finalizados: {finishedSalesAssets.length}</span>
                 <span>Cortes curtos: {shortTrafficAssets.length}</span>
+                {alterationLocked ? <span>Alteração bloqueada</span> : null}
               </div>
             </div>
             <table className="table table-sm align-middle">
@@ -646,322 +402,12 @@ export default function ExperimentVideoTab({
         </div>
       </div>
 
-      <form className="card" onSubmit={handleSubmit}>
-        <div className="card-body">
-          <h5 className="card-title mb-1">Solicitar vídeo VEO</h5>
-          <p className="text-muted small mb-3">
-            Use como teaser/cena curta. Para hero principal, priorize Luma nos
-            vídeos planejados.
-          </p>
-          <div className="row g-3">
-            <div className="col-md-3">
-              <label className="form-label">Slot</label>
-              <select
-                className="form-select"
-                value={formState.slot}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    slot: event.target.value as ExperimentVideoSlot,
-                  }))
-                }
-              >
-                {VIDEO_SLOT_OPTIONS.map((slot) => (
-                  <option key={slot} value={slot}>
-                    {slot}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="col-md-6">
-              <label className="form-label">Título interno</label>
-              <input
-                className="form-control"
-                value={formState.title}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    title: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Provider</label>
-              <input
-                className="form-control"
-                value={formState.providerName}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    providerName: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-6">
-              <label className="form-label">Objetivo</label>
-              <input
-                className="form-control"
-                value={formState.objective}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    objective: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-6">
-              <label className="form-label">Métrica primária</label>
-              <input
-                className="form-control"
-                value={formState.primaryMetric}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    primaryMetric: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Duração alvo</label>
-              <input
-                className="form-control"
-                type="number"
-                min="1"
-                value={formState.targetDurationSeconds}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    targetDurationSeconds: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Modo</label>
-              <select
-                className="form-select"
-                value={formState.executionMode}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    executionMode: event.target
-                      .value as SalesVideoExecutionMode,
-                  }))
-                }
-              >
-                {EXECUTION_MODE_OPTIONS.map((mode) => (
-                  <option key={mode} value={mode}>
-                    {mode}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="col-md-6">
-              <label className="form-label">Persona / estilo</label>
-              <div className="row g-2">
-                <div className="col-md-4">
-                  <input
-                    className="form-control"
-                    placeholder="Persona"
-                    value={formState.personaName}
-                    onChange={(event) =>
-                      setFormState((prev) => ({
-                        ...prev,
-                        personaName: event.target.value,
-                      }))
-                    }
-                  />
-                </div>
-                <div className="col-md-4">
-                  <input
-                    className="form-control"
-                    placeholder="Estilo"
-                    value={formState.personaStyle}
-                    onChange={(event) =>
-                      setFormState((prev) => ({
-                        ...prev,
-                        personaStyle: event.target.value,
-                      }))
-                    }
-                  />
-                </div>
-                <div className="col-md-4">
-                  <input
-                    className="form-control"
-                    placeholder="Voz"
-                    value={formState.voiceStyle}
-                    onChange={(event) =>
-                      setFormState((prev) => ({
-                        ...prev,
-                        voiceStyle: event.target.value,
-                      }))
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Hook</label>
-              <input
-                className="form-control"
-                value={formState.hookText}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    hookText: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">CTA</label>
-              <input
-                className="form-control"
-                value={formState.ctaText}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    ctaText: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-12">
-              <label className="form-label">Imagem da personagem OpenAI</label>
-              <textarea
-                className="form-control"
-                rows={6}
-                value={formState.characterImagePrompt}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    characterImagePrompt: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Modelo da imagem</label>
-              <input
-                className="form-control"
-                value={formState.characterImageModel}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    characterImageModel: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Job OpenAI</label>
-              <input
-                className="form-control"
-                value={formState.characterImageJobId}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    characterImageJobId: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">Asset da imagem</label>
-              <input
-                className="form-control"
-                type="number"
-                min="1"
-                value={formState.characterImageAssetId}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    characterImageAssetId: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-md-3">
-              <label className="form-label">URL de referência</label>
-              <input
-                className="form-control"
-                value={formState.characterImageReferenceUrl}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    characterImageReferenceUrl: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-12">
-              <label className="form-label">Script para VEO</label>
-              <textarea
-                className="form-control"
-                rows={10}
-                value={formState.scriptText}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    scriptText: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-12">
-              <label className="form-label">Legenda / observações</label>
-              <textarea
-                className="form-control"
-                rows={3}
-                value={formState.captionText}
-                onChange={(event) =>
-                  setFormState((prev) => ({
-                    ...prev,
-                    captionText: event.target.value,
-                  }))
-                }
-              />
-            </div>
-            <div className="col-12">
-              <div className="form-check">
-                <input
-                  id="requiredForRelease"
-                  className="form-check-input"
-                  type="checkbox"
-                  checked={formState.requiredForRelease}
-                  onChange={(event) =>
-                    setFormState((prev) => ({
-                      ...prev,
-                      requiredForRelease: event.target.checked,
-                    }))
-                  }
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor="requiredForRelease"
-                >
-                  Obrigatório para liberar campanha
-                </label>
-              </div>
-            </div>
-          </div>
-          <div className="mt-3">
-            <button
-              className="btn btn-primary"
-              type="submit"
-              disabled={!canSubmit}
-            >
-              {requestVeoVideo.isPending
-                ? "Solicitando..."
-                : "Solicitar vídeo VEO"}
-            </button>
-          </div>
-        </div>
-      </form>
+      <div className="alert alert-warning border mb-0">
+        A geração de vídeos foi retirada do experimento. Para criar novos
+        vídeos, gerar variações, finalizar peças para venda e acompanhar custo,
+        use a central única em{" "}
+        <Link to={productVideoUrl}>Vídeos do produto</Link>.
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/salesVideo/ProductSalesVideoPage.css
+++ b/frontend/src/pages/salesVideo/ProductSalesVideoPage.css
@@ -1,0 +1,249 @@
+.product-video-page {
+  color: #111827;
+}
+
+.product-video-page__header,
+.product-video-page__context,
+.product-video-page__table-heading,
+.product-video-page__hero-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.product-video-page__header {
+  margin-bottom: 1rem;
+}
+
+.product-video-page__header p {
+  max-width: 760px;
+  margin: 0;
+  color: #475569;
+}
+
+.product-video-page__context,
+.product-video-page__metrics {
+  margin-bottom: 1rem;
+}
+
+.product-video-page__context {
+  flex-wrap: wrap;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.85rem;
+}
+
+.product-video-page__context div,
+.product-video-page__metric {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.product-video-page__context span,
+.product-video-page__metric span,
+.product-video-page__table-heading span,
+.product-video-page__hero-copy span,
+.product-video-page__provider-note span,
+.product-video-page__strategy span {
+  color: #64748b;
+  font-size: 0.84rem;
+}
+
+.product-video-page__metrics {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.product-video-page__metric,
+.product-video-page__panel,
+.product-video-page__hero-panel,
+.product-video-page__script,
+.product-video-page__render {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.product-video-page__metric {
+  padding: 0.75rem;
+  background: #f8fafc;
+}
+
+.product-video-page__metric strong {
+  font-size: 1.15rem;
+}
+
+.product-video-page__layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.product-video-page__sidebar,
+.product-video-page__main,
+.product-video-page__profile-list,
+.product-video-page__panel,
+.product-video-page__script,
+.product-video-page__render {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.product-video-page__panel,
+.product-video-page__script,
+.product-video-page__render {
+  padding: 1rem;
+}
+
+.product-video-page__panel-heading {
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.product-video-page__profile {
+  width: 100%;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.product-video-page__profile strong,
+.product-video-page__profile span,
+.product-video-page__provider-note strong,
+.product-video-page__provider-note span,
+.product-video-page__strategy strong,
+.product-video-page__strategy span {
+  display: block;
+}
+
+.product-video-page__profile span {
+  color: #64748b;
+  font-size: 0.86rem;
+  margin-top: 0.2rem;
+}
+
+.product-video-page__profile--active {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.product-video-page__empty {
+  margin: 0;
+  color: #64748b;
+}
+
+.product-video-page__inline-fields,
+.product-video-page__workflow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.product-video-page__hero-panel {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.95fr) minmax(280px, 1.05fr);
+  gap: 1rem;
+  padding: 1rem;
+  align-items: stretch;
+  background: #fffdf7;
+}
+
+.product-video-page__hero-copy h2 {
+  font-size: 1.35rem;
+  margin: 0.2rem 0 0.45rem;
+}
+
+.product-video-page__hero-copy p {
+  color: #475569;
+  margin: 0 0 1rem;
+}
+
+.product-video-page__preview {
+  min-height: 300px;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #111827;
+}
+
+.product-video-page__preview video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+  object-fit: contain;
+  background: #111827;
+}
+
+.product-video-page__preview-empty {
+  display: grid;
+  min-height: 300px;
+  place-items: center;
+  align-content: center;
+  gap: 0.35rem;
+  padding: 1rem;
+  color: #f8fafc;
+  text-align: center;
+}
+
+.product-video-page__preview-empty span {
+  color: #cbd5e1;
+}
+
+.product-video-page__script textarea {
+  min-height: 250px;
+  resize: vertical;
+}
+
+.product-video-page__provider-note,
+.product-video-page__strategy {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 0.75rem;
+}
+
+.product-video-page__strategy {
+  display: grid;
+  gap: 0.35rem;
+  background: #f8fff9;
+}
+
+.product-video-page .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+@media (max-width: 1100px) {
+  .product-video-page__metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .product-video-page__layout,
+  .product-video-page__hero-panel,
+  .product-video-page__workflow {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .product-video-page__header,
+  .product-video-page__table-heading,
+  .product-video-page__hero-actions {
+    display: grid;
+    justify-content: stretch;
+  }
+
+  .product-video-page__metrics,
+  .product-video-page__inline-fields {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/salesVideo/ProductSalesVideoPage.tsx
+++ b/frontend/src/pages/salesVideo/ProductSalesVideoPage.tsx
@@ -1,43 +1,212 @@
 import { FormEvent, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import {
+  BadgeDollarSign,
+  Clapperboard,
+  FileText,
+  PlayCircle,
+  RefreshCcw,
+  Save,
+  Video,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import PageTitle from "../../components/PageTitle";
+import { AdaptiveVideoPlayer } from "../../components/AdaptiveVideoPlayer";
+import { TenantContextBanner } from "../../components/TenantContextBanner";
+import { useAsset } from "../../api/media/useAsset";
 import { useProduct } from "../../api/product/useProduct";
 import { useSalesVideoProfiles } from "../../api/salesVideo/useSalesVideoProfiles";
 import { useCreateSalesVideoProfile } from "../../api/salesVideo/useCreateSalesVideoProfile";
-import { SalesVideoKind } from "../../api/salesVideo/types";
-import { TenantContextBanner } from "../../components/TenantContextBanner";
+import { useProductSalesVideoJobs } from "../../api/salesVideo/useProductSalesVideoJobs";
+import { useApproveSalesVideoScript } from "../../api/salesVideo/useApproveSalesVideoScript";
+import { useRequestVideoRender } from "../../api/salesVideo/useRequestVideoRender";
+import { useTenantContext } from "../../utils/tenantContext";
+import {
+  SalesVideoJob,
+  SalesVideoKind,
+  SalesVideoProfile,
+} from "../../api/salesVideo/types";
+import {
+  buildSalesVideoRenderMetadata,
+  DEFAULT_SALES_VIDEO_PROVIDER,
+  findSalesVideoProviderOption,
+  SALES_VIDEO_PROVIDER_OPTIONS,
+} from "../../api/salesVideo/videoProviderCatalog";
+import "./ProductSalesVideoPage.css";
 
 const VIDEO_KIND_OPTIONS: SalesVideoKind[] = ["HERO", "OBJECTION", "PROOF"];
 
-export default function ProductSalesVideoPage() {
-  const { productId } = useParams();
-  const { data: product, isLoading: productLoading } = useProduct(productId);
-  const { data: profiles, isLoading: profilesLoading } = useSalesVideoProfiles(productId);
-  const createProfile = useCreateSalesVideoProfile(productId);
-  const [formState, setFormState] = useState({
-    videoKind: "HERO" as SalesVideoKind,
+const DEFAULT_SCRIPT = [
+  "Hook: voce sente que sua imagem ainda nao comunica a presenca que voce quer?",
+  "Dor: nao e falta de roupa. E falta de clareza sobre os sinais que sua imagem envia.",
+  "Mecanismo: o Metodo MUSA cria um plano de 7 dias com microacoes para ajustar presenca, elegancia e intencao.",
+  "Desejo: pequenos sinais visuais mudam como voce se percebe e como entra nos ambientes.",
+  "CTA: veja agora seu plano MUSA personalizado.",
+].join("\n\n");
+
+type ProfileFormState = {
+  videoKind: SalesVideoKind;
+  title: string;
+  personaName: string;
+  personaStyle: string;
+  voiceStyle: string;
+  language: string;
+  targetDurationSeconds: string;
+  landingPageId: string;
+};
+
+function emptyProfileForm(): ProfileFormState {
+  return {
+    videoKind: "HERO",
     title: "",
     personaName: "",
     personaStyle: "",
     voiceStyle: "",
     language: "pt-BR",
-    targetDurationSeconds: "",
+    targetDurationSeconds: "30",
     landingPageId: "",
-  });
+  };
+}
+
+export default function ProductSalesVideoPage() {
+  const { productId } = useParams();
+  const tenantContext = useTenantContext();
+  const { data: product, isLoading: productLoading } = useProduct(productId);
+  const { data: profiles, isLoading: profilesLoading } =
+    useSalesVideoProfiles(productId);
+  const { data: jobs, isLoading: jobsLoading } =
+    useProductSalesVideoJobs(productId);
+  const [selectedProfileId, setSelectedProfileId] = useState<string>("");
+  const [selectedProviderName, setSelectedProviderName] = useState(
+    DEFAULT_SALES_VIDEO_PROVIDER.providerName,
+  );
+  const [profileForm, setProfileForm] =
+    useState<ProfileFormState>(emptyProfileForm);
+  const [scriptText, setScriptText] = useState(DEFAULT_SCRIPT);
+  const createProfile = useCreateSalesVideoProfile(productId);
+  const approveScript = useApproveSalesVideoScript(
+    selectedProfileId || undefined,
+  );
+  const requestRender = useRequestVideoRender(selectedProfileId || undefined);
 
   const profileList = useMemo(() => profiles ?? [], [profiles]);
+  const jobList = useMemo(() => jobs ?? [], [jobs]);
+  const selectedProfile = useMemo(() => {
+    if (selectedProfileId) {
+      return profileList.find(
+        (profile) => String(profile.id) === selectedProfileId,
+      );
+    }
+    return profileList[0];
+  }, [profileList, selectedProfileId]);
+  const effectiveProfileId = selectedProfile ? String(selectedProfile.id) : "";
+  const selectedProvider =
+    findSalesVideoProviderOption(selectedProviderName) ??
+    DEFAULT_SALES_VIDEO_PROVIDER;
+  const latestReadyJob = useMemo(
+    () =>
+      jobList.find(
+        (job) =>
+          job.status === "VIDEO_READY" &&
+          (Boolean(job.streamPlaybackUrl) || Boolean(job.assetId)),
+      ),
+    [jobList],
+  );
+  const productCost = useMemo(
+    () => summarizeProductVideoCost(jobList),
+    [jobList],
+  );
+  const funnelMetrics = useMemo(
+    () => summarizeFunnel(profileList, jobList),
+    [profileList, jobList],
+  );
 
   if (!productId) {
     return (
       <div>
         <PageTitle>Vídeos do Produto</PageTitle>
-        <p>Informe um produto válido para visualizar os perfis de vídeo.</p>
+        <p>Informe um produto válido para visualizar os vídeos.</p>
       </div>
     );
   }
 
-  if (productLoading || profilesLoading) {
+  const handleCreateProfile = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!profileForm.title.trim()) {
+      toast.error("Informe um título para o vídeo");
+      return;
+    }
+    const duration = parseOptionalNumber(profileForm.targetDurationSeconds);
+    const landingPageId = parseOptionalNumber(profileForm.landingPageId);
+    try {
+      const created = await createProfile.mutateAsync({
+        videoKind: profileForm.videoKind,
+        title: profileForm.title.trim(),
+        personaName: profileForm.personaName.trim() || undefined,
+        personaStyle: profileForm.personaStyle.trim() || undefined,
+        voiceStyle: profileForm.voiceStyle.trim() || undefined,
+        language: profileForm.language.trim() || undefined,
+        targetDurationSeconds: duration,
+        landingPageId,
+      });
+      setSelectedProfileId(String(created.id));
+      setProfileForm(emptyProfileForm());
+      toast.success("Vídeo criado no produto");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Falha ao criar vídeo",
+      );
+    }
+  };
+
+  const handleSaveScript = async () => {
+    if (!effectiveProfileId) {
+      toast.error("Crie ou selecione um vídeo antes do roteiro");
+      return;
+    }
+    if (!scriptText.trim()) {
+      toast.error("O roteiro precisa de texto");
+      return;
+    }
+    try {
+      await approveScript.mutateAsync({
+        scriptText,
+        hookText: firstLine(scriptText),
+        ctaText: "Ver meu plano MUSA de 7 dias",
+        captionText:
+          "Diagnostico MUSA: entenda o que sua imagem comunica hoje.",
+        approvedBy: tenantContext.userEmail,
+      });
+      toast.success("Roteiro salvo e aprovado");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Falha ao salvar roteiro",
+      );
+    }
+  };
+
+  const handleRequestRender = async () => {
+    if (!effectiveProfileId) {
+      toast.error("Crie ou selecione um vídeo antes de gerar");
+      return;
+    }
+    try {
+      await requestRender.mutateAsync({
+        requestedBy: tenantContext.userEmail,
+        providerFamily: selectedProvider.providerFamily,
+        providerName: selectedProvider.providerName,
+        executionMode: "TEST",
+        metadataJson: buildSalesVideoRenderMetadata(selectedProvider),
+      });
+      toast.success("Geração de vídeo solicitada");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Falha ao solicitar geração",
+      );
+    }
+  };
+
+  if (productLoading || profilesLoading || jobsLoading) {
     return (
       <div>
         <PageTitle>Vídeos do Produto #{productId}</PageTitle>
@@ -46,229 +215,520 @@ export default function ProductSalesVideoPage() {
     );
   }
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!formState.title.trim()) {
-      toast.error("Informe um título para o perfil");
-      return;
-    }
-    const duration = formState.targetDurationSeconds.trim()
-      ? Number(formState.targetDurationSeconds)
-      : undefined;
-    if (duration !== undefined && Number.isNaN(duration)) {
-      toast.error("Duração alvo inválida");
-      return;
-    }
-    const landingPageId = formState.landingPageId.trim()
-      ? Number(formState.landingPageId)
-      : undefined;
-    if (landingPageId !== undefined && Number.isNaN(landingPageId)) {
-      toast.error("ID da landing precisa ser numérico");
-      return;
-    }
-
-    try {
-      await createProfile.mutateAsync({
-        videoKind: formState.videoKind,
-        title: formState.title.trim(),
-        personaName: formState.personaName.trim() || undefined,
-        personaStyle: formState.personaStyle.trim() || undefined,
-        voiceStyle: formState.voiceStyle.trim() || undefined,
-        language: formState.language.trim() || undefined,
-        targetDurationSeconds: duration,
-        landingPageId,
-      });
-      toast.success("Perfil de vídeo criado");
-      setFormState((prev) => ({
-        ...prev,
-        title: "",
-        personaName: "",
-        personaStyle: "",
-        voiceStyle: "",
-        targetDurationSeconds: "",
-        landingPageId: prev.landingPageId,
-      }));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Falha ao criar perfil";
-      toast.error(message);
-    }
-  };
-
   return (
-    <div>
-      <PageTitle>Vídeos do Produto #{productId}</PageTitle>
-      <TenantContextBanner className="mb-3" />
-      <div className="mb-3 d-flex gap-2 align-items-center">
-        <Link to="/products" className="btn btn-link p-0">
-          &larr; Voltar para produtos
+    <div className="product-video-page">
+      <div className="product-video-page__header">
+        <div>
+          <PageTitle>Vídeos do produto</PageTitle>
+          <p>
+            Central única para criar, gerar, revisar e medir custo dos vídeos
+            comerciais do produto.
+          </p>
+        </div>
+        <Link to="/products" className="btn btn-outline-secondary">
+          Voltar
         </Link>
-        {product && (
-          <span className="text-muted">
-            Nicho: <strong>{product.niche}</strong> — Avatar: <strong>{product.avatar}</strong>
-          </span>
-        )}
       </div>
 
-      <section className="mb-4">
-        <div className="d-flex justify-content-between align-items-center mb-2">
-          <h2 className="h5 mb-0">Perfis cadastrados</h2>
-          <small className="text-muted">
-            Acompanhe status, script e últimos jobs diretamente nesta lista.
-          </small>
+      <TenantContextBanner className="mb-3" />
+
+      <section className="product-video-page__context">
+        <div>
+          <span>Produto</span>
+          <strong>{product?.name || product?.slug || `#${productId}`}</strong>
         </div>
-        <div className="table-responsive">
-          <table className="table table-striped">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Título</th>
-                <th>Tipo</th>
-                <th>Status</th>
-                <th>Script</th>
-                <th>Último job</th>
-                <th>Landing</th>
-                <th>Ações</th>
-              </tr>
-            </thead>
-            <tbody>
-              {profileList.length === 0 && (
-                <tr>
-                  <td colSpan={8} className="text-center text-muted">
-                    Nenhum perfil cadastrado.
-                  </td>
-                </tr>
-              )}
-              {profileList.map((profile) => (
-                <tr key={profile.id}>
-                  <td>{profile.id}</td>
-                  <td>{profile.title}</td>
-                  <td>{profile.videoKind}</td>
-                  <td>{profile.status}</td>
-                  <td>{profile.latestScript?.status ?? "—"}</td>
-                  <td>
-                    {profile.lastJob
-                      ? `${profile.lastJob.jobType} · ${profile.lastJob.status}`
-                      : "—"}
-                  </td>
-                  <td>{profile.landingPageId ?? "—"}</td>
-                  <td>
-                    <Link
-                      to={`/sales-videos/profiles/${profile.id}`}
-                      className="btn btn-sm btn-outline-primary"
-                    >
-                      Ver perfil
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div>
+          <span>Nicho</span>
+          <strong>{product?.niche || "Nao informado"}</strong>
+        </div>
+        <div>
+          <span>Avatar</span>
+          <strong>{product?.avatar || "Nao informado"}</strong>
         </div>
       </section>
 
-      <section>
-        <h2 className="h5 mb-3">Novo perfil de vídeo</h2>
-        <form className="card p-3" onSubmit={handleSubmit}>
-          <div className="row g-3">
-            <div className="col-md-4">
-              <label className="form-label">Tipo do vídeo</label>
+      <section className="product-video-page__metrics">
+        <Metric label="Perfis de vídeo" value={String(profileList.length)} />
+        <Metric label="Jobs de produção" value={String(jobList.length)} />
+        <Metric label="Vídeos prontos" value={String(funnelMetrics.ready)} />
+        <Metric label="Em produção" value={String(funnelMetrics.running)} />
+        <Metric label="Falhas" value={String(funnelMetrics.failed)} />
+        <Metric label="Custo total" value={formatUsd(productCost.total)} />
+      </section>
+
+      <section className="product-video-page__layout">
+        <aside className="product-video-page__sidebar">
+          <div className="product-video-page__panel">
+            <div className="product-video-page__panel-heading">
+              <Video size={18} aria-hidden="true" />
+              <strong>Vídeos cadastrados</strong>
+            </div>
+            <div className="product-video-page__profile-list">
+              {profileList.length === 0 ? (
+                <p className="product-video-page__empty">
+                  Nenhum vídeo criado para este produto.
+                </p>
+              ) : (
+                profileList.map((profile) => (
+                  <button
+                    key={profile.id}
+                    type="button"
+                    className={
+                      String(profile.id) === effectiveProfileId
+                        ? "product-video-page__profile product-video-page__profile--active"
+                        : "product-video-page__profile"
+                    }
+                    onClick={() => setSelectedProfileId(String(profile.id))}
+                  >
+                    <strong>{profile.title}</strong>
+                    <span>
+                      {profile.videoKind} · {profile.status}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <form
+            className="product-video-page__panel"
+            onSubmit={handleCreateProfile}
+          >
+            <div className="product-video-page__panel-heading">
+              <Clapperboard size={18} aria-hidden="true" />
+              <strong>Novo vídeo</strong>
+            </div>
+            <label className="form-label" htmlFor="video-kind">
+              Tipo
+            </label>
+            <select
+              id="video-kind"
+              className="form-select"
+              value={profileForm.videoKind}
+              onChange={(event) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  videoKind: event.target.value as SalesVideoKind,
+                }))
+              }
+            >
+              {VIDEO_KIND_OPTIONS.map((kind) => (
+                <option key={kind} value={kind}>
+                  {kind}
+                </option>
+              ))}
+            </select>
+            <label className="form-label" htmlFor="video-title">
+              Título interno
+            </label>
+            <input
+              id="video-title"
+              className="form-control"
+              value={profileForm.title}
+              onChange={(event) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  title: event.target.value,
+                }))
+              }
+              placeholder="Hero falado MUSA"
+            />
+            <label className="form-label" htmlFor="video-persona">
+              Persona
+            </label>
+            <input
+              id="video-persona"
+              className="form-control"
+              value={profileForm.personaName}
+              onChange={(event) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  personaName: event.target.value,
+                }))
+              }
+              placeholder="Visitante MUSA"
+            />
+            <label className="form-label" htmlFor="video-style">
+              Estilo visual
+            </label>
+            <input
+              id="video-style"
+              className="form-control"
+              value={profileForm.personaStyle}
+              onChange={(event) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  personaStyle: event.target.value,
+                }))
+              }
+              placeholder="Premium acessivel, realista"
+            />
+            <label className="form-label" htmlFor="video-voice">
+              Voz
+            </label>
+            <input
+              id="video-voice"
+              className="form-control"
+              value={profileForm.voiceStyle}
+              onChange={(event) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  voiceStyle: event.target.value,
+                }))
+              }
+              placeholder="Feminina, natural, consultiva"
+            />
+            <div className="product-video-page__inline-fields">
+              <div>
+                <label className="form-label" htmlFor="video-duration">
+                  Duração
+                </label>
+                <input
+                  id="video-duration"
+                  className="form-control"
+                  type="number"
+                  min="1"
+                  value={profileForm.targetDurationSeconds}
+                  onChange={(event) =>
+                    setProfileForm((prev) => ({
+                      ...prev,
+                      targetDurationSeconds: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div>
+                <label className="form-label" htmlFor="video-language">
+                  Idioma
+                </label>
+                <input
+                  id="video-language"
+                  className="form-control"
+                  value={profileForm.language}
+                  onChange={(event) =>
+                    setProfileForm((prev) => ({
+                      ...prev,
+                      language: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+            <button
+              className="btn btn-primary w-100"
+              type="submit"
+              disabled={createProfile.isPending}
+            >
+              <Save size={16} aria-hidden="true" />
+              {createProfile.isPending ? "Criando..." : "Criar vídeo"}
+            </button>
+          </form>
+        </aside>
+
+        <main className="product-video-page__main">
+          <section className="product-video-page__hero-panel">
+            <div className="product-video-page__hero-copy">
+              <span>Produção selecionada</span>
+              <h2>{selectedProfile?.title ?? "Nenhum vídeo selecionado"}</h2>
+              <p>
+                Use esta área para roteiro, geração e acompanhamento.
+                Experimentos devem consumir vídeos aprovados daqui, sem criar
+                vídeos próprios.
+              </p>
+              <div className="product-video-page__hero-actions">
+                {selectedProfile ? (
+                  <Link
+                    className="btn btn-outline-primary"
+                    to={`/sales-videos/profiles/${selectedProfile.id}`}
+                  >
+                    Abrir detalhes
+                  </Link>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleRequestRender}
+                  disabled={!effectiveProfileId || requestRender.isPending}
+                >
+                  <PlayCircle size={16} aria-hidden="true" />
+                  {requestRender.isPending ? "Solicitando..." : "Gerar vídeo"}
+                </button>
+              </div>
+            </div>
+            <LatestVideoPreview job={latestReadyJob} />
+          </section>
+
+          <section className="product-video-page__workflow">
+            <div className="product-video-page__script">
+              <div className="product-video-page__panel-heading">
+                <FileText size={18} aria-hidden="true" />
+                <strong>Roteiro comercial</strong>
+              </div>
+              <textarea
+                className="form-control"
+                rows={12}
+                value={scriptText}
+                onChange={(event) => setScriptText(event.target.value)}
+              />
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={handleSaveScript}
+                disabled={!effectiveProfileId || approveScript.isPending}
+              >
+                <Save size={16} aria-hidden="true" />
+                {approveScript.isPending
+                  ? "Salvando..."
+                  : "Salvar roteiro aprovado"}
+              </button>
+            </div>
+
+            <div className="product-video-page__render">
+              <div className="product-video-page__panel-heading">
+                <RefreshCcw size={18} aria-hidden="true" />
+                <strong>Geração</strong>
+              </div>
+              <label className="form-label" htmlFor="video-provider">
+                Provider
+              </label>
               <select
+                id="video-provider"
                 className="form-select"
-                value={formState.videoKind}
+                value={selectedProvider.providerName}
                 onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, videoKind: event.target.value as SalesVideoKind }))
+                  setSelectedProviderName(event.target.value)
                 }
               >
-                {VIDEO_KIND_OPTIONS.map((kind) => (
-                  <option key={kind} value={kind}>
-                    {kind}
+                {SALES_VIDEO_PROVIDER_OPTIONS.map((provider) => (
+                  <option key={provider.key} value={provider.providerName}>
+                    {provider.label}
                   </option>
                 ))}
               </select>
+              <div className="product-video-page__provider-note">
+                <strong>{selectedProvider.label}</strong>
+                <span>{selectedProvider.recommendedUse}</span>
+              </div>
+              <div className="product-video-page__strategy">
+                <strong>Direção comercial</strong>
+                <span>VEO para blocos curtos falados e anúncios.</span>
+                <span>
+                  Luma/Kling para visual premium quando houver pós-produção.
+                </span>
+                <span>
+                  Vídeo final deve conduzir dor, mecanismo, desejo e CTA.
+                </span>
+              </div>
             </div>
-            <div className="col-md-8">
-              <label className="form-label">Título interno</label>
-              <input
-                className="form-control"
-                value={formState.title}
-                onChange={(event) => setFormState((prev) => ({ ...prev, title: event.target.value }))}
-                placeholder="Ex.: Vídeo hero para a oferta principal"
-              />
+          </section>
+
+          <section className="product-video-page__panel">
+            <div className="product-video-page__table-heading">
+              <div className="product-video-page__panel-heading">
+                <BadgeDollarSign size={18} aria-hidden="true" />
+                <strong>Jobs e custos do produto</strong>
+              </div>
+              <span>
+                {productCost.knownCount}/{jobList.length} com custo conhecido
+              </span>
             </div>
-            <div className="col-md-4">
-              <label className="form-label">Persona</label>
-              <input
-                className="form-control"
-                value={formState.personaName}
-                onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, personaName: event.target.value }))
-                }
-                placeholder="Nome da persona"
-              />
+            <div className="table-responsive">
+              <table className="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Job</th>
+                    <th>Vídeo</th>
+                    <th>Tipo</th>
+                    <th>Status</th>
+                    <th>Provider</th>
+                    <th>Custo</th>
+                    <th>Asset</th>
+                    <th>Atualizado</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {jobList.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="text-muted text-center">
+                        Nenhum job registrado para este produto.
+                      </td>
+                    </tr>
+                  ) : (
+                    jobList.map((job) => (
+                      <tr key={job.id}>
+                        <td>#{job.id}</td>
+                        <td>{profileTitle(profileList, job.profileId)}</td>
+                        <td>{job.jobType}</td>
+                        <td>
+                          <span className="badge text-bg-info">
+                            {job.status}
+                          </span>
+                        </td>
+                        <td>{job.providerName ?? job.providerFamily}</td>
+                        <td>{formatUsd(readJobCost(job))}</td>
+                        <td>{job.assetId ? `#${job.assetId}` : "—"}</td>
+                        <td>
+                          {formatDate(
+                            job.updatedAt ?? job.finishedAt ?? job.requestedAt,
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
             </div>
-            <div className="col-md-4">
-              <label className="form-label">Estilo da persona</label>
-              <input
-                className="form-control"
-                value={formState.personaStyle}
-                onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, personaStyle: event.target.value }))
-                }
-                placeholder="Ex.: consultiva, descontraída"
-              />
-            </div>
-            <div className="col-md-4">
-              <label className="form-label">Estilo de voz</label>
-              <input
-                className="form-control"
-                value={formState.voiceStyle}
-                onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, voiceStyle: event.target.value }))
-                }
-                placeholder="Ex.: calorosa, urgente"
-              />
-            </div>
-            <div className="col-md-4">
-              <label className="form-label">Idioma</label>
-              <input
-                className="form-control"
-                value={formState.language}
-                onChange={(event) => setFormState((prev) => ({ ...prev, language: event.target.value }))}
-                placeholder="pt-BR"
-              />
-            </div>
-            <div className="col-md-4">
-              <label className="form-label">Duração alvo (segundos)</label>
-              <input
-                className="form-control"
-                type="number"
-                min="0"
-                value={formState.targetDurationSeconds}
-                onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, targetDurationSeconds: event.target.value }))
-                }
-              />
-            </div>
-            <div className="col-md-4">
-              <label className="form-label">Landing page (ID opcional)</label>
-              <input
-                className="form-control"
-                type="number"
-                value={formState.landingPageId}
-                onChange={(event) =>
-                  setFormState((prev) => ({ ...prev, landingPageId: event.target.value }))
-                }
-                placeholder="123"
-              />
-            </div>
-          </div>
-          <div className="mt-3">
-            <button className="btn btn-primary" type="submit" disabled={createProfile.isPending}>
-              {createProfile.isPending ? "Salvando..." : "Criar perfil"}
-            </button>
-          </div>
-        </form>
+          </section>
+        </main>
       </section>
     </div>
   );
+}
+
+function LatestVideoPreview({ job }: { job?: SalesVideoJob }) {
+  const { data: asset } = useAsset(job?.assetId ?? undefined);
+  const assetUrl = asset?.publicUrl ?? "";
+  const playbackUrl = job?.streamPlaybackUrl?.trim() || assetUrl;
+
+  return (
+    <div className="product-video-page__preview">
+      {playbackUrl ? (
+        <AdaptiveVideoPlayer
+          src={playbackUrl}
+          fallbackSrc={assetUrl}
+          controls
+        />
+      ) : (
+        <div className="product-video-page__preview-empty">
+          <PlayCircle size={44} aria-hidden="true" />
+          <strong>Sem vídeo pronto</strong>
+          <span>Gere um vídeo para preencher o preview do produto.</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="product-video-page__metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function summarizeFunnel(profiles: SalesVideoProfile[], jobs: SalesVideoJob[]) {
+  return {
+    ready: jobs.filter((job) => job.status === "VIDEO_READY").length,
+    running: jobs.filter((job) =>
+      [
+        "VIDEO_REQUESTED",
+        "VIDEO_PROCESSING",
+        "SCRIPT_PENDING",
+        "STORYBOARD_PENDING",
+      ].includes(job.status),
+    ).length,
+    failed: jobs.filter((job) => job.status === "VIDEO_FAILED").length,
+    scripted: profiles.filter(
+      (profile) => profile.latestScript?.status === "APPROVED",
+    ).length,
+  };
+}
+
+function summarizeProductVideoCost(jobs: SalesVideoJob[]) {
+  return jobs.reduce(
+    (acc, job) => {
+      const cost = readJobCost(job);
+      if (cost == null) {
+        return acc;
+      }
+      return {
+        total: acc.total + cost,
+        knownCount: acc.knownCount + 1,
+      };
+    },
+    { total: 0, knownCount: 0 },
+  );
+}
+
+function readJobCost(job: SalesVideoJob) {
+  const metadataCost = readNumericJsonField(job.metadataJson, [
+    "cost_usd",
+    "costUsd",
+  ]);
+  if (metadataCost != null) {
+    return metadataCost;
+  }
+  return readNumericJsonField(job.auditSnapshotJson, ["cost_usd", "costUsd"]);
+}
+
+function readNumericJsonField(
+  json: string | null | undefined,
+  fields: string[],
+) {
+  if (!json) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    for (const field of fields) {
+      const value = parsed[field];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+      }
+      if (typeof value === "string" && value.trim()) {
+        const numeric = Number(value);
+        if (Number.isFinite(numeric)) {
+          return numeric;
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function profileTitle(profiles: SalesVideoProfile[], profileId: number) {
+  return (
+    profiles.find((profile) => profile.id === profileId)?.title ??
+    `Profile #${profileId}`
+  );
+}
+
+function parseOptionalNumber(value: string) {
+  if (!value.trim()) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function firstLine(value: string) {
+  return value
+    .split("\n")
+    .find((line) => line.trim())
+    ?.trim();
+}
+
+function formatUsd(value?: number | null) {
+  if (value == null) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 4,
+  }).format(value);
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
 }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Itens opcionais selecionados pelo usuário para complementar o prompt:
Leia e use como base o documento em : /docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md

Histórico da conversa:
Usuário: vejo apenas videos planejados tem algum problema ?

Modelo: {"titulo":"Vídeos só planejados","comentario":"Sim, há um problema **se a expectativa era já ter vídeos renderizados**.\n\nPelo backend e banco real, o experimento 68 tem 4 vídeos `LANDING_HERO`, todos com:\n\n- `status=PLANNED`\n- `reviewStatus=PENDING`\n- `salesVideoJobId=null`\n- `assetId=null`\n- `assetUrl=null`\n- `cost=null`\n\nOu seja: o sistema registrou o **plano criativo dos 4 clipes**, mas ainda **não criou job de renderização** nem gerou arquivo de vídeo.\n\n**Conclusão:** não parece falha do renderizador neste ponto. O render simplesmente não foi disparado/vinculado. Também confirmei que não há `sales_video_job` criado depois de `23/07/2026 17:20 UTC` para esse fluxo.\n\n**Impacto comercial:** enquanto estiver assim, a landing mostra “Vídeo ainda não disponível” e a campanha não deveria ser liberada como funil com vídeo obrigatório. Para vender melhor, esse hero precisa virar vídeo real com `READY + APPROVED + assetUrl`.\n\n**Alternativas avaliadas:**\n\n1. Manter como planejado por enquanto: serve só como planejamento criativo. Baixo esforço, mas não ajuda a conversão agora.\n2. Solicitar cada vídeo manualmente pelo formulário atual: rápido, mas a tela está orientada a VEO, enquanto a estratégia documentada para MUSA recomenda Luma Ray 3.2 como principal.\n3. Melhor caminho: transformar os 4 assets planejados Luma em jobs reais de renderização, preservando vínculo, custo, asset e aprovação. É o caminho mais aderente ao objetivo de venda e rastreabilidade.\n\nMinha recomendação: tratar isso como **pendência operacional do funil**, não como erro visual da tela.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs diretos do video-management-service; isso permitiria confirmar status do worker Luma com mais precisão quando houver jobs criados.","orientacaoProximaAcao":"Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados."}

Usuário: Execute sua orientação : 
Para avançar, peça para eu implementar ou acionar o fluxo que transforma os 4 vídeos planejados do experimento 68 em jobs reais de renderização Luma, mantendo vínculo com os assets já criados.

Modelo: {"titulo":"Render dos planejados pronto","comentario":"Implementei o fluxo para transformar vídeos planejados em jobs reais sem duplicar os assets.\n\n**O que mudou:**\n\n- Backend ganhou o endpoint `POST /api/experiments/{id}/video-assets/planned-render-requests`.\n- Ele pega assets `PLANNED` sem `salesVideoJobId`, cria `profile + script + job` no SalesVideo e atualiza o próprio asset para `GENERATING`.\n- Frontend ganhou a ação **Renderizar planejados** na aba Vídeo do experimento.\n- Swagger e registro de experimentos foram atualizados.\n\n**Validação:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou com 7 testes.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n\n**Importante:** ainda não criei PR e não publiquei nada. Os 4 vídeos do experimento 68 continuam sem render em produção até essa mudança passar por PR/deploy e a ação ser executada no Marketing Hub.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar essa mudança; depois do deploy, use a ação Renderizar planejados na aba Vídeo do experimento 68 para criar os 4 jobs Luma vinculados aos assets existentes."}

Usuário: esta fazendo o deploy, acompanhe pelo github e depois Execute a Renderização dos Videos do experimento 68 pelo Marketing Hub veja se vai funcioanr corretamente ajuste o que for necessario.

Modelo: {"titulo":"Renderização falhou na Luma","comentario":"Acompanhei o deploy no GitHub até concluir com sucesso e executei a renderização dos vídeos do experimento 68 pelo contrato do Marketing Hub.\n\n**Resultado operacional:**\n\n- O deploy do PR `#4480` terminou com sucesso.\n- A chamada `POST /api/experiments/68/video-assets/planned-render-requests` funcionou.\n- Os 4 assets saíram de `PLANNED` para `GENERATING`.\n- Foram criados os jobs `20431`, `20432`, `20433` e `20434`.\n\n**Problema encontrado:**\n\nOs 4 jobs falharam imediatamente no executor de vídeo com:\n\n`404 Not Found from POST https://api.lumalabs.ai/v1/generations`\n\nA causa-raiz é integração desatualizada com a Luma. A documentação atual da Luma Agents usa o host:\n\n`https://agents.lumalabs.ai/v1/generations`\n\nReferências consultadas:\n\n- https://docs.agents.lumalabs.ai/\n- https://docs.agents.lumalabs.ai/guides/videos/generation/\n\n**Ajustes deixados prontos na branch/worktree:**\n\n- Corrigi o host padrão da Luma no `video-management-service` para `https://agents.lumalabs.ai`.\n- Atualizei o teste do provider Luma para proteger esse contrato.\n- Corrigi o backend para sincronizar falha de render no asset do experimento, evitando a tela ficar presa em `GENERATING` quando o job já está `VIDEO_FAILED`.\n- Ajustei o endpoint de renderização planejada para permitir reprocessar o mesmo asset quando o job anterior falhou, sem duplicar vídeos.\n\n**Validação:**\n\n- `video-management-service`: `LumaRayVideoProviderTest` passou com 3 testes.\n- Backend: `SalesVideoJobServiceTest` + `ExperimentVideoAssetServiceTest` passaram com 13 testes.\n\n**Estado atual em produção:**\n\n- Os assets `5`, `6`, `7`, `8` do experimento 68 ainda estão `GENERATING`.\n- Os jobs vinculados `20431` a `20434` estão `VIDEO_FAILED`.\n- A renderização correta ainda depende de publicar estes novos ajustes.\n\nNão criei PR, conforme sua regra.","sugestaoMelhoriaAmbiente":"O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.","orientacaoProximaAcao":"Peça o PR/deploy destes ajustes. Depois do deploy, execute novamente `Renderizar planejados` no experimento 68; o sistema agora conseguirá reprocessar os mesmos 4 assets com jobs falhados."}

Usuário: implemente:
O MCP não expõe logs do `video-management-service`; isso ajudaria a confirmar diretamente o request/response do executor sem depender apenas do banco e do status dos jobs.

Modelo: {"titulo":"Logs do vídeo no MCP","comentario":"Implementei a melhoria para o MCP consultar logs do `video-management-service`.\n\n**O que ficou pronto:**\n\n- `java_module_logs` agora aceita o módulo `video-management-service`.\n- Default configurado: `http://177.153.62.107:8095/actuator/logfile`.\n- `video-management-service` agora grava log em `/app/logs/video-management-service.log`.\n- O Actuator do vídeo agora expõe `/actuator/logfile`.\n- `deploy/docker-compose.yml` persiste os logs do vídeo em volume.\n- README e contrato operacional do MCP foram atualizados.\n- Teste novo garante que o MCP lê logs do `video-management-service`.\n\n**Validação executada:**\n\n- `mcp-server`: `mvn -q test` passou.\n- `video-management-service`: `mvn -q test` passou.\n- `docker compose -f deploy/docker-compose.yml config` passou, com apenas aviso já existente de `version` obsoleto.\n- `git diff --check` sem problemas.\n\nNão criei PR e não publiquei nada. A mudança está pronta na worktree para passar pelo fluxo normal de PR/deploy.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy desta alteração. Depois do deploy, poderemos chamar `java_module_logs` com `module=video-management-service` para acompanhar a nova renderização dos vídeos do experimento 68 com logs reais do executor."}

Usuário: verifique se o github action terminou e tente novamente produzir os videos pelo marketing hub se tiver problemas novamente faça o ajuste, teste no seu ambiente antes de entregar.

Modelo: {"titulo":"Render ainda bloqueado","comentario":"Acompanhei o GitHub Action: o deploy terminou com sucesso.\n\nDepois executei novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub.\n\n**Resultado:**\n\n- A chamada funcionou com `executionMode=TEST`.\n- Foram criados novos jobs: `20435`, `20436`, `20437`, `20438`.\n- A falha antiga de URL Luma legada **não voltou**.\n- A Luma chegou a gerar URLs de MP4, mas o worker falhou ao baixar os arquivos S3:\n\n`400 Bad Request from GET https://ai-lumalabs-vespa-production.s3.amazonaws.com/...mp4`\n\n**Causa-raiz:** o download do MP4 da Luma precisa preservar a URL presignada exatamente como recebida. A documentação atual da Luma diz que o resultado vem em `output[].url` como URL presignada e deve ser baixado imediatamente para storage próprio: https://docs.agents.lumalabs.ai/guides/videos/generation/ e https://docs.agents.lumalabs.ai/guides/error-handling/\n\n**Ajuste implementado na branch/worktree:**\n\n- Separei o cliente de download do cliente autenticado da API Luma.\n- O download agora usa `URI.create(videoUrl)` para preservar query string/assinatura da URL presignada.\n- O teste agora garante que:\n  - chamadas para API Luma continuam com `Authorization: Bearer`;\n  - download S3 não recebe `Authorization`;\n  - query presignada `X-Amz-*` não é perdida.\n\n**Validação local:**\n\n- `mvn test -Dtest=LumaRayVideoProviderTest`: passou.\n- `mvn test` no `video-management-service`: passou com 21 testes.\n\n**Estado atual em produção:** os 4 assets do experimento 68 estão `FAILED` porque a correção ainda não foi publicada. Não criei PR.","sugestaoMelhoriaAmbiente":"Adicionar `video-management-service` à tool MCP `java_module_logs`; hoje o MCP ainda não lista esse módulo, então a investigação dependeu de banco/eventos e não do log direto do worker.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste. Depois do deploy, execute novamente a ação Renderizar planejados no experimento 68 para criar novos jobs e validar o download correto dos MP4s."}

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: CODEX_TURN_STALLED

Usuário: aguarde o final do deploy do git hub action depois tente novamente gerar os videos para o experimento 68 pelo sistema

Modelo: {"titulo":"Deploy de vídeo travou","comentario":"O GitHub Action **ainda não terminou**.\n\n**O que aconteceu:**\n\n- Reexecutei o workflow `Build & Deploy containers` do run `30039506257`.\n- A imagem do `video-management-service` foi construída com sucesso.\n- Os testes do serviço passaram no GitHub Action.\n- O deploy ficou preso por mais de 20 minutos em `Upload image to VIDEO VPS`.\n\n**Causa provável:** o workflow usa `scp` para enviar `video-management-image.tar` ao VPS. Esse upload não tem retomada parcial nem timeout efetivo, então pode ficar travado em transferência pesada.\n\n**Ajuste que deixei pronto na worktree:**\n\n- Troquei o upload do vídeo de `scp` para `rsync -az --partial --append-verify`.\n- Adicionei `timeout` para evitar GitHub Action preso indefinidamente.\n- Validei com `actionlint` e `git diff --check`: passou.\n\n**Alternativas avaliadas:**\n\n1. Tentar renderizar agora: alto risco de usar o worker antigo e repetir a falha de download do MP4.\n2. Esperar indefinidamente o deploy atual: baixo valor, porque o job já está preso no upload.\n3. Melhor caminho: publicar o ajuste do workflow, deixar o deploy rodar com upload resiliente e só depois executar a renderização do experimento 68.\n\nAinda **não tentei gerar os vídeos novamente**, porque o deploy do worker corrigido não foi concluído. Também **não criei PR**, conforme sua regra.","sugestaoMelhoriaAmbiente":"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste do workflow. Depois que esse deploy concluir, eu executo novamente a renderização dos vídeos do experimento 68 pelo Marketing Hub e acompanho o resultado."}

Usuário: vc não tem ? Mas vc tem chave do github
"Ter acesso a logs em tempo real do job do GitHub Action enquanto ele ainda está em execução permitiria confirmar com mais precisão se o upload está transferindo lentamente ou realmente travado."

Modelo: {"titulo":"Acesso GitHub limitado","comentario":"Você tem razão em questionar.\n\nEu tenho **algum acesso ao GitHub**, mas ao testar agora o `gh` neste ambiente ele falhou com:\n\n`the token in GITHUB_TOKEN is missing required scope 'read:org'`\n\nEntão a frase correta seria:\n\n**Eu não tenho, neste momento, acesso confiável via CLI aos logs do GitHub Action em tempo real.**\n\nAlém disso, mesmo com acesso ao GitHub, há uma limitação prática: o GitHub Actions normalmente mostra logs por blocos já emitidos. Se o passo está travado dentro de um `scp` sem imprimir progresso, o log pode ficar parado sem provar se está transferindo devagar ou congelado.\n\nO ajuste que propus continua válido: trocar `scp` por `rsync` com progresso parcial e timeout melhora o deploy porque transforma um travamento silencioso em execução observável e recuperável.\n\nResumo objetivo:\n\n- Sim, existe chave/credencial GitHub no ambiente.\n- Não, ela não está funcionando plenamente via `gh` agora por falta de escopo.\n- Mesmo com acesso, o passo atual pode não emitir progresso útil se o comando não logar nada.\n- A melhoria correta é tornar o workflow mais observável e resiliente.","sugestaoMelhoriaAmbiente":"Conceder ao token GitHub usado no ambiente escopos suficientes para consultar Actions/logs do repositório via `gh`, incluindo permissões compatíveis com organização privada quando aplicável.","orientacaoProximaAcao":"Se quiser que eu acompanhe Actions diretamente por CLI, ajuste/autorizе o token GitHub do ambiente com os escopos necessários. Caso contrário, posso continuar trabalhando com os dados disponíveis e deixar o workflow mais robusto no repositório."}

Usuário: agora terminou verifique se gerou conseguimos gerar os videos

Modelo: {"titulo":"Vídeos gerados","comentario":"Sim, conseguimos gerar os vídeos do experimento 68.\n\n**Resultado confirmado:**\n\n- Deploy do GitHub Action terminou com sucesso.\n- Executei a renderização pelo Marketing Hub.\n- Foram criados os jobs `20439`, `20440`, `20441`, `20442`.\n- Os 4 jobs finalizaram como `VIDEO_READY`.\n- Os 4 assets do experimento 68 agora estão `READY`, com `assetUrl` público e `asset_id` preenchido.\n- Validei os arquivos com `ffprobe`: todos são MP4 H.264, vertical `720x1280`, duração aproximada de `30s`.\n\n**Ponto de atenção comercial:**\n\nOs vídeos estavam planejados como clipes curtos de `8s`, mas o fluxo Luma atual monta 3 cenas de 10s, gerando vídeos finais de cerca de `30s`. Tecnicamente funcionou; para tráfego, eu trataria isso como material válido para revisão, mas avaliaria se o hero precisa de uma versão mais curta para primeira dobra e anúncios.\n\n**Estado atual:** os vídeos ainda estão com `review_status=PENDING`. Ou seja, existem e estão prontos tecnicamente, mas ainda precisam de aprovação/revisão antes de serem usados como ativo final de campanha.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Revise os 4 vídeos na aba Vídeo do experimento 68 e aprove os melhores. Se quiser manter a estratégia original de clipes rápidos, peça para eu ajustar o fluxo Luma para gerar versão curta alinhada ao planejamento de 8s."}

Usuário: deo onde vem esse planejamento de 8 minutos ? acho que isso era uma limigtação do antigo provedor de videos o veo. Analise o que vc considera melhora para vendas.

Modelo: {"titulo":"Melhor vídeo para vender","comentario":"Você está certo: **não existe planejamento de 8 minutos** e, no experimento 68, também **não encontrei planejamento real de 8 segundos nos assets**.\n\nA origem do “8s” vem do catálogo legado do frontend para **VEO**, onde ele aparece como provider de **teasers curtos/cenas isoladas**. Já a estratégia atual do sistema coloca **Luma Ray 3.2** como provider principal para hero premium, com montagem de vídeo final perto de **30s**.\n\n**Evidência do experimento 68:**\n\n- Os 4 assets estão `READY`.\n- Provider real: `LUMA_RAY_3_2`.\n- Duração gravada: `30s` cada.\n- Cada vídeo foi montado com `3 cenas x 10s`.\n- O planejamento salvo nos assets contém apenas ângulo/caption, não duração de 8s.\n\n**Minha leitura para vendas:**\n\nO melhor não é voltar para 8s como regra geral. Para uma landing de produto novo como MUSA, o vídeo precisa atravessar a estrada: dor → relevância → mecanismo → desejo → CTA. Em 8s, normalmente só dá para gerar atenção, não desejo suficiente.\n\n**Alternativas avaliadas:**\n\n1. **Usar só vídeos de 8s**  \nBom para anúncio e hook rápido, mas fraco para explicar mecanismo e valor. Risco: muita curiosidade e pouca conversão.\n\n2. **Usar só vídeos de 30s**  \nMelhor para landing/hero, porque permite mostrar dor, transformação e mecanismo. Risco: longo demais para tráfego frio se os primeiros 3 segundos não forem fortes.\n\n3. **Melhor caminho: estratégia híbrida**  \nManter vídeo de 30s para a landing e gerar cortes/variações curtas de 10-15s para anúncios. Isso atende venda e aquisição: anúncio captura atenção; landing aprofunda desejo.\n\n**Recomendação objetiva:**\n\n- Para a **landing do experimento 68**: use o melhor vídeo de 30s, desde que o primeiro impacto visual seja forte nos 3 primeiros segundos.\n- Para **Meta Ads/Reels/Stories**: criar versões curtas de 10-15s com foco em uma única promessa.\n- Não usar os 4 vídeos de 30s como se fossem todos equivalentes; escolha um como hero principal e use os outros como variações de teste ou retargeting.\n\n**Prioridade comercial dos ângulos:**\n\n1. `Dor do espelho`: melhor para tráfego frio, porque começa pela dor reconhecível.\n2. `Presença sem luxo`: bom para promessa aspiracional sem parecer inacessível.\n3. `Microações de 7 dias`: bom para explicar mecanismo e reduzir esforço percebido.\n4. `Plano MUSA personalizado`: melhor para CTA/retargeting, não como primeira abordagem.\n\nConclusão: o ajuste ideal para vender mais não é “voltar para 8s”. É transformar o módulo em uma lógica de **vídeo hero de 30s + derivados curtos para tráfego**, com aprovação comercial baseada no papel de cada vídeo no funil.","sugestaoMelhoriaAmbiente":""}

Usuário: Ajuste o Marketing Hub para seguir essa recomendação sua


Modelo: {"titulo":"Marketing Hub ajustado","comentario":"Implementei a estratégia híbrida de vídeo para venda.\n\n**O que mudou:**\n\n- `LANDING_HERO` com Luma agora é tratado como **hero comercial de 30s**.\n- Se vier duração curta legada, menor que 25s, o backend normaliza para 30s no render planejado.\n- O job passa a gravar `commercialStrategy` nos metadados: papel no funil, uso recomendado, hero 30s e derivados 10-15s para mídia paga.\n- A aba Vídeo agora mostra:\n  - hero pronto;\n  - hero aprovado;\n  - cortes curtos;\n  - papel de cada vídeo no funil;\n  - uso recomendado: Landing, Ads/Reels, Formulário, Checkout ou Teste.\n- O formulário VEO ficou sinalizado como uso de teaser/cena curta, não como caminho principal para hero.\n- Atualizei o documento canônico e o registro do experimento para evitar voltar à regra antiga do VEO.\n\n**Validação executada:**\n\n- Backend: `ExperimentVideoAssetServiceTest` passou.\n- Spotless restrito aos arquivos Java alterados passou.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n- `git diff --check` passou.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar esta mudança no Marketing Hub. Depois do deploy, a aba Vídeo do experimento 68 já deve orientar a escolha do hero principal e separar os demais vídeos como variações/cortes para tráfego."}

Usuário: deu erro no github verifique e ajuste

Modelo: {"titulo":"Erro do GitHub corrigido","comentario":"Verifiquei o GitHub Action com erro: o workflow `Build & Deploy containers` falhou no backend, no teste `ExperimentServiceTest.updateStatusPreservesReleaseTimestampForBaseline`.\n\n**Causa-raiz:** o teste comparava o timestamp logo após `Instant.now()` em memória. No próximo passo, o valor era recarregado do banco H2 com pequena diferença de precisão, gerando falha intermitente de `1ms`. Não era falha comercial do fluxo de vídeos.\n\n**Ajuste feito:**\n\n- Corrigi o teste para usar um timestamp fixo e persistido.\n- A regra validada continua a mesma: ao pausar um experimento, o Marketing Hub deve preservar o timestamp de liberação para Facebook, sem recriá-lo.\n\n**Alternativas avaliadas:**\n\n1. Aumentar tolerância de tempo no teste: rápido, mas mascararia regressão real.\n2. Alterar a regra no service: risco desnecessário, porque a regra de negócio estava correta.\n3. Melhor caminho: fixar o timestamp persistido no teste e validar preservação real. Foi o que implementei.\n\n**Validação:**\n\n- Teste específico que falhou no GitHub: passou.\n- Classe completa `ExperimentServiceTest`: passou com 28 testes.\n- Suíte completa do backend `mvn -q test`: passou; 244 relatórios Surefire sem failures/errors.\n- `git diff --check`: passou.\n\n**Observação:** `mvn spotless:check` global falhou por violações preexistentes em milhares de arquivos, começando por `GeraSalesPageStageServiceTest.java`, fora do arquivo alterado. Não apliquei formatação global para não gerar um diff enorme e não relacionado.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"Configurar Spotless com ratchet ou checagem apenas de arquivos alterados evitaria que violações antigas bloqueassem validações pequenas e focadas.","orientacaoProximaAcao":"Peça o PR/deploy deste ajuste para o GitHub Action rodar novamente com a correção."}

Usuário: aguarde terminar o deploy e vamos preparar seguir na preparação do experimento 68

Modelo: {"titulo":"Deploy concluído","comentario":"O deploy terminou com sucesso no GitHub.\n\n**Estado do experimento 68:**\n\n- Experimento: `MUSA-H001-E006`\n- Status: `PLANNED`\n- Tipo: `PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL`\n- CTA: `Ver meu plano MUSA de 7 dias`\n- Clube MUSA: responde `200`\n- Vídeos: 4 assets `READY`, todos com 30s, Luma Ray 3.2 e asset público\n- Pendência principal: os 4 vídeos ainda estão com `reviewStatus=PENDING`\n\n**Minha recomendação para vender melhor:**\n\n1. Aprovar como hero principal o vídeo da **Dor do espelho**: ele é o melhor para tráfego frio porque começa pela dor reconhecível.\n2. Usar **Presença sem luxo** como variação aspiracional.\n3. Usar **Microações de 7 dias** para reforçar mecanismo e reduzir dúvida.\n4. Usar **Plano MUSA personalizado** para retargeting/CTA, não como primeira abordagem.\n\n**Alternativas avaliadas:**\n\n- Liberar campanha agora: rápido, mas arriscado porque os vídeos ainda não foram aprovados.\n- Gerar mais vídeos: custo extra sem necessidade imediata; já temos material suficiente para revisar.\n- Melhor caminho: aprovar 1 hero principal, classificar os outros 3 por papel no funil e só depois avançar campanha.\n\n**Ponto técnico/comercial de atenção:** encontrei divergência entre o contrato público do Clube MUSA em produção e o repositório local sobre textos críticos de health/copy. A página está carregando e não há erro visual, mas antes de escalar tráfego eu trataria isso como item de alinhamento para evitar validar campanha em cima de uma versão diferente da fonte versionada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Revise/aprove o vídeo principal na aba Vídeo do experimento 68. Minha escolha recomendada para hero é o asset `5` / job `20442`, ângulo `Dor do espelho`."}

Usuário: eu não entendi as personagens não falam nada ?

Modelo: {"titulo":"Vídeos estão mudos","comentario":"Sim: **as personagens não falam nos vídeos atuais**.\n\nConfirmei tecnicamente com `ffprobe`: os 4 MP4s do experimento 68 têm apenas stream de **vídeo H.264**. Não há stream de áudio.\n\nIsso aconteceu porque o fluxo atual da Luma foi montado para gerar **cenas visuais editoriais**, não vídeos finais com personagem falando. A própria lógica do provider pede cenas “adequadas para legendas posteriores”, e os assets salvos têm texto como **Legenda**, não como fala da personagem.\n\n**Minha leitura para vendas:**\n\nNão considero ideal usar esses vídeos como peça final isolada. Eles funcionam como **base visual premium**, mas ainda falta a camada que vende:\n\n- legenda/caption grande e emocional;\n- narração feminina em português;\n- música leve de fundo;\n- CTA claro para o diagnóstico;\n- versão curta para anúncios.\n\n**Alternativas:**\n\n1. **Usar mudo como hero visual**  \nServe para fundo de landing com headline forte. Baixo esforço, mas vende menos sozinho.\n\n2. **Adicionar narração + legendas por cima**  \nMelhor custo-benefício. Vende mesmo se a personagem não mexer a boca, e funciona bem em anúncio porque muita gente assiste sem som.\n\n3. **Gerar personagem falando com lip-sync**  \nPode aumentar conexão, mas tem mais risco de parecer artificial e mais custo. Eu usaria depois, como teste específico, não como primeira correção.\n\n**Recomendação:** transformar os vídeos atuais em criativos finalizados com **voz off + legendas + trilha**, mantendo as imagens Luma como base. Para o experimento 68, isso é melhor para venda do que tentar obrigar a personagem a falar agora.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça para eu implementar no Marketing Hub a etapa de pós-produção dos vídeos: voz off em português, legendas sobrepostas, trilha leve e exportação das versões finais para landing e anúncios."}

Usuário: numero 5 não esta com uma nuvem branca, veja.

Modelo: {"titulo":"Asset 5 não deve ser aprovado","comentario":"Sim. Você está certo: o vídeo/asset **5** está com uma névoa branca forte, parecendo uma nuvem/filtro sobre a cena.\n\nIsso muda minha recomendação anterior. O **ângulo comercial** do asset 5 é bom (`Dor do espelho`), mas a **execução visual não está boa para hero principal**, porque:\n\n- reduz nitidez da personagem;\n- passa sensação de vídeo “embaçado” ou mal renderizado;\n- enfraquece o impacto dos 3 primeiros segundos;\n- pode diminuir confiança na primeira dobra da landing.\n\nSobre as personagens: pelo planejamento atual, elas **não falam**. Os vídeos foram pensados como cenas editoriais com legenda/trilha depois, não como vídeo com fala/narração. Para venda, isso pode funcionar, mas só se a imagem estiver muito clara e a legenda conduzir bem a promessa.\n\n**Alternativas avaliadas:**\n\n1. **Aprovar o asset 5 mesmo assim**  \nNão recomendo. O conceito é bom, mas a névoa atrapalha a percepção premium.\n\n2. **Usar outro vídeo pronto como hero**  \nPode ser caminho rápido, especialmente se o asset 6 ou 7 estiver visualmente mais limpo. Mas perderíamos o melhor gancho de dor inicial.\n\n3. **Melhor caminho: regenerar o asset 5 com o mesmo ângulo, mas prompt mais rígido contra névoa/filtro**  \nMinha recomendação. Manter a dor do espelho, porém exigir imagem limpa, iluminação natural clara, sem haze, sem fumaça, sem blur, rosto/reflexo nítidos e ambiente editorial realista.\n\n**Decisão comercial recomendada agora:**\n\n- **Não aprovar o asset 5 atual.**\n- Regenerar o clipe `Dor do espelho`.\n- Depois escolher entre:\n  - novo asset de dor como hero principal;\n  - asset 6 como alternativa aspiracional;\n  - asset 7 como apoio de mecanismo.\n\nPara vender melhor, o hero precisa começar com dor reconhecível, mas sem parecer defeito visual. O asset 5 tem a ideia certa e a execução errada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Autorize a regeneração do asset 5/ângulo Dor do espelho com prompt corrigido para imagem limpa, sem névoa branca, e eu executo pelo Marketing Hub e valido o resultado."}

Usuário: o video que foi feito com o VEO a personagem falava veja se voce consegue recuperar eles gostei daquele. No Luma e no kling não da pra colocar a personagem explicando o produto ou conversando com a cliente ?

Modelo: {"titulo":"VEO recuperado","comentario":"Recuperei o vídeo VEO que você gostou no experimento 68.\n\n**Resultado confirmado:**\n\n- Novo asset recuperado: `9`\n- Provider: `VEO`\n- Job original: `20430`\n- Asset original: `1905`\n- Status no experimento: `READY`\n- Revisão: `PENDING`\n- Slot: `AD`\n- Duração: `8s`\n- Áudio: sim, confirmado por `ffprobe`\n\nNão marquei como obrigatório para liberação, porque ele é curto demais para substituir automaticamente o hero de 30s. Ele agora entra melhor como **criativo curto falado para anúncio/referência**, não como hero final obrigatório.\n\n**Sobre Luma e Kling:** dá para colocar personagem explicando/conversando, mas o Marketing Hub ainda não está usando esse fluxo. O que rodamos em Luma foi apenas geração visual. A documentação atual da Luma informa voz, narração, áudio nativo e lip-sync; a do Kling também informa lip-sync com voz/TTS; e o VEO 3.1 gera vídeo de 8s com áudio nativo e aceita fala no prompt.\n\nFontes: Luma Audio Capabilities, Luma Lip Sync Guide, Kling Lip Sync Guide e Google Veo 3.1 Gemini API.\n\n**Minha recomendação para vender melhor:**\n\n1. Usar o asset `9` VEO como referência do tom certo: personagem falando vende mais rápido para tráfego frio.\n2. Manter Luma/Kling para imagem premium, mas adicionar etapa de voz/lip-sync/pós-produção antes de aprovar como peça final.\n3. Melhor caminho: criar no Marketing Hub uma esteira comercial de vídeo em duas saídas: `VEO falado curto para ads` + `hero premium com voz/legenda para landing`.\n\nA causa do incômodo ficou clara: não era só estética. Os vídeos Luma ficaram mudos, então faltou a camada de venda direta.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Revise o asset 9 na aba Vídeo do experimento 68. Se ele realmente for a direção que você quer, o próximo ajuste é implementar no Marketing Hub a geração planejada de vídeos com fala/voz/lip-sync, usando VEO como principal para criativos falados curtos e Luma/Kling apenas quando houver etapa de áudio sincronizado."}

Usuário: Vamos testar diversas possibilidedes, Execute sua orientação : 
Peça para eu implementar no Marketing Hub a etapa de pós-produção dos vídeos: voz off em português, legendas sobrepostas, trilha leve e exportação das versões finais para landing e anúncios.

Modelo: {"titulo":"Pós-produção implementada","comentario":"Implementei no Marketing Hub a etapa de **pós-produção dos vídeos** para transformar os vídeos brutos do experimento 68 em peças mais vendáveis.\n\n**O que ficou pronto:**\n\n- Nova ação na aba Vídeo: **Finalizar para venda**.\n- Backend cria jobs de `POST_PRODUCTION` para vídeos `READY`.\n- Worker de vídeo agora consegue gerar versão final com:\n  - voz off em português;\n  - legendas sobrepostas;\n  - trilha leve;\n  - MP4 final para landing/anúncios;\n  - arquivo VTT de legenda.\n- O sistema preserva o vídeo original como fonte e grava metadados comerciais da versão final.\n- A lógica evita duplicar pós-produções já concluídas e permite retry quando falhar.\n\n**Validação executada:**\n\n- Backend: testes de vídeo do experimento passaram.\n- Backend completo: `mvn test` passou.\n- Worker de vídeo completo: `mvn test` passou.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n- `git diff --check` passou.\n\n**Limitação real do ambiente:** não consegui validar o build Docker local porque o Docker daemon não está disponível neste ambiente. O Dockerfile foi ajustado para incluir `espeak-ng` e fontes, necessários para a voz e legendas.\n\n**Observação importante:** isto implementa **voz off + legenda + trilha**, não lip-sync/personagem falando com movimento de boca. Para venda agora, esse é o melhor custo-benefício: aproveita os vídeos já gerados, melhora clareza da promessa e permite testar rápido landing e anúncios.","sugestaoMelhoriaAmbiente":"Disponibilizar Docker daemon ativo no ambiente permitiria validar a imagem final do video-management-service antes do PR/deploy.","orientacaoProximaAcao":"Peça o PR/deploy desta mudança. Depois do deploy, use a ação Finalizar para venda na aba Vídeo do experimento 68 para gerar as versões finais com voz, legenda e trilha."}

Usuário: pesquise na internet os provedores que oferecem video com lipsync

Modelo: {"titulo":"Provedores com lip-sync","comentario":"Pesquisei provedores atuais com foco em uso comercial no Marketing Hub.\n\n**Conclusão direta:** sim, existem opções para personagem explicando o produto ou conversando com a cliente. Para venda, eu separaria em 3 linhas:\n\n1. **VEO 3.1 / Gemini API**  \nMelhor para testar criativos curtos falados, com áudio nativo e diálogo. É bom para anúncios de 8-10s, hooks e variações rápidas. Fonte: https://ai.google.dev/gemini-api/docs/video\n\n2. **Kling AI Lip Sync**  \nBoa opção para lip-sync em vídeo já gerado ou personagem controlada. Tem API específica de lip-sync. Eu testaria para transformar vídeos visuais em personagem falando. Fonte: https://kling.ai/document-api/api/video/lip-sync\n\n3. **Sync Labs / ElevenLabs Sync 3**  \nProvavelmente o melhor caminho técnico para pós-produção: pega um vídeo existente + áudio e sincroniza a boca. Isso combina bem com o que já fizemos no Marketing Hub: gerar voz off em português e depois aplicar lip-sync. Fontes: https://sync.so/docs/introduction e https://elevenlabs.io/docs/overview/capabilities/image-video\n\n**Outros provedores relevantes:**\n\n- **D-ID**: bom para talking avatar a partir de imagem, mais simples e direto para apresentadora falando. Fonte: https://docs.d-id.com/docs/quickstart\n- **HeyGen**: forte para avatar comercial, tradução, voz e vídeos de apresentação. Bom para validação rápida, talvez menos ideal para automação profunda se a API/plano limitar. Fonte: https://www.heygen.com/tool/create-ai-lip-sync-videos\n- **Synthesia**: forte para vídeos corporativos/explicativos com avatar, menos natural para criativo emocional de tráfego frio. Fonte: https://docs.synthesia.io/reference/introduction\n- **Luma**: tem recursos relacionados a lip-sync/modificação de vídeo, mas eu não colocaria como primeira escolha para fala vendável agora. Usaria mais para visual premium. Fonte: https://docs.lumalabs.ai/docs/modify-video\n\n**Minha recomendação para vendas no experimento 68:**\n\n- **Curto prazo:** usar o vídeo VEO falado que você gostou como referência de tom e testar novos criativos curtos falados.\n- **Melhor evolução do Marketing Hub:** adicionar um estágio `LIP_SYNC` depois da pós-produção:\n  - vídeo base Luma/Kling/VEO;\n  - script comercial em português;\n  - voz feminina;\n  - lip-sync;\n  - legenda;\n  - exportação para landing e anúncios.\n- **Provider prioritário para integrar primeiro:** `Sync Labs` ou `ElevenLabs Sync 3`, porque encaixa melhor em vídeos já existentes.\n- **Provider para teste de criativo novo falado:** `VEO 3.1`, porque já vimos que ele entrega personagem com áudio e você gostou do resultado.\n\n**Alternativas avaliadas:**\n\n1. **Só VEO falado**: rápido e bom para ads, mas limitado para hero premium longo.\n2. **Só Luma/Kling com lip-sync**: visual melhor, mas exige mais pós-produção e validação.\n3. **Melhor caminho híbrido**: VEO para criativos curtos falados + Luma/Kling para base visual premium + Sync/ElevenLabs para lip-sync final. É o melhor equilíbrio entre velocidade, qualidade e venda.\n\nMinha decisão: o Marketing Hub deve tratar lip-sync como uma etapa própria do funil de vídeo, não como detalhe do provider inicial.","sugestaoMelhoriaAmbiente":"Para testar na prática, ajudaria ter chaves ativas de Sync Labs/ElevenLabs Image & Video, D-ID ou HeyGen além das chaves Luma/Kling já disponíveis."}

Usuário: no caso de VEO será que é possivel juntar varios de 8 segundos para fazer videos maiores ? Conseguimos colocar isso no Marketing Hub ?

Modelo: {"titulo":"VEO em vídeos maiores","comentario":"Sim, dá para colocar isso no Marketing Hub.\n\nPelo que confirmei na documentação atual, o VEO 3.1 gera clipes curtos, normalmente de até **8 segundos**, com áudio nativo. Também há recursos de **extensão de vídeo**, mas eu não trataria isso como única aposta para venda. Fontes: https://ai.google.dev/gemini-api/docs/veo e https://ai.google.dev/gemini-api/docs/video\n\n**Minha recomendação comercial:** criar no Marketing Hub uma esteira de **vídeo falado em blocos**.\n\nEm vez de pedir um vídeo grande direto, o sistema geraria vários VEOs de 8s, cada um com uma função na estrada de compra:\n\n1. **Hook/dor**: “Você se arruma, olha no espelho e ainda sente que falta presença?”\n2. **Identificação**: personagem conversa com a cliente e valida a situação.\n3. **Mecanismo**: explica o plano MUSA de 7 dias.\n4. **Prova/visualização**: mostra pequenas mudanças possíveis.\n5. **CTA**: chama para ver o plano personalizado.\n\nDepois o Marketing Hub junta tudo em um vídeo maior de 24s, 32s ou 40s, com transições, legenda, áudio nivelado e CTA final.\n\n**Alternativas avaliadas:**\n\n- **Um VEO único de 8s**: ótimo para anúncio curto, mas limitado para explicar e vender.\n- **VEO extendido**: pode funcionar, mas tem mais risco de perder controle da mensagem e continuidade.\n- **Vários VEOs de 8s montados pelo Marketing Hub**: melhor opção. Dá controle comercial, permite testar blocos e reutilizar cenas em anúncios, landing e retargeting.\n\n**Como eu colocaria no sistema:**\n\n- Nova ação: **Gerar vídeo falado em sequência**.\n- O backend cria um pacote com vários jobs VEO vinculados ao mesmo experimento.\n- Cada job recebe papel no funil: dor, mecanismo, desejo, CTA.\n- O worker gera os clipes VEO com fala.\n- Depois a pós-produção junta os clipes em um MP4 final.\n- A tela mostra os clipes individuais e o vídeo composto final.\n\nPara vendas, esse caminho é melhor que tentar forçar Luma/Kling mudo a vender sozinho. O VEO falado deve virar o motor de criativos persuasivos curtos, e o Marketing Hub deve montar esses blocos em narrativas maiores.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Se quiser, peça para eu implementar essa esteira no Marketing Hub: VEO em blocos de 8s + montagem automática em vídeo maior para o experimento 68."}

Última mensagem do usuário:
Vamos retirar a geraçaõ de videos dos experimentos e colocar na tela de produtos
Refaça toda essa tela: http://191.252.181.168:5173/products/4/sales-videos
Ficando ela pronta para a geração e gerenciamento dos videos, retire do experimento.   Depois coloque nos documentos canonicos a localização única de gerenciamento de videos do produto.
Coloque tambem o custo de cada video e o custo total do produto com videos.

**Resumo das alterações:**
{"titulo":"Tela de vídeos ajustada","comentario":"Implementei a mudança: vídeos agora são gerenciados pela tela do produto `/products/4/sales-videos`, não mais pela aba do experimento.\n\n**O que ficou pronto:**\n\n- Refiz a tela de vídeos do produto como central de criação, geração, revisão e custos.\n- Adicionei custo por job/vídeo e custo total do produto.\n- Criei endpoint backend `GET /api/products/{productId}/sales-videos/jobs` para a tela consolidar os jobs do produto.\n- Removi da aba Vídeo do experimento as ações de gerar/renderizar/finalizar vídeos.\n- A aba do experimento agora fica como revisão/histórico e direciona para a central do produto.\n- Atualizei o documento canônico `avatar-sales-video-canonical-rules.md` definindo `/products/{productId}/sales-videos` como localização única de gerenciamento.\n\n**Validação:**\n\n- Backend: `SalesVideoJobServiceTest` passou.\n- Frontend: `npm run typecheck` passou.\n- Frontend: `npm run build` passou.\n- Prettier nos arquivos alterados passou.\n- Validação visual local com Playwright passou usando dados simulados; a tela carregou com custo total e custo por vídeo.\n\nNão criei PR e não publiquei nada.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Peça o PR/deploy quando quiser publicar a mudança. Depois do deploy, a preparação dos vídeos do produto 4 deve ser feita pela tela `/products/4/sales-videos`."}