### PR TITLE
AI Hub: {"titulo":"Acesso confirmado e causa identificada","comentario":"O acesso SSH como `root` funcionou.\n\n**Causa-raiz confirmada:** o proxy reinicia porque ainda não existe certificado para `digicomdigital.com.br` e a imagem Nginx não possui `opens…

### DIFF
--- a/lead-portal-payments-service/docker-compose.yml
+++ b/lead-portal-payments-service/docker-compose.yml
@@ -48,7 +48,9 @@ services:
       - lead-portal-payments-net
 
   proxy:
-    image: nginx:1.25-alpine
+    build:
+      context: ./docker/proxy
+    image: marketinghub/lead-portal-payments-proxy:local
     depends_on:
       lead-portal-payments-service:
         condition: service_started

--- a/lead-portal-payments-service/docker/proxy/Dockerfile
+++ b/lead-portal-payments-service/docker/proxy/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.25-alpine
+
+# O proxy precisa criar certificados temporários no primeiro boot, antes da
+# emissão dos certificados definitivos pelo Certbot.
+RUN apk add --no-cache openssl


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…