### PR TITLE
AI Hub: {"titulo":"Gate de áudio ajustado","comentario":"Ajustei o Marketing Hub para impedir que vídeo sem áudio avance para aprovação humana.\n\n**O que mudou:**\n- Vídeos de experimento agora têm o campo `has_audio` persistido.\n- A fila `/creative-vid…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -32,9 +32,11 @@ import com.marketinghub.storage.StorageException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.HttpStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -245,6 +247,11 @@ public class CreativeService {
         ExperimentVideoAsset videoAsset = experimentVideoAssetRepository.findById(id).orElseThrow();
         if (status == CreativeStatus.READY && !hasPublicExperimentVideoUrl(videoAsset)) {
             throw new IllegalArgumentException("Vídeo de experimento aprovado precisa ter URL pública.");
+        }
+        if (status == CreativeStatus.READY && !Boolean.TRUE.equals(videoAsset.getHasAudio())) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Vídeo de experimento aprovado precisa ter áudio validado.");
         }
         ExperimentVideoReviewStatus reviewStatus = toExperimentVideoReviewStatus(status);
         if (reviewStatus == ExperimentVideoReviewStatus.REJECTED && !StringUtils.hasText(rejectionReason)) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoAsset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/ExperimentVideoAsset.java
@@ -80,6 +80,9 @@ public class ExperimentVideoAsset {
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
 
+    @Column(name = "has_audio")
+    private Boolean hasAudio;
+
     @Column(name = "aspect_ratio", length = 16)
     private String aspectRatio;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/CreateExperimentVideoAssetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/CreateExperimentVideoAssetRequest.java
@@ -22,6 +22,7 @@ public record CreateExperimentVideoAssetRequest(
         String assetUrl,
         String thumbnailUrl,
         Integer durationSeconds,
+        Boolean hasAudio,
         String aspectRatio,
         String requestJson,
         String responseJson,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/ExperimentVideoAssetDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/ExperimentVideoAssetDto.java
@@ -23,6 +23,7 @@ public record ExperimentVideoAssetDto(
         String assetUrl,
         String thumbnailUrl,
         Integer durationSeconds,
+        Boolean hasAudio,
         String aspectRatio,
         String requestJson,
         String responseJson,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/UpdateExperimentVideoAssetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/dto/UpdateExperimentVideoAssetRequest.java
@@ -20,6 +20,7 @@ public record UpdateExperimentVideoAssetRequest(
         String assetUrl,
         String thumbnailUrl,
         Integer durationSeconds,
+        Boolean hasAudio,
         String aspectRatio,
         String requestJson,
         String responseJson,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetJobSyncService.java
@@ -1,9 +1,11 @@
 package com.marketinghub.experiment.video.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.marketinghub.experiment.video.ExperimentVideoAsset;
+import com.marketinghub.experiment.video.ExperimentVideoReviewStatus;
 import com.marketinghub.experiment.video.ExperimentVideoStatus;
 import com.marketinghub.repository.jpa.experiment.video.ExperimentVideoAssetRepository;
 import com.marketinghub.salesvideo.SalesVideoJob;
@@ -12,6 +14,7 @@ import com.marketinghub.salesvideo.dto.JobFailureRequest;
 import com.marketinghub.salesvideo.service.SalesVideoCompletedRenderAssetSync;
 import com.marketinghub.salesvideo.service.SalesVideoProductionCostCalculator;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRenderAssetSync {
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
+    private static final String NO_AUDIO_REJECTION_REASON =
+            "Reprovado na qualidade: vídeo final não possui faixa de áudio. Gerar novamente com voz, mixagem ou trilha audível antes da aprovação humana.";
 
     private final ExperimentVideoAssetRepository repository;
     private final SalesVideoProductionCostCalculator costCalculator;
@@ -90,11 +95,74 @@ public class ExperimentVideoAssetJobSyncService implements SalesVideoCompletedRe
         if (durationSeconds != null) {
             videoAsset.setDurationSeconds(durationSeconds);
         }
+        Boolean hasAudio = resolveHasAudio(request);
+        if (hasAudio != null) {
+            videoAsset.setHasAudio(hasAudio);
+        }
         if (costUsd != null) {
             videoAsset.setCost(costUsd);
         }
         videoAsset.setResponseJson(request.getMetadataJson());
         videoAsset.setStatus(ExperimentVideoStatus.READY);
+        if (Boolean.FALSE.equals(hasAudio)) {
+            rejectWithoutAudio(videoAsset);
+        }
+    }
+
+    /** Bloqueia uso comercial quando a qualidade confirma ausência de áudio. */
+    private void rejectWithoutAudio(ExperimentVideoAsset videoAsset) {
+        videoAsset.setReviewStatus(ExperimentVideoReviewStatus.REJECTED);
+        videoAsset.setRejectionReason(NO_AUDIO_REJECTION_REASON);
+        videoAsset.setReviewedBy("Marketing Hub Quality Gate");
+        videoAsset.setReviewedAt(Instant.now());
+    }
+
+    /** Extrai do metadata auditável se o arquivo final possui faixa de áudio. */
+    private Boolean resolveHasAudio(JobCompletionRequest request) {
+        if (request == null || request.getMetadataJson() == null || request.getMetadataJson().isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode metadata = OBJECT_MAPPER.readTree(request.getMetadataJson());
+            return firstBoolean(metadata, "hasAudio", "has_audio", "audioPresent", "audio_present")
+                    .or(() -> audioStreamCount(metadata))
+                    .orElse(null);
+        } catch (JsonProcessingException ex) {
+            return null;
+        }
+    }
+
+    /** Lê flags booleanas aceitas para compatibilidade com workers diferentes. */
+    private Optional<Boolean> firstBoolean(JsonNode metadata, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode value = metadata.get(fieldName);
+            if (value != null && value.isBoolean()) {
+                return Optional.of(value.asBoolean());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Interpreta contagens de streams de áudio vindas de ffprobe ou metadata normalizado. */
+    private Optional<Boolean> audioStreamCount(JsonNode metadata) {
+        JsonNode audioStreams = metadata.get("audio_streams");
+        if (audioStreams == null) {
+            audioStreams = metadata.get("audioStreams");
+        }
+        if (audioStreams != null && audioStreams.isNumber()) {
+            return Optional.of(audioStreams.asInt() > 0);
+        }
+        JsonNode streams = metadata.get("streams");
+        if (streams != null && streams.isArray()) {
+            for (JsonNode stream : streams) {
+                JsonNode codecType = stream.get("codec_type");
+                if (codecType != null && "audio".equalsIgnoreCase(codecType.asText())) {
+                    return Optional.of(true);
+                }
+            }
+            return Optional.of(false);
+        }
+        return Optional.empty();
     }
 
     /** Registra a causa da falha no ativo para a tela não permanecer como gerando. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetService.java
@@ -151,6 +151,7 @@ public class ExperimentVideoAssetService {
                 .assetUrl(request.assetUrl())
                 .thumbnailUrl(request.thumbnailUrl())
                 .durationSeconds(request.durationSeconds())
+                .hasAudio(request.hasAudio())
                 .aspectRatio(request.aspectRatio())
                 .requestJson(request.requestJson())
                 .responseJson(request.responseJson())
@@ -339,6 +340,9 @@ public class ExperimentVideoAssetService {
         if (request.durationSeconds() != null) {
             videoAsset.setDurationSeconds(request.durationSeconds());
         }
+        if (request.hasAudio() != null) {
+            videoAsset.setHasAudio(request.hasAudio());
+        }
         if (request.aspectRatio() != null) {
             videoAsset.setAspectRatio(request.aspectRatio());
         }
@@ -388,6 +392,11 @@ public class ExperimentVideoAssetService {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "rejectionReason is required when rejecting a video asset");
+        }
+        if (newStatus == ExperimentVideoReviewStatus.APPROVED && !Boolean.TRUE.equals(videoAsset.getHasAudio())) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "video asset must pass audio quality check before human approval");
         }
         videoAsset.setReviewStatus(newStatus);
         videoAsset.setReviewedBy(StringUtils.hasText(request.reviewedBy()) ? request.reviewedBy().trim() : null);
@@ -884,6 +893,7 @@ public class ExperimentVideoAssetService {
                 videoAsset.getAssetUrl(),
                 videoAsset.getThumbnailUrl(),
                 videoAsset.getDurationSeconds(),
+                videoAsset.getHasAudio(),
                 videoAsset.getAspectRatio(),
                 videoAsset.getRequestJson(),
                 videoAsset.getResponseJson(),

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/video/ExperimentVideoAssetRepository.java
@@ -73,6 +73,7 @@ public interface ExperimentVideoAssetRepository extends JpaRepository<Experiment
                     (v.assetUrl is not null and trim(v.assetUrl) <> '')
                  or v.asset is not null
                )
+               and v.hasAudio = true
              order by v.id desc
             """)
     List<ExperimentVideoAsset> findReadyExperimentVideosForReview(
@@ -90,6 +91,7 @@ public interface ExperimentVideoAssetRepository extends JpaRepository<Experiment
                     (v.assetUrl is not null and trim(v.assetUrl) <> '')
                  or v.asset is not null
                )
+               and v.hasAudio = true
              order by v.id desc
             """)
     List<ExperimentVideoAsset> findReadyExperimentVideosForReviewByReviewStatus(

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-25-experiment-video-audio-quality-gate.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-07-25-experiment-video-audio-quality-gate.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-07-25-experiment-video-audio-quality-gate
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_video_asset
+        - not:
+            - columnExists:
+                tableName: experiment_video_asset
+                columnName: has_audio
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_video_asset
+                ADD COLUMN has_audio BIT(1) NULL AFTER duration_seconds;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-07-25-experiment-video-audio-quality-gate.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-07-25-product-video-image-gallery.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -142,6 +142,7 @@ class CreativeControllerTest {
                 .model("heygen")
                 .status(ExperimentVideoStatus.READY)
                 .assetUrl("https://cdn.test/e002.mp4")
+                .hasAudio(true)
                 .reviewStatus(ExperimentVideoReviewStatus.PENDING)
                 .requiredForRelease(true)
                 .build());
@@ -196,6 +197,7 @@ class CreativeControllerTest {
                 .model("heygen")
                 .status(ExperimentVideoStatus.READY)
                 .assetUrl("https://cdn.test/e002.mp4")
+                .hasAudio(true)
                 .reviewStatus(ExperimentVideoReviewStatus.PENDING)
                 .requiredForRelease(true)
                 .build());
@@ -209,6 +211,60 @@ class CreativeControllerTest {
 
         ExperimentVideoAsset updated = videoAssetRepository.findById(videoAsset.getId()).orElseThrow();
         assertThat(updated.getReviewStatus()).isEqualTo(ExperimentVideoReviewStatus.APPROVED);
+    }
+
+    /** Garante que vídeo sem áudio não passe da qualidade para aprovação humana. */
+    @Test
+    void listVideoReviewEndpointDoesNotReturnExperimentVideoAssetWithoutAudio() throws Exception {
+        Experiment experiment = experimentRepository.findById(expId).orElseThrow();
+        videoAssetRepository.save(ExperimentVideoAsset.builder()
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.LANDING_HERO)
+                .objective("Video sem audio nao deve ir para aprovacao")
+                .primaryMetric("checkout_start_rate")
+                .script("Roteiro aprovado")
+                .prompt("Prompt aprovado")
+                .provider("HEYGEN")
+                .model("heygen")
+                .status(ExperimentVideoStatus.READY)
+                .assetUrl("https://cdn.test/sem-audio.mp4")
+                .hasAudio(false)
+                .reviewStatus(ExperimentVideoReviewStatus.PENDING)
+                .requiredForRelease(true)
+                .build());
+
+        mockMvc.perform(get("/api/creatives/video-review").param("status", "DRAFT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    /** Garante que a API também bloqueia aprovação direta de vídeo sem áudio validado. */
+    @Test
+    void videoReviewStatusEndpointRejectsApprovalWithoutAudioQuality() throws Exception {
+        Experiment experiment = experimentRepository.findById(expId).orElseThrow();
+        ExperimentVideoAsset videoAsset = videoAssetRepository.save(ExperimentVideoAsset.builder()
+                .experiment(experiment)
+                .slot(ExperimentVideoSlot.LANDING_HERO)
+                .objective("Video E002")
+                .primaryMetric("checkout_start_rate")
+                .script("Roteiro aprovado")
+                .prompt("Prompt aprovado")
+                .provider("HEYGEN")
+                .model("heygen")
+                .status(ExperimentVideoStatus.READY)
+                .assetUrl("https://cdn.test/e002.mp4")
+                .hasAudio(false)
+                .reviewStatus(ExperimentVideoReviewStatus.PENDING)
+                .requiredForRelease(true)
+                .build());
+
+        mockMvc.perform(patch("/api/creatives/video-review/EXPERIMENT_VIDEO_ASSET/" + videoAsset.getId() + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"READY\"}"))
+                .andExpect(status().isBadRequest());
+
+        ExperimentVideoAsset updated = videoAssetRepository.findById(videoAsset.getId()).orElseThrow();
+        assertThat(updated.getReviewStatus()).isEqualTo(ExperimentVideoReviewStatus.PENDING);
     }
 
     /** Garante que a reprovação preserve o motivo para orientar a próxima geração. */
@@ -226,6 +282,7 @@ class CreativeControllerTest {
                 .model("heygen")
                 .status(ExperimentVideoStatus.READY)
                 .assetUrl("https://cdn.test/e002.mp4")
+                .hasAudio(true)
                 .reviewStatus(ExperimentVideoReviewStatus.PENDING)
                 .requiredForRelease(true)
                 .build());

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/video/service/ExperimentVideoAssetServiceTest.java
@@ -121,6 +121,7 @@ class ExperimentVideoAssetServiceTest {
                 null,
                 null,
                 15,
+                null,
                 "9:16",
                 null,
                 null,
@@ -462,6 +463,7 @@ class ExperimentVideoAssetServiceTest {
                 "https://cdn.test/video.mp4",
                 null,
                 15,
+                true,
                 "9:16",
                 null,
                 null,
@@ -508,6 +510,7 @@ class ExperimentVideoAssetServiceTest {
                 "https://cdn.test/video.mp4",
                 null,
                 null,
+                true,
                 null,
                 null,
                 null,
@@ -526,6 +529,7 @@ class ExperimentVideoAssetServiceTest {
         assertThat(dto.reviewedBy()).isEqualTo("aprovador@marketinghub.local");
         assertThat(dto.reviewedAt()).isNotNull();
         assertThat(dto.assetUrl()).isEqualTo("https://cdn.test/video.mp4");
+        assertThat(dto.hasAudio()).isTrue();
     }
 
     /** Garante que reprovação humana sempre explique a causa para nova criação. */
@@ -549,6 +553,7 @@ class ExperimentVideoAssetServiceTest {
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
                 service.update(39L, 5L, new UpdateExperimentVideoAssetRequest(
+                        null,
                         null,
                         null,
                         null,

--- a/docs/marketing/fluxo-aprovacao-videos-experimentos.md
+++ b/docs/marketing/fluxo-aprovacao-videos-experimentos.md
@@ -6,8 +6,8 @@ Objetivo comercial: nenhum video gerado deve entrar em campanha, PDE ou pagina d
 
 1. O video deve ser gerado na tela de videos do produto, porque o produto e a fonte do portfolio reutilizavel.
 2. O resultado passa por analise de qualidade visual, audio, clareza da mensagem e aderencia ao papel no funil.
-3. Se a qualidade bloquear o uso, o video deve ser rejeitado ou refeito antes de seguir para uso comercial.
-4. Quando o video estiver com `status=READY` e URL publica, ele aparece em `/creative-video-review` para aprovacao humana.
+3. Se a qualidade bloquear o uso, o video deve ser rejeitado com motivo auditavel ou refeito antes de seguir para uso comercial.
+4. Quando o video estiver com `status=READY`, URL publica e `has_audio=true`, ele aparece em `/creative-video-review` para aprovacao humana.
 5. A aprovacao humana muda `review_status` para `APPROVED` e libera o video para o portfolio do produto.
 6. A reprovacao exige motivo, muda `review_status` para `REJECTED` e impede uso em campanha, PDE ou pagina.
 7. O motivo de reprovacao deve ser usado como restricao da proxima geracao, refacao ou pos-producao.
@@ -23,6 +23,7 @@ Objetivo comercial: nenhum video gerado deve entrar em campanha, PDE ou pagina d
 
 - A mensagem precisa reforcar dor, promessa, mecanismo e CTA do produto/experimento.
 - A personagem precisa manter consistencia visual com as imagens aprovadas.
+- O video precisa ter audio confirmado pela analise de qualidade antes de chegar a aprovacao humana.
 - O audio, legenda e ritmo precisam estar claros para consumo rapido.
 - O video nao pode prometer resultado garantido, parecer luxo inacessivel ou gerar estranhamento visual.
 - O video precisa reduzir incerteza, risco e esforco percebido, nao apenas parecer bonito.
@@ -30,6 +31,6 @@ Objetivo comercial: nenhum video gerado deve entrar em campanha, PDE ou pagina d
 ## Uso do motivo de reprovacao
 
 - Reprovacao por qualidade visual deve virar restricao explicita de prompt ou pos-producao.
-- Reprovacao por audio deve orientar nova voz, mixagem, legenda ou corte.
+- Reprovacao por audio deve orientar nova voz, mixagem, trilha, legenda ou corte.
 - Reprovacao por mensagem deve orientar novo roteiro, hook, analogia, mecanismo ou CTA.
 - O mesmo erro nao deve reaparecer em nova geracao do mesmo produto; se reaparecer, tratar como causa-raiz de processo, nao como erro isolado.

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -52,7 +52,8 @@ Fluxo obrigatório de aprovação e portfólio de vídeos:
 
 - todo vídeo com objetivo de campanha, PDE ou página de venda deve ser gerado a partir da tela de vídeos do produto, mantendo o produto como fonte do portfólio reutilizável;
 - após a geração, o vídeo deve passar por análise de qualidade visual, áudio, clareza da mensagem e aderência ao papel no funil;
-- quando o vídeo estiver com `status=READY` e URL pública, deve aparecer na tela `/creative-video-review` para aprovação humana;
+- quando o vídeo estiver com `status=READY`, URL pública e `has_audio=true`, deve aparecer na tela `/creative-video-review` para aprovação humana;
+- vídeo sem áudio ou sem confirmação de áudio não pode seguir para aprovação humana nem virar `APPROVED`; quando a análise confirmar `has_audio=false`, o ativo deve ser marcado como reprovado por qualidade com motivo auditável;
 - a tela `/creative-video-review` é a fila humana final: aprovação muda `review_status` para `APPROVED` e libera o vídeo para o portfólio do produto;
 - pode existir mais de um vídeo `APPROVED` no mesmo produto/experimento, pois eles podem cumprir papéis diferentes no funil, PDE, landing, anúncios ou cortes de campanha;
 - vídeo reprovado deve manter `review_status=REJECTED` e `rejection_reason` preenchido, sem uso em campanha, PDE, página de venda ou liberação para `RUNNING`;

--- a/docs/swagger/experiment-video-assets-swagger.yaml
+++ b/docs/swagger/experiment-video-assets-swagger.yaml
@@ -136,6 +136,9 @@ components:
           type: string
         durationSeconds:
           type: integer
+        hasAudio:
+          type: boolean
+          description: Indica se a análise de qualidade confirmou faixa de áudio no vídeo final.
         aspectRatio:
           type: string
           example: "9:16"


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…