### PR TITLE
AI Hub: {"titulo":"Integração PDE v6 corrigida","comentario":"Executei a correção no backend principal para o cockpit/funil do experimento 77.\n\n**O que foi ajustado:**\n\n- O funil PDE agora consulta o analytics usando a URL versionada do experimento, p…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,9 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
   - Use esta tool antes de concluir, por inferência de log ou comportamento, qual commit/build está rodando em produção.
   - Parâmetro disponível:
     1. `module` (**obrigatório**): módulo permitido para consulta de identidade de build.
-  - Módulo inicial aceito: `pde-platform-backend`.
+  - Módulos aceitos por padrão: `backend` e `pde-platform-backend`.
+  - Use `module=backend` para confirmar a identidade do backend principal do Marketing Hub que alimenta cockpit/funil.
+  - Use `module=pde-platform-backend` para confirmar a identidade do backend PDE.
   - A tool consulta o `/actuator/info` configurado para o módulo e retorna `version`, `commitId`, `branch` e `buildTime` quando o serviço publica esses campos.
   - Se `buildIdentityPublished=false`, o MCP confirmou que o endpoint respondeu, mas o runtime ainda não publicou identidade rastreável; nesse caso, não trate container recente ou tag `latest` como prova de commit em execução.
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -1097,7 +1097,9 @@ public class ExperimentFunnelService {
     }
     PdeAnalyticsSummary summary;
     try {
-      summary = pdeAnalyticsClient.fetchSummary(DEFAULT_PDE_PRODUCT_SLUG);
+      summary =
+          pdeAnalyticsClient.fetchSummary(
+              DEFAULT_PDE_PRODUCT_SLUG, experiment.getFollowUpActionUrl());
     } catch (Exception ex) {
       log.error(
           "Falha ao consultar analytics PDE para consolidar funil do experimento; experimentId={} productSlug={}",

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCockpitService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCockpitService.java
@@ -101,6 +101,8 @@ public class ExperimentCockpitService {
     if (BigDecimal.ZERO.compareTo(spend) == 0 && experiment.getTotalCost() != null) {
       spend = experiment.getTotalCost();
     }
+    long measuredPageViews =
+        Math.max(analytics.pageViews(), stageTotal(funnelStages, ExperimentFunnelStage.VISUALIZACAO_FORM));
     long leads = stageTotal(funnelStages, ExperimentFunnelStage.ENVIO_FORM);
     long checkoutAccesses = stageTotal(funnelStages, ExperimentFunnelStage.ACESSO_CHECKOUT);
     long purchases = stageTotal(funnelStages, ExperimentFunnelStage.COMPRA);
@@ -115,7 +117,7 @@ public class ExperimentCockpitService {
         clicks,
         percentage(clicks, impressions),
         metric != null ? metric.getCpc() : null,
-        analytics.pageViews(),
+        measuredPageViews,
         leads,
         checkoutAccesses,
         purchases,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -938,7 +938,7 @@ class ExperimentFunnelServiceRenderCompleteTest {
             any(),
             any()))
         .thenReturn(List.of("120250506594240326"));
-    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias"))
+    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias", null))
         .thenReturn(
             new PdeAnalyticsSummary(
                 "metodo-musa-7-dias",
@@ -1041,7 +1041,7 @@ class ExperimentFunnelServiceRenderCompleteTest {
             any(),
             any()))
         .thenReturn(List.of("120250506596000326"));
-    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias"))
+    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias", null))
         .thenReturn(
             new PdeAnalyticsSummary(
                 "metodo-musa-7-dias",
@@ -1126,7 +1126,7 @@ class ExperimentFunnelServiceRenderCompleteTest {
             any(),
             any()))
         .thenReturn(List.of());
-    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias"))
+    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias", "https://v6.clubemusa.com.br"))
         .thenReturn(
             new PdeAnalyticsSummary(
                 "metodo-musa-7-dias",
@@ -1202,6 +1202,8 @@ class ExperimentFunnelServiceRenderCompleteTest {
     assertEquals(70, pdeEntry.getTotalCount());
     assertEquals(34, videoPartial.getTotalCount());
     assertEquals(12, videoComplete.getTotalCount());
+    verify(pdeAnalyticsClient)
+        .fetchSummary("metodo-musa-7-dias", "https://v6.clubemusa.com.br");
   }
 
   /** Valida que render-complete rejeita slug vazio. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentCockpitServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentCockpitServiceTest.java
@@ -1,0 +1,97 @@
+package com.marketinghub.experiment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.experiment.ExperimentType;
+import com.marketinghub.experiment.dto.ExperimentDiagnosticsDto;
+import com.marketinghub.experiment.dto.ExperimentDiagnosticsSeverity;
+import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.experiment.funnel.ExperimentFunnelDiagnosticService;
+import com.marketinghub.experiment.funnel.ExperimentFunnelService;
+import com.marketinghub.experiment.funnel.ExperimentFunnelStage;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Testa a consolidação comercial do cockpit de experimentos. */
+@ExtendWith(MockitoExtension.class)
+class ExperimentCockpitServiceTest {
+
+  @Mock private ExperimentRepository experimentRepository;
+  @Mock private ExperimentReadinessService readinessService;
+  @Mock private ExperimentDiagnosticsService diagnosticsService;
+  @Mock private ExperimentFunnelService funnelService;
+  @Mock private ExperimentFunnelDiagnosticService funnelDiagnosticService;
+
+  @InjectMocks private ExperimentCockpitService service;
+
+  /**
+   * Garante que entradas medidas no PDE contam como página carregada antes do diagnóstico de
+   * conversão.
+   */
+  @Test
+  void getCockpitUsesPdeEntryAsMeasuredPageViewForBottleneck() {
+    ExperimentCampaignMetric campaignMetric =
+        ExperimentCampaignMetric.builder().impressions(100L).clicks(20L).build();
+    Experiment experiment =
+        Experiment.builder()
+            .id(77L)
+            .name("MUSA v6")
+            .experimentType(ExperimentType.PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL)
+            .campaignMetric(campaignMetric)
+            .build();
+    when(experimentRepository.findById(77L)).thenReturn(Optional.of(experiment));
+    when(readinessService.summarize(77L))
+        .thenReturn(new ExperimentReadinessSummaryDto(false, 0, false, 0, false, false, 0, 0, List.of(), List.of()));
+    when(diagnosticsService.diagnose(77L))
+        .thenReturn(
+            new ExperimentDiagnosticsDto(
+                ExperimentDiagnosticsSeverity.INFO,
+                "Pronto",
+                "Sem bloqueio operacional.",
+                null,
+                List.of(),
+                null));
+    when(funnelService.summarizeLandingAnalytics(77L))
+        .thenReturn(new ExperimentLandingAnalyticsDto(0, 0, 0, 0, 0, 0, null, List.of(), List.of(), List.of(), null, null, List.of()));
+    when(funnelService.summarize(77L))
+        .thenReturn(
+            List.of(
+                stage(ExperimentFunnelStage.VISUALIZACAO_FORM, 29),
+                stage(ExperimentFunnelStage.VIDEO_VISTO_PARCIAL, 12),
+                stage(ExperimentFunnelStage.VIDEO_VISTO_COMPLETO, 6),
+                stage(ExperimentFunnelStage.ENVIO_FORM, 0),
+                stage(ExperimentFunnelStage.ACESSO_CHECKOUT, 0),
+                stage(ExperimentFunnelStage.COMPRA, 0)));
+    when(funnelDiagnosticService.diagnose(77L))
+        .thenReturn(new ExperimentFunnelDiagnosticsResponseDto(List.of(), null));
+    when(funnelService.approvedRevenue(77L)).thenReturn(BigDecimal.ZERO);
+
+    var cockpit = service.getCockpit(77L);
+
+    assertEquals(29, cockpit.scoreboard().pageViews());
+    assertEquals("PAGINA_SEM_CONVERSAO", cockpit.bottleneck().code());
+  }
+
+  /** Cria uma etapa mínima do funil para o teste do cockpit. */
+  private ExperimentFunnelStageDto stage(ExperimentFunnelStage stage, long totalCount) {
+    ExperimentFunnelStageDto dto = new ExperimentFunnelStageDto();
+    dto.setStage(stage);
+    dto.setLabel(stage.getLabel());
+    dto.setOrder(stage.getOrder());
+    dto.setTotalCount(totalCount);
+    return dto;
+  }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-31 — Experimento 77: cockpit passa a ler analytics PDE v6 pelo destino do experimento
+
+- causa-raiz confirmada no código do backend principal: o funil de experimentos PDE consultava o analytics MUSA pelo cliente padrão, sem passar o `followUpActionUrl` versionado do experimento; com isso, a leitura podia cair no host padrão e não no slot v6 usado pelo experimento 77.
+- problema comercial: o PDE v6 já media sessões, entradas e vídeo, mas o cockpit podia mostrar funil zerado e sugerir gargalo falso de pós-clique, contaminando a decisão de liberar, pausar ou ajustar tráfego.
+- ajuste preparado: `ExperimentFunnelService` passa a consultar `/summary` usando a URL pública versionada do experimento, e `ExperimentCockpitService` considera a etapa real `VISUALIZACAO_FORM` como visualização medida quando a origem é PDE, evitando diagnosticar "clique sem página" quando houve entrada no MUSA.
+- prevenção: testes focados garantem que a v6 usa `https://v6.clubemusa.com.br` na chamada do analytics e que o cockpit classifica entrada PDE como página medida antes de decidir o gargalo comercial.
+- impacto comercial esperado: recuperar a leitura clique -> entrada PDE -> vídeo -> login/paywall/checkout do experimento 77, permitindo decidir sobre criativos, segmentação e oferta sem zeros falsos.
+
 ## 2026-07-30 — Experimento 76: jornadas PDE protegidas contra ordenação pesada
 
 - causa-raiz complementar: mesmo com o resumo principal protegido, a consulta de jornadas recentes ainda podia exigir agrupamento/ordenação por sessão sem índice composto adequado no MySQL 5.7.

--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -43,6 +43,8 @@ Quando precisar confirmar qual versão/commit de um módulo está rodando em pro
 - Implementação: `src/main/java/com/marketinghub/mcpserver/service/RuntimeBuildInfoService.java`.
 - Contrato JSON-RPC: `src/main/java/com/marketinghub/mcpserver/controller/McpController.java`.
 - Configuração: bloco `mcp.build-info` em `src/main/resources/application.yml`.
-- Módulo inicial configurado: `pde-platform-backend`, apontando para `http://163.245.200.7:8096/actuator/info`.
+- Módulos configurados por padrão:
+  - `backend`, apontando para `http://191.252.181.168/actuator/info`.
+  - `pde-platform-backend`, apontando para `http://163.245.200.7:8096/actuator/info`.
 
 Não inferir commit produtivo apenas por container recente, tag `latest` ou horário de deploy. Se a tool retornar `buildIdentityPublished=false`, o MCP confirmou que o endpoint respondeu, mas o runtime ainda não publicou commit, branch, build time ou version rastreável.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -122,7 +122,8 @@ O tool `runtime_build_info` consulta endpoints permitidos de `GET /actuator/info
 Configuração:
 
 - `MCP_BUILD_INFO_ENABLED` (default `true`);
-- `MCP_BUILD_INFO_ALLOWED_MODULES` (default `pde-platform-backend`);
+- `MCP_BUILD_INFO_ALLOWED_MODULES` (default `backend,pde-platform-backend`);
+- `MCP_BUILD_INFO_BACKEND_URL` (default `http://191.252.181.168/actuator/info`);
 - `MCP_BUILD_INFO_PDE_PLATFORM_BACKEND_URL` (default `http://163.245.200.7:8096/actuator/info`);
 - `MCP_BUILD_INFO_TIMEOUT_SECONDS` (default `10`).
 
@@ -130,6 +131,10 @@ Exemplo JSON-RPC:
 
 ```json
 {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"runtime_build_info","arguments":{"module":"pde-platform-backend"}}}
+```
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"runtime_build_info","arguments":{"module":"backend"}}}
 ```
 
 Quando o serviço publica os campos, a resposta estruturada inclui `summary.version`, `summary.commitId`, `summary.branch` e `summary.buildTime`. Quando `buildIdentityPublished=false`, o endpoint respondeu, mas o módulo ainda não expõe commit/build rastreável; nesse caso, é necessário ajustar o próprio módulo para publicar `git.properties`/`build-info.properties` no Actuator.

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -76,8 +76,9 @@ mcp:
     restart-enabled: ${MCP_DOCKER_OPS_RESTART_ENABLED:false}
   build-info:
     enabled: ${MCP_BUILD_INFO_ENABLED:true}
-    allowed-modules: ${MCP_BUILD_INFO_ALLOWED_MODULES:pde-platform-backend}
+    allowed-modules: ${MCP_BUILD_INFO_ALLOWED_MODULES:backend,pde-platform-backend}
     module-info-urls:
+      backend: ${MCP_BUILD_INFO_BACKEND_URL:http://191.252.181.168/actuator/info}
       pde-platform-backend: ${MCP_BUILD_INFO_PDE_PLATFORM_BACKEND_URL:http://163.245.200.7:8096/actuator/info}
     timeout-seconds: ${MCP_BUILD_INFO_TIMEOUT_SECONDS:10}
   vps-host-inventory:

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -87,7 +87,9 @@ class McpControllerTest {
         registry.add("mcp.docker-ops.timeout-seconds", () -> "5");
         registry.add("mcp.docker-ops.restart-enabled", () -> "false");
         registry.add("mcp.build-info.enabled", () -> "true");
-        registry.add("mcp.build-info.allowed-modules", () -> "pde-platform-backend");
+        registry.add("mcp.build-info.allowed-modules", () -> "backend,pde-platform-backend");
+        registry.add("mcp.build-info.module-info-urls.backend",
+                () -> "http://127.0.0.1:1/actuator/info");
         registry.add("mcp.build-info.module-info-urls.pde-platform-backend",
                 () -> "http://127.0.0.1:1/actuator/info");
         registry.add("mcp.build-info.timeout-seconds", () -> "1");

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/RuntimeBuildInfoServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/RuntimeBuildInfoServiceTest.java
@@ -67,6 +67,25 @@ class RuntimeBuildInfoServiceTest {
     }
 
     /**
+     * Garante que o backend principal do Marketing Hub pode ser consultado pela mesma tool.
+     */
+    @Test
+    void shouldReadMainBackendBuildIdentity() throws Exception {
+        RuntimeBuildInfoService service = new RuntimeBuildInfoService(buildProperties("""
+                {"git":{"branch":"main","commit":{"id":"123456789abc"}},"build":{"version":"2.0.0","time":"2026-07-31T12:00:00Z"}}
+                """));
+
+        Map<String, Object> result = service.readBuildInfo("backend");
+
+        assertEquals("backend", result.get("module"));
+        assertTrue((Boolean) result.get("buildIdentityPublished"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> summary = (Map<String, Object>) result.get("summary");
+        assertEquals("123456789abc", summary.get("commitId"));
+        assertEquals("main", summary.get("branch"));
+    }
+
+    /**
      * Monta propriedades MCP apontando o build info para um servidor HTTP local.
      */
     private McpProperties buildProperties(String actuatorBody) throws Exception {
@@ -120,8 +139,10 @@ class RuntimeBuildInfoServiceTest {
         );
         McpProperties.BuildInfo buildInfo = new McpProperties.BuildInfo(
                 true,
-                List.of("pde-platform-backend"),
-                Map.of("pde-platform-backend", infoUrl),
+                List.of("backend", "pde-platform-backend"),
+                Map.of(
+                        "backend", infoUrl,
+                        "pde-platform-backend", infoUrl),
                 5
         );
         McpProperties.VpsHostInventory vpsHostInventory = new McpProperties.VpsHostInventory(


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…