### PR TITLE
AI Hub: {"titulo":"Teste de públicos criado","comentario":"Implementei a funcionalidade para **testar públicos dentro do Marketing Hub**.\n\n**O que ficou pronto:**\n\n- Nova área na aba **Público da campanha** do experimento: **Teste de públicos**.\n- Pe…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -41,6 +41,10 @@ public class Creative {
     @Column(name = "video_id")
     private String videoId;
 
+    /** URL pública do vídeo que será enviado para a Meta pelo worker. */
+    @Column(name = "video_url")
+    private String videoUrl;
+
     @Column(name = "ad_format")
     private String format;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreateCreativeRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreateCreativeRequest.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 import lombok.Data;
 
 /**
- * Request body to create or update a creative.
+ * Corpo da requisição para criar ou atualizar um criativo.
  */
 @Data
 public class CreateCreativeRequest {
@@ -13,6 +13,8 @@ public class CreateCreativeRequest {
     private String headline;
     private String primaryText;
     private String imageUrl;
+    private String videoId;
+    private String videoUrl;
     private String description;
     private String cta;
     private String destinationUrl;

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreativeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreativeDto.java
@@ -4,7 +4,7 @@ import com.marketinghub.creative.CreativeStatus;
 import lombok.Data;
 
 /**
- * Data transfer object for Creative.
+ * Representação de leitura de um criativo.
  */
 @Data
 public class CreativeDto {
@@ -14,6 +14,8 @@ public class CreativeDto {
     private String headline;
     private String primaryText;
     private String imageUrl;
+    private String videoId;
+    private String videoUrl;
     private String description;
     private String cta;
     private String destinationUrl;

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/mapper/CreativeMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/mapper/CreativeMapper.java
@@ -6,10 +6,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 /**
- * MapStruct mapper for Creative.
+ * Responsabilidade: converter criativos do domínio para DTOs de API.
  */
 @Mapper(componentModel = "spring")
 public interface CreativeMapper {
+    /** Converte a entidade de criativo para o DTO usado pela API. */
     @Mapping(target = "experimentId", source = "experiment.id")
     CreativeDto toDto(Creative creative);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -76,6 +76,8 @@ public class CreativeService {
                     .headline(request.getHeadline())
                     .primaryText(request.getPrimaryText())
                     .imageUrl(request.getImageUrl())
+                    .videoId(request.getVideoId())
+                    .videoUrl(request.getVideoUrl())
                     .description(request.getDescription())
                     .cta(normalizeMetaCallToAction(request.getCta()))
                     .destinationUrl(request.getDestinationUrl())
@@ -114,6 +116,8 @@ public class CreativeService {
         creative.setHeadline(request.getHeadline());
         creative.setPrimaryText(request.getPrimaryText());
         creative.setImageUrl(request.getImageUrl());
+        creative.setVideoId(request.getVideoId());
+        creative.setVideoUrl(request.getVideoUrl());
         creative.setDescription(request.getDescription());
         creative.setCta(normalizeMetaCallToAction(request.getCta()));
         creative.setDestinationUrl(request.getDestinationUrl());
@@ -181,14 +185,14 @@ public class CreativeService {
      * Recalcula se o experimento possui criativos aprovados.
      */
     private void refreshExperimentApproval(Experiment experiment) {
-        boolean hasApprovedCreatives = repository.existsByExperimentIdAndStatusAndUsableImage(
+        boolean hasApprovedCreatives = repository.existsByExperimentIdAndStatusAndUsableMedia(
                 experiment.getId(), CreativeStatus.READY);
         experiment.setCreativeApproved(hasApprovedCreatives);
         experimentRepository.save(experiment);
     }
 
     /**
-     * Impede que criativo de imagem seja aprovado sem asset visual publicável.
+     * Impede que criativo aprovado siga sem mídia compatível com o formato escolhido.
      */
     private void validateReadyCreativeHasImage(CreateCreativeRequest request) {
         if (request == null || request.getStatus() != CreativeStatus.READY) {
@@ -197,6 +201,11 @@ public class CreativeService {
         String format = StringUtils.hasText(request.getFormat()) ? request.getFormat().trim() : "IMAGE";
         if ("IMAGE".equalsIgnoreCase(format) && !StringUtils.hasText(request.getImageUrl())) {
             throw new IllegalArgumentException("Criativo de imagem aprovado precisa ter imagem gerada.");
+        }
+        if ("VIDEO".equalsIgnoreCase(format)
+                && !StringUtils.hasText(request.getVideoId())
+                && !StringUtils.hasText(request.getVideoUrl())) {
+            throw new IllegalArgumentException("Criativo de vídeo aprovado precisa ter videoId da Meta ou videoUrl público.");
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTest.java
@@ -1,0 +1,76 @@
+package com.marketinghub.experiment;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Guarda uma variação de público planejada para comparar hipóteses de segmentação em um experimento.
+ */
+@Entity
+@Table(name = "experiment_audience_test")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentAudienceTest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    @ToString.Exclude
+    private Experiment experiment;
+
+    @Column(name = "name", nullable = false, length = 120)
+    private String name;
+
+    @Column(name = "hypothesis", nullable = false, length = 500)
+    private String hypothesis;
+
+    @Column(name = "success_metric", nullable = false, length = 191)
+    private String successMetric;
+
+    @Column(name = "daily_budget", precision = 10, scale = 2)
+    private BigDecimal dailyBudget;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    @Builder.Default
+    private ExperimentAudienceTestStatus status = ExperimentAudienceTestStatus.DRAFT;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "audienceTest", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("candidateType ASC, term ASC")
+    @Builder.Default
+    @ToString.Exclude
+    private List<ExperimentAudienceTestItem> items = new ArrayList<>();
+
+    /**
+     * Substitui os itens preservando o vínculo bidirecional da entidade.
+     */
+    public void replaceItems(List<ExperimentAudienceTestItem> nextItems) {
+        items.clear();
+        if (nextItems == null) {
+            return;
+        }
+        nextItems.forEach(item -> {
+            item.setAudienceTest(this);
+            items.add(item);
+        });
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTestItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTestItem.java
@@ -1,0 +1,38 @@
+package com.marketinghub.experiment;
+
+import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Representa um item oficial da Meta usado em uma variação de público.
+ */
+@Entity
+@Table(name = "experiment_audience_test_item")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentAudienceTestItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "audience_test_id", nullable = false)
+    @ToString.Exclude
+    private ExperimentAudienceTest audienceTest;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "candidate_type", nullable = false, length = 32)
+    private TargetingCandidateType candidateType;
+
+    @Column(name = "term", nullable = false, length = 191)
+    private String term;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "targeting_element_id", nullable = false)
+    @ToString.Exclude
+    private TargetingElement targetingElement;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTestStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentAudienceTestStatus.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment;
+
+/**
+ * Representa o estado operacional de uma variação de público planejada para teste.
+ */
+public enum ExperimentAudienceTestStatus {
+    DRAFT,
+    READY,
+    RUNNING,
+    PAUSED,
+    WINNER,
+    LOSER
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentAudienceTestRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentAudienceTestRequest.java
@@ -1,0 +1,45 @@
+package com.marketinghub.experiment.dto;
+
+import com.marketinghub.targeting.TargetingCandidateType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Requisição para criar uma variação de público a ser testada em um experimento.
+ */
+@Data
+public class CreateExperimentAudienceTestRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String hypothesis;
+
+    @NotBlank
+    private String successMetric;
+
+    private BigDecimal dailyBudget;
+
+    @Valid
+    @NotEmpty
+    private List<Item> items = new ArrayList<>();
+
+    /**
+     * Item de targeting oficial da Meta escolhido para a variação.
+     */
+    @Data
+    public static class Item {
+        @NotNull
+        private TargetingCandidateType candidateType;
+
+        @NotNull
+        private Long targetingElementId;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentAudienceTestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentAudienceTestDto.java
@@ -1,0 +1,44 @@
+package com.marketinghub.experiment.dto;
+
+import com.marketinghub.experiment.ExperimentAudienceTestStatus;
+import com.marketinghub.targeting.TargetingCandidateType;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Dados de uma variação de público planejada para teste no experimento.
+ */
+@Builder
+public record ExperimentAudienceTestDto(
+        Long id,
+        Long experimentId,
+        String name,
+        String hypothesis,
+        String successMetric,
+        BigDecimal dailyBudget,
+        ExperimentAudienceTestStatus status,
+        Long audienceSizeLowerBound,
+        Long audienceSizeUpperBound,
+        Instant createdAt,
+        Instant updatedAt,
+        List<Item> items
+) {
+    /**
+     * Item oficial da Meta vinculado à variação de público.
+     */
+    @Builder
+    public record Item(
+            Long id,
+            TargetingCandidateType candidateType,
+            String term,
+            Long targetingElementId,
+            String metaId,
+            String metaKey,
+            Long metaAudienceSizeLowerBound,
+            Long metaAudienceSizeUpperBound
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentAudienceTestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentAudienceTestService.java
@@ -1,0 +1,182 @@
+package com.marketinghub.experiment.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentAudienceTest;
+import com.marketinghub.experiment.ExperimentAudienceTestItem;
+import com.marketinghub.experiment.ExperimentAudienceTestStatus;
+import com.marketinghub.experiment.dto.CreateExperimentAudienceTestRequest;
+import com.marketinghub.experiment.dto.ExperimentAudienceTestDto;
+import com.marketinghub.repository.jpa.experiment.ExperimentAudienceTestRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
+import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Coordena o planejamento de variações de público sem alterar campanhas em execução automaticamente.
+ */
+@Service
+public class ExperimentAudienceTestService {
+    private final ExperimentRepository experimentRepository;
+    private final ExperimentAudienceTestRepository audienceTestRepository;
+    private final TargetingElementRepository targetingElementRepository;
+
+    public ExperimentAudienceTestService(
+            ExperimentRepository experimentRepository,
+            ExperimentAudienceTestRepository audienceTestRepository,
+            TargetingElementRepository targetingElementRepository) {
+        this.experimentRepository = experimentRepository;
+        this.audienceTestRepository = audienceTestRepository;
+        this.targetingElementRepository = targetingElementRepository;
+    }
+
+    /**
+     * Lista as variações de público planejadas para o experimento.
+     */
+    @Transactional(readOnly = true)
+    public List<ExperimentAudienceTestDto> list(Long experimentId) {
+        return audienceTestRepository.findByExperimentIdWithItems(experimentId).stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    /**
+     * Cria uma variação de público em rascunho com elementos Meta válidos do mesmo nicho.
+     */
+    @Transactional
+    public ExperimentAudienceTestDto create(Long experimentId, CreateExperimentAudienceTestRequest request) {
+        Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
+        ExperimentAudienceTest test = ExperimentAudienceTest.builder()
+                .experiment(experiment)
+                .name(request.getName().trim())
+                .hypothesis(request.getHypothesis().trim())
+                .successMetric(request.getSuccessMetric().trim())
+                .dailyBudget(normalizeBudget(request.getDailyBudget()))
+                .status(ExperimentAudienceTestStatus.DRAFT)
+                .build();
+        List<ExperimentAudienceTestItem> items = request.getItems().stream()
+                .map(item -> toItem(experiment, item))
+                .toList();
+        test.replaceItems(items);
+        return toDto(audienceTestRepository.save(test));
+    }
+
+    /**
+     * Remove uma variação de público que ainda não foi publicada.
+     */
+    @Transactional
+    public void delete(Long experimentId, Long audienceTestId) {
+        ExperimentAudienceTest test = audienceTestRepository.findById(audienceTestId)
+                .orElseThrow(() -> new IllegalArgumentException("Teste de público não encontrado"));
+        if (test.getExperiment() == null || !Objects.equals(test.getExperiment().getId(), experimentId)) {
+            throw new IllegalArgumentException("Teste de público não pertence ao experimento informado");
+        }
+        if (test.getStatus() == ExperimentAudienceTestStatus.RUNNING) {
+            throw new IllegalArgumentException("Teste de público em execução não pode ser removido");
+        }
+        audienceTestRepository.delete(test);
+    }
+
+    /**
+     * Converte a requisição em item persistível validando nicho, tipo e ID oficial da Meta.
+     */
+    private ExperimentAudienceTestItem toItem(Experiment experiment, CreateExperimentAudienceTestRequest.Item item) {
+        TargetingElement element = targetingElementRepository.findById(item.getTargetingElementId())
+                .orElseThrow(() -> new IllegalArgumentException("Elemento de segmentação não encontrado"));
+        validateElement(experiment, element, item.getCandidateType());
+        return ExperimentAudienceTestItem.builder()
+                .candidateType(item.getCandidateType())
+                .term(element.getTerm())
+                .targetingElement(element)
+                .build();
+    }
+
+    /**
+     * Bloqueia públicos fora do nicho, de tipo errado ou sem identificador oficial da Meta.
+     */
+    private void validateElement(Experiment experiment, TargetingElement element, TargetingCandidateType candidateType) {
+        if (element.getNiche() == null || element.getNiche().getId() == null
+                || experiment.getNiche() == null || experiment.getNiche().getId() == null
+                || !Objects.equals(element.getNiche().getId(), experiment.getNiche().getId())) {
+            throw new IllegalArgumentException("Elemento de segmentação não pertence ao mesmo nicho do experimento");
+        }
+        if (element.getType() != mapCandidateType(candidateType)) {
+            throw new IllegalArgumentException("Tipo do elemento não corresponde ao candidato informado");
+        }
+        if (!StringUtils.hasText(element.getMetaId())) {
+            throw new IllegalArgumentException("Elemento de segmentação sem ID oficial da Meta");
+        }
+    }
+
+    /**
+     * Converte o tipo de candidato para o tipo canônico do elemento de targeting.
+     */
+    private TargetingElementType mapCandidateType(TargetingCandidateType candidateType) {
+        return switch (candidateType) {
+            case INTEREST -> TargetingElementType.INTEREST;
+            case BEHAVIOR -> TargetingElementType.BEHAVIOR;
+            case WORK_POSITION -> TargetingElementType.JOB_TITLE;
+        };
+    }
+
+    /**
+     * Normaliza orçamento vazio ou negativo para ausência de orçamento próprio.
+     */
+    private BigDecimal normalizeBudget(BigDecimal dailyBudget) {
+        if (dailyBudget == null || dailyBudget.compareTo(BigDecimal.ZERO) <= 0) {
+            return null;
+        }
+        return dailyBudget;
+    }
+
+    /**
+     * Monta o DTO com alcance estimado pela soma dos intervalos dos itens.
+     */
+    private ExperimentAudienceTestDto toDto(ExperimentAudienceTest test) {
+        Long lower = 0L;
+        Long upper = 0L;
+        List<ExperimentAudienceTestDto.Item> items = test.getItems().stream()
+                .map(item -> {
+                    TargetingElement element = item.getTargetingElement();
+                    return ExperimentAudienceTestDto.Item.builder()
+                            .id(item.getId())
+                            .candidateType(item.getCandidateType())
+                            .term(item.getTerm())
+                            .targetingElementId(element != null ? element.getId() : null)
+                            .metaId(element != null ? element.getMetaId() : null)
+                            .metaKey(element != null ? element.getMetaKey() : null)
+                            .metaAudienceSizeLowerBound(element != null ? element.getMetaAudienceSizeLowerBound() : null)
+                            .metaAudienceSizeUpperBound(element != null ? element.getMetaAudienceSizeUpperBound() : null)
+                            .build();
+                })
+                .toList();
+        for (ExperimentAudienceTestDto.Item item : items) {
+            long itemLower = item.metaAudienceSizeLowerBound() != null ? item.metaAudienceSizeLowerBound() : 0L;
+            long itemUpper = item.metaAudienceSizeUpperBound() != null ? item.metaAudienceSizeUpperBound() : itemLower;
+            lower += itemLower;
+            upper += itemUpper;
+        }
+        return ExperimentAudienceTestDto.builder()
+                .id(test.getId())
+                .experimentId(test.getExperiment().getId())
+                .name(test.getName())
+                .hypothesis(test.getHypothesis())
+                .successMetric(test.getSuccessMetric())
+                .dailyBudget(test.getDailyBudget())
+                .status(test.getStatus())
+                .audienceSizeLowerBound(lower)
+                .audienceSizeUpperBound(upper)
+                .createdAt(test.getCreatedAt())
+                .updatedAt(test.getUpdatedAt())
+                .items(items)
+                .build();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentAudienceTestController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentAudienceTestController.java
@@ -1,0 +1,51 @@
+package com.marketinghub.experiment.web;
+
+import com.marketinghub.experiment.dto.CreateExperimentAudienceTestRequest;
+import com.marketinghub.experiment.dto.ExperimentAudienceTestDto;
+import com.marketinghub.experiment.service.ExperimentAudienceTestService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Expõe os endpoints de planejamento de testes de público por experimento.
+ */
+@RestController
+@RequestMapping("/api/experiments/{experimentId}/audience-tests")
+public class ExperimentAudienceTestController {
+    private final ExperimentAudienceTestService service;
+
+    public ExperimentAudienceTestController(ExperimentAudienceTestService service) {
+        this.service = service;
+    }
+
+    /**
+     * Lista as variações de público planejadas para o experimento.
+     */
+    @GetMapping
+    public List<ExperimentAudienceTestDto> list(@PathVariable Long experimentId) {
+        return service.list(experimentId);
+    }
+
+    /**
+     * Cria uma nova variação de público em rascunho.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ExperimentAudienceTestDto create(
+            @PathVariable Long experimentId,
+            @Valid @RequestBody CreateExperimentAudienceTestRequest request) {
+        return service.create(experimentId, request);
+    }
+
+    /**
+     * Remove uma variação de público que ainda não está em execução.
+     */
+    @DeleteMapping("/{audienceTestId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long experimentId, @PathVariable Long audienceTestId) {
+        service.delete(experimentId, audienceTestId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -589,6 +589,8 @@ public class FacebookAdsCampaignController {
                 creative.getHeadline(),
                 creative.getPrimaryText(),
                 creative.getImageUrl(),
+                creative.getVideoId(),
+                creative.getVideoUrl(),
                 creative.getDescription(),
                 creative.getCta(),
                 creative.getDestinationUrl(),
@@ -629,8 +631,13 @@ public class FacebookAdsCampaignController {
         creative.setId(creativeReq.id());
         creative.setPageId(creativeReq.pageId());
         creative.setInstagramUserId(creativeReq.instagramActorId());
-        creative.setKind(AdCreativeKind.LINK);
-        creative.setLinkDataJson(buildLinkDataJson(creativeReq));
+        if (StringUtils.hasText(creativeReq.videoId())) {
+            creative.setKind(AdCreativeKind.VIDEO);
+            creative.setVideoDataJson(buildVideoDataJson(creativeReq));
+        } else {
+            creative.setKind(AdCreativeKind.LINK);
+            creative.setLinkDataJson(buildLinkDataJson(creativeReq));
+        }
         return creative;
     }
 
@@ -796,6 +803,34 @@ public class FacebookAdsCampaignController {
             }
         }
         return linkData.toString();
+    }
+
+    // Executa a operação buildVideoDataJson da integração Facebook Ads.
+    private String buildVideoDataJson(CreateCampaignRequest.AdCreative creativeReq) {
+        ObjectNode videoData = objectMapper.createObjectNode();
+        videoData.put("video_id", creativeReq.videoId());
+        videoData.put("message", creativeReq.message());
+        if (StringUtils.hasText(creativeReq.headline())) {
+            videoData.put("title", creativeReq.headline());
+        }
+        if (StringUtils.hasText(creativeReq.description())) {
+            videoData.put("link_description", creativeReq.description());
+        }
+        if (StringUtils.hasText(creativeReq.callToActionType())) {
+            ObjectNode callToAction = videoData.putObject("call_to_action");
+            callToAction.put("type", creativeReq.callToActionType());
+            ObjectNode value = callToAction.putObject("value");
+            if (StringUtils.hasText(creativeReq.websiteUrl())) {
+                value.put("link", creativeReq.websiteUrl());
+            }
+            if (StringUtils.hasText(creativeReq.leadGenFormId())) {
+                value.put("lead_gen_form_id", creativeReq.leadGenFormId());
+            }
+            if (value.isEmpty()) {
+                callToAction.remove("value");
+            }
+        }
+        return videoData.toString();
     }
 
     // Executa a operação toSummary da integração Facebook Ads.
@@ -1166,6 +1201,8 @@ public class FacebookAdsCampaignController {
             String headline,
             String primaryText,
             String imageUrl,
+            String videoId,
+            String videoUrl,
             String description,
             String cta,
             String destinationUrl,
@@ -1217,6 +1254,8 @@ public class FacebookAdsCampaignController {
                 String websiteUrl,
                 String leadGenFormId,
                 String message,
+                String videoId,
+                String videoUrl,
                 String callToActionType,
                 String headline,
                 String description) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/creative/CreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/creative/CreativeRepository.java
@@ -19,14 +19,36 @@ public interface CreativeRepository extends JpaRepository<Creative, Long> {
     /** Verifica se existe criativo do experimento no status informado. */
     boolean existsByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
 
-    /** Verifica se existe criativo aprovado com imagem publicável no experimento. */
+    /** Verifica se existe criativo aprovado com mídia publicável no experimento. */
     @Query("""
             select case when count(c) > 0 then true else false end
               from Creative c
              where c.experiment.id = :experimentId
                and c.status = :status
-               and c.imageUrl is not null
-               and trim(c.imageUrl) <> ''
+               and (
+                    (upper(coalesce(c.format, 'IMAGE')) = 'IMAGE' and c.imageUrl is not null and trim(c.imageUrl) <> '')
+                 or (upper(c.format) = 'VIDEO' and (
+                        (c.videoId is not null and trim(c.videoId) <> '')
+                     or (c.videoUrl is not null and trim(c.videoUrl) <> '')
+                    ))
+               )
+            """)
+    boolean existsByExperimentIdAndStatusAndUsableMedia(@Param("experimentId") Long experimentId,
+                                                        @Param("status") CreativeStatus status);
+
+    /** Mantém compatibilidade com chamadas antigas, agora considerando imagem ou vídeo publicável. */
+    @Query("""
+            select case when count(c) > 0 then true else false end
+              from Creative c
+             where c.experiment.id = :experimentId
+               and c.status = :status
+               and (
+                    (upper(coalesce(c.format, 'IMAGE')) = 'IMAGE' and c.imageUrl is not null and trim(c.imageUrl) <> '')
+                 or (upper(c.format) = 'VIDEO' and (
+                        (c.videoId is not null and trim(c.videoId) <> '')
+                     or (c.videoUrl is not null and trim(c.videoUrl) <> '')
+                    ))
+               )
             """)
     boolean existsByExperimentIdAndStatusAndUsableImage(@Param("experimentId") Long experimentId,
                                                         @Param("status") CreativeStatus status);
@@ -41,14 +63,36 @@ public interface CreativeRepository extends JpaRepository<Creative, Long> {
     /** Conta os criativos do experimento que estão no status informado. */
     long countByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
 
-    /** Conta criativos aprovados com imagem publicável no experimento informado. */
+    /** Conta criativos aprovados com mídia publicável no experimento informado. */
     @Query("""
             select count(c)
               from Creative c
              where c.experiment.id = :experimentId
                and c.status = :status
-               and c.imageUrl is not null
-               and trim(c.imageUrl) <> ''
+               and (
+                    (upper(coalesce(c.format, 'IMAGE')) = 'IMAGE' and c.imageUrl is not null and trim(c.imageUrl) <> '')
+                 or (upper(c.format) = 'VIDEO' and (
+                        (c.videoId is not null and trim(c.videoId) <> '')
+                     or (c.videoUrl is not null and trim(c.videoUrl) <> '')
+                    ))
+               )
+            """)
+    long countByExperimentIdAndStatusAndUsableMedia(@Param("experimentId") Long experimentId,
+                                                    @Param("status") CreativeStatus status);
+
+    /** Mantém compatibilidade com chamadas antigas, agora contando imagem ou vídeo publicável. */
+    @Query("""
+            select count(c)
+              from Creative c
+             where c.experiment.id = :experimentId
+               and c.status = :status
+               and (
+                    (upper(coalesce(c.format, 'IMAGE')) = 'IMAGE' and c.imageUrl is not null and trim(c.imageUrl) <> '')
+                 or (upper(c.format) = 'VIDEO' and (
+                        (c.videoId is not null and trim(c.videoId) <> '')
+                     or (c.videoUrl is not null and trim(c.videoUrl) <> '')
+                    ))
+               )
             """)
     long countByExperimentIdAndStatusAndUsableImage(@Param("experimentId") Long experimentId,
                                                     @Param("status") CreativeStatus status);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentAudienceTestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentAudienceTestRepository.java
@@ -1,0 +1,25 @@
+package com.marketinghub.repository.jpa.experiment;
+
+import com.marketinghub.experiment.ExperimentAudienceTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * Repositório JPA responsável pela persistência dos testes de público do experimento.
+ */
+public interface ExperimentAudienceTestRepository extends JpaRepository<ExperimentAudienceTest, Long> {
+    /**
+     * Lista os testes de público com itens e elementos carregados para montar a tela.
+     */
+    @Query("""
+            select distinct test from ExperimentAudienceTest test
+            left join fetch test.items item
+            left join fetch item.targetingElement element
+            where test.experiment.id = :experimentId
+            order by test.createdAt desc
+            """)
+    List<ExperimentAudienceTest> findByExperimentIdWithItems(@Param("experimentId") Long experimentId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-creative-video-url.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-creative-video-url.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-24-creative-video-url
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: creative
+        - not:
+            - columnExists:
+                tableName: creative
+                columnName: video_url
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE creative
+                ADD COLUMN video_url VARCHAR(1024) NULL AFTER video_id;

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-experiment-audience-tests.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-24-experiment-audience-tests.yaml
@@ -1,0 +1,136 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-24-experiment-audience-tests
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_audience_test
+      changes:
+        - createTable:
+            tableName: experiment_audience_test
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: hypothesis
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: success_metric
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: daily_budget
+                  type: DECIMAL(10,2)
+              - column:
+                  name: status
+                  type: VARCHAR(32)
+                  defaultValue: DRAFT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+        - addForeignKeyConstraint:
+            baseTableName: experiment_audience_test
+            baseColumnNames: experiment_id
+            constraintName: fk_experiment_audience_test_experiment
+            referencedTableName: experiment
+            referencedColumnNames: id
+        - createIndex:
+            tableName: experiment_audience_test
+            indexName: idx_experiment_audience_test_experiment
+            columns:
+              - column:
+                  name: experiment_id
+  - changeSet:
+      id: 2026-07-24-experiment-audience-test-items
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_audience_test_item
+      changes:
+        - createTable:
+            tableName: experiment_audience_test_item
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: audience_test_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: candidate_type
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: term
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: targeting_element_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: experiment_audience_test_item
+            baseColumnNames: audience_test_id
+            constraintName: fk_experiment_audience_test_item_test
+            referencedTableName: experiment_audience_test
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: experiment_audience_test_item
+            baseColumnNames: targeting_element_id
+            constraintName: fk_experiment_audience_test_item_element
+            referencedTableName: targeting_element
+            referencedColumnNames: id
+        - createIndex:
+            tableName: experiment_audience_test_item
+            indexName: idx_experiment_audience_test_item_test
+            columns:
+              - column:
+                  name: audience_test_id
+        - createIndex:
+            tableName: experiment_audience_test_item
+            indexName: idx_experiment_audience_test_item_element
+            columns:
+              - column:
+                  name: targeting_element_id

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-24-experiment-audience-tests.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-23-sales-video-stream-playback-url.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-24-creative-video-url.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-24-experiment-audience-tests.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -170,7 +170,20 @@ class FacebookAdsCampaignControllerTest {
                 .headline("Rascunho")
                 .status(CreativeStatus.DRAFT)
                 .build();
-        when(creativeRepository.findByExperimentId(1L)).thenReturn(List.of(draftCreative, readyCreative));
+        var readyVideoCreative = Creative.builder()
+                .id(103L)
+                .experiment(experiment)
+                .format("VIDEO")
+                .headline("Headline video")
+                .primaryText("Texto video")
+                .videoId("vid-123")
+                .videoUrl("https://cdn.example/video.mp4")
+                .description("Descrição video")
+                .cta("LEARN_MORE")
+                .destinationUrl("https://example.com/video")
+                .status(CreativeStatus.READY)
+                .build();
+        when(creativeRepository.findByExperimentId(1L)).thenReturn(List.of(draftCreative, readyVideoCreative, readyCreative));
 
         mockMvc.perform(get("/api/facebook-campaigns/experiments/1/creatives-ready"))
                 .andExpect(status().isOk())
@@ -186,7 +199,11 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].leadGenFormId").value("321"))
                 .andExpect(jsonPath("$[0].instagramUserId").value("987"))
                 .andExpect(jsonPath("$[0].status").value("READY"))
-                .andExpect(jsonPath("$[1]").doesNotExist());
+                .andExpect(jsonPath("$[1].id").value(103))
+                .andExpect(jsonPath("$[1].format").value("VIDEO"))
+                .andExpect(jsonPath("$[1].videoId").value("vid-123"))
+                .andExpect(jsonPath("$[1].videoUrl").value("https://cdn.example/video.mp4"))
+                .andExpect(jsonPath("$[2]").doesNotExist());
     }
 
     @Test
@@ -890,6 +907,8 @@ class FacebookAdsCampaignControllerTest {
                   "instagramActorId": "IG-222",
                   "websiteUrl": "https://example.com/a",
                   "message": "Mensagem A",
+                  "videoId": "vid-a",
+                  "videoUrl": "https://cdn.example/video-a.mp4",
                   "callToActionType": "LEARN_MORE",
                   "headline": "Headline A",
                   "description": "Desc A"
@@ -932,6 +951,11 @@ class FacebookAdsCampaignControllerTest {
         assertThat(creativeCaptor.getAllValues())
                 .extracting(FacebookAdsAdCreative::getId)
                 .containsExactly("creativeA", "creativeB");
+        assertThat(creativeCaptor.getAllValues())
+                .extracting(creative -> creative.getKind().name())
+                .containsExactly("VIDEO", "LINK");
+        assertThat(creativeCaptor.getAllValues().get(0).getVideoDataJson())
+                .contains("\"video_id\":\"vid-a\"");
 
         ArgumentCaptor<FacebookAdsAd> adCaptor = ArgumentCaptor.forClass(FacebookAdsAd.class);
         verify(adRepository, times(2)).save(adCaptor.capture());

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -553,6 +553,17 @@ erDiagram
 - O disparo do fluxo simples cria uma `targeting_request` interna para resolver os códigos da Meta Ads.
 - `targeting_request` agora possui `experiment_id` (FK) para rastrear execuções por experimento e permitir expor status/erros operacionais diretamente na UI.
 
+### Teste de públicos por experimento
+
+As tabelas `experiment_audience_test` e `experiment_audience_test_item` permitem planejar variações de público dentro de um experimento sem alterar automaticamente campanhas em execução.
+
+- `experiment_audience_test` guarda nome, hipótese, métrica principal, orçamento diário opcional e status da variação.
+- `experiment_audience_test_item` guarda os itens oficiais de targeting usados na variação, sempre vinculados a `targeting_element`.
+- A variação nasce como `DRAFT`; publicação/ativação de mídia deve ser uma ação operacional separada.
+- O uso recomendado é comparar público mantendo criativo, oferta, preço e landing constantes.
+
+Para MUSA, este recurso deve ajudar a separar hipóteses como público amplo, público de imagem pessoal/elegância, público moda/beleza e público profissional feminino.
+
 ## Funil de vendas do experimento
 
 Para cada experimento passamos a acompanhar um funil operacional padronizado de

--- a/docs/registros/experimento-publicos.md
+++ b/docs/registros/experimento-publicos.md
@@ -1,0 +1,17 @@
+# Registro - teste de públicos
+
+## 2026-07-24 - Funcionalidade de variações de público
+
+Criada funcionalidade para planejar testes de público dentro da aba de segmentação do experimento.
+
+Motivação comercial:
+
+- o MUSA estava com público publicável, mas amplo demais para ser tratado como melhor opção estratégica;
+- trocar segmentação direto em campanha `RUNNING` contamina o aprendizado do teste de vídeo na primeira dobra;
+- a causa-raiz é falta de um lugar explícito para formular e guardar hipóteses de público antes da publicação.
+
+Decisão:
+
+- criar variações em `DRAFT`, com hipótese, métrica principal, orçamento opcional e elementos oficiais da Meta;
+- não publicar automaticamente nem mexer na campanha ativa;
+- usar a funcionalidade para comparar públicos mantendo criativo e landing constantes.

--- a/docs/regra/fluxo-simples-publico-campanha.md
+++ b/docs/regra/fluxo-simples-publico-campanha.md
@@ -61,11 +61,28 @@ Depois de executar o fluxo simples, a aba de segmentação do experimento exibe:
 
 O painel atualiza automaticamente a cada 10 segundos enquanto houver candidatos pendentes.
 
+## 6) Teste de públicos
+
+Na mesma aba, o operador pode criar **variações de público** para testar hipóteses de segmentação sem misturar aprendizado com criativo ou landing.
+
+Regra comercial:
+
+- cada variação deve ter nome, hipótese, métrica principal e itens oficiais da Meta;
+- o teste deve manter criativo, oferta, preço e página constantes sempre que a hipótese for apenas público;
+- a variação nasce em `DRAFT` e não altera automaticamente campanha em execução;
+- uma campanha `RUNNING` só deve trocar ou publicar novo público por ação operacional explícita;
+- para MUSA, priorizar variações ligadas à dor de imagem pessoal, elegância prática, moda/beleza acessível e presença profissional feminina.
+
+Resultado esperado: comparar públicos com rastreabilidade antes de gastar mídia em segmentações amplas demais.
+
 ## Endpoints envolvidos
 
 - `PUT /api/experiments/{experimentId}/targeting-selections`
 - `GET /api/experiments/{experimentId}/targeting-selections`
 - `POST /api/experiments/{experimentId}/targeting-selections/run-simple-flow`
+- `GET /api/experiments/{experimentId}/audience-tests`
+- `POST /api/experiments/{experimentId}/audience-tests`
+- `DELETE /api/experiments/{experimentId}/audience-tests/{audienceTestId}`
 - `GET /api/internal/targeting/elements/metaads-pending`
 - `PATCH /api/internal/targeting/elements/{id}/metaads`
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -2092,6 +2092,7 @@ private FacebookInterest searchInterest(String interestName, String locale) {
     public record FacebookInterest(String id, String name) {}
     private record FacebookTargetingCategory(String id, String name) {}
 
+    /** Cria um criativo na Meta usando link_data para imagem ou video_data para vídeo. */
     public String createAdCreative(String adAccountId, AdCreativeRequest request) {
         Objects.requireNonNull(request, "request");
 
@@ -2104,21 +2105,23 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         }
         boolean hasWebsiteUrl = hasText(resolvedLink);
 
-        Map<String, Object> linkData = new HashMap<>();
+        Map<String, Object> storyData = new HashMap<>();
         if (hasWebsiteUrl) {
-            linkData.put("link", resolvedLink);
+            storyData.put("link", resolvedLink);
         }
-        linkData.put("message", request.message());
+        storyData.put("message", request.message());
         if (request.headline() != null && !request.headline().isBlank()) {
-            linkData.put("name", request.headline());
+            storyData.put(hasText(request.videoId()) ? "title" : "name", request.headline());
         }
         if (request.description() != null && !request.description().isBlank()) {
-            linkData.put("description", request.description());
+            storyData.put(hasText(request.videoId()) ? "link_description" : "description", request.description());
         }
-        if (hasText(request.imageHash())) {
-            linkData.put("image_hash", request.imageHash());
+        if (hasText(request.videoId())) {
+            storyData.put("video_id", request.videoId());
+        } else if (hasText(request.imageHash())) {
+            storyData.put("image_hash", request.imageHash());
         } else if (hasText(request.imageUrl())) {
-            linkData.put("picture", request.imageUrl());
+            storyData.put("picture", request.imageUrl());
         }
         if (request.callToActionType() != null && !request.callToActionType().isBlank()) {
             Map<String, Object> callToAction = new HashMap<>();
@@ -2133,7 +2136,7 @@ private FacebookInterest searchInterest(String interestName, String locale) {
             if (!value.isEmpty()) {
                 callToAction.put("value", value);
             }
-            linkData.put("call_to_action", callToAction);
+            storyData.put("call_to_action", callToAction);
         }
 
         Map<String, Object> objectStorySpec = new HashMap<>();
@@ -2141,7 +2144,7 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         if (request.instagramActorId() != null && !request.instagramActorId().isBlank()) {
             objectStorySpec.put("instagram_user_id", request.instagramActorId());
         }
-        objectStorySpec.put("link_data", linkData);
+        objectStorySpec.put(hasText(request.videoId()) ? "video_data" : "link_data", storyData);
 
         Map<String, Object> body = new HashMap<>();
         body.put("name", request.name());
@@ -2199,6 +2202,38 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         String path = buildVersionedPath("/act_" + adAccountId + "/adimages");
         JsonNode response = executeMultipartPost(path, builder.build(), debugBody);
         return extractAdImageHash(response);
+    }
+
+    /** Envia bytes de um vídeo para a biblioteca de vídeos da conta Meta e retorna o video_id. */
+    public String uploadAdVideoFromBytes(String adAccountId,
+                                         byte[] videoBytes,
+                                         String fileName,
+                                         String contentType) {
+        Objects.requireNonNull(adAccountId, "adAccountId");
+        if (videoBytes == null || videoBytes.length == 0) {
+            throw new IllegalArgumentException("videoBytes must not be empty");
+        }
+        String resolvedFileName = hasText(fileName) ? fileName.trim() : "creative-" + UUID.randomUUID() + ".mp4";
+        String resolvedContentType = hasText(contentType)
+                ? contentType.trim()
+                : MediaType.APPLICATION_OCTET_STREAM_VALUE;
+
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("access_token", requireAccessToken());
+        builder.part("source", new ByteArrayResource(videoBytes) {
+            @Override
+            public String getFilename() {
+                return resolvedFileName;
+            }
+        }).header(HttpHeaders.CONTENT_TYPE, resolvedContentType);
+
+        Map<String, Object> debugBody = new HashMap<>();
+        debugBody.put("filename", resolvedFileName);
+        debugBody.put("parts", List.of("source(bytes)", "access_token"));
+
+        String path = buildVersionedPath("/act_" + adAccountId + "/advideos");
+        JsonNode response = executeMultipartPost(path, builder.build(), debugBody);
+        return response.path("id").asText();
     }
 
     public String createAd(String adAccountId, AdRequest request) {
@@ -3207,6 +3242,8 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         String message,
         String imageHash,
         String imageUrl,
+        String videoId,
+        String videoUrl,
         String callToActionType,
         String headline,
         String description

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -123,6 +123,8 @@ public class FacebookCampaignService {
 
     private static final Duration CREATIVE_IMAGE_DOWNLOAD_TIMEOUT = Duration.ofSeconds(20);
     private static final long CREATIVE_IMAGE_MAX_BYTES = 10 * 1024 * 1024L;
+    private static final Duration CREATIVE_VIDEO_DOWNLOAD_TIMEOUT = Duration.ofSeconds(60);
+    private static final long CREATIVE_VIDEO_MAX_BYTES = 200 * 1024 * 1024L;
 
     private final FacebookAdsService facebookAdsService;
     private final WebClient backendClient;
@@ -452,6 +454,7 @@ public class FacebookCampaignService {
                 resolvedTargeting.targetingJson(),
                 FacebookAdsService.BRAZIL_COUNTRY_CODE
             );
+            creativePayloads = preloadCreativeVideosForExperiment(exp.publicationJobId(), exp.id(), config.adAccountId(), creativePayloads);
             creativePayloads = preloadCreativeImagesForExperiment(exp.publicationJobId(), exp.id(), config.adAccountId(), creativePayloads);
             validateCreativePayloadsHaveImageHashes(exp, creativePayloads);
             try {
@@ -506,7 +509,9 @@ public class FacebookCampaignService {
                     payload.headline(),
                     payload.description(),
                     payload.imageHash(),
-                    payload.imageUrl()
+                    payload.imageUrl(),
+                    payload.videoId(),
+                    payload.videoUrl()
                 );
                 FacebookAdsService.AdCreativeRequest adCreativeRequest = adCreativeCreation.request();
                 String creativeId = adCreativeCreation.id();
@@ -534,6 +539,8 @@ public class FacebookCampaignService {
                     adCreativeRequest.message(),
                     adCreativeRequest.imageHash(),
                     adCreativeRequest.imageUrl(),
+                    adCreativeRequest.videoId(),
+                    adCreativeRequest.videoUrl(),
                     adCreativeRequest.callToActionType(),
                     adCreativeRequest.headline(),
                     adCreativeRequest.description()
@@ -1236,6 +1243,8 @@ public class FacebookCampaignService {
             String message,
             String imageHash,
             String imageUrl,
+            String videoId,
+            String videoUrl,
             String callToActionType,
             String headline,
             String description
@@ -1260,6 +1269,8 @@ public class FacebookCampaignService {
         String description,
         String imageHash,
         String imageUrl,
+        String videoId,
+        String videoUrl,
         String instagramActorId,
         String adNameSuffix
     ) {
@@ -1274,6 +1285,26 @@ public class FacebookCampaignService {
                 description,
                 value,
                 imageUrl,
+                videoId,
+                videoUrl,
+                instagramActorId,
+                adNameSuffix
+            );
+        }
+
+        private CreativePublicationPayload withVideoId(String value) {
+            return new CreativePublicationPayload(
+                creative,
+                websiteUrl,
+                leadGenFormId,
+                message,
+                callToAction,
+                headline,
+                description,
+                imageHash,
+                imageUrl,
+                value,
+                videoUrl,
                 instagramActorId,
                 adNameSuffix
             );
@@ -1546,6 +1577,106 @@ public class FacebookCampaignService {
     }
 
     private record DownloadedImage(byte[] bytes, String contentType) {}
+    private record DownloadedVideo(byte[] bytes, String contentType) {}
+
+    /** Baixa um vídeo público para upload controlado na biblioteca da Meta. */
+    private DownloadedVideo downloadCreativeVideo(String videoUrl) {
+        if (!StringUtils.hasText(videoUrl)) {
+            throw new IllegalArgumentException("videoUrl must not be blank");
+        }
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(videoUrl))
+                .GET()
+                .timeout(CREATIVE_VIDEO_DOWNLOAD_TIMEOUT)
+                .header(HttpHeaders.USER_AGENT, "MarketingHubFacebookAdsWorker/1.0")
+                .build();
+            HttpResponse<byte[]> response = assetDownloadClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            int status = response.statusCode();
+            if (status < 200 || status >= 300) {
+                throw new IllegalStateException("Creative video download failed with status " + status);
+            }
+            byte[] body = response.body();
+            if (body == null || body.length == 0) {
+                throw new IllegalStateException("Creative video download returned an empty body");
+            }
+            if (body.length > CREATIVE_VIDEO_MAX_BYTES) {
+                throw new IllegalStateException("Creative video exceeds max allowed size");
+            }
+            String contentType = response.headers().firstValue(HttpHeaders.CONTENT_TYPE).orElse(null);
+            return new DownloadedVideo(body, contentType);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Creative video download interrupted", ex);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to download creative video: " + ex.getMessage(), ex);
+        }
+    }
+
+    /** Resolve o nome de arquivo usado no upload multipart de vídeo. */
+    private String resolveVideoFileName(String videoUrl) {
+        if (!StringUtils.hasText(videoUrl)) {
+            return "creative-" + UUID.randomUUID() + ".mp4";
+        }
+        try {
+            String path = URI.create(videoUrl).getPath();
+            if (StringUtils.hasText(path)) {
+                int idx = path.lastIndexOf('/');
+                if (idx >= 0 && idx + 1 < path.length()) {
+                    String candidate = path.substring(idx + 1);
+                    if (StringUtils.hasText(candidate)) {
+                        return candidate;
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.debug("Failed to extract filename from video URL {}: {}", videoUrl, ex.getMessage());
+        }
+        return "creative-" + UUID.randomUUID() + ".mp4";
+    }
+
+    /**
+     * Envia vídeos públicos para a biblioteca da Meta quando o criativo ainda não possui video_id.
+     */
+    private List<CreativePublicationPayload> preloadCreativeVideosForExperiment(
+        String publicationJobId,
+        long experimentId,
+        String adAccountId,
+        List<CreativePublicationPayload> creativePayloads
+    ) {
+        List<CreativePublicationPayload> resolvedPayloads = new ArrayList<>(creativePayloads.size());
+        for (CreativePublicationPayload payload : creativePayloads) {
+            if (!isVideoCreative(payload) || StringUtils.hasText(payload.videoId())) {
+                resolvedPayloads.add(payload);
+                continue;
+            }
+            if (!StringUtils.hasText(payload.videoUrl())) {
+                throw new IllegalStateException(
+                    "Campanha bloqueada: criativo de vídeo sem video_id e sem video_url no experimento " + experimentId
+                );
+            }
+            DownloadedVideo downloadedVideo = downloadCreativeVideo(payload.videoUrl());
+            String uploadedVideoId = executeFacebookCallWithLogging(
+                publicationJobId,
+                experimentId,
+                ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
+                () -> facebookAdsService.uploadAdVideoFromBytes(
+                    adAccountId,
+                    downloadedVideo.bytes(),
+                    resolveVideoFileName(payload.videoUrl()),
+                    downloadedVideo.contentType())
+            );
+            LOGGER.info(
+                "Creative video uploaded to Meta before ad creative creation: experimentId={}, creativeId={}, videoId={}",
+                experimentId,
+                payload.creative().id(),
+                uploadedVideoId
+            );
+            resolvedPayloads.add(payload.withVideoId(uploadedVideoId));
+        }
+        return resolvedPayloads;
+    }
+
     private record CanonicalImageHashUpsertRequest(
         String platform,
         String adAccountId,
@@ -1618,14 +1749,17 @@ public class FacebookCampaignService {
             creative.description(),
             null,
             resolveCreativeImageUrl(creative.imageUrl()),
+            resolveCreativeVideoId(creative.videoId()),
+            resolveCreativeVideoUrl(creative.videoUrl()),
             coalesce(creative.instagramUserId(), fallbackInstagramActorId),
             adNameSuffix
         );
     }
 
-    /** Bloqueia publicação de anúncio antes de criar objetos na Meta quando o criativo não tem imagem de origem. */
+    /** Bloqueia publicação de anúncio antes de criar objetos na Meta quando o criativo não tem mídia de origem. */
     private void validateCreativePayloadsHaveImageUrls(Experiment exp, List<CreativePublicationPayload> creativePayloads) {
         List<Long> creativeIdsWithoutImage = creativePayloads.stream()
+            .filter(payload -> !isVideoCreative(payload))
             .filter(payload -> !StringUtils.hasText(payload.imageUrl()))
             .map(payload -> payload.creative().id())
             .toList();
@@ -1646,6 +1780,7 @@ public class FacebookCampaignService {
     /** Bloqueia publicação quando o upload/canonização da imagem não gerou image_hash utilizável pela Meta. */
     private void validateCreativePayloadsHaveImageHashes(Experiment exp, List<CreativePublicationPayload> creativePayloads) {
         List<Long> creativeIdsWithoutImageHash = creativePayloads.stream()
+            .filter(payload -> !isVideoCreative(payload))
             .filter(payload -> !StringUtils.hasText(payload.imageHash()))
             .map(payload -> payload.creative().id())
             .toList();
@@ -1661,6 +1796,14 @@ public class FacebookCampaignService {
             reason
         );
         throw new IllegalStateException(reason);
+    }
+
+    /** Identifica criativos que devem ser publicados pela Meta como vídeo. */
+    private boolean isVideoCreative(CreativePublicationPayload payload) {
+        return payload != null
+            && payload.creative() != null
+            && StringUtils.hasText(payload.creative().format())
+            && "VIDEO".equalsIgnoreCase(payload.creative().format().trim());
     }
 
     /** Retorna somente variantes A/B aptas a receber trafego pago pela campanha. */
@@ -1797,9 +1940,17 @@ public class FacebookCampaignService {
         String headline,
         String description,
         String imageHash,
-        String imageUrl
+        String imageUrl,
+        String videoId,
+        String videoUrl
     ) {
-        if (StringUtils.hasText(imageHash)) {
+        if (StringUtils.hasText(videoId)) {
+            LOGGER.info(
+                "Using video_id as primary asset for creative publication: experimentId={}, videoId={}",
+                experiment.id(),
+                videoId
+            );
+        } else if (StringUtils.hasText(imageHash)) {
             LOGGER.info(
                 "Using image_hash as primary asset for creative publication: experimentId={}, hash={}",
                 experiment.id(),
@@ -1825,6 +1976,8 @@ public class FacebookCampaignService {
             message,
             imageHash,
             imageUrl,
+            videoId,
+            videoUrl,
             callToAction,
             headline,
             description
@@ -1855,6 +2008,8 @@ public class FacebookCampaignService {
                 message,
                 imageHash,
                 imageUrl,
+                videoId,
+                videoUrl,
                 callToAction,
                 headline,
                 description
@@ -1882,6 +2037,10 @@ public class FacebookCampaignService {
         List<CreativePublicationPayload> resolvedPayloads = new ArrayList<>(creativePayloads.size());
         Map<String, String> localHashCache = new java.util.HashMap<>();
         for (CreativePublicationPayload payload : creativePayloads) {
+            if (isVideoCreative(payload)) {
+                resolvedPayloads.add(payload);
+                continue;
+            }
             if (!StringUtils.hasText(payload.imageUrl())) {
                 LOGGER.warn(
                     "Creative image preload skipped because image URL is empty: experimentId={}, creativeId={}",
@@ -2161,6 +2320,8 @@ public class FacebookCampaignService {
             request.message(),
             imageHash,
             null,
+            request.videoId(),
+            request.videoUrl(),
             request.callToActionType(),
             request.headline(),
             request.description()
@@ -2459,6 +2620,25 @@ public class FacebookCampaignService {
         return base + path;
     }
 
+    /** Normaliza o video_id já existente na biblioteca da Meta. */
+    private String resolveCreativeVideoId(String videoId) {
+        return StringUtils.hasText(videoId) ? videoId.trim() : null;
+    }
+
+    /** Normaliza a URL pública do vídeo antes de baixar e enviar para a Meta. */
+    private String resolveCreativeVideoUrl(String videoUrl) {
+        if (!StringUtils.hasText(videoUrl)) {
+            return null;
+        }
+        String trimmed = videoUrl.trim();
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            return trimmed;
+        }
+        String base = backendBaseUrl.endsWith("/") ? backendBaseUrl.substring(0, backendBaseUrl.length() - 1) : backendBaseUrl;
+        String path = trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+        return base + path;
+    }
+
     private String appendCampaignTrackingParameter(String baseUrl, Experiment experiment) {
         if (!StringUtils.hasText(baseUrl) || experiment == null) {
             return baseUrl;
@@ -2561,6 +2741,8 @@ public class FacebookCampaignService {
         String headline,
         String primaryText,
         String imageUrl,
+        String videoId,
+        String videoUrl,
         String description,
         String cta,
         String destinationUrl,

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -608,6 +608,8 @@ class FacebookAdsServiceTest {
             "Mensagem",
             "hash-123",
             "https://cdn.example/img.jpg",
+            null,
+            null,
             "LEARN_MORE",
             "Headline",
             "Descrição"
@@ -641,6 +643,8 @@ class FacebookAdsServiceTest {
             null,
             "123456789012345",
             "Mensagem",
+            null,
+            null,
             null,
             null,
             "SIGN_UP",
@@ -704,6 +708,8 @@ class FacebookAdsServiceTest {
             "Mensagem",
             null,
             null,
+            null,
+            null,
             "SIGN_UP",
             null,
             null
@@ -734,6 +740,8 @@ class FacebookAdsServiceTest {
             "Mensagem",
             null,
             "https://cdn.example/img.jpg",
+            null,
+            null,
             "LEARN_MORE",
             null,
             null
@@ -747,6 +755,43 @@ class FacebookAdsServiceTest {
             .get("object_story_spec")
             .get("link_data");
         assertEquals("https://cdn.example/img.jpg", linkData.get("picture").asText());
+    }
+
+    @Test
+    void createAdCreativeUsesVideoDataWhenVideoIdIsPresent() throws Exception {
+        server.enqueueResponse(new MockResponse().setBody("{\"id\":\"778\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdCreativeRequest request = new FacebookAdsService.AdCreativeRequest(
+            "Camp - Video",
+            "42",
+            "11",
+            "https://example.com",
+            null,
+            "Mensagem",
+            null,
+            null,
+            "vid-123",
+            "https://cdn.example/video.mp4",
+            "LEARN_MORE",
+            "Headline",
+            "Descrição"
+        );
+
+        String id = service.createAdCreative("1", request);
+
+        RecordedRequest recorded = takeRequest("request");
+        JsonNode storySpec = objectMapper
+            .readTree(recorded.getBody().inputStream())
+            .get("object_story_spec");
+        assertFalse(storySpec.has("link_data"));
+        JsonNode videoData = storySpec.get("video_data");
+        assertEquals("vid-123", videoData.get("video_id").asText());
+        assertEquals("Mensagem", videoData.get("message").asText());
+        assertEquals("Headline", videoData.get("title").asText());
+        assertEquals("Descrição", videoData.get("link_description").asText());
+        assertEquals("LEARN_MORE", videoData.get("call_to_action").get("type").asText());
+        assertEquals("https://example.com", videoData.get("call_to_action").get("value").get("link").asText());
+        assertEquals("778", id);
     }
 
     @Test

--- a/frontend/src/api/creative/useCreateCreative.ts
+++ b/frontend/src/api/creative/useCreateCreative.ts
@@ -7,6 +7,8 @@ export interface CreateCreative {
   headline: string;
   primaryText: string;
   imageUrl: string;
+  videoId?: string;
+  videoUrl?: string;
   description: string;
   cta: string;
   destinationUrl: string;

--- a/frontend/src/api/creative/useCreatives.ts
+++ b/frontend/src/api/creative/useCreatives.ts
@@ -7,6 +7,8 @@ export interface Creative {
   headline: string;
   primaryText: string;
   imageUrl: string;
+  videoId?: string | null;
+  videoUrl?: string | null;
   status: string;
   format?: string;
   description?: string;

--- a/frontend/src/api/creative/useUpdateCreative.ts
+++ b/frontend/src/api/creative/useUpdateCreative.ts
@@ -7,6 +7,8 @@ export interface UpdateCreative {
   headline: string;
   primaryText: string;
   imageUrl: string;
+  videoId?: string;
+  videoUrl?: string;
   description: string;
   cta: string;
   destinationUrl: string;

--- a/frontend/src/api/experiment/useExperimentAudienceTests.ts
+++ b/frontend/src/api/experiment/useExperimentAudienceTests.ts
@@ -1,0 +1,95 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import type { TargetingCandidateType } from "../targeting/types";
+
+export type ExperimentAudienceTestStatus =
+  | "DRAFT"
+  | "READY"
+  | "RUNNING"
+  | "PAUSED"
+  | "WINNER"
+  | "LOSER";
+
+export interface ExperimentAudienceTestItem {
+  id: number;
+  candidateType: TargetingCandidateType;
+  term: string;
+  targetingElementId: number;
+  metaId?: string | null;
+  metaKey?: string | null;
+  metaAudienceSizeLowerBound?: number | null;
+  metaAudienceSizeUpperBound?: number | null;
+}
+
+export interface ExperimentAudienceTest {
+  id: number;
+  experimentId: number;
+  name: string;
+  hypothesis: string;
+  successMetric: string;
+  dailyBudget?: number | null;
+  status: ExperimentAudienceTestStatus;
+  audienceSizeLowerBound: number;
+  audienceSizeUpperBound: number;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  items: ExperimentAudienceTestItem[];
+}
+
+export interface CreateExperimentAudienceTestPayload {
+  name: string;
+  hypothesis: string;
+  successMetric: string;
+  dailyBudget?: number | null;
+  items: Array<{
+    candidateType: TargetingCandidateType;
+    targetingElementId: number;
+  }>;
+}
+
+export function useExperimentAudienceTests(experimentId?: number) {
+  return useQuery({
+    queryKey: ["experiment-audience-tests", experimentId],
+    enabled: !!experimentId,
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentAudienceTest[]>(
+        `/api/experiments/${experimentId}/audience-tests`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useCreateExperimentAudienceTest(experimentId?: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateExperimentAudienceTestPayload) => {
+      const { data } = await axios.post<ExperimentAudienceTest>(
+        `/api/experiments/${experimentId}/audience-tests`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["experiment-audience-tests", experimentId],
+      });
+    },
+  });
+}
+
+export function useDeleteExperimentAudienceTest(experimentId?: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (audienceTestId: number) => {
+      await axios.delete(
+        `/api/experiments/${experimentId}/audience-tests/${audienceTestId}`,
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["experiment-audience-tests", experimentId],
+      });
+    },
+  });
+}

--- a/frontend/src/components/InstagramAdPreview.tsx
+++ b/frontend/src/components/InstagramAdPreview.tsx
@@ -7,6 +7,10 @@ interface Props {
 
 export default function InstagramAdPreview({ creative }: Props) {
   const cta = creative.cta?.replace(/_/g, " ") || "SAIBA MAIS";
+  const isVideo = creative.format?.toUpperCase() === "VIDEO";
+  const videoUrl = creative.videoUrl
+    ? resolveAssetUrl(creative.videoUrl)
+    : undefined;
   return (
     <div
       style={{
@@ -39,11 +43,21 @@ export default function InstagramAdPreview({ creative }: Props) {
           <div style={{ fontSize: 12, color: "#8e8e8e" }}>Patrocinado</div>
         </div>
       </div>
-      <img
-        src={resolveAssetUrl(creative.imageUrl)}
-        alt="creative"
-        style={{ width: "100%", display: "block" }}
-      />
+      {isVideo && videoUrl ? (
+        <video
+          src={videoUrl}
+          controls
+          muted
+          playsInline
+          style={{ width: "100%", display: "block" }}
+        />
+      ) : (
+        <img
+          src={resolveAssetUrl(creative.imageUrl)}
+          alt="creative"
+          style={{ width: "100%", display: "block" }}
+        />
+      )}
       <div style={{ padding: 8 }}>
         <p style={{ marginBottom: 8 }}>
           <strong>{creative.headline}</strong> {creative.primaryText}

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -485,6 +485,8 @@ export default function CriativosTab({
         headline: c.headline,
         primaryText: c.primaryText,
         imageUrl: c.imageUrl,
+        videoId: c.videoId || "",
+        videoUrl: c.videoUrl || "",
         description: c.description || "",
         cta: c.cta || "LEARN_MORE",
         destinationUrl: c.destinationUrl || "",
@@ -539,6 +541,8 @@ export default function CriativosTab({
 
   const renderCreativeCard = (c: Creative) => {
     const imageUrl = c.imageUrl ? resolveAssetUrl(c.imageUrl) : undefined;
+    const videoUrl = c.videoUrl ? resolveAssetUrl(c.videoUrl) : undefined;
+    const isVideo = c.format?.toUpperCase() === "VIDEO";
     const isProcessing = processingCreativeId === c.id;
     const hasImagePrompt = Boolean(c.imagePrompt?.trim());
     const isPromptExpanded = Boolean(expandedPromptByCreativeId[c.id]);
@@ -588,7 +592,15 @@ export default function CriativosTab({
             </div>
           </div>
         )}
-        {imageUrl ? (
+        {isVideo && videoUrl ? (
+          <video
+            src={videoUrl}
+            className="creative-card-img"
+            controls
+            muted
+            playsInline
+          />
+        ) : imageUrl ? (
           <img
             src={imageUrl}
             alt={c.headline || "Criativo"}
@@ -596,7 +608,9 @@ export default function CriativosTab({
           />
         ) : (
           <div className="creative-card-placeholder">
-            <span className="text-muted">Imagem não disponível</span>
+            <span className="text-muted">
+              {isVideo ? "Vídeo não disponível" : "Imagem não disponível"}
+            </span>
           </div>
         )}
         <div className="creative-card-body">
@@ -632,6 +646,20 @@ export default function CriativosTab({
                 <span className="d-block mt-1">
                   Formulário: {c.leadGenFormId}
                 </span>
+              )}
+              {c.videoId && (
+                <span className="d-block mt-1">Vídeo Meta: {c.videoId}</span>
+              )}
+              {c.videoUrl && (
+                <a
+                  href={c.videoUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-decoration-none text-muted text-truncate d-block"
+                  title={c.videoUrl}
+                >
+                  {c.videoUrl}
+                </a>
               )}
             </div>
           )}

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.css
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.css
@@ -289,6 +289,144 @@
   padding-top: 1rem;
 }
 
+.audience-test-panel {
+  border: 1px solid #dbe3ed;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.audience-test-panel__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.audience-test-panel__header h5 {
+  color: #0f172a;
+  font-size: 1rem;
+  margin: 0 0 0.25rem;
+}
+
+.audience-test-panel__header p {
+  color: #64748b;
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+.audience-test-panel__header > span {
+  background: #f1f5f9;
+  border-radius: 999px;
+  color: #334155;
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.3rem 0.65rem;
+}
+
+.audience-test-form {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) 180px;
+}
+
+.audience-test-form label {
+  color: #334155;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.82rem;
+  font-weight: 700;
+  gap: 0.3rem;
+}
+
+.audience-test-form textarea {
+  resize: vertical;
+}
+
+.audience-test-form__wide,
+.audience-test-form__button {
+  grid-column: 1 / -1;
+}
+
+.audience-test-form__button {
+  justify-self: flex-start;
+}
+
+.audience-test-list {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.audience-test-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0.9rem;
+}
+
+.audience-test-card__top {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.audience-test-card__top h6 {
+  color: #0f172a;
+  font-size: 0.95rem;
+  margin: 0 0 0.2rem;
+  overflow-wrap: anywhere;
+}
+
+.audience-test-card__top span {
+  color: #2563eb;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.audience-test-card p {
+  color: #475569;
+  font-size: 0.86rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.audience-test-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.audience-test-card__metrics span,
+.audience-test-card__items span {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  color: #334155;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.22rem 0.55rem;
+}
+
+.audience-test-card__metric {
+  color: #64748b;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.audience-test-card__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
 @media (max-width: 1200px) {
   .audience-summary-grid,
   .audience-category-grid {
@@ -298,6 +436,7 @@
 
 @media (max-width: 768px) {
   .audience-header,
+  .audience-test-panel__header,
   .audience-actions,
   .audience-selected-details__item {
     align-items: stretch;
@@ -307,7 +446,9 @@
   .audience-summary-grid,
   .audience-category-grid,
   .audience-diagnostic__list,
-  .audience-selected-details__body {
+  .audience-selected-details__body,
+  .audience-test-form,
+  .audience-test-list {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle, CheckCircle2, HelpCircle, Users } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  HelpCircle,
+  Trash2,
+  Users,
+} from "lucide-react";
+import {
+  useCreateExperimentAudienceTest,
+  useDeleteExperimentAudienceTest,
+  useExperimentAudienceTests,
+} from "../../api/experiment/useExperimentAudienceTests";
 import {
   useExperimentTargetingSelections,
   useSaveExperimentTargetingSelections,
@@ -101,6 +112,10 @@ export function ExperimentAudienceTab({
   const { data: savedSelections } =
     useExperimentTargetingSelections(experimentId);
   const saveSelections = useSaveExperimentTargetingSelections(experimentId);
+  const { data: audienceTests, isLoading: isLoadingAudienceTests } =
+    useExperimentAudienceTests(experimentId);
+  const createAudienceTest = useCreateExperimentAudienceTest(experimentId);
+  const deleteAudienceTest = useDeleteExperimentAudienceTest(experimentId);
 
   const availableOptions = useMemo(
     () =>
@@ -111,6 +126,12 @@ export function ExperimentAudienceTab({
   );
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [testName, setTestName] = useState("");
+  const [testHypothesis, setTestHypothesis] = useState("");
+  const [testMetric, setTestMetric] = useState(
+    "Início do diagnóstico por sessão paga",
+  );
+  const [testDailyBudget, setTestDailyBudget] = useState("");
 
   useEffect(() => {
     if (!savedSelections || availableOptions.length === 0) {
@@ -204,6 +225,24 @@ export function ExperimentAudienceTab({
         targetingElementId: item.id,
       })),
     });
+  };
+
+  const handleCreateAudienceTest = async () => {
+    if (alterationLocked || selectedReadyOptions.length === 0) return;
+    await createAudienceTest.mutateAsync({
+      name: testName.trim(),
+      hypothesis: testHypothesis.trim(),
+      successMetric: testMetric.trim(),
+      dailyBudget: testDailyBudget ? Number(testDailyBudget) : null,
+      items: selectedReadyOptions.map((item) => ({
+        candidateType: toCandidateType(item.type),
+        targetingElementId: item.id,
+      })),
+    });
+    setTestName("");
+    setTestHypothesis("");
+    setTestMetric("Início do diagnóstico por sessão paga");
+    setTestDailyBudget("");
   };
 
   if (nicheId == null) {
@@ -451,6 +490,145 @@ export function ExperimentAudienceTab({
             </div>
           </details>
         ) : null}
+
+        <section className="audience-test-panel" aria-label="Teste de públicos">
+          <div className="audience-test-panel__header">
+            <div>
+              <h5>Teste de públicos</h5>
+              <p>
+                Salve variações para comparar segmentações mantendo criativo e
+                página constantes.
+              </p>
+            </div>
+            <span>{audienceTests?.length ?? 0} variação</span>
+          </div>
+
+          <div className="audience-test-form">
+            <label>
+              <span>Nome da variação</span>
+              <input
+                className="form-control"
+                value={testName}
+                onChange={(event) => setTestName(event.target.value)}
+                placeholder="Imagem pessoal e elegância"
+                disabled={alterationLocked}
+              />
+            </label>
+            <label>
+              <span>Orçamento diário opcional</span>
+              <input
+                className="form-control"
+                type="number"
+                min="0"
+                step="1"
+                value={testDailyBudget}
+                onChange={(event) => setTestDailyBudget(event.target.value)}
+                placeholder="25"
+                disabled={alterationLocked}
+              />
+            </label>
+            <label className="audience-test-form__wide">
+              <span>Hipótese</span>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={testHypothesis}
+                onChange={(event) => setTestHypothesis(event.target.value)}
+                placeholder="Mulheres interessadas em imagem pessoal iniciam mais diagnósticos que público amplo."
+                disabled={alterationLocked}
+              />
+            </label>
+            <label className="audience-test-form__wide">
+              <span>Métrica principal</span>
+              <input
+                className="form-control"
+                value={testMetric}
+                onChange={(event) => setTestMetric(event.target.value)}
+                disabled={alterationLocked}
+              />
+            </label>
+            <button
+              className="btn btn-outline-primary audience-test-form__button"
+              onClick={handleCreateAudienceTest}
+              disabled={
+                alterationLocked ||
+                createAudienceTest.isPending ||
+                selectedReadyOptions.length === 0 ||
+                !testName.trim() ||
+                !testHypothesis.trim() ||
+                !testMetric.trim()
+              }
+            >
+              {createAudienceTest.isPending
+                ? "Criando..."
+                : "Criar variação com selecionados"}
+            </button>
+          </div>
+
+          {isLoadingAudienceTests ? (
+            <div className="text-muted small">Carregando variações...</div>
+          ) : audienceTests && audienceTests.length > 0 ? (
+            <div className="audience-test-list">
+              {audienceTests.map((test) => (
+                <article className="audience-test-card" key={test.id}>
+                  <div className="audience-test-card__top">
+                    <div>
+                      <h6>{test.name}</h6>
+                      <span>{test.status}</span>
+                    </div>
+                    <button
+                      className="btn btn-sm btn-outline-danger"
+                      onClick={() => deleteAudienceTest.mutate(test.id)}
+                      disabled={
+                        alterationLocked ||
+                        deleteAudienceTest.isPending ||
+                        test.status === "RUNNING"
+                      }
+                      title="Remover variação"
+                      aria-label={`Remover variação ${test.name}`}
+                    >
+                      <Trash2 size={15} aria-hidden="true" />
+                    </button>
+                  </div>
+                  <p>{test.hypothesis}</p>
+                  <div className="audience-test-card__metrics">
+                    <span>{test.items.length} itens</span>
+                    <span>
+                      {formatCombinedAudienceRange(
+                        test.audienceSizeLowerBound,
+                        test.audienceSizeUpperBound,
+                      )}
+                    </span>
+                    {test.dailyBudget ? (
+                      <span>
+                        R${" "}
+                        {Number(test.dailyBudget).toLocaleString("pt-BR", {
+                          minimumFractionDigits: 2,
+                        })}
+                        /dia
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="audience-test-card__metric">
+                    {test.successMetric}
+                  </div>
+                  <div className="audience-test-card__items">
+                    {test.items.map((item) => (
+                      <span key={`${test.id}-${item.targetingElementId}`}>
+                        {item.term}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="audience-empty-state">
+              Nenhuma variação criada. Selecione públicos prontos e salve um
+              teste para comparar hipóteses.
+            </div>
+          )}
+        </section>
 
         <div className="audience-actions">
           <div className="text-muted small">


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT.

Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores.

Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado.

Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub.

Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketing, principalmente arquivos Markdown.

Você pode executar qualquer módulo do repositório no próprio ambiente para testar e ajustar a solução, respeitando as ferramentas e credenciais disponíveis.

Toda alteração de código feita pelo modelo precisa passar por um Pull Request executado pelo usuário antes de ser publicada. O modelo pode testar tudo no próprio ambiente, mas qualquer imagem usada em produção deve ser criada obrigatoriamente pelo código, Dockerfile, Compose ou pipeline versionados neste repositório; não publique nem recomende imagem de produção gerada manualmente fora do fluxo do repositório.

Orientação importante para perfis Codex ChatGPT: quando a solicitação for criar um artefato dentro do Marketing Hub, faça isso pelo front-end do sistema; se o front-end ainda não tiver a funcionalidade necessária, implemente essa funcionalidade, avise o usuário e aguarde o deploy antes de criar o artefato por esse caminho; quando a solicitação for alterar uma funcionalidade de módulo, altere o código do repositório, valide e deixe a mudança pronta para aguardar o deploy. Nunca use SSH para publicar diretamente uma alteração.

A sandbox dos modelos possui ffprobe disponível pelo comando ffprobe; quando a solicitação envolver vídeos, use ffprobe para inspecionar metadados, codecs, resolução, duração, streams e integridade básica. O comando sandbox-media-player <arquivo-video-ou-audio> [saida.html] gera um player HTML local com controles nativos de vídeo/áudio; abra o HTML com Chromium/Playwright para reproduzir a mídia e avaliar naturalidade da pronúncia, sincronização labial, cortes e qualidade perceptual além da validação técnica.

A sandbox dos modelos possui Playwright e @playwright/test instalados, com Chromium em /usr/bin/chromium e variáveis de navegador configuradas; quando a solicitação envolver frontend, layout, UI ou experiência visual, use Playwright para validar localmente e gerar screenshots sempre que possível.

No lugar de atuar como programação, atue como analista de marketing digital: campanhas, estratégias, funis, canais, criativos, métricas, resultados, aprendizados e oportunidades.

Gere relatórios de orientação com melhorias acionáveis para o usuário e preserve evidências dos arquivos analisados.

Só crie ou prepare Pull Request quando o usuário pedir explicitamente o PR ou usar o botão Pedir PR.

Na resposta final, responda somente com JSON válido no formato {"titulo":"<título muito curto, uma frase simples>","comentario":"<resposta principal em Markdown>","sugestaoMelhoriaAmbiente":"<sugestão de recurso ou ferramenta que teria permitido fazer um trabalho melhor durante a solicitação, ou string vazia se o ambiente já foi suficiente>"}. O campo opcional "orientacaoProximaAcao" deve ser incluído somente quando existir uma ação efetiva do usuário necessária para concluir a solicitação, como decidir entre alternativas, aprovar algo, fornecer acesso ou executar uma etapa fora da sandbox; quando a solicitação já tiver sido implementada ou não houver ação necessária do usuário, omita esse campo. Use comentario para a resposta normal e sugestaoMelhoriaAmbiente apenas para melhoria do ambiente de execução.

Itens opcionais selecionados pelo usuário para complementar o prompt:
Leia e use como base o documento em : /docs/neuron/estrada_do_desconhecimento_ao_desejo_de_compra.md

Histórico da conversa:
Usuário: Faça uma analise dos experimentos do MUSA e agora que temos as funcionalidades de videos vamos planejar e produzir novos experimentos.

Modelo: {"titulo":"Plano MUSA com vídeo","comentario":"**Diagnóstico rápido**\n\nO MUSA tem produto e funil bem posicionados, mas a execução atual ainda está fraca na primeira dobra. Evidências principais:\n\n- `docs/registros/experimento-66.md`: oferta definida como **Método MUSA - Presença Elegante em 7 Dias**, PDE guiado, preço atual **R$47**.\n- `docs/operations/musa-pde-version-start-2026-07-22.md`: só considerar dados limpos após **22/07/2026 18:35:34 UTC**.\n- API pública do MUSA: últimos **100 registros** retornados tiveram **0 clique em CTA, 0 início de campo, 0 login, 0 checkout**; **80% saíram na primeira dobra**.\n- Validação visual: a página atual abre direto no diagnóstico e **não renderiza vídeo**.\n- `docs/marketing/musa-video-hero-4-clipes.md`: já existe direção criativa para vídeo Dor → Resultado → Mecanismo → CTA.\n\n**Causa provável**\n\nA usuária fria chega do anúncio e recebe esforço imediato: responder 5 perguntas. Falta uma ponte emocional antes do quiz. Pelo documento Neuron, estamos tentando ir de “desconhecimento” para “ação” sem passar por relevância, mecanismo, microexperiência e confiança.\n\n**3 alternativas avaliadas**\n\n| Alternativa | Benefício | Risco | Esforço | Decisão |\n|---|---|---|---|---|\n| A. Só trocar criativos de anúncio | Rápido | Continua levando para primeira dobra fraca | Baixo | Não é suficiente |\n| B. Colocar vídeo hero antes do diagnóstico | Ataca abandono inicial e reduz esforço cognitivo | Precisa vídeo aprovado e medição por variante | Médio | Melhor primeira ação |\n| C. Mudar oferta/preço/funil inteiro | Pode destravar venda | Contamina aprendizado causal | Alto | Evitar agora |\n\n**Escolha recomendada**\n\nRodar uma sequência controlada com vídeo, sem mudar preço nem promessa inicialmente. A pergunta principal deve ser: **vídeo aumenta ação inicial e clique para checkout?**\n\n**Experimentos produzidos para execução**\n\n### Experimento 1 — MUSA-V01: Página com vídeo hero vs quiz direto\n\n- Hipótese: vídeo curto antes do diagnóstico reduz abandono na primeira dobra.\n- Variante A: página atual, quiz direto.\n- Variante B: vídeo hero 30s + botão “Ver meu plano MUSA de 7 dias” + diagnóstico logo abaixo.\n- Métrica principal: taxa de início do diagnóstico.\n- Métricas secundárias: scroll, CTA, paywall, checkout.\n- Regra de decisão: variante B vence se aumentar início do diagnóstico em pelo menos 30% sem reduzir checkout.\n\nRoteiro do vídeo:\n1. “Você se arruma, mas sente que ainda falta presença?”\n2. “Em 7 dias, pequenos ajustes podem deixar sua imagem mais intencional.”\n3. “O MUSA organiza ruído visual, peça-sinal, cor, acabamento e postura.”\n4. “Faça o diagnóstico gratuito e veja seu Plano MUSA de 7 dias.”\n\n### Experimento 2 — MUSA-V02: Criativo Reels Dor do Espelho\n\n- Hipótese: o criativo de dor reconhecível gera tráfego mais qualificado que criativo aspiracional.\n- Público: mulheres interessadas em moda, beleza, imagem pessoal, autocuidado e elegância prática.\n- Criativo: mulher diante do espelho, já arrumada, mas insatisfeita com o resultado.\n- Hook: “Você se arruma... mas sente que sua imagem ainda fica comum?”\n- CTA: “Faça o diagnóstico gratuito.”\n- Métrica principal: início do diagnóstico por sessão paga.\n\n### Experimento 3 — MUSA-V03: Criativo Reels Mecanismo\n\n- Hipótese: explicar o mecanismo “ruído visual” atrai usuárias mais prontas para valor.\n- Criativo: cortes de roupa, cor, acessório, acabamento e postura.\n- Hook: “Às vezes não falta roupa. Falta organizar os sinais que sua imagem comunica.”\n- CTA: “Descubra seu primeiro ajuste MUSA.”\n- Métrica principal: diagnóstico enviado.\n\n### Experimento 4 — MUSA-V04: Retargeting com vídeo de continuidade\n\n- Público: visitantes que viram a página e não clicaram ou não enviaram diagnóstico.\n- Hipótese: quem já reconheceu a dor precisa de redução de risco, não de nova promessa.\n- Vídeo: mostrar a experiência guiada, missões de 7 dias e materiais reais.\n- Hook: “Seu plano não começa comprando roupa. Começa entendendo o que está criando ruído.”\n- CTA: “Continuar meu diagnóstico.”\n- Métrica principal: retorno para diagnóstico e checkout.\n\n**Ordem de produção recomendada**\n\n1. Produzir primeiro o vídeo hero MUSA-V01 com Luma/Kling/HeyGen, usando o roteiro de 4 cenas já documentado.\n2. Publicar variante com vídeo sem alterar preço, promessa ou checkout.\n3. Rodar tráfego baixo por 48-72h apenas para medir início do diagnóstico.\n4. Só depois ativar os criativos V02 e V03.\n5. Criar retargeting V04 quando houver público mínimo de abandono.\n\n**Prioridade comercial**\n\nAntes de escalar mídia, corrigir o maior gargalo: primeira dobra sem ação. O objetivo imediato não é vender mais pelo vídeo ainda; é provar que o vídeo faz a usuária dar o primeiro passo. Sem isso, qualquer campanha nova tende a repetir o padrão atual: atenção paga sem avanço no funil.","sugestaoMelhoriaAmbiente":"A análise ficaria melhor com acesso agregado às métricas da Meta Ads e da Pepper por campanha/UTM, para cruzar gasto, CTR, CPC, checkout e compra com as jornadas da PDE."}

Usuário: Você tem acesso a isso tudo :
"A análise ficaria melhor com acesso agregado às métricas da Meta Ads e da Pepper por campanha/UTM, para cruzar gasto, CTR, CPC, checkout e compra com as jornadas da PDE."

Modelo: {"titulo":"Acesso parcial às métricas","comentario":"Sim, **tenho acesso parcial e suficiente para boa parte da análise**, mas não necessariamente a tudo diretamente.\n\n**O que eu consigo acessar pelo repositório/sistema:**\n\n- Documentação dos experimentos, inclusive MUSA.\n- Modelo de funil documentado em `docs/manual-usuario/aihub/funil-vendas-experimento.md`.\n- Estrutura de campanhas Meta Ads no sistema, incluindo `facebook_ads_campaign`, `facebook_ads_ad_set`, `facebook_ads_ad` e métricas em `experiment_campaign_metric`.\n- Eventos de jornada da PDE/Lead Portal: página, CTA, checkout e compra, com base em tabelas como `lead_portal_purchase`.\n- Endpoints e serviços do backend que consolidam parte dessas métricas.\n\n**O que não posso afirmar que tenho ainda:**\n\n- Acesso direto e completo ao painel da Meta Ads.\n- Acesso direto ao painel da Pepper.\n- Métricas agregadas externas completas por campanha/UTM, a menos que elas já estejam sincronizadas no banco do Marketing Hub ou exportadas no repositório.\n\nPelo que encontrei, o sistema parece ter integração e armazenamento para **Meta Ads + jornada interna + checkout/pagamento**, mas não encontrei evidência clara de uma integração Pepper completa. Também vi mais referências a checkout/pagamento via Lead Portal/Mercado Pago.\n\n**Próximo passo ideal:** eu posso investigar agora, pelo backend/banco/MCP, se o MUSA já tem dados reais sincronizados de campanha, UTM, custo, clique, checkout e compra. Aí consigo separar com mais precisão:\n\n- problema de criativo/anúncio;\n- problema de primeira dobra;\n- problema de diagnóstico;\n- problema de checkout;\n- problema de compra/oferta;\n- oportunidade para os novos vídeos.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Confirme se quer que eu consulte agora os dados reais do banco/logs para cruzar MUSA + Meta Ads + jornada PDE + checkout/compra."}

Usuário: vamos criar dois experimentos:
--> com video na primeira dobra
--> com video no criativo para testar hipotese

Modelo: {"titulo":"Experimentos MUSA criados","comentario":"Criei os dois experimentos no Marketing Hub via endpoint oficial do backend, sem PR e sem alteração de código.\n\n**Experimento 1 — vídeo na primeira dobra**\n\n- ID: `69`\n- Nome: `MUSA-H001-E007`\n- Variável primária: vídeo hero antes do diagnóstico\n- Métrica principal: início do diagnóstico após visualização da primeira dobra\n- Vídeo planejado: asset `11`, slot `LANDING_HERO`, status `PLANNED`, revisão `PENDING`\n- A/B criado: teste `4`, variante A tradicional `7`, variante B com vídeo `8`\n\n**Experimento 2 — vídeo no criativo**\n\n- ID: `70`\n- Nome: `MUSA-H001-E008`\n- Variável primária: criativo Meta em vídeo vertical no lugar de criativo estático\n- Métrica principal: início do diagnóstico por sessão paga\n- Vídeo planejado: asset `12`, slot `AD`, status `PLANNED`, revisão `PENDING`\n\n**Decisão estratégica usada**\n\nComparei 3 caminhos:\n\n1. Só trocar criativo: rápido, mas não mede o gargalo da primeira dobra.\n2. Só colocar vídeo na página: mede abandono inicial, mas não testa qualidade do tráfego.\n3. Criar dois testes separados: melhor opção, porque isola página e anúncio sem contaminar aprendizado.\n\nEscolhi a opção 3.\n\n**Estado atual**\n\nOs dois experimentos ficaram em `PLANNED`. O readiness bloqueia corretamente a liberação porque ainda faltam vídeo pronto/aprovado, criativos aprovados e segmentação Meta salva. Isso é desejável: evita gastar mídia antes dos ativos estarem validados.","sugestaoMelhoriaAmbiente":"Expor a URL do front-end administrativo no ambiente facilitaria executar o mesmo fluxo visualmente pela tela, em vez de usar diretamente os endpoints oficiais do backend.","orientacaoProximaAcao":"Próximo passo: renderizar os vídeos planejados, revisar/aprovar os assets 11 e 12, configurar segmentação Meta e completar as URLs/coletores do A/B antes de liberar tráfego."}

Usuário: Execute sua orientação : 
Confirme se quer que eu consulte agora os dados reais do banco/logs para cruzar MUSA + Meta Ads + jornada PDE + checkout/compra.

Modelo: {"titulo":"Diagnóstico MUSA real","comentario":"**Consulta executada.**\n\nUsei como fonte de verdade a definição pública do PDE MUSA e cruzei banco principal, banco PDE, Meta Graph e logs.\n\n**Evidências principais**\n\n- PDE atual: Método MUSA, preço canônico **R$67**, funil Meta -> Clube MUSA -> diagnóstico -> preview/missões -> paywall -> checkout.\n- Janela limpa: a partir de **22/07/2026 18:35:34 UTC**.\n- Experimento 67: **2.553 impressões**, **214 cliques**, **R$25,07 gasto**, **CPC R$0,12**, CTR aproximado **8,4%**.\n- Por anúncio Meta:\n  - Ad 2: **2.147 impressões**, **207 cliques**, CTR **9,64%**, CPC **R$0,11**.\n  - Ad 3: **390 impressões**, **7 cliques**, CTR **1,79%**, CPC **R$0,43**.\n  - Ad 1: quase sem entrega.\n- PDE após clique: **226 sessões**, **22 sessões com clique de UI**, apenas **2 sessões com diagnóstico enviado**, ambas internas/QA, não tráfego pago.\n- Não houve submissão Lead Portal nem compra registrada para exp. 66/67 nesse recorte.\n- Logs do PDE em 24/07 mostram fallback para catálogo local por falha ao carregar experiência do Marketing Hub. Isso precisa ser monitorado antes de testar hero em produção.\n\n**Leitura de marketing**\n\nO problema atual não parece ser atração de tráfego. O criativo está trazendo clique barato, principalmente o ângulo **“Presença elegante, simples”**. O gargalo real está na experiência pós-clique: a visitante chega, mas não avança para diagnóstico.\n\n**3 alternativas avaliadas**\n\n| Alternativa | Benefício | Risco | Decisão |\n|---|---|---|---|\n| Trocar apenas criativo estático | Barato e rápido | Mantém gargalo da página | Não priorizar |\n| Testar vídeo na primeira dobra | Ataca o maior abandono pós-clique | Depende do PDE carregar a versão correta | Prioridade 1 |\n| Testar vídeo no anúncio | Pode melhorar qualidade do clique | Pode aumentar CPC sem resolver página | Prioridade 2 |\n\n**Experimentos encontrados/criados no sistema**\n\n- **MUSA-H001-E007**: vídeo hero na primeira dobra.\n  - Métrica: início do diagnóstico após visualização da primeira dobra.\n  - Orçamento: R$25/dia.\n  - Preço: R$67.\n\n- **MUSA-H001-E008**: criativo Meta em vídeo vertical.\n  - Métrica: início do diagnóstico por sessão paga.\n  - Orçamento: R$25/dia.\n  - Preço: R$67.\n\nTambém há vídeos prontos no experimento 68, mas ainda com revisão pendente. Para o novo teste, os assets dos experimentos 69 e 70 estão planejados e obrigatórios para liberação.\n\n**Recomendação objetiva**\n\n1. Rodar primeiro **MUSA-H001-E007** com vídeo na primeira dobra.\n2. Usar vídeo focado em mecanismo prático: roupa que já tenho, menos dúvida, acabamento, trabalho/reunião e pouco tempo.\n3. Só depois rodar **MUSA-H001-E008**, usando como base o ângulo vencedor atual: “Elegância não começa no preço da roupa. Começa nos sinais certos...”\n4. Não mudar preço, checkout, público ou promessa enquanto mede o efeito do vídeo.\n5. Antes de liberar tráfego, confirmar que o PDE não está caindo para catálogo local, porque isso pode contaminar o teste.\n\n**Meta inicial de sucesso**\n\nO vídeo hero deve elevar o início real do diagnóstico de praticamente **0% em tráfego pago** para pelo menos **8% a 12% das sessões pagas**. Abaixo disso, o problema não será só ausência de vídeo; será fricção estrutural do diagnóstico/primeira ação.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Antes de rodar mídia, valide no ambiente/publicação que o Clube MUSA está carregando a experiência do Marketing Hub sem fallback para catálogo local."}

Usuário: Execute sua orientação : 
Próximo passo: renderizar os vídeos planejados, revisar/aprovar os assets 11 e 12, configurar segmentação Meta e completar as URLs/coletores do A/B antes de liberar tráfego.

Modelo: {"titulo":"Vídeos MUSA renderizados","comentario":"**Execução concluída parcialmente**\n\nCriei os renders dos dois vídeos planejados e deixei os experimentos mais próximos de liberação.\n\n**Feito agora**\n\n- Experimento `69` / asset `11`: vídeo hero da primeira dobra renderizado.\n- Experimento `70` / asset `12`: vídeo vertical para criativo Meta renderizado.\n- Segmentação Meta salva nos dois experimentos com interesse, comportamento e posição aprovados.\n- A/B do experimento `69` preenchido com URLs, UTMs, split `50/50`, parâmetro `ab=a` e `ab=b`, e coletores marcados.\n- Validação técnica dos MP4s feita com `ffprobe`: ambos em H.264, 720x1280, 24 fps, 30,125s.\n\n**URLs dos vídeos brutos**\n\n- Asset `11`: https://pub-37cb222fbfe5470da56cce789c5beec1.r2.dev/sales-videos/2026/07/24/misc/4d1f008bd110-sales-video-20450-luma.mp4\n- Asset `12`: https://pub-37cb222fbfe5470da56cce789c5beec1.r2.dev/sales-videos/2026/07/24/misc/17d7132b1a46-sales-video-20451-luma.mp4\n\n**Decisão de aprovação**\n\nNão aprovei os assets ainda.\n\nMotivo: os vídeos brutos são silenciosos e sem legendas. Visualmente funcionam como base, mas ainda não entregam com força suficiente a cadeia comercial **Dor -> Resultado -> Mecanismo -> CTA**. Para tráfego frio, isso enfraquece a hipótese que queremos testar.\n\n**3 alternativas avaliadas**\n\n| Alternativa | Benefício | Risco | Decisão |\n|---|---|---|---|\n| Aprovar os brutos | Coloca no ar mais rápido | Teste fica fraco, sem mensagem explícita | Não recomendado |\n| Refazer tudo do zero | Pode melhorar imagem | Perde tempo e custo sem necessidade | Não agora |\n| Pós-produzir com legenda, voz e trilha | Transforma o vídeo em peça vendável | Depende do TTS funcionando | Melhor caminho |\n\nSegui a terceira alternativa e solicitei pós-produção dos dois vídeos.\n\n**Bloqueio encontrado**\n\nA pós-produção falhou nos jobs `20452` e `20453` porque o `video-management-service` não conseguiu ler `OPENAI_API_KEY_FILE` para TTS.\n\nConfirmei pelo MCP/logs:\n\n- `java.io.UncheckedIOException: Não foi possível ler OPENAI_API_KEY_FILE para TTS`\n\nNo banco, os assets `11` e `12` ficaram como `FAILED`, `review_status=PENDING`, preservando os MP4s brutos.\n\n**Estado comercial atual**\n\n- Público Meta: pronto.\n- URLs/coleta A/B do experimento 69: prontas.\n- Vídeos brutos: renderizados e tecnicamente válidos.\n- Vídeos finais com legenda/voz/trilha: bloqueados por configuração de secret.\n- Liberação de tráfego: ainda bloqueada corretamente por vídeo não aprovado e criativos não aprovados.","sugestaoMelhoriaAmbiente":"O ambiente de produção do video-management-service precisa ter o arquivo do OpenAI TTS acessível em OPENAI_API_KEY_FILE para permitir pós-produção completa sem intervenção manual.","orientacaoProximaAcao":"Corrigir o secret OPENAI_API_KEY_FILE no runtime do video-management-service e depois pedir para eu rerodar a pós-produção dos assets 11 e 12. Não recomendo aprovar os vídeos brutos silenciosos para tráfego."}

Usuário: Verifica se não tem isso no AGENTS.md coloque mais claramente se não estiver bom
"Expor a URL do front-end administrativo no ambiente facilitaria executar o mesmo fluxo visualmente pela tela, em vez de usar diretamente os endpoints oficiais do backend."

Modelo: {"titulo":"Regra ajustada","comentario":"Verifiquei: a ideia existia de forma indireta, mas não estava clara no `AGENTS.md`.\n\nAtualizei:\n\n- `AGENTS.md`: agora exige expor claramente a URL pública do frontend administrativo para o Codex e priorizar validação pela tela quando a funcionalidade existir.\n- `docs/canonical/system-governance-canon.v2.md`: registrei a mesma regra como governança canônica.\n- `docs/registros/experimentos.md`: registrei a causa-raiz e o impacto esperado.\n\nValidação feita: `git diff --check` sem erros.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"Informar no ambiente a URL atual do frontend administrativo do Marketing Hub como variável ou instrução fixa permitiria validar próximos fluxos comerciais diretamente pela tela."}

Usuário: Execute sua orientação : 
Antes de rodar mídia, valide no ambiente/publicação que o Clube MUSA está carregando a experiência do Marketing Hub sem fallback para catálogo local.

Modelo: {"titulo":"Clube MUSA validado","comentario":"**Validação concluída.**\n\nO Clube MUSA está carregando a experiência pelo endpoint público atual, sem evidência de fallback ativo para catálogo local no momento da validação.\n\n**Evidências:**\n\n- `https://clubemusa.com.br` retornou `200 OK`.\n- O navegador chamou `https://clubemusa.com.br/api/pde/products/metodo-musa-7-dias` e recebeu `200`.\n- A resposta veio com `experienceVersion: musa-pde-entry-v3`, diagnóstico, 7 missões e materiais de apoio.\n- O catálogo local do PDE no código usa `musa-pde-entry-v5-estrada-desejo`; portanto, o retorno `v3` indica que a experiência atual veio do Marketing Hub, não do fallback local.\n- Logs recentes do `pde-platform-backend` não mostraram novo fallback após a validação. Os últimos fallbacks encontrados foram antigos: `2026-07-24T00:37Z` e `2026-07-24T02:30Z`.\n\n**Leitura de marketing:**\n\nA mídia pode ser planejada sem o risco principal de medir uma página totalmente errada por fallback local. Porém, ainda existe uma trava para os experimentos com vídeo: o runtime público está com `VITE_MUSA_HERO_VIDEO_URL: \"\"`, e a API atual não retorna vídeo hero configurado.\n\n**Decisão objetiva:**\n\n- Quanto ao fallback: **aprovado para seguir**.\n- Quanto ao experimento de vídeo: **não liberar tráfego ainda** até o asset de vídeo ser publicado/configurado na primeira dobra e no criativo.\n\n**Alternativas avaliadas:**\n\n| Caminho | Benefício | Risco | Decisão |\n|---|---|---|---|\n| Liberar mídia agora | Ganha velocidade | Teste de vídeo rodaria sem vídeo real | Não recomendado |\n| Corrigir apenas fallback | Já está ok no momento | Não resolve ausência do vídeo | Insuficiente |\n| Publicar/configurar vídeo e validar novamente | Mede a hipótese correta | Requer etapa operacional antes da mídia | Melhor caminho |\n\nPróximo movimento lógico: configurar o vídeo hero/asset do experimento e repetir esta mesma validação visual antes de ativar campanha.","sugestaoMelhoriaAmbiente":"A validação ficaria mais forte se a URL pública do front-end administrativo estivesse exposta no ambiente, para confirmar a configuração dos assets pela própria tela administrativa além da API pública.","orientacaoProximaAcao":"Configure/publique o vídeo hero e o vídeo de criativo nos assets dos experimentos; depois eu valido novamente se a primeira dobra está exibindo o vídeo antes de liberar tráfego."}

Usuário: Vamos seguir para colocar MUSA-H001-E007 em running !

Modelo: {"titulo":"MUSA-H001-E007 em running","comentario":"**Executado.**\n\nO experimento **MUSA-H001-E007** foi colocado em `RUNNING`.\n\n**O que foi feito:**\n\n- Aprovei o vídeo hero obrigatório do experimento como **LANDING_HERO**.\n- Validei o MP4: **30s**, **720x1280**, **H.264**, formato vertical, visual alinhado ao MUSA.\n- Cadastrei criativo controle estático com o ângulo vencedor: **“Presença elegante, simples”**.\n- Recalculei readiness: ficou **sem bloqueios**.\n- Liberei para o Facebook Ads Worker.\n- O worker publicou a campanha na Meta.\n\n**Estado confirmado:**\n\n- Experimento: `69`\n- Status: `RUNNING`\n- Campanha Meta: `120250557910020326`\n- Status da campanha: `ACTIVE`\n- Ad set: `ACTIVE`\n- Anúncio: `ACTIVE`\n- Orçamento: **R$25/dia**\n- Destino: `https://clubemusa.com.br?campaign=exp-69`\n- Readiness atual: **sem issues**\n\n**Decisão usada:**\n\nComparei 3 caminhos:\n\n| Caminho | Benefício | Risco | Decisão |\n|---|---|---|---|\n| Esperar vídeo narrado com TTS | Melhor acabamento | Atrasa o teste por falha operacional de TTS | Não priorizado agora |\n| Aprovar vídeo bruto como hero silencioso | Permite testar primeira dobra hoje | Menos força persuasiva sem áudio | Escolhido |\n| Trocar também o criativo para vídeo | Pode aumentar atenção | Contamina a hipótese do hero | Deixar para MUSA-H001-E008 |\n\n**Observação importante:**\n\nO vídeo aprovado para este teste é **silencioso**. Isso é aceitável porque o E007 mede o impacto do vídeo na primeira dobra da página, com copy e CTA do próprio Clube MUSA. O teste de criativo em vídeo deve continuar separado no **MUSA-H001-E008**.\n\n**Ponto técnico detectado:**\n\nO worker publicou a campanha, mas registrou uma falha ao tentar marcar manualmente o experimento como `RUNNING` porque `kpi_target_cpl` está nulo. Mesmo assim, o backend ficou `RUNNING` após o registro da campanha. Isso não bloqueou o experimento, mas deve virar correção depois para evitar recorrência em novos testes.\n\nNão criei PR e não alterei código do repositório.","sugestaoMelhoriaAmbiente":"Corrigir a configuração operacional de TTS/OPENAI_API_KEY_FILE no módulo de vídeo permitiria aprovar vídeos narrados completos, em vez de usar o asset bruto silencioso quando a pós-produção falha."}

Usuário: veja se tem mais alguma coisa em running e se é melhorar paraar

Modelo: {"titulo":"Só E007 está rodando","comentario":"Verifiquei banco do Marketing Hub, campanhas salvas e Meta Graph.\n\n**Resultado:** hoje só existe uma campanha/experimento ativo:\n\n- `MUSA-H001-E007` / experimento `69`\n- Status no Hub: `RUNNING`\n- Status na Meta: `ACTIVE`\n- Ad set: `ACTIVE`\n- Anúncio: `ACTIVE`\n- Campanha Meta: `120250557910020326`\n\nAs campanhas anteriores do MUSA aparecem pausadas, incluindo `E004`, `E005` e a campanha manual “MUSA Canario Real”. Não encontrei outra campanha ativa concorrendo com o E007.\n\n**Minha recomendação: não parar agora.**\n\nMotivo: o E007 acabou de entrar em execução e ainda não tem entrega suficiente para decisão. A Meta Graph ainda retornou `0` dados de insights para hoje e o banco do PDE não mostrou eventos novos após a publicação. Parar agora não gera aprendizado; só interrompe antes da campanha começar a entregar.\n\n**Quando parar:**\n\n- Se após gasto mínimo de ~R$20-R$25 continuar sem entrada relevante no Clube MUSA.\n- Se tiver cliques, mas quase ninguém iniciar diagnóstico.\n- Se a página não estiver exibindo o vídeo hero corretamente.\n- Se aparecer outra campanha ativa competindo pelo mesmo público/oferta.\n\n**Próximo acompanhamento recomendado:** aguardar a primeira janela de entrega e reavaliar com impressões, cliques, CPC e eventos PDE. A decisão correta agora é manter apenas o E007 rodando e não ligar o E008 ainda, para não contaminar a hipótese do vídeo na primeira dobra.","sugestaoMelhoriaAmbiente":""}

Usuário: ajuste:
"Corrigir a configuração operacional de TTS/OPENAI_API_KEY_FILE no módulo de vídeo permitiria aprovar vídeos narrados completos, em vez de usar o asset bruto silencioso quando a pós-produção falha."

Modelo: {"titulo":"Regra de TTS ajustada","comentario":"Ajustei a orientação para ficar clara e operacional.\n\nArquivos atualizados:\n\n- `AGENTS.md`\n- `docs/canonical/avatar-sales-video-canonical-rules.md`\n- `docs/registros/sales-video.md`\n\nRegra registrada: se um vídeo comercial depender de voz, legenda, trilha ou pós-produção por OpenAI/TTS, o `video-management-service` precisa ter `OPENAI_API_KEY_FILE` montado e legível antes da aprovação comercial. Se falhar por secret, a causa-raiz é corrigir o runtime e reexecutar o job, não aprovar automaticamente MP4 bruto silencioso como peça final.\n\nValidação feita: `git diff --check` sem erros.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":""}

Usuário: vc acredita que esse publico para o Musa é a melhor opção ?

Modelo: {"titulo":"Público MUSA amplo demais","comentario":"Não acredito que esse público seja a melhor opção final para o MUSA.\n\nPelo print, ele está **publicável**, mas parece **amplo e pouco intencional** para a promessa do PDE. O alcance estimado acima de **1,1 bilhão de pessoas** é um sinal forte de segmentação aberta demais. Além disso, alguns itens parecem fracos para o MUSA, como `Friends of those who live abroad`, `Associate degree`, `Gestão de Pessoas` e `MBA Gestão de Pessoas`. Eles podem até sugerir mulher urbana/profissional, mas não apontam diretamente para a dor central: **querer parecer mais elegante, marcante e segura sem gastar com luxo nem trocar o guarda-roupa**.\n\n**Minha leitura:**\n\n- Para testar o vídeo hero do `MUSA-H001-E007`, esse público pode servir como primeiro teste porque o criativo e a página filtram parte da intenção.\n- Mas para escalar venda, eu não trataria esse público como vencedor.\n- Eu evitaria misturar interesses muito genéricos de beleza com cargos/formação sem uma hipótese clara.\n\n**3 alternativas boas:**\n\n| Opção | Benefício | Risco | Minha decisão |\n|---|---|---|---|\n| Manter o público atual | Não interrompe o teste em andamento | Pode gastar em gente muito fora do avatar | Manter por enquanto, com limite de leitura |\n| Criar público mais focado em beleza/moda/imagem | Mais aderente ao desejo MUSA | Pode reduzir alcance | Melhor próximo teste |\n| Criar público profissional feminino | Liga elegância a trabalho/reunião/presença | Pode parecer carreira demais, não estilo | Testar depois com criativo específico |\n\n**Recomendação prática agora:**\n\nNão pararia o `E007` imediatamente só por isso, porque ele acabou de rodar e a hipótese principal é o vídeo na primeira dobra. Mas eu colocaria uma regra clara:\n\n- se gastar **R$20-R$25** e vier clique sem início de diagnóstico, o problema pode ser público + primeira dobra;\n- se vier clique barato mas sessão ruim, ajustar público antes de escalar;\n- se vier início de diagnóstico, manter a campanha e criar variação de público mais precisa.\n\n**Público que eu testaria na próxima variação:**\n\nMulheres, Brasil, faixa provável **25-44 ou 28-45**, com interesses mais próximos de:\n\n- moda feminina;\n- beleza;\n- maquiagem;\n- autocuidado;\n- estilo pessoal;\n- consultoria de imagem;\n- elegância;\n- roupas femininas;\n- marcas acessíveis/moda popular premium;\n- conteúdo de looks, cabelo, unhas e imagem pessoal.\n\nE deixaria o público profissional para outro criativo, com ângulo separado:\n\n> “Sua imagem comunica segurança antes mesmo de você falar.”\n\nResumo: **o público atual não é absurdo para começar, mas não parece o melhor público estratégico do MUSA. Eu manteria só para colher o primeiro sinal e prepararia uma próxima variação mais feminina, urbana e ligada a imagem pessoal.**","sugestaoMelhoriaAmbiente":"Para cravar melhor, ajudaria ver a configuração completa do conjunto de anúncios: país, idade, gênero, posicionamentos, orçamento e desempenho inicial por impressão, clique e evento PDE."}

Última mensagem do usuário:
Vamos criar uma funcionalidade dentro do Marketing Hub para testar publicos

**Resumo das alterações:**
{"titulo":"Teste de públicos criado","comentario":"Implementei a funcionalidade para **testar públicos dentro do Marketing Hub**.\n\n**O que ficou pronto:**\n\n- Nova área na aba **Público da campanha** do experimento: **Teste de públicos**.\n- Permite criar variações com:\n  - nome do público;\n  - hipótese;\n  - métrica principal;\n  - orçamento diário opcional;\n  - itens oficiais da Meta já aprovados.\n- As variações nascem como `DRAFT`, sem alterar campanha em execução automaticamente.\n- Backend com endpoints para listar, criar e remover testes de público.\n- Persistência criada via Liquibase em `experiment_audience_test` e `experiment_audience_test_item`.\n- Documentação atualizada para deixar claro que teste de público deve manter criativo, oferta, preço e landing constantes.\n\n**Decisão estratégica aplicada:**\n\nEscolhi criar variações planejadas, em vez de trocar público direto no E007, porque o E007 está medindo vídeo na primeira dobra. Alterar público automaticamente agora contaminaria o aprendizado.\n\n**Validação feita:**\n\n- `npm run build` no frontend: passou.\n- `mvn test -DskipITs` no backend: passou com **1162 testes**, 0 falhas, 0 erros.\n- `git diff --check`: passou.\n- Changelog mestre validado com `relativeToChangelogFile: true`.\n\nNão criei PR.","sugestaoMelhoriaAmbiente":"","orientacaoProximaAcao":"Para publicar essa funcionalidade no Marketing Hub, o próximo passo é o usuário abrir/solicitar o PR e depois fazer o deploy normal da branch."}