### PR TITLE
Corrige host do certificado institucional Digicom

### DIFF
--- a/.github/workflows/lead-portal-payments-ci.yml
+++ b/.github/workflows/lead-portal-payments-ci.yml
@@ -101,7 +101,9 @@ jobs:
       contents: read
       packages: read
     env:
-      DEPLOY_HOST: 163.245.200.7
+      # O institucional permanece no host legado que recebe o DNS de
+      # digicomdigital.com.br. Os PDEs do Clube MUSA continuam no host canônico.
+      DEPLOY_HOST: ${{ inputs.issue_digicomdigital_certificate == 'true' && '191.252.102.54' || '163.245.200.7' }}
       DEPLOY_USER: root
       REMOTE_PATH: ${{ secrets.LEAD_PORTAL_PAYMENTS_REMOTE_PATH || '/root/lead-portal-payments-service' }}
       IMAGE_REGISTRY: ghcr.io
@@ -112,6 +114,11 @@ jobs:
       LEAD_PORTAL_PAYMENTS_NETWORK: ${{ secrets.LEAD_PORTAL_PAYMENTS_NETWORK != '' && secrets.LEAD_PORTAL_PAYMENTS_NETWORK || 'public-net' }}
     steps:
       - uses: actions/checkout@v4
+      - name: Validate certificate target
+        if: inputs.issue_clubemusa_certificate == 'true' && inputs.issue_digicomdigital_certificate == 'true'
+        run: |
+          echo "Selecione apenas um domínio por execução para impedir emissão no host incorreto." >&2
+          exit 1
       - name: Configure SSH
         env:
           VPS_SSH_KEY: ${{ secrets.LEAD_PORTAL_PAYMENTS_VPS_SSH_KEY != '' && secrets.LEAD_PORTAL_PAYMENTS_VPS_SSH_KEY || secrets.PDE_PLATFORM_VPS_SSH_KEY != '' && secrets.PDE_PLATFORM_VPS_SSH_KEY || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.SSH_PRIVATE_KEY }}

--- a/lead-portal-payments-service/README.md
+++ b/lead-portal-payments-service/README.md
@@ -137,9 +137,11 @@ O workflow `CI – Lead Portal Payments Service` (`.github/workflows/lead-portal
 
 1. **Testes** – roda `mvn test` com Java 21.
 2. **Build da imagem** – monta a imagem multi-stage e publica no GitHub Container Registry (`ghcr.io/<owner>/lead-portal-payments-service`) com tags `latest` e o SHA do commit, reaproveitando cache remoto.
-3. **Deploy** – apenas em pushes para `main`, o GitHub Actions acessa o VPS `163.245.200.7`, cria um backup remoto de `docker/proxy/html`, sincroniza este diretório via `rsync`, instala Docker/Compose quando necessário, força o login no GHCR, garante que a network Docker (`public-net` por padrão) exista, aplica `docker compose -f docker-compose.deploy.yml up -d --remove-orphans` e finaliza com `docker image prune -af` para remover imagens antigas. O compose de deploy é autônomo e usa somente a imagem publicada, sem herdar o `build` do compose local.
+3. **Deploy** – no disparo manual padrão, o GitHub Actions acessa o VPS canônico do Clube MUSA (`163.245.200.7`), cria um backup remoto de `docker/proxy/html`, sincroniza este diretório via `rsync`, instala Docker/Compose quando necessário, força o login no GHCR, garante que a network Docker (`public-net` por padrão) exista, aplica `docker compose -f docker-compose.deploy.yml up -d --remove-orphans` e finaliza com `docker image prune -af`. Quando `issue_digicomdigital_certificate=true`, o workflow publica o mesmo proxy no host institucional `191.252.102.54`, que recebe o DNS de `digicomdigital.com.br`, antes de emitir o certificado. O compose de deploy é autônomo e usa somente a imagem publicada, sem herdar o `build` do compose local.
 
 Depois que o DNS de `clubemusa.com.br` e subdomínios versionados apontar para `163.245.200.7`, execute o workflow manualmente com `issue_clubemusa_certificate=true` para emitir/renovar o certificado Let's Encrypt do Clube MUSA e recriar o proxy.
+
+Para publicar o site institucional, confirme que `digicomdigital.com.br` e `www.digicomdigital.com.br` apontam para `191.252.102.54` e execute o workflow manualmente com `issue_digicomdigital_certificate=true`. Esse modo seleciona o host institucional, publica a rota do domínio, emite o certificado Let's Encrypt e recria o proxy sem deslocar o deploy canônico do Clube MUSA.
 
 O `rsync` continua usando `--delete` para manter o serviço limpo, mas protege contra deleção os ativos comerciais públicos gerados pelo Marketing Hub antes de entrarem no `main`:
 


### PR DESCRIPTION
## O que mudou

- seleciona `191.252.102.54` quando o workflow emite o certificado de `digicomdigital.com.br`;
- mantém `163.245.200.7` como host canônico dos PDEs do Clube MUSA;
- bloqueia a seleção simultânea dos dois certificados;
- documenta o roteamento operacional por domínio.

## Causa-raiz

O DNS institucional aponta para `191.252.102.54`, mas o workflow tentava emitir o desafio Lets Encrypt em `163.245.200.7`, produzindo 404.

## Validações

- `git diff --check`
- YAML lint do workflow
- `docker compose config --quiet` com imagem de validação
