### PR TITLE
AI Hub: {"titulo":"Tela de vídeo criada","comentario":"Implementei a tela de produção de vídeo por nicho e o botão no detalhe do nicho.\n\n**Verificação feita**\n- Existe página dinâmica de detalhe: `/niches/:nicheId`.\n- Consultei o backend: há **62 expe…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-product-musa-current-price-47.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-product-musa-current-price-47.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-24-product-musa-current-price-47.yaml
+  - changeSet:
+      id: 2026-07-24-product-musa-current-price-47-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: current_price_brl
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET current_price_brl = 47.00,
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -48,6 +48,9 @@ databaseChangeLog:
       file: changesets/2026-07-19-product-musa-current-price-67.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-24-product-musa-current-price-47.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-19-product-musa-logo-and-ai-positioning.yaml
       relativeToChangelogFile: true
   - include:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import SuccessProductDetailPage from "./pages/successProduct/SuccessProductDetai
 import EditSuccessProductPage from "./pages/successProduct/EditSuccessProductPage";
 import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 import NicheListPage from "./pages/niche/NicheListPage";
+import NicheVideoProductionPage from "./pages/niche/NicheVideoProductionPage";
 import AiServiceListPage from "./pages/aiService/AiServiceListPage";
 import NewAiServicePage from "./pages/aiService/NewAiServicePage";
 import EditAiServicePage from "./pages/aiService/EditAiServicePage";
@@ -223,6 +224,10 @@ export default function App() {
                 <Route index element={<NicheListPage />} />
                 <Route path="new" element={<Navigate to=".." replace />} />
                 <Route path=":nicheId" element={<NicheDetailPage />} />
+                <Route
+                  path=":nicheId/video-production"
+                  element={<NicheVideoProductionPage />}
+                />
                 <Route path=":nicheId/edit" element={<LegacyNicheRedirect />} />
                 <Route
                   path=":nicheId/hypotheses/new"

--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -118,6 +118,12 @@ describe("niche navigation", () => {
     await screen.findByText("Fitness");
     await user.click(screen.getByRole("link", { name: "Detalhes" }));
     await screen.findByText("Hipóteses do nicho");
+    await user.click(screen.getByRole("link", { name: /produzir vídeos/i }));
+    expect(await screen.findAllByText("Produção de vídeo")).not.toHaveLength(0);
+    await screen.findByText("Avatar HeyGen");
+    await screen.findByRole("button", { name: /solicitar avatar/i });
+    await user.click(screen.getByRole("link", { name: /voltar ao nicho/i }));
+    await screen.findByText("Hipóteses do nicho");
     expect(screen.queryByRole("link", { name: /^criar hipótese$/i })).toBeNull();
     await user.click(screen.getByRole("link", { name: /entrar/i }));
     await screen.findByText("Dor");

--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -64,6 +64,7 @@
   align-items: center;
   gap: 0.35rem;
   line-height: 1.2;
+  min-width: 0;
   white-space: nowrap;
 }
 
@@ -84,7 +85,10 @@
 
 .app-breadcrumbs__item-text {
   display: inline-block;
+  max-width: min(52vw, 42rem);
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -38,6 +38,7 @@ import {
   Target,
   Briefcase,
   Activity,
+  Video,
 } from "lucide-react";
 import "./NicheDetailPage.css";
 
@@ -481,6 +482,13 @@ export default function NicheDetailPage() {
           </p>
         </div>
         <div className="niche-detail__actions">
+          <Link
+            className="btn btn-primary niche-detail__action-btn"
+            to="video-production"
+          >
+            <Video size={18} />
+            <span>Produzir vídeos</span>
+          </Link>
           <button
             type="button"
             className="btn btn-outline-secondary niche-detail__action-btn"

--- a/frontend/src/pages/niche/NicheVideoProductionPage.css
+++ b/frontend/src/pages/niche/NicheVideoProductionPage.css
@@ -1,0 +1,261 @@
+.niche-video-production {
+  color: #111827;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.niche-video-production__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.niche-video-production__header .page-title {
+  margin-bottom: 0.35rem;
+}
+
+.niche-video-production__subtitle {
+  color: #475569;
+  margin: 0;
+  max-width: 780px;
+}
+
+.niche-video-production__badge {
+  align-items: center;
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 999px;
+  color: #3730a3;
+  display: inline-flex;
+  font-size: 0.86rem;
+  font-weight: 700;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  white-space: nowrap;
+}
+
+.niche-video-production__metrics {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.niche-video-production__metric {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  padding: 0.85rem;
+}
+
+.niche-video-production__metric span {
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.niche-video-production__metric strong {
+  color: #111827;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.niche-video-production__strategy {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.niche-video-production__strategy article {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem;
+}
+
+.niche-video-production__strategy strong {
+  color: #0f172a;
+}
+
+.niche-video-production__strategy span,
+.niche-video-production__section-header p,
+.niche-video-production__card-body p {
+  color: #475569;
+}
+
+.niche-video-production__experiments {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.niche-video-production__section-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.niche-video-production__section-header h2 {
+  font-size: 1.2rem;
+  margin: 0 0 0.25rem;
+}
+
+.niche-video-production__section-header p {
+  margin: 0;
+}
+
+.niche-video-production__empty {
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  color: #64748b;
+  padding: 1rem;
+  text-align: center;
+}
+
+.niche-video-production__cards {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+.niche-video-production__card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.niche-video-production__preview {
+  background: #111827;
+  display: grid;
+  min-height: 200px;
+  place-items: center;
+}
+
+.niche-video-production__preview video {
+  background: #111827;
+  display: block;
+  height: 220px;
+  object-fit: contain;
+  width: 100%;
+}
+
+.niche-video-production__preview-empty {
+  color: #f8fafc;
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  place-items: center;
+  text-align: center;
+}
+
+.niche-video-production__card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0.9rem;
+}
+
+.niche-video-production__card-topline,
+.niche-video-production__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.niche-video-production__card-topline {
+  color: #64748b;
+  font-size: 0.82rem;
+  font-weight: 700;
+  justify-content: space-between;
+}
+
+.niche-video-production__pill {
+  align-items: center;
+  background: #f1f5f9;
+  border-radius: 999px;
+  color: #475569;
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem 0.55rem;
+}
+
+.niche-video-production__pill--ok {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.niche-video-production__pill--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.niche-video-production__card-body h3 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.niche-video-production__card-body p {
+  margin: 0;
+}
+
+.niche-video-production__card-body dl {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+}
+
+.niche-video-production__card-body dt {
+  color: #64748b;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.niche-video-production__card-body dd {
+  font-size: 0.9rem;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.niche-video-production__actions .btn {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+@media (max-width: 1100px) {
+  .niche-video-production__metrics,
+  .niche-video-production__strategy {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .niche-video-production__header,
+  .niche-video-production__section-header {
+    flex-direction: column;
+  }
+
+  .niche-video-production__metrics,
+  .niche-video-production__strategy,
+  .niche-video-production__cards {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/pages/niche/NicheVideoProductionPage.tsx
+++ b/frontend/src/pages/niche/NicheVideoProductionPage.tsx
@@ -1,0 +1,377 @@
+import { useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Clapperboard,
+  PlayCircle,
+  ShieldAlert,
+  Video,
+} from "lucide-react";
+import PageTitle from "../../components/PageTitle";
+import { TenantContextBanner } from "../../components/TenantContextBanner";
+import { useBreadcrumbs } from "../../app/breadcrumbs";
+import { useNiche } from "../../api/niche/useNiche";
+import { useExperimentsByNiche } from "../../api/experiment/useExperimentsByNiche";
+import type { Experiment } from "../../api/experiment/useExperiments";
+import {
+  ExperimentVideoAsset,
+  useAllExperimentVideoAssets,
+} from "../../api/experiment/useExperimentVideoAssets";
+import { useRequestExperimentVeoVideo } from "../../api/experiment/useRequestExperimentVeoVideo";
+import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
+import { useTenantContext } from "../../utils/tenantContext";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
+import "./NicheVideoProductionPage.css";
+
+const HEYGEN_PROVIDER_NAME = "HEYGEN";
+
+function formatDate(value?: string | null) {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "-";
+  return parsed.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatUsd(value?: number | null) {
+  if (value == null) return "-";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function buildAvatarScript(experiment: Experiment, nicheName: string) {
+  const pain = experiment.singlePain || experiment.hypothesis;
+  const promise = experiment.funnelPromise || experiment.primaryCta || experiment.name;
+  const cta = experiment.primaryCta || "ver como funciona";
+
+  return [
+    `Se voce atua em ${nicheName}, talvez reconheca isto: ${pain}.`,
+    `A ideia deste teste e mostrar, em poucos segundos, um caminho mais simples para chegar em ${promise}.`,
+    "Voce nao precisa entender tecnologia. A promessa precisa ficar clara: uma entrada simples, um mecanismo plausivel e um resultado percebido no seu caso.",
+    `Se isso fizer sentido para voce, clique em ${cta} e veja o proximo passo.`,
+  ].join(" ");
+}
+
+function getReadyApprovedCount(videos: ExperimentVideoAsset[]) {
+  return videos.filter(
+    (video) => video.status === "READY" && video.reviewStatus === "APPROVED",
+  ).length;
+}
+
+function getBlockedCount(videos: ExperimentVideoAsset[]) {
+  return videos.filter(
+    (video) =>
+      video.requiredForRelease &&
+      (video.status !== "READY" || video.reviewStatus !== "APPROVED"),
+  ).length;
+}
+
+export default function NicheVideoProductionPage() {
+  const { nicheId } = useParams();
+  const numericNicheId = Number(nicheId);
+  const { data: niche, isLoading: isLoadingNiche } = useNiche(numericNicheId);
+  const { data: experiments, isLoading: isLoadingExperiments } =
+    useExperimentsByNiche(nicheId);
+  const videoLibraryQuery = useAllExperimentVideoAssets();
+
+  useBreadcrumbs([
+    {
+      label: niche?.name || "...",
+      to: nicheId ? `/niches/${nicheId}` : "/niches",
+      icon: nicheIcon,
+    },
+    { label: "Produção de vídeo" },
+  ]);
+
+  const experimentList = useMemo(() => experiments ?? [], [experiments]);
+  const experimentIds = useMemo(
+    () => new Set(experimentList.map((experiment) => Number(experiment.id))),
+    [experimentList],
+  );
+  const nicheVideos = useMemo(
+    () =>
+      (videoLibraryQuery.data ?? []).filter((video) =>
+        experimentIds.has(Number(video.experimentId)),
+      ),
+    [experimentIds, videoLibraryQuery.data],
+  );
+  const videosByExperiment = useMemo(() => {
+    return nicheVideos.reduce<Record<string, ExperimentVideoAsset[]>>(
+      (acc, video) => {
+        const key = String(video.experimentId);
+        acc[key] = [...(acc[key] ?? []), video];
+        return acc;
+      },
+      {},
+    );
+  }, [nicheVideos]);
+  const readyApprovedCount = getReadyApprovedCount(nicheVideos);
+  const blockedCount = getBlockedCount(nicheVideos);
+  const plannedCount = nicheVideos.filter(
+    (video) => video.status === "PLANNED",
+  ).length;
+  const generatingCount = nicheVideos.filter(
+    (video) => video.status === "GENERATING",
+  ).length;
+  const isLoading =
+    isLoadingNiche || isLoadingExperiments || videoLibraryQuery.isLoading;
+
+  if (isLoadingNiche) return <p>Carregando nicho...</p>;
+  if (!niche) return <p>Nicho não encontrado.</p>;
+
+  return (
+    <div className="niche-video-production">
+      <div className="niche-video-production__header">
+        <div>
+          <Link
+            className="btn btn-sm btn-outline-secondary mb-3"
+            to={nicheId ? `/niches/${nicheId}` : "/niches"}
+          >
+            <ArrowLeft size={16} aria-hidden="true" />
+            Voltar ao nicho
+          </Link>
+          <PageTitle icon={nicheIcon}>Produção de vídeo</PageTitle>
+          <p className="niche-video-production__subtitle">
+            Central do nicho {niche.name} para validar hipóteses com avatar,
+            explicar mecanismo e reduzir incerteza antes de escalar tráfego.
+          </p>
+        </div>
+        <span className="niche-video-production__badge">
+          <Video size={16} aria-hidden="true" />
+          Avatar HeyGen
+        </span>
+      </div>
+
+      <TenantContextBanner className="mb-3" />
+
+      <section className="niche-video-production__metrics">
+        <SummaryMetric label="Experimentos" value={String(experimentList.length)} />
+        <SummaryMetric label="Videos do nicho" value={String(nicheVideos.length)} />
+        <SummaryMetric label="Planejados" value={String(plannedCount)} />
+        <SummaryMetric label="Gerando" value={String(generatingCount)} />
+        <SummaryMetric label="Prontos aprovados" value={String(readyApprovedCount)} />
+        <SummaryMetric label="Bloqueios" value={String(blockedCount)} />
+      </section>
+
+      <section className="niche-video-production__strategy">
+        <article>
+          <strong>Dor reconhecível</strong>
+          <span>O roteiro começa pela situação do nicho, não pelo produto.</span>
+        </article>
+        <article>
+          <strong>Mecanismo simples</strong>
+          <span>O avatar deve tornar a promessa plausível em 20 a 45 segundos.</span>
+        </article>
+        <article>
+          <strong>Teste rápido</strong>
+          <span>HeyGen entra como validação inicial, antes de avatar proprietário.</span>
+        </article>
+      </section>
+
+      <section className="niche-video-production__experiments">
+        <div className="niche-video-production__section-header">
+          <div>
+            <h2>Experimentos do nicho</h2>
+            <p>
+              Cada card mostra a situação de vídeo do experimento e permite
+              solicitar um avatar de teste quando ainda não há peça pronta.
+            </p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="niche-video-production__empty">
+            Carregando produção de vídeos...
+          </div>
+        ) : experimentList.length === 0 ? (
+          <div className="niche-video-production__empty">
+            Nenhum experimento vinculado a este nicho.
+          </div>
+        ) : (
+          <div className="niche-video-production__cards">
+            {experimentList.map((experiment) => (
+              <ExperimentVideoProductionCard
+                key={experiment.id}
+                experiment={experiment}
+                nicheName={niche.name}
+                videos={videosByExperiment[String(experiment.id)] ?? []}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="niche-video-production__metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function ExperimentVideoProductionCard({
+  experiment,
+  nicheName,
+  videos,
+}: {
+  experiment: Experiment;
+  nicheName: string;
+  videos: ExperimentVideoAsset[];
+}) {
+  const tenantContext = useTenantContext();
+  const requestVideo = useRequestExperimentVeoVideo(experiment.id);
+  const readyApproved = getReadyApprovedCount(videos);
+  const blockers = getBlockedCount(videos);
+  const latestVideo = [...videos].sort((a, b) => {
+    const aDate = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+    const bDate = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+    return bDate - aDate;
+  })[0];
+  const playbackUrl = latestVideo?.assetUrl
+    ? resolveAssetUrl(latestVideo.assetUrl)
+    : "";
+  const thumbnailUrl = latestVideo?.thumbnailUrl
+    ? resolveAssetUrl(latestVideo.thumbnailUrl)
+    : "";
+  const canRequestAvatar = !requestVideo.isPending;
+
+  const handleRequestAvatar = async () => {
+    try {
+      await requestVideo.mutateAsync({
+        slot: "LANDING_HERO",
+        title: `Avatar HeyGen - ${experiment.name}`,
+        objective:
+          "Validar se um avatar humano explica a dor, o mecanismo e a promessa com mais clareza antes de escalar a campanha.",
+        primaryMetric: "clique no checkout ou CTA principal após assistir",
+        personaName: `Representante do nicho ${nicheName}`,
+        personaStyle:
+          "especialista acessível, direto, comercial e confiável para validação rápida",
+        voiceStyle: "português do Brasil, claro, humano e sem tom de aula longa",
+        language: "pt-BR",
+        targetDurationSeconds: 35,
+        scriptText: buildAvatarScript(experiment, nicheName),
+        hookText: experiment.singlePain || experiment.hypothesis,
+        ctaText: experiment.primaryCta || "Ver o próximo passo",
+        captionText:
+          "Teste de avatar para medir clareza da promessa e confiança no mecanismo.",
+        providerName: HEYGEN_PROVIDER_NAME,
+        executionMode: "TEST",
+        requestedBy: tenantContext.userEmail,
+        requiredForRelease: false,
+      });
+      toast.success("Avatar HeyGen solicitado para o experimento.");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Não foi possível solicitar o avatar agora.";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <article className="niche-video-production__card">
+      <div className="niche-video-production__preview">
+        {playbackUrl ? (
+          <video
+            src={playbackUrl}
+            poster={thumbnailUrl || undefined}
+            controls
+            playsInline
+            preload="metadata"
+          />
+        ) : (
+          <div className="niche-video-production__preview-empty">
+            <PlayCircle size={36} aria-hidden="true" />
+            <span>Sem vídeo renderizado</span>
+          </div>
+        )}
+      </div>
+      <div className="niche-video-production__card-body">
+        <div className="niche-video-production__card-topline">
+          <span>Experimento #{experiment.id}</span>
+          {blockers > 0 ? (
+            <span className="niche-video-production__pill niche-video-production__pill--warning">
+              <ShieldAlert size={14} aria-hidden="true" />
+              {blockers} bloqueio(s)
+            </span>
+          ) : readyApproved > 0 ? (
+            <span className="niche-video-production__pill niche-video-production__pill--ok">
+              <CheckCircle2 size={14} aria-hidden="true" />
+              Aprovado
+            </span>
+          ) : (
+            <span className="niche-video-production__pill">
+              Sem asset pronto
+            </span>
+          )}
+        </div>
+        <h3>{experiment.name || `Experimento ${experiment.id}`}</h3>
+        <p>{experiment.hypothesis || "Hipótese não informada."}</p>
+        <dl>
+          <div>
+            <dt>Status</dt>
+            <dd>{experiment.status}</dd>
+          </div>
+          <div>
+            <dt>Objetivo</dt>
+            <dd>{experiment.campaignObjective ?? "-"}</dd>
+          </div>
+          <div>
+            <dt>Vídeos</dt>
+            <dd>{videos.length}</dd>
+          </div>
+          <div>
+            <dt>Última produção</dt>
+            <dd>{formatDate(latestVideo?.updatedAt)}</dd>
+          </div>
+          <div>
+            <dt>Provider</dt>
+            <dd>{latestVideo?.provider ?? "-"}</dd>
+          </div>
+          <div>
+            <dt>Custo</dt>
+            <dd>{formatUsd(latestVideo?.cost)}</dd>
+          </div>
+        </dl>
+        <div className="niche-video-production__actions">
+          <Link
+            className="btn btn-sm btn-outline-primary"
+            to={`/experiments/${experiment.id}`}
+          >
+            Abrir experimento
+          </Link>
+          {latestVideo?.salesVideoProfileId ? (
+            <Link
+              className="btn btn-sm btn-outline-secondary"
+              to={`/sales-videos/profiles/${latestVideo.salesVideoProfileId}`}
+            >
+              Perfil de vídeo
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            disabled={!canRequestAvatar}
+            onClick={handleRequestAvatar}
+          >
+            <Clapperboard size={15} aria-hidden="true" />
+            Solicitar avatar
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica. O comando sandbox-media-player <arquivo-video-ou-audio> [saida.html] gera um player HTML local com controles nativos de vídeo/áudio; abra o HTML com Chromium/Playwright para reproduzir a mídia e avaliar naturalidade da pronúncia, sincronização labial, cortes e qualidade perceptual além da validação técnica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Itens opcionais selecionados pelo usuário para complementar o prompt:
Leia e use como base o documento em : /docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md

Histórico da conversa:
Usuário: Esstou achando que os videos de avatar da heygen podem funcionar muito bem para rapidamente validar hipoteses o que vc achar ? Poderiamos colocar eles tabem como assets de nichos para validar hipoteses no experimentos. 

Modelo: {"titulo":"Avatar pode acelerar validação","comentario":"Sim, faz bastante sentido. Minha leitura é que vídeos de avatar da HeyGen podem funcionar muito bem como **asset rápido de validação de hipótese**, principalmente quando o produto ainda é novo e o público precisa atravessar a estrada: desconhecimento → relevância → mecanismo → confiança.\n\nPelo que vi nos documentos, o Marketing Hub já aponta nessa direção:\n\n- `docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md`: vídeo/avatar ajuda a reduzir incerteza, explicar mecanismo e aumentar confiança.\n- `docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md`: já existe hipótese formal de testar página tradicional vs página com vídeo humano/avatar.\n- `docs/canonical/avatar-sales-video-canonical-rules.md`: o avatar pronto é recomendado para validação inicial de promessa e criativo; avatar proprietário fica melhor depois que houver sinal comercial.\n- `docs/canonical/procedimento-experimento-canon.v1.md`: já existe regra de que página com vídeo humano/avatar precisa de vídeo `READY + APPROVED` para liberar tráfego.\n\n**Minha recomendação:** sim, devemos tratar avatar HeyGen como uma nova classe de asset de nicho/hipótese, mas com função bem definida.\n\nAlternativas avaliadas:\n\n1. **Usar avatar só como vídeo final da página de venda**  \n   Benefício: mais controle de qualidade.  \n   Risco: lento demais para validação rápida.  \n   Aderência: boa para escala, fraca para descoberta.\n\n2. **Usar avatar como criativo rápido de anúncio e/ou seção curta na landing**  \n   Benefício: valida dor, promessa, mecanismo e confiança com velocidade.  \n   Risco: se o roteiro for genérico, valida apenas curiosidade pelo vídeo, não a hipótese.  \n   Aderência: melhor para o objetivo atual.\n\n3. **Criar avatar proprietário por nicho desde o início**  \n   Benefício: maior diferenciação de marca.  \n   Risco: custo e tempo antes de saber se a dor vende.  \n   Aderência: melhor depois de sinal positivo.\n\n**Escolha recomendada:** começar pela alternativa 2.\n\nO melhor uso seria criar, para cada hipótese forte, um pacote mínimo de vídeo:\n\n- vídeo curto de 20 a 45 segundos;\n- fala direta sobre uma dor concreta do nicho;\n- explicação simples do mecanismo;\n- prova visual ou amostra do entregável;\n- CTA para comprar, ver amostra ou continuar a partir do resultado.\n\nCritério importante: o vídeo não deve ser “um apresentador falando bonito”. Ele precisa validar uma pergunta comercial específica:\n\n> Esta dor + este mecanismo + esta oferta ficam mais compreensíveis e desejáveis quando explicados por avatar?\n\nEu colocaria isso como asset versionado do experimento/nicho, com métricas próprias:\n\n- play rate;\n- 50% view;\n- clique no checkout após assistir;\n- compra após assistir;\n- comparação com página sem vídeo;\n- custo por sinal comercial válido.\n\nDireção prática: usar HeyGen primeiro como **avatar pronto para teste de mercado**, não como identidade definitiva. Se um nicho mostrar clique no checkout, compra ou lead qualificado, aí sim vale pensar em avatar proprietário, roteiro mais refinado e produção mais premium.","sugestaoMelhoriaAmbiente":""}

Última mensagem do usuário:
verifica se existe uma pagina de detalhe de nicho e se todos os nichos de nossos experimentos possuem uma se sim crie uma tela de produção de video e coloque o botão de nevagar para ela na pagina de detalhe de nicho.

**Resumo das alterações:**
{"titulo":"Tela de vídeo criada","comentario":"Implementei a tela de produção de vídeo por nicho e o botão no detalhe do nicho.\n\n**Verificação feita**\n- Existe página dinâmica de detalhe: `/niches/:nicheId`.\n- Consultei o backend: há **62 experimentos**, **0 sem nicheId**, e **12 nichos vinculados a experimentos**. Portanto, todos os nichos usados por experimentos têm rota de detalhe disponível.\n\n**O que ficou pronto**\n- Novo botão **Produzir vídeos** na página de detalhe do nicho.\n- Nova rota: `/niches/:nicheId/video-production`.\n- Tela lista os experimentos do nicho, vídeos existentes, status, bloqueios, provider, custo e última produção.\n- Botão **Solicitar avatar** por experimento, usando provider `HEYGEN` em modo `TEST`, com roteiro inicial orientado à jornada: dor reconhecível → mecanismo → redução de incerteza → CTA.\n- Corrigi também o breadcrumb global para não quebrar visualmente com nomes longos de nicho.\n\n**Validação**\n- `npm run typecheck`: passou.\n- `npm test -- --run NicheFlow.test.tsx`: passou.\n- `npm run build`: passou, com aviso já esperado de bundle grande.\n- Validação visual com Playwright na rota `/niches/21/video-production`: passou, sem erros de console e sem sobreposição.","sugestaoMelhoriaAmbiente":"Configurar `VITE_API_URL=http://127.0.0.1:5173` automaticamente no ambiente local do frontend evitaria falhas de validação visual, porque o app usa `window.location.hostname` por padrão e perde a porta do Vite.","orientacaoProximaAcao":"Para publicar essa alteração, o próximo passo é você pedir o PR quando quiser levar a mudança para revisão/deploy."}