### PR TITLE
AI Hub: {"titulo":"CI vermelho corrigido","comentario":"**Causa do erro:** o GitHub Actions falhou no `Facebook Ads Worker CI`, job `test`, porque o runner não tinha `ffmpeg`. O teste `MetaVideoNormalizerTest` depende de `ffmpeg/ffprobe` para validar o ví…

### DIFF
--- a/.github/workflows/facebook-ads-worker.yml
+++ b/.github/workflows/facebook-ads-worker.yml
@@ -28,6 +28,8 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: maven
+      - name: Install video tooling
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - name: Run tests
         run: mvn -B -s settings.xml test
       - name: Build

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/MetaVideoNormalizerTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/MetaVideoNormalizerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -80,9 +81,14 @@ class MetaVideoNormalizerTest {
      * Verifica se o comando está disponível sem falhar o teste em ambientes mínimos.
      */
     private boolean commandExists(String command) throws Exception {
-        Process process = new ProcessBuilder(command, "-version")
-            .redirectErrorStream(true)
-            .start();
+        Process process;
+        try {
+            process = new ProcessBuilder(command, "-version")
+                .redirectErrorStream(true)
+                .start();
+        } catch (IOException ex) {
+            return false;
+        }
         return process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0;
     }
 


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…