### PR TITLE
AI Hub: {"titulo":"Experimento 77 corrigido","comentario":"Prossegui no experimento 77 e encontrei a causa real do cockpit ainda zerado.\n\n**Causa confirmada:** o PDE v6 está saudável, mas o summary público demora cerca de **5 a 7 segundos** para respond…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClient.java
@@ -1,5 +1,6 @@
 package com.marketinghub.experiment.monitoring.pde;
 
+import java.net.http.HttpClient;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -15,11 +16,14 @@ public class PdeAnalyticsHttpClient implements PdeAnalyticsClient {
   private final RestClient restClient;
   private final JdkClientHttpRequestFactory requestFactory;
 
-  /** Inicializa o cliente HTTP com timeouts curtos para não travar o painel do Hub. */
+  /** Inicializa o cliente HTTP com timeouts configuráveis para não zerar o cockpit por lentidão. */
   public PdeAnalyticsHttpClient(
-      @Value("${integrations.pde-platform.base-url:" + DEFAULT_PDE_BASE_URL + "}") String baseUrl) {
-    this.requestFactory = new JdkClientHttpRequestFactory();
-    this.requestFactory.setReadTimeout(Duration.ofSeconds(4));
+      @Value("${integrations.pde-platform.base-url:" + DEFAULT_PDE_BASE_URL + "}") String baseUrl,
+      @Value("${integrations.pde-platform.connect-timeout:PT3S}") Duration connectTimeout,
+      @Value("${integrations.pde-platform.read-timeout:PT15S}") Duration readTimeout) {
+    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
+    this.requestFactory = new JdkClientHttpRequestFactory(httpClient);
+    this.requestFactory.setReadTimeout(readTimeout);
     this.restClient =
         RestClient.builder()
             .baseUrl(trimTrailingSlash(baseUrl))

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -105,6 +105,8 @@ integrations.fashion-chat.connect-timeout=${FASHION_CHAT_CONNECT_TIMEOUT:PT2S}
 integrations.fashion-chat.read-timeout=${FASHION_CHAT_READ_TIMEOUT:PT0S}
 
 integrations.pde-platform.base-url=${PDE_PLATFORM_BASE_URL:https://v5.clubemusa.com.br}
+integrations.pde-platform.connect-timeout=${PDE_PLATFORM_CONNECT_TIMEOUT:PT3S}
+integrations.pde-platform.read-timeout=${PDE_PLATFORM_READ_TIMEOUT:PT15S}
 
 # Lead portal asset storage (Cloudflare R2)
 lead-portal.storage.bucket=${LEAD_PORTAL_STORAGE_BUCKET:leadportal}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/monitoring/pde/PdeAnalyticsHttpClientTest.java
@@ -1,0 +1,111 @@
+package com.marketinghub.experiment.monitoring.pde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Valida o cliente HTTP que consulta o analytics administrativo do PDE. */
+class PdeAnalyticsHttpClientTest {
+
+  private HttpServer server;
+  private ExecutorService executor;
+
+  /** Encerra o servidor HTTP local usado pelos testes. */
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  /** Garante que o client suporta summaries saudáveis que demoram mais que quatro segundos. */
+  @Test
+  void fetchSummaryWaitsForHealthySlowPdeSummary() throws Exception {
+    server =
+        HttpServer.create(
+            new InetSocketAddress("127.0.0.1", 0),
+            0);
+    server.createContext(
+        "/api/pde/access/analytics/metodo-musa-7-dias/summary",
+        this::respondSlowSummary);
+    executor = Executors.newSingleThreadExecutor();
+    server.setExecutor(executor);
+    server.start();
+
+    PdeAnalyticsHttpClient client =
+        new PdeAnalyticsHttpClient(
+            "http://127.0.0.1:" + server.getAddress().getPort(),
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(7));
+
+    PdeAnalyticsSummary summary = client.fetchSummary("metodo-musa-7-dias");
+
+    assertThat(summary.productSlug()).isEqualTo("metodo-musa-7-dias");
+    assertThat(summary.currentExperienceVersion())
+        .isEqualTo("musa-pde-entry-v6-video-motivacional");
+    assertThat(summary.pedEntries()).isEqualTo(29);
+  }
+
+  /** Responde um summary mínimo após atraso compatível com a produção do PDE v6. */
+  private void respondSlowSummary(HttpExchange exchange) throws IOException {
+    try {
+      Thread.sleep(5_100);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Servidor de teste interrompido", ex);
+    }
+    byte[] body =
+        """
+        {
+          "productSlug": "metodo-musa-7-dias",
+          "currentExperienceVersion": "musa-pde-entry-v6-video-motivacional",
+          "totalEvents": 371,
+          "rawTotalEvents": 371,
+          "uniqueVisitors": 29,
+          "sessions": 29,
+          "rawSessions": 29,
+          "humanSessions": 29,
+          "botSuspectedSessions": 0,
+          "platformCrawlerSessions": 0,
+          "internalQaSessions": 0,
+          "unknownSessions": 0,
+          "pedEntries": 29,
+          "pageViews": 29,
+          "loginStarted": 0,
+          "loginCompleted": 0,
+          "paywallViewed": 0,
+          "subscriptionClicked": 0,
+          "subscriptionApproved": 0,
+          "accessReleased": 0,
+          "firstUse": 0,
+          "checkoutStarted": 0,
+          "totalVisibleMs": 13375288,
+          "lastEventAt": "2026-07-30T21:51:38-03:00",
+          "events": [],
+          "experienceVersions": [],
+          "trafficSources": [],
+          "trafficQualityBreakdown": [],
+          "deviceBreakdown": [],
+          "screenSizeBreakdown": [],
+          "recentJourneys": []
+        }
+        """
+            .getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, body.length);
+    exchange.getResponseBody().write(body);
+    exchange.close();
+  }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-07-31 — Experimento 77: timeout do analytics PDE v6 no cockpit
+
+- causa-raiz confirmada em producao: o endpoint publico do PDE v6 respondia HTTP 200 em aproximadamente 5 a 7 segundos, mas o client HTTP do backend principal tinha timeout fixo de leitura de 4 segundos; por isso o diagnostico do cockpit retornava `PDE_SUMMARY_ERROR` e o funil do experimento 77 seguia zerado.
+- problema comercial: o cockpit podia transformar lentidao operacional saudavel do summary em falsa ausencia de entrada/video, bloqueando leitura de oferta e decisao de trafego.
+- ajuste preparado: `PdeAnalyticsHttpClient` passa a usar timeouts configuraveis (`integrations.pde-platform.connect-timeout` e `integrations.pde-platform.read-timeout`) com leitura padrao de 15 segundos, suficiente para o summary administrativo atual.
+- prevencao: teste HTTP local simula um summary lento, acima de quatro segundos, e garante que o client espera a resposta valida em vez de quebrar antes do fallback por versao do slot.
+- impacto comercial esperado: permitir que o cockpit 77 reflita as sessoes, entradas e consumo de video da v6 quando o PDE esta saudavel, evitando zero falso antes de liberar ou bloquear trafego pago.
+
 ## 2026-07-31 — Experimento 77: seleção explícita da experiência PDE v6 no cockpit
 
 - causa-raiz confirmada no backend principal: quando o summary do PDE retornava `currentExperienceVersion` como v5 e a v6 apenas dentro de `experienceVersions`, o funil do experimento 77 podia depender de fallback por token da URL em vez do slot produtivo cadastrado no Marketing Hub.


### PR DESCRIPTION
- Antes de começar leia o documento em http://191.252.181.168:8000/api/products/public/metodo-musa-7-dias/marketing-definition.md e use como fonte de verdade sobre o PDE. Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produ…