### PR TITLE
AI Hub: {"titulo":"Action corrigida localmente","comentario":"**Causa-raiz confirmada**\n\nA GitHub Action falhou no backend porque entradas inválidas com `@Valid` estavam caindo no handler global genérico de `Exception` e virando HTTP `500`, quando dever…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/web/ApiExceptionHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/web/ApiExceptionHandler.java
@@ -2,6 +2,7 @@ package com.marketinghub.web;
 
 import com.marketinghub.salesvideo.exception.VideoModuleException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -12,9 +13,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -77,6 +83,31 @@ public class ApiExceptionHandler {
             message = "O upload do arquivo foi interrompido antes do envio completo. Verifique sua conexão e tente novamente.";
         }
         return buildResponse(HttpStatus.BAD_REQUEST, message, request, null);
+    }
+
+    /**
+     * Converte falhas de validação de entrada em HTTP 400 sem registrar como erro interno.
+     */
+    @ExceptionHandler({
+        MethodArgumentNotValidException.class,
+        HandlerMethodValidationException.class,
+        ConstraintViolationException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpMessageNotReadableException.class,
+        BindException.class
+    })
+    public ResponseEntity<Map<String, Object>> handleValidationException(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        LOGGER.warn(
+            "Requisição inválida rejeitada. method={}, uri={}, query={}, reason={}",
+            request.getMethod(),
+            request.getRequestURI(),
+            request.getQueryString(),
+            exception.getMessage()
+        );
+        return buildResponse(HttpStatus.BAD_REQUEST, "Requisição inválida.", request, null);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/web/ApiExceptionHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/web/ApiExceptionHandlerTest.java
@@ -2,16 +2,24 @@ package com.marketinghub.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.server.ResponseStatusException;
 
+/**
+ * Responsabilidade: validar a tradução global de exceções HTTP para respostas padronizadas.
+ */
 class ApiExceptionHandlerTest {
 
     private final ApiExceptionHandler handler = new ApiExceptionHandler();
 
+    /**
+     * Verifica que uma ResponseStatusException preserva o status e a mensagem definidos pela regra de negócio.
+     */
     @Test
     void shouldConvertResponseStatusExceptionToBody() {
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -27,6 +35,9 @@ class ApiExceptionHandlerTest {
             .containsEntry("path", "/api/creatives");
     }
 
+    /**
+     * Verifica que upload multipart interrompido retorna orientação segura para nova tentativa.
+     */
     @Test
     void shouldReturnBadRequestWhenMultipartStreamEndsUnexpectedly() {
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -48,6 +59,29 @@ class ApiExceptionHandlerTest {
             .containsEntry("path", "/api/assets");
     }
 
+    /**
+     * Verifica que falhas de validação são tratadas como erro de requisição, não como falha interna.
+     */
+    @Test
+    @DisplayName("Deve converter validação inválida em HTTP 400")
+    void shouldReturnBadRequestWhenValidationFails() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.setRequestURI("/api/angles");
+        BindException exception = new BindException(new Object(), "request");
+
+        var response = handler.handleValidationException(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody())
+            .containsEntry("status", HttpStatus.BAD_REQUEST.value())
+            .containsEntry("message", "Requisição inválida.")
+            .containsEntry("path", "/api/angles");
+    }
+
+    /**
+     * Verifica que erro inesperado continua retornando HTTP 500 com requestId rastreável.
+     */
     @Test
     void shouldReturnRequestIdWhenUnexpectedExceptionBecomesInternalServerError() {
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…