### PR TITLE
AI Hub: {"titulo":"Cockpit 77 corrigido","comentario":"Implementei a correção no backend principal.\n\n**O que mudou:**\n\n- O cockpit/funil agora resolve a `experienceVersion` esperada pelo slot produtivo cadastrado no Marketing Hub.\n- Para `https://v6.…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -3,6 +3,8 @@ package com.marketinghub.experiment.funnel;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentType;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.dto.ExperimentPdeCockpitDiagnosticsDto;
+import com.marketinghub.experiment.funnel.dto.PdeExperienceVersionDiagnosticDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
@@ -19,6 +21,7 @@ import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
 import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
 import com.marketinghub.leadportal.dto.RegisterLeadPortalSubmissionRequest;
 import com.marketinghub.model.Lead;
+import com.marketinghub.pde.PdeProductionSlot;
 import com.marketinghub.repository.jpa.core.LeadRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
@@ -101,6 +104,83 @@ public class ExperimentFunnelService {
         .filter(stage -> shouldExposeStage(experiment, stage.getStage()))
         .sorted(Comparator.comparingInt(ExperimentFunnelStageDto::getOrder))
         .toList();
+  }
+
+  /** Diagnostica a integração PDE usada pelo cockpit para explicar filtros, versão e fallback. */
+  public ExperimentPdeCockpitDiagnosticsDto diagnosePdeCockpitIntegration(Long experimentId) {
+    Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
+    String followUpActionUrl = experiment.getFollowUpActionUrl();
+    Optional<String> normalizedDomain = normalizeDomainFromUrl(followUpActionUrl);
+    Optional<String> versionToken = resolveVersionTokenFromUrl(followUpActionUrl);
+    ExpectedPdeExperienceVersion expectedVersion =
+        resolveExpectedPdeExperienceVersionDiagnostic(followUpActionUrl);
+    if (!isPdeMembershipSubscriptionFunnel(experiment)) {
+      return new ExperimentPdeCockpitDiagnosticsDto(
+          experimentId,
+          false,
+          followUpActionUrl,
+          normalizedDomain.orElse(null),
+          followUpActionUrl,
+          DEFAULT_PDE_PRODUCT_SLUG,
+          false,
+          null,
+          expectedVersion.value().orElse(null),
+          expectedVersion.source(),
+          versionToken.orElse(null),
+          null,
+          false,
+          List.of(),
+          0,
+          0,
+          false,
+          "NOT_PDE_MEMBERSHIP_FUNNEL",
+          List.of(),
+          null,
+          null);
+    }
+
+    PdeAnalyticsSummary summary;
+    try {
+      summary = pdeAnalyticsClient.fetchSummary(DEFAULT_PDE_PRODUCT_SLUG, followUpActionUrl);
+    } catch (Exception ex) {
+      log.error(
+          "Falha ao diagnosticar analytics PDE do cockpit; experimentId={} productSlug={} followUpActionUrl={}",
+          experimentId,
+          DEFAULT_PDE_PRODUCT_SLUG,
+          followUpActionUrl,
+          ex);
+      return new ExperimentPdeCockpitDiagnosticsDto(
+          experimentId,
+          true,
+          followUpActionUrl,
+          normalizedDomain.orElse(null),
+          followUpActionUrl,
+          DEFAULT_PDE_PRODUCT_SLUG,
+          false,
+          null,
+          expectedVersion.value().orElse(null),
+          expectedVersion.source(),
+          versionToken.orElse(null),
+          null,
+          false,
+          List.of(),
+          0,
+          0,
+          false,
+          "PDE_SUMMARY_ERROR",
+          List.of(),
+          ex.getClass().getSimpleName(),
+          ex.getMessage());
+    }
+    List<String> attributionCodes = fetchExperimentAttributionCodes(experimentId);
+    return buildPdeCockpitDiagnostics(
+        experimentId,
+        followUpActionUrl,
+        normalizedDomain.orElse(null),
+        versionToken.orElse(null),
+        expectedVersion,
+        summary,
+        attributionCodes);
   }
 
   /** Soma a receita aprovada atribuida ao experimento dentro do escopo canônico do funil. */
@@ -1320,6 +1400,114 @@ public class ExperimentFunnelService {
         parsePdeInstant(summary.lastEventAt()));
   }
 
+  /** Monta o diagnóstico com a mesma decisão de atribuição e fallback usada no funil PDE. */
+  private ExperimentPdeCockpitDiagnosticsDto buildPdeCockpitDiagnostics(
+      Long experimentId,
+      String followUpActionUrl,
+      String normalizedDomain,
+      String versionToken,
+      ExpectedPdeExperienceVersion expectedVersion,
+      PdeAnalyticsSummary summary,
+      List<String> attributionCodes) {
+    List<String> safeAttributionCodes =
+        attributionCodes == null ? List.of() : attributionCodes.stream().distinct().toList();
+    Optional<PdeAnalyticsSummary.PdeExperienceVersionMetric> matchingVersion =
+        findMatchingExperienceVersion(summary, followUpActionUrl);
+    boolean attributionFilterApplied =
+        !safeAttributionCodes.isEmpty() && summary.trafficSources() != null;
+    List<PdeAnalyticsSummary.PdeTrafficSourceMetric> matchingTrafficSources =
+        attributionFilterApplied
+            ? summary.trafficSources().stream()
+                .filter(source -> source != null && matchesPdeAttribution(source, safeAttributionCodes))
+                .toList()
+            : List.of();
+    boolean fallbackUsed =
+        shouldUsePdeDiagnosticFallback(
+            attributionFilterApplied, matchingTrafficSources, matchingVersion);
+    return new ExperimentPdeCockpitDiagnosticsDto(
+        experimentId,
+        true,
+        followUpActionUrl,
+        normalizedDomain,
+        followUpActionUrl,
+        DEFAULT_PDE_PRODUCT_SLUG,
+        true,
+        summary.currentExperienceVersion(),
+        expectedVersion.value().orElse(null),
+        expectedVersion.source(),
+        versionToken,
+        matchingVersion
+            .map(PdeAnalyticsSummary.PdeExperienceVersionMetric::experienceVersion)
+            .orElse(null),
+        attributionFilterApplied,
+        safeAttributionCodes,
+        matchingTrafficSources.size(),
+        matchingTrafficSources.stream()
+            .mapToLong(PdeAnalyticsSummary.PdeTrafficSourceMetric::sessions)
+            .sum(),
+        fallbackUsed,
+        resolvePdeDiagnosticFallbackReason(
+            attributionFilterApplied, matchingTrafficSources, matchingVersion),
+        toPdeExperienceVersionDiagnostics(summary),
+        null,
+        null);
+  }
+
+  /** Indica se o diagnóstico deve marcar que o cockpit precisou fugir do filtro por UTM. */
+  private boolean shouldUsePdeDiagnosticFallback(
+      boolean attributionFilterApplied,
+      List<PdeAnalyticsSummary.PdeTrafficSourceMetric> matchingTrafficSources,
+      Optional<PdeAnalyticsSummary.PdeExperienceVersionMetric> matchingVersion) {
+    if (!attributionFilterApplied) {
+      return true;
+    }
+    return matchingTrafficSources.isEmpty() && matchingVersion.isPresent();
+  }
+
+  /** Explica o motivo do fallback para facilitar investigação do cockpit zerado. */
+  private String resolvePdeDiagnosticFallbackReason(
+      boolean attributionFilterApplied,
+      List<PdeAnalyticsSummary.PdeTrafficSourceMetric> matchingTrafficSources,
+      Optional<PdeAnalyticsSummary.PdeExperienceVersionMetric> matchingVersion) {
+    if (!attributionFilterApplied && matchingVersion.isPresent()) {
+      return "NO_ATTRIBUTION_CODES_VERSION_MATCH";
+    }
+    if (!attributionFilterApplied) {
+      return "NO_ATTRIBUTION_CODES_GLOBAL_SUMMARY";
+    }
+    if (matchingTrafficSources.isEmpty() && matchingVersion.isPresent()) {
+      return "ATTRIBUTION_NOT_MATCHING_VERSION_AVAILABLE";
+    }
+    if (matchingTrafficSources.isEmpty()) {
+      return "ATTRIBUTION_NOT_MATCHING_NO_VERSION";
+    }
+    return "ATTRIBUTION_MATCHED";
+  }
+
+  /** Lista as versões PDE retornadas pelo summary para comparar com a versão esperada. */
+  private List<PdeExperienceVersionDiagnosticDto> toPdeExperienceVersionDiagnostics(
+      PdeAnalyticsSummary summary) {
+    if (summary.experienceVersions() == null) {
+      return List.of();
+    }
+    return summary.experienceVersions().stream()
+        .filter(version -> version != null)
+        .map(
+            version ->
+                new PdeExperienceVersionDiagnosticDto(
+                    version.experienceVersion(),
+                    version.totalEvents(),
+                    version.sessions(),
+                    version.pdeEntries(),
+                    version.videoPartial(),
+                    version.videoComplete(),
+                    version.loginStarted(),
+                    version.paywallViewed(),
+                    Math.max(version.subscriptionClicked(), version.checkoutStarted()),
+                    version.subscriptionApproved()))
+        .toList();
+  }
+
   /** Localiza a versão comercial do PDE correspondente ao slot versionado da URL do experimento. */
   private Optional<PdeAnalyticsSummary.PdeExperienceVersionMetric> findMatchingExperienceVersion(
       PdeAnalyticsSummary summary, String followUpActionUrl) {
@@ -1348,10 +1536,25 @@ public class ExperimentFunnelService {
    * Hub.
    */
   private Optional<String> resolveExpectedPdeExperienceVersion(String followUpActionUrl) {
+    return resolveExpectedPdeExperienceVersionDiagnostic(followUpActionUrl).value();
+  }
+
+  /** Resolve a versão esperada do PDE e registra a origem dessa decisão para diagnóstico. */
+  private ExpectedPdeExperienceVersion resolveExpectedPdeExperienceVersionDiagnostic(
+      String followUpActionUrl) {
     return normalizeDomainFromUrl(followUpActionUrl)
         .flatMap(pdeProductionSlotRepository::findFirstByDomain)
-        .map(slot -> slot.getExperienceVersion())
-        .filter(version -> version != null && !version.isBlank());
+        .map(this::toExpectedPdeExperienceVersion)
+        .orElse(new ExpectedPdeExperienceVersion(Optional.empty(), "NONE"));
+  }
+
+  /** Extrai a versão comercial do slot PDE quando o cadastro operacional a publicou. */
+  private ExpectedPdeExperienceVersion toExpectedPdeExperienceVersion(PdeProductionSlot slot) {
+    String experienceVersion = slot.getExperienceVersion();
+    if (experienceVersion == null || experienceVersion.isBlank()) {
+      return new ExpectedPdeExperienceVersion(Optional.empty(), "SLOT_WITHOUT_EXPERIENCE_VERSION");
+    }
+    return new ExpectedPdeExperienceVersion(Optional.of(experienceVersion), "PDE_PRODUCTION_SLOT");
   }
 
   /** Extrai o token de versão da URL pública quando o slot ainda não existe no cadastro. */
@@ -2069,6 +2272,9 @@ public class ExperimentFunnelService {
   private String firstNonBlank(String value, String fallback) {
     return value == null || value.isBlank() ? fallback : value.trim();
   }
+
+  /** Representa a versão esperada do PDE e a origem operacional dessa decisão. */
+  private record ExpectedPdeExperienceVersion(Optional<String> value, String source) {}
 
   /**
    * Converte números textuais de duração para long, retornando zero quando ausentes ou inválidos.

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -24,6 +24,7 @@ import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.StageAggregation;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
+import com.marketinghub.repository.jpa.pde.PdeProductionSlotRepository;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -63,6 +64,7 @@ public class ExperimentFunnelService {
   private final ExperimentFunnelStandbyService standbyService;
   private final PdeAnalyticsClient pdeAnalyticsClient;
   private final InternalAnalyticsTrafficFilter internalAnalyticsTrafficFilter;
+  private final PdeProductionSlotRepository pdeProductionSlotRepository;
 
   static final String FLOW_SCOPE_CONDITION =
       """
@@ -1324,15 +1326,69 @@ public class ExperimentFunnelService {
     if (summary.experienceVersions() == null || followUpActionUrl == null) {
       return Optional.empty();
     }
+    Optional<String> expectedExperienceVersion = resolveExpectedPdeExperienceVersion(followUpActionUrl);
+    if (expectedExperienceVersion.isPresent()) {
+      return summary.experienceVersions().stream()
+          .filter(metric -> metric != null && metric.experienceVersion() != null)
+          .filter(metric -> metric.experienceVersion().equals(expectedExperienceVersion.get()))
+          .findFirst();
+    }
+    Optional<String> versionToken = resolveVersionTokenFromUrl(followUpActionUrl);
+    if (versionToken.isEmpty()) {
+      return Optional.empty();
+    }
+    return summary.experienceVersions().stream()
+        .filter(metric -> metric != null && metric.experienceVersion() != null)
+        .filter(metric -> metric.experienceVersion().contains(versionToken.get()))
+        .findFirst();
+  }
+
+  /**
+   * Resolve a versão comercial esperada pelo cadastro operacional do slot publicado no Marketing
+   * Hub.
+   */
+  private Optional<String> resolveExpectedPdeExperienceVersion(String followUpActionUrl) {
+    return normalizeDomainFromUrl(followUpActionUrl)
+        .flatMap(pdeProductionSlotRepository::findFirstByDomain)
+        .map(slot -> slot.getExperienceVersion())
+        .filter(version -> version != null && !version.isBlank());
+  }
+
+  /** Extrai o token de versão da URL pública quando o slot ainda não existe no cadastro. */
+  private Optional<String> resolveVersionTokenFromUrl(String followUpActionUrl) {
     Matcher matcher = MUSA_VERSIONED_HOST_PATTERN.matcher(followUpActionUrl.trim());
     if (!matcher.matches()) {
       return Optional.empty();
     }
-    String versionToken = "-v" + matcher.group(1) + "-";
-    return summary.experienceVersions().stream()
-        .filter(metric -> metric != null && metric.experienceVersion() != null)
-        .filter(metric -> metric.experienceVersion().contains(versionToken))
-        .findFirst();
+    return Optional.of("-v" + matcher.group(1) + "-");
+  }
+
+  /** Normaliza o domínio de uma URL para consulta do slot produtivo PDE. */
+  private Optional<String> normalizeDomainFromUrl(String url) {
+    if (url == null || url.isBlank()) {
+      return Optional.empty();
+    }
+    String normalized = url.trim().replaceFirst("^https?://", "").replaceFirst("^//", "");
+    int pathStart = normalized.indexOf('/');
+    if (pathStart >= 0) {
+      normalized = normalized.substring(0, pathStart);
+    }
+    int queryStart = normalized.indexOf('?');
+    if (queryStart >= 0) {
+      normalized = normalized.substring(0, queryStart);
+    }
+    int hashStart = normalized.indexOf('#');
+    if (hashStart >= 0) {
+      normalized = normalized.substring(0, hashStart);
+    }
+    int portStart = normalized.indexOf(':');
+    if (portStart >= 0) {
+      normalized = normalized.substring(0, portStart);
+    }
+    if (normalized.isBlank() || !normalized.contains(".")) {
+      return Optional.empty();
+    }
+    return Optional.of(normalized.toLowerCase());
   }
 
   /** Soma eventos PDE globais preservando compatibilidade com contratos antigos do backend PDE. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentPdeCockpitDiagnosticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentPdeCockpitDiagnosticsDto.java
@@ -1,0 +1,27 @@
+package com.marketinghub.experiment.funnel.dto;
+
+import java.util.List;
+
+/** Contrato de diagnóstico operacional da integração PDE usada pelo cockpit do experimento. */
+public record ExperimentPdeCockpitDiagnosticsDto(
+    Long experimentId,
+    boolean pdeMembershipFunnel,
+    String followUpActionUrl,
+    String normalizedDomain,
+    String requestedPdeBaseUrl,
+    String productSlug,
+    boolean pdeSummaryLoaded,
+    String currentExperienceVersion,
+    String expectedExperienceVersion,
+    String expectedExperienceVersionSource,
+    String versionTokenFallback,
+    String matchedExperienceVersion,
+    boolean attributionFilterApplied,
+    List<String> attributionCodes,
+    int matchedTrafficSources,
+    long matchedTrafficSessions,
+    boolean fallbackUsed,
+    String fallbackReason,
+    List<PdeExperienceVersionDiagnosticDto> availableExperienceVersions,
+    String errorType,
+    String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/PdeExperienceVersionDiagnosticDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/PdeExperienceVersionDiagnosticDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.funnel.dto;
+
+/** Contrato de uma versão PDE disponível no summary usado pelo diagnóstico do cockpit. */
+public record PdeExperienceVersionDiagnosticDto(
+    String experienceVersion,
+    long totalEvents,
+    long sessions,
+    long pdeEntries,
+    long videoPartial,
+    long videoComplete,
+    long loginStarted,
+    long paywallViewed,
+    long checkoutIntent,
+    long subscriptionApproved) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -12,6 +12,7 @@ import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentStrategicPositioningRequest;
 import com.marketinghub.experiment.dto.UpdateSelectedSampleEmailRequest;
 import com.marketinghub.experiment.funnel.ExperimentFunnelService;
+import com.marketinghub.experiment.funnel.dto.ExperimentPdeCockpitDiagnosticsDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.experiment.salespageab.service.ExperimentSalesPageAbTestService;
@@ -118,6 +119,12 @@ public class ExperimentController {
   @GetMapping("/{id}/cockpit")
   public ExperimentCockpitDto cockpit(@PathVariable Long id) {
     return cockpitService.getCockpit(id);
+  }
+
+  /** Retorna diagnóstico da integração PDE usada para montar o cockpit do experimento. */
+  @GetMapping("/{id}/cockpit/pde-diagnostics")
+  public ExperimentPdeCockpitDiagnosticsDto pdeCockpitDiagnostics(@PathVariable Long id) {
+    return funnelService.diagnosePdeCockpitIntegration(id);
   }
 
   /** Retorna diagnósticos operacionais e comerciais do experimento. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -1325,6 +1325,117 @@ class ExperimentFunnelServiceRenderCompleteTest {
     assertEquals(Instant.parse("2026-07-31T00:51:38Z"), pdeEntry.getLastEventAt());
   }
 
+  /** Valida que o diagnóstico do cockpit explica URL, versão PDE e fallback usados no funil. */
+  @Test
+  void diagnosePdeCockpitIntegrationExplainsVersionFallback() {
+    Experiment experiment =
+        Experiment.builder()
+            .id(77L)
+            .experimentType(ExperimentType.PDE_MEMBERSHIP_SUBSCRIPTION_FUNNEL)
+            .followUpActionUrl("https://v6.clubemusa.com.br")
+            .build();
+    when(experimentRepository.findById(77L)).thenReturn(Optional.of(experiment));
+    when(jdbcTemplate.queryForList(
+            any(String.class),
+            eq(String.class),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
+        .thenReturn(List.of("campanha-do-experimento-77"));
+    when(pdeAnalyticsClient.fetchSummary("metodo-musa-7-dias", "https://v6.clubemusa.com.br"))
+        .thenReturn(
+            new PdeAnalyticsSummary(
+                "metodo-musa-7-dias",
+                "musa-pde-entry-v5-video-explicativo",
+                420,
+                35,
+                35,
+                35,
+                35,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                13375288,
+                "2026-07-30T21:51:38-03:00",
+                List.of(),
+                List.of(
+                    new PdeAnalyticsSummary.PdeExperienceVersionMetric(
+                        "musa-pde-entry-v6-video-motivacional",
+                        371,
+                        29,
+                        29,
+                        0,
+                        0,
+                        12,
+                        6,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0)),
+                List.of(
+                    new PdeAnalyticsSummary.PdeTrafficSourceMetric(
+                        "Meta",
+                        "ig",
+                        "paid",
+                        "120250665503920326",
+                        "120250665505440326",
+                        27,
+                        27,
+                        0,
+                        12,
+                        6,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        13311927,
+                        "2026-07-30T21:51:38-03:00")),
+                List.of(),
+                List.of(),
+                List.of()));
+    when(pdeProductionSlotRepository.findFirstByDomain("v6.clubemusa.com.br"))
+        .thenReturn(
+            Optional.of(
+                PdeProductionSlot.builder()
+                    .domain("v6.clubemusa.com.br")
+                    .publicUrl("https://v6.clubemusa.com.br")
+                    .experienceVersion("musa-pde-entry-v6-video-motivacional")
+                    .build()));
+
+    var diagnostics = service.diagnosePdeCockpitIntegration(77L);
+
+    assertTrue(diagnostics.pdeSummaryLoaded());
+    assertEquals("https://v6.clubemusa.com.br", diagnostics.requestedPdeBaseUrl());
+    assertEquals("metodo-musa-7-dias", diagnostics.productSlug());
+    assertEquals("v6.clubemusa.com.br", diagnostics.normalizedDomain());
+    assertEquals("musa-pde-entry-v5-video-explicativo", diagnostics.currentExperienceVersion());
+    assertEquals("musa-pde-entry-v6-video-motivacional", diagnostics.expectedExperienceVersion());
+    assertEquals("PDE_PRODUCTION_SLOT", diagnostics.expectedExperienceVersionSource());
+    assertEquals("-v6-", diagnostics.versionTokenFallback());
+    assertEquals("musa-pde-entry-v6-video-motivacional", diagnostics.matchedExperienceVersion());
+    assertTrue(diagnostics.attributionFilterApplied());
+    assertEquals(0, diagnostics.matchedTrafficSources());
+    assertTrue(diagnostics.fallbackUsed());
+    assertEquals("ATTRIBUTION_NOT_MATCHING_VERSION_AVAILABLE", diagnostics.fallbackReason());
+    assertEquals(1, diagnostics.availableExperienceVersions().size());
+    assertEquals(29, diagnostics.availableExperienceVersions().get(0).pdeEntries());
+  }
+
   /** Valida que render-complete rejeita slug vazio. */
   @Test
   void registerFormRenderCompletedFailsWhenSlugIsMissing() {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -18,12 +18,14 @@ import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAna
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsClient;
 import com.marketinghub.experiment.monitoring.pde.PdeAnalyticsSummary;
 import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
+import com.marketinghub.pde.PdeProductionSlot;
 import com.marketinghub.repository.jpa.core.LeadRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.LandingAnalyticsEventProjection;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository.VisitorRecurrenceProjection;
+import com.marketinghub.repository.jpa.pde.PdeProductionSlotRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +58,8 @@ class ExperimentFunnelServiceRenderCompleteTest {
 
   @Mock private InternalAnalyticsTrafficFilter internalAnalyticsTrafficFilter;
 
+  @Mock private PdeProductionSlotRepository pdeProductionSlotRepository;
+
   @InjectMocks private ExperimentFunnelService service;
 
   /** Configura stubs comuns para permitir criação de eventos normalizados novos. */
@@ -68,6 +72,7 @@ class ExperimentFunnelServiceRenderCompleteTest {
         .when(landingAnalyticsEventRepository.aggregateVisitorsByExperiment(any(), any()))
         .thenReturn(List.of());
     lenient().when(internalAnalyticsTrafficFilter.isInternal(any())).thenReturn(false);
+    lenient().when(pdeProductionSlotRepository.findFirstByDomain(any())).thenReturn(Optional.empty());
   }
 
   /** Valida que o render-complete grava visualização do formulário com visitante e campanha. */
@@ -1293,6 +1298,14 @@ class ExperimentFunnelServiceRenderCompleteTest {
                 List.of(),
                 List.of(),
                 List.of()));
+    when(pdeProductionSlotRepository.findFirstByDomain("v6.clubemusa.com.br"))
+        .thenReturn(
+            Optional.of(
+                PdeProductionSlot.builder()
+                    .domain("v6.clubemusa.com.br")
+                    .publicUrl("https://v6.clubemusa.com.br")
+                    .experienceVersion("musa-pde-entry-v6-video-motivacional")
+                    .build()));
 
     var summary = service.summarize(77L);
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-31 — Experimento 77: seleção explícita da experiência PDE v6 no cockpit
+
+- causa-raiz confirmada no backend principal: quando o summary do PDE retornava `currentExperienceVersion` como v5 e a v6 apenas dentro de `experienceVersions`, o funil do experimento 77 podia depender de fallback por token da URL em vez do slot produtivo cadastrado no Marketing Hub.
+- problema comercial: o cockpit podia seguir mostrando funil zerado para o experimento 77 mesmo com eventos reais da v6, impedindo leitura confiável antes de liberar tráfego pago.
+- ajuste preparado: `ExperimentFunnelService` passa a resolver a `experienceVersion` esperada pelo domínio do destino (`v6.clubemusa.com.br`) no cadastro de `pde_production_slot` e seleciona exatamente `musa-pde-entry-v6-video-motivacional` dentro de `experienceVersions`; o fallback por token `-v6-` fica apenas para ausência de slot.
+- prevenção: teste focado cobre o caso real do experimento 77 com summary principal em v5, métrica v6 existente e UTM divergente, garantindo que o cockpit use a linha correta da v6.
+- impacto comercial esperado: liberar decisão do cockpit por entrada PDE, vídeo, diagnóstico, paywall, checkout e compra sem misturar v5/v6 nem interpretar zero falso como rejeição da oferta.
+
 ## 2026-07-31 — PDE MUSA v7: jornada científica dos 7 sinais
 
 - decisão comercial: a nova organização dos 7 dias deve entrar como v7 científica, preservando a v6 como controle de leitura no cockpit.


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…