### PR TITLE
AI Hub: {"titulo":"Preço unificado em R$67","comentario":"Assumi que “Método Muda” se refere ao **Método MUSA**.\n\nPreço unificado para **R$67,00**.\n\n**Feito:**\n- Atualizei produção: `metodo-musa-7-dias` agora retorna `currentPriceBrl: 67`.\n- A defin…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-product-commercial-catalog.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-16-product-commercial-catalog.yaml
@@ -103,7 +103,7 @@ databaseChangeLog:
                 'pde-platform; lead-portal-payments-service; backend/ads-service; frontend.',
                 'PDE - Produto Digital Experiencial',
                 'VALIDACAO_COMERCIAL',
-                47.00,
+                67.00,
                 'Mulher quer parecer mais elegante e marcante sem gastar com luxo, trocar o guarda-roupa inteiro ou depender de compras impulsivas.',
                 'Experimento 66',
                 'Primeiro produto canônico do Marketing Hub. Produto deve se vincular principalmente à hipótese/oferta, manter nicho como contexto estratégico e acumular experimentos como histórico de validação e escala.',

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-product-musa-current-price-67-final.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-product-musa-current-price-67-final.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - logicalFilePath: db/changelog/changesets/2026-07-24-product-musa-current-price-67-final.yaml
+  - changeSet:
+      id: 2026-07-24-product-musa-current-price-67-final-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: product
+        - columnExists:
+            tableName: product
+            columnName: slug
+        - columnExists:
+            tableName: product
+            columnName: current_price_brl
+        - columnExists:
+            tableName: product
+            columnName: updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE product
+                 SET current_price_brl = 67.00,
+                     updated_at = CURRENT_TIMESTAMP
+               WHERE slug = 'metodo-musa-7-dias';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -51,6 +51,9 @@ databaseChangeLog:
       file: changesets/2026-07-24-product-musa-current-price-47.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-07-24-product-musa-current-price-67-final.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-19-product-musa-logo-and-ai-positioning.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/service/ProductServiceTest.java
@@ -36,7 +36,7 @@ class ProductServiceTest {
         request.setSlug("metodo-musa-7-dias");
         request.setLogoUrl("https://clubemusa.com.br/assets/logo-musa.svg");
         request.setMarketNicheId(10L);
-        request.setCurrentPriceBrl(new BigDecimal("47.00"));
+        request.setCurrentPriceBrl(new BigDecimal("67.00"));
         request.setTargetAudience("Mulheres urbanas");
         request.setScientificEvidencePack("Evidence Pack MUSA v1");
         request.setPdeExperienceJson("{\"slug\":\"metodo-musa-7-dias\",\"missions\":[]}");
@@ -53,7 +53,7 @@ class ProductServiceTest {
         assertThat(updated.getName()).isEqualTo(request.getName());
         assertThat(updated.getSlug()).isEqualTo(request.getSlug());
         assertThat(updated.getLogoUrl()).isEqualTo("https://clubemusa.com.br/assets/logo-musa.svg");
-        assertThat(updated.getCurrentPriceBrl()).isEqualByComparingTo("47.00");
+        assertThat(updated.getCurrentPriceBrl()).isEqualByComparingTo("67.00");
         assertThat(updated.getTargetAudience()).isEqualTo(request.getTargetAudience());
         assertThat(updated.getScientificEvidencePack()).isEqualTo("Evidence Pack MUSA v1");
         assertThat(updated.getPdeExperienceJson()).contains("\"metodo-musa-7-dias\"");
@@ -78,7 +78,7 @@ class ProductServiceTest {
                 .logoUrl("https://clubemusa.com.br/assets/logo-musa.svg")
                 .productType("PDE")
                 .commercialStatus("validação comercial")
-                .currentPriceBrl(new BigDecimal("47.00"))
+                .currentPriceBrl(new BigDecimal("67.00"))
                 .marketNiche(niche)
                 .targetAudience("Mulheres que querem parecer elegantes sem trocar o guarda-roupa inteiro")
                 .primaryHypothesis("Mulheres desejam presença elegante com baixo esforço e baixo gasto.")

--- a/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/web/ProductControllerTest.java
@@ -54,7 +54,7 @@ class ProductControllerTest {
         CreateProductRequest request = new CreateProductRequest();
         request.setName("Método MUSA - Presença Elegante em 7 Dias");
         request.setMarketNicheId(10L);
-        request.setCurrentPriceBrl(new BigDecimal("47.00"));
+        request.setCurrentPriceBrl(new BigDecimal("67.00"));
 
         Product product = Product.builder().id(1L).name(request.getName()).build();
         ProductDto response = new ProductDto();
@@ -73,7 +73,7 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.name").value(request.getName()))
                 .andExpect(jsonPath("$.logoUrl").value("https://clubemusa.com.br/assets/logo-musa.svg"))
-                .andExpect(jsonPath("$.currentPriceBrl").value(47.00));
+                .andExpect(jsonPath("$.currentPriceBrl").value(67.00));
     }
 
     /** Deve expor a definição pública de mercado do produto como Markdown. */


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE.

Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica. O comando sandbox-media-player <arquivo-video-ou-audio> [saida.html] gera um player HTML local com controles nativos de vídeo/áudio; abra o HTML com Chromium/Playwright para reproduzir a mídia e avaliar naturalidade da pronúncia, sincronização labial, cortes e qualidade perceptual além da validação técnica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Itens opcionais selecionados pelo usuário para complementar o prompt:
Leia e use como base o documento em : /docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md

Histórico da conversa:
Usuário: Esstou achando que os videos de avatar da heygen podem funcionar muito bem para rapidamente validar hipoteses o que vc achar ? Poderiamos colocar eles tabem como assets de nichos para validar hipoteses no experimentos. 

Modelo: {"titulo":"Avatar pode acelerar validação","comentario":"Sim, faz bastante sentido. Minha leitura é que vídeos de avatar da HeyGen podem funcionar muito bem como **asset rápido de validação de hipótese**, principalmente quando o produto ainda é novo e o público precisa atravessar a estrada: desconhecimento → relevância → mecanismo → confiança.\n\nPelo que vi nos documentos, o Marketing Hub já aponta nessa direção:\n\n- `docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md`: vídeo/avatar ajuda a reduzir incerteza, explicar mecanismo e aumentar confiança.\n- `docs/marketing/teste-ab-pagina-venda-video-vs-tradicional.md`: já existe hipótese formal de testar página tradicional vs página com vídeo humano/avatar.\n- `docs/canonical/avatar-sales-video-canonical-rules.md`: o avatar pronto é recomendado para validação inicial de promessa e criativo; avatar proprietário fica melhor depois que houver sinal comercial.\n- `docs/canonical/procedimento-experimento-canon.v1.md`: já existe regra de que página com vídeo humano/avatar precisa de vídeo `READY + APPROVED` para liberar tráfego.\n\n**Minha recomendação:** sim, devemos tratar avatar HeyGen como uma nova classe de asset de nicho/hipótese, mas com função bem definida.\n\nAlternativas avaliadas:\n\n1. **Usar avatar só como vídeo final da página de venda**  \n   Benefício: mais controle de qualidade.  \n   Risco: lento demais para validação rápida.  \n   Aderência: boa para escala, fraca para descoberta.\n\n2. **Usar avatar como criativo rápido de anúncio e/ou seção curta na landing**  \n   Benefício: valida dor, promessa, mecanismo e confiança com velocidade.  \n   Risco: se o roteiro for genérico, valida apenas curiosidade pelo vídeo, não a hipótese.  \n   Aderência: melhor para o objetivo atual.\n\n3. **Criar avatar proprietário por nicho desde o início**  \n   Benefício: maior diferenciação de marca.  \n   Risco: custo e tempo antes de saber se a dor vende.  \n   Aderência: melhor depois de sinal positivo.\n\n**Escolha recomendada:** começar pela alternativa 2.\n\nO melhor uso seria criar, para cada hipótese forte, um pacote mínimo de vídeo:\n\n- vídeo curto de 20 a 45 segundos;\n- fala direta sobre uma dor concreta do nicho;\n- explicação simples do mecanismo;\n- prova visual ou amostra do entregável;\n- CTA para comprar, ver amostra ou continuar a partir do resultado.\n\nCritério importante: o vídeo não deve ser “um apresentador falando bonito”. Ele precisa validar uma pergunta comercial específica:\n\n> Esta dor + este mecanismo + esta oferta ficam mais compreensíveis e desejáveis quando explicados por avatar?\n\nEu colocaria isso como asset versionado do experimento/nicho, com métricas próprias:\n\n- play rate;\n- 50% view;\n- clique no checkout após assistir;\n- compra após assistir;\n- comparação com página sem vídeo;\n- custo por sinal comercial válido.\n\nDireção prática: usar HeyGen primeiro como **avatar pronto para teste de mercado**, não como identidade definitiva. Se um nicho mostrar clique no checkout, compra ou lead qualificado, aí sim vale pensar em avatar proprietário, roteiro mais refinado e produção mais premium.","sugestaoMelhoriaAmbiente":""}

Usuário: verifica se existe uma pagina de detalhe de nicho e se todos os nichos de nossos experimentos possuem uma se sim crie uma tela de produção de video e coloque o botão de nevagar para ela na pagina de detalhe de nicho.

Modelo: {"titulo":"Tela de vídeo criada","comentario":"Implementei a tela de produção de vídeo por nicho e o botão no detalhe do nicho.\n\n**Verificação feita**\n- Existe página dinâmica de detalhe: `/niches/:nicheId`.\n- Consultei o backend: há **62 experimentos**, **0 sem nicheId**, e **12 nichos vinculados a experimentos**. Portanto, todos os nichos usados por experimentos têm rota de detalhe disponível.\n\n**O que ficou pronto**\n- Novo botão **Produzir vídeos** na página de detalhe do nicho.\n- Nova rota: `/niches/:nicheId/video-production`.\n- Tela lista os experimentos do nicho, vídeos existentes, status, bloqueios, provider, custo e última produção.\n- Botão **Solicitar avatar** por experimento, usando provider `HEYGEN` em modo `TEST`, com roteiro inicial orientado à jornada: dor reconhecível → mecanismo → redução de incerteza → CTA.\n- Corrigi também o breadcrumb global para não quebrar visualmente com nomes longos de nicho.\n\n**Validação**\n- `npm run typecheck`: passou.\n- `npm test -- --run NicheFlow.test.tsx`: passou.\n- `npm run build`: passou, com aviso já esperado de bundle grande.\n- Validação visual com Playwright na rota `/niches/21/video-production`: passou, sem erros de console e sem sobreposição.","sugestaoMelhoriaAmbiente":"Configurar `VITE_API_URL=http://127.0.0.1:5173` automaticamente no ambiente local do frontend evitaria falhas de validação visual, porque o app usa `window.location.hostname` por padrão e perde a porta do Vite.","orientacaoProximaAcao":"Para publicar essa alteração, o próximo passo é você pedir o PR quando quiser levar a mudança para revisão/deploy."}

Usuário: a tela de planejamento ja esta liberada para planejar a semana que começa dia 27/7 ?

Modelo: {"titulo":"Semana 27/7 liberada","comentario":"Sim. A tela de Planejamento já está liberada para planejar a semana que começa em **27/07/2026**.\n\nPelo backend em produção, o plano ativo de julho tem:\n\n- **Semana 3:** 20/07/2026 até 26/07/2026\n- `objectivesEditable: true`\n- Mensagem: **“Objetivos liberados até 2026-07-28.”**\n\nIsso significa que, hoje **24/07/2026**, você já pode entrar no card da **Semana 3** e preencher os **objetivos para a próxima semana**, que é justamente a semana **27/07/2026 a 02/08/2026**.\n\nObservação importante: a edição não aparece no card da própria Semana 4. Pelo desenho atual, o sistema planeja a próxima semana a partir do card da semana anterior. Então o caminho correto é:\n\n**Planejamento → Julho 2026 → Semana 3 → Objetivos para a próxima semana**\n\nNão alterei código; fiz apenas a verificação no repositório e na API de produção.","sugestaoMelhoriaAmbiente":""}

Usuário: Faça nosso planejamento 

Modelo: {"titulo":"Planejamento feito","comentario":"Planejamento da semana **27/07/2026 a 02/08/2026** registrado no Marketing Hub.\n\nUsei o card da **Semana 3**, que é o local correto para planejar a próxima semana. A API confirmou `objectivesEditable: true` e os 4 objetivos ficaram gravados.\n\n**Direção escolhida:** fechar julho com foco em venda real do MUSA/PDE, sem liberar gasto antes de validar funil, vídeo, checkout, acesso e tracking.\n\n**Objetivos registrados:**\n\n1. Validar em produção o funil MUSA/PDE: primeira dobra, diagnóstico, checkout, acesso e métricas.\n2. Transformar o experimento 68 em teste comercial vendável com vídeo hero completo: Dor → Resultado → Mecanismo → CTA.\n3. Rodar validação controlada do Método MUSA por **R$47**, com 2 a 3 criativos e teto baixo de gasto.\n4. Fechar julho por evidência: compra, checkout click ou gargalo de promessa/página antes de criar nova campanha.\n\n**Alternativas avaliadas:**\n\n- Escalar tráfego agora: rápido, mas arriscado porque ainda existe bloqueio de tracking/funil.\n- Criar novos produtos/experimentos: aumenta atividade, mas não resolve a causa-raiz da falta de venda.\n- Focar MUSA/PDE + vídeo + validação controlada: melhor aderência ao objetivo de primeira venda com menor desperdício.\n\n**Base usada:** `docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md`, `docs/canonical/commercial-planning-canon.v1.md`, `docs/marketing/plano-evolucao-funil-primeira-venda.md`, `docs/marketing/musa-video-hero-4-clipes.md`, `docs/canonical/avatar-sales-video-canonical-rules.md` e registros do experimento MUSA.\n\nNão alterei código e não criei PR.","sugestaoMelhoriaAmbiente":""}

Usuário: 47 não 67 reais

Modelo: {"titulo":"Preço corrigido para R$47","comentario":"Corrigido.\n\n- O planejamento da Semana 3 já estava correto com **Método MUSA por R$47**.\n- Encontrei a inconsistência real no catálogo de produtos: o produto `metodo-musa-7-dias` estava em produção com `currentPriceBrl: 67`.\n- Atualizei em produção pelo backend para **R$47**.\n- Também deixei a correção versionada no repositório via Liquibase para evitar recorrência em novos ambientes.\n\nArquivos alterados na worktree:\n\n- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`\n- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-product-musa-current-price-47.yaml`\n\nValidação: API de produção agora retorna `currentPriceBrl: 47`. Não criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar a correção versionada no fluxo oficial, peça o PR quando quiser levar essa mudança para revisão/deploy."}

Última mensagem do usuário:
Vamos unificar o preço para ficar bem claro: Metodo Muda preço : R$ 67,00

**Resumo das alterações:**
{"titulo":"Preço unificado em R$67","comentario":"Assumi que “Método Muda” se refere ao **Método MUSA**.\n\nPreço unificado para **R$67,00**.\n\n**Feito:**\n- Atualizei produção: `metodo-musa-7-dias` agora retorna `currentPriceBrl: 67`.\n- A definição pública PDE já mostra: **Preço atual: R$67,00**.\n- Corrigi a fonte versionada no Liquibase para novos ambientes terminarem em R$67.\n- Atualizei os testes de produto que ainda validavam R$47.\n\n**Validação:**\n- `ProductServiceTest` e `ProductControllerTest`: **14 testes, 0 falhas**.\n- Conferi o changelog mestre: includes relativos com `relativeToChangelogFile: true`.\n\n**Decisão aplicada:** manter R$67 como preço único. R$47 deixaria menos atrito, mas agora gerava confusão de posicionamento e inconsistência entre catálogo, PDE e comunicação. Para a etapa atual, clareza de oferta é mais importante.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Quando quiser publicar a correção versionada pelo fluxo oficial, peça o PR."}