### PR TITLE
AI Hub: {"titulo":"Analytics PDE corrigido","comentario":"**Ajuste preparado no repositório.**\n\nCorrigi a causa-raiz complementar do analytics PDE: a consulta de jornadas recentes ainda podia pesar no MySQL 5.7 por agrupar/ordenar sessões sem índice com…

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,10 @@
+## 2026-07-30 — Experimento 76: jornadas PDE protegidas contra ordenação pesada
+
+- causa-raiz complementar: mesmo com o resumo principal protegido, a consulta de jornadas recentes ainda podia exigir agrupamento/ordenação por sessão sem índice composto adequado no MySQL 5.7.
+- problema comercial: a tela poderia continuar perdendo o diagnóstico de abandono pós-clique, impedindo separar clique barato, sessão real, vídeo, primeira interação e checkout.
+- ajuste preparado: as jornadas recentes do analytics PDE passaram a considerar apenas tráfego humano elegível e o schema operacional ganhou índice idempotente por produto, qualidade, sessão e horário.
+- prevenção: testes do backend PDE validam o novo índice e impedem que robôs/crawlers voltem a aparecer nas jornadas comerciais usadas para decisão de campanha.
+
 ## 2026-07-30 — Experimento 76: analytics PDE deixa de cair por breakdown de UTM
 
 - causa-raiz confirmada no backend PDE: o resumo `/api/pde/access/analytics/metodo-musa-7-dias/summary` podia retornar erro 500 quando o breakdown de origem de tráfego exigia ordenação pesada no MySQL 5.7.

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/AccessService.java
@@ -564,11 +564,13 @@ public class AccessService {
                     MAX(occurred_at) AS last_event_at
                   FROM pde_funnel_event
                   WHERE product_slug = ?
+                    AND traffic_quality = 'HUMAN'
                   GROUP BY COALESCE(session_id, event_id)
                   ORDER BY last_event_at DESC
                   LIMIT ?
                 ) recent ON recent.resolved_session_id = COALESCE(e.session_id, e.event_id)
                 WHERE e.product_slug = ?
+                  AND e.traffic_quality = 'HUMAN'
                 ORDER BY recent.last_event_at DESC, e.occurred_at ASC, e.id ASC
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {

--- a/pde-platform/backend/src/main/java/com/marketinghub/pde/service/PdeDatabaseMigrationService.java
+++ b/pde-platform/backend/src/main/java/com/marketinghub/pde/service/PdeDatabaseMigrationService.java
@@ -28,6 +28,7 @@ public class PdeDatabaseMigrationService {
     private static final String TRAFFIC_PROVIDER_COLUMN = "traffic_provider";
     private static final String TRAFFIC_QUALITY_INDEX = "idx_pde_funnel_product_quality_time";
     private static final String TRAFFIC_SOURCE_INDEX = "idx_pde_funnel_product_quality_utm_session";
+    private static final String JOURNEY_SESSION_INDEX = "idx_pde_funnel_product_quality_session_time";
     private static final String AI_GUIDANCE_TABLE = "pde_ai_guidance_request";
     private static final String ACCESS_TOKEN_COLUMN = "access_token";
     private static final String AI_GUIDANCE_ACCESS_GRANT_FK = "fk_pde_ai_guidance_access_grant";
@@ -227,6 +228,19 @@ public class PdeDatabaseMigrationService {
                             + "(product_slug(80), traffic_quality(40), utm_source(60), utm_medium(60), "
                             + "utm_campaign(80), utm_content(80), session_id(64), occurred_at)");
             log.info("Índice de origem de tráfego criado no funil PDE; index={}", TRAFFIC_SOURCE_INDEX);
+        }
+        if (!objectExists(
+                connection,
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS "
+                        + "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?",
+                FUNNEL_EVENT_TABLE,
+                JOURNEY_SESSION_INDEX)) {
+            executeSql(
+                    connection,
+                    "ALTER TABLE pde_funnel_event "
+                            + "ADD KEY idx_pde_funnel_product_quality_session_time "
+                            + "(product_slug(80), traffic_quality(40), session_id(64), occurred_at)");
+            log.info("Índice de jornadas recentes criado no funil PDE; index={}", JOURNEY_SESSION_INDEX);
         }
     }
 

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/AccessServiceTest.java
@@ -641,11 +641,8 @@ class AccessServiceTest {
                 .extracting("trafficQuality")
                 .contains("HUMAN", "BOT_SUSPECTED");
         assertThat(summary.recentJourneys())
-                .anySatisfy(journey -> {
-                    assertThat(journey.sessionId()).isEqualTo("session-bot");
-                    assertThat(journey.trafficQuality()).isEqualTo("BOT_SUSPECTED");
-                    assertThat(journey.trafficProvider()).isEqualTo("META");
-                });
+                .singleElement()
+                .satisfies(journey -> assertThat(journey.sessionId()).isEqualTo("session-human"));
     }
 
     /** Confirma que jornadas por sessão retornam vazio no modo local sem banco analítico. */
@@ -673,12 +670,12 @@ class AccessServiceTest {
                 var statement = connection.createStatement()) {
             statement.execute("""
                     INSERT INTO pde_funnel_event (
-                      event_id, product_slug, event_type, source, page_url, session_id, visitor_id,
+                      event_id, product_slug, event_type, source, page_url, traffic_quality, session_id, visitor_id,
                       visible_ms, action_name, metadata_json, occurred_at
                     )
                     VALUES (
                       'event-session-time-1', 'metodo-musa-7-dias', 'PAGE_VISIBLE_TIME', 'test',
-                      'https://clubemusa.com.br/acesso', 'session-time-1', 'visitor-time-1',
+                      'https://clubemusa.com.br/acesso', 'HUMAN', 'session-time-1', 'visitor-time-1',
                       1200, 'page_visibility_flush', '{"screenName":"login_first_access"}',
                       TIMESTAMP '2026-07-24 21:07:16'
                     )

--- a/pde-platform/backend/src/test/java/com/marketinghub/pde/service/PdeDatabaseMigrationServiceTest.java
+++ b/pde-platform/backend/src/test/java/com/marketinghub/pde/service/PdeDatabaseMigrationServiceTest.java
@@ -31,6 +31,7 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(false);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(false);
         PreparedStatement trafficSourceIndexStatement = existingObjectStatement(false);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(false);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(false);
         PreparedStatement operationalFailureTableStatement = existingObjectStatement(true);
         Statement ddlStatement = mock(Statement.class);
@@ -46,6 +47,7 @@ class PdeDatabaseMigrationServiceTest {
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
                         trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         operationalFailureTableStatement);
         when(connection.createStatement()).thenReturn(ddlStatement);
@@ -80,6 +82,10 @@ class PdeDatabaseMigrationServiceTest {
                         + "ADD KEY idx_pde_funnel_product_quality_utm_session "
                         + "(product_slug(80), traffic_quality(40), utm_source(60), utm_medium(60), "
                         + "utm_campaign(80), utm_content(80), session_id(64), occurred_at)");
+        ddlOrder.verify(ddlStatement).executeUpdate(
+                "ALTER TABLE pde_funnel_event "
+                        + "ADD KEY idx_pde_funnel_product_quality_session_time "
+                        + "(product_slug(80), traffic_quality(40), session_id(64), occurred_at)");
     }
 
     /** Confirma que a migração não executa DDL quando o schema já está atualizado. */
@@ -96,6 +102,7 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(true);
         PreparedStatement trafficSourceIndexStatement = existingObjectStatement(true);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceFkStatement = existingObjectStatement(false);
         PreparedStatement accessTokenLengthStatement = columnLengthStatement(120);
@@ -112,6 +119,7 @@ class PdeDatabaseMigrationServiceTest {
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
                         trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         aiGuidanceFkStatement,
                         accessTokenLengthStatement,
@@ -138,6 +146,7 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(true);
         PreparedStatement trafficSourceIndexStatement = existingObjectStatement(true);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceFkStatement = existingObjectStatement(true);
         PreparedStatement accessTokenLengthStatement = columnLengthStatement(40);
@@ -155,6 +164,7 @@ class PdeDatabaseMigrationServiceTest {
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
                         trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         aiGuidanceFkStatement,
                         accessTokenLengthStatement,
@@ -186,6 +196,7 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(true);
         PreparedStatement trafficSourceIndexStatement = existingObjectStatement(true);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceFkStatement = existingObjectStatement(true);
         PreparedStatement accessTokenLengthStatement = columnLengthStatement(36);
@@ -203,6 +214,7 @@ class PdeDatabaseMigrationServiceTest {
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
                         trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         aiGuidanceFkStatement,
                         accessTokenLengthStatement,
@@ -234,6 +246,7 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(true);
         PreparedStatement trafficSourceIndexStatement = existingObjectStatement(true);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceFkStatement = existingObjectStatement(false);
         PreparedStatement accessTokenLengthStatement = columnLengthStatement(120);
@@ -251,6 +264,7 @@ class PdeDatabaseMigrationServiceTest {
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
                         trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         aiGuidanceFkStatement,
                         accessTokenLengthStatement,
@@ -278,6 +292,8 @@ class PdeDatabaseMigrationServiceTest {
         PreparedStatement trafficQualityReasonColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficProviderColumnStatement = existingObjectStatement(true);
         PreparedStatement trafficQualityIndexStatement = existingObjectStatement(true);
+        PreparedStatement trafficSourceIndexStatement = existingObjectStatement(true);
+        PreparedStatement journeySessionIndexStatement = existingObjectStatement(true);
         PreparedStatement aiGuidanceTableStatement = existingObjectStatement(false);
         PreparedStatement aiGuidanceFkStatement = existingObjectStatement(false);
         PreparedStatement accessTokenLengthStatement = columnLengthStatement(120);
@@ -294,6 +310,8 @@ class PdeDatabaseMigrationServiceTest {
                         trafficQualityReasonColumnStatement,
                         trafficProviderColumnStatement,
                         trafficQualityIndexStatement,
+                        trafficSourceIndexStatement,
+                        journeySessionIndexStatement,
                         aiGuidanceTableStatement,
                         aiGuidanceFkStatement,
                         accessTokenLengthStatement,

--- a/pde-platform/local-validation/mysql-init/001-pde-local-schema.sql
+++ b/pde-platform/local-validation/mysql-init/001-pde-local-schema.sql
@@ -67,6 +67,9 @@ CREATE TABLE IF NOT EXISTS pde_funnel_event (
     product_slug(80), traffic_quality(40), utm_source(60), utm_medium(60),
     utm_campaign(80), utm_content(80), session_id(64), occurred_at
   ),
+  KEY idx_pde_funnel_product_quality_session_time (
+    product_slug(80), traffic_quality(40), session_id(64), occurred_at
+  ),
   KEY idx_pde_funnel_product_event_time (product_slug, event_type, occurred_at),
   KEY idx_pde_funnel_session_time (session_id, occurred_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…