### PR TITLE
Melhora conversão visual do Agenda Cheia

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6491,3 +6491,8 @@
 - ajuste preparado: o backend PDE passa a publicar a identidade de build também no `/actuator/info`, com `build`, `git` e bloco `pde`; o workflow PDE valida esse endpoint no pós-deploy; o compose do MCP passa a herdar o datasource `PDE_ACCESS_JDBC_*` do PDE quando `MCP_PDE_DATASOURCE_*` não for definido.
 - prevenção: antes de usar métricas PDE para pausar, escalar ou trocar criativo/oferta, validar `runtime_build_info(module=pde-platform-backend)` e `pde_db_health`, conectando commit, imagem, API pública e schema efetivo.
 - impacto comercial esperado: reduzir risco de decidir escala de tráfego pago com API antiga, banco errado ou cockpit lendo uma versão diferente da experiência pública.
+# Agenda Cheia Nail Design — qualidade visual do kit (2026-08-03)
+
+- Causa-raiz confirmada após o pacote real do pagamento `170895084433`: fotografias tecnicamente distintas ainda podiam deixar as unhas pequenas, repetir linguagem visual e perder força comercial porque o prompt não exigia protagonismo mensurável e o compositor cobria uma área excessiva da foto.
+- Correção: o prompt fotográfico passou a exigir unhas ocupando de 35% a 55% do enquadramento, diversidade explícita de pose/ângulo/cor/fundo/contexto e leitura mobile; o compositor reduziu o card de texto e adicionou chamada curta para WhatsApp ou reserva.
+- Prevenção de recorrência: teste de contrato protege as exigências comerciais centrais do prompt. Tráfego permanece bloqueado até um pacote real atingir avaliação visual humana mínima de 9/10.

--- a/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/AgendaCheiaKitProductionService.java
+++ b/lead-portal-payments-service/src/main/java/com/marketinghub/payments/service/AgendaCheiaKitProductionService.java
@@ -173,20 +173,21 @@ public class AgendaCheiaKitProductionService {
         graphics.setPaint(new java.awt.GradientPaint(0, 0, new Color(0, 0, 0, 15), 0, height, new Color(0, 0, 0, 115)));
         graphics.fillRect(0, 0, width, height);
         float cardY = switch (variant % 3) {
-            case 0 -> height * .56f;
-            case 1 -> height * .50f;
-            default -> height * .62f;
+            case 0 -> height * .68f;
+            case 1 -> height * .64f;
+            default -> height * .71f;
         };
-        float cardHeight = height * .30f;
+        float cardHeight = height * .22f;
         graphics.setColor(new Color(255, 255, 255, 238));
         graphics.fill(new RoundRectangle2D.Float(58, cardY, width - 116, cardHeight, 42, 42));
         graphics.setColor(palette[variant % palette.length]);
         graphics.fill(new RoundRectangle2D.Float(58, cardY, 18, cardHeight, 18, 18));
         graphics.setColor(new Color(48, 25, 37));
         graphics.setFont(new Font("SansSerif", Font.BOLD, width / 18));
-        drawWrapped(graphics, headline, 102, (int) (cardY + height * .07f), width - 204, width / 16);
+        drawWrapped(graphics, headline, 102, (int) (cardY + height * .055f), width - 204, width / 16);
         graphics.setFont(new Font("SansSerif", Font.PLAIN, width / 34));
-        graphics.drawString(serviceName(briefing), 102, (int) (cardY + cardHeight - height * .055f));
+        graphics.drawString(serviceName(briefing), 102, (int) (cardY + cardHeight - height * .035f));
+        drawActionChip(graphics, width, height, cardY, variant);
         graphics.setFont(new Font("SansSerif", Font.BOLD, width / 38));
         graphics.drawString(publicText(briefing.getProfessionalName()), 70, 92);
         graphics.setFont(new Font("SansSerif", Font.PLAIN, width / 45));
@@ -195,6 +196,22 @@ public class AgendaCheiaKitProductionService {
         graphics.dispose();
         ImageIO.write(image, "png", output.toFile());
         return output;
+    }
+
+    /** Aplica uma chamada comercial curta e legível sem encobrir a fotografia. */
+    private void drawActionChip(Graphics2D graphics, int width, int height, float cardY, int variant) {
+        String action = variant % 2 == 0 ? "CHAME NO WHATSAPP" : "RESERVE SEU HORÁRIO";
+        int chipWidth = width / 3;
+        int chipHeight = Math.max(42, height / 28);
+        int chipX = width - chipWidth - 70;
+        int chipY = (int) cardY - chipHeight - 24;
+        graphics.setColor(new Color(36, 120, 82, 242));
+        graphics.fill(new RoundRectangle2D.Float(chipX, chipY, chipWidth, chipHeight, 22, 22));
+        graphics.setColor(Color.WHITE);
+        graphics.setFont(new Font("SansSerif", Font.BOLD, Math.max(20, width / 48)));
+        FontMetrics metrics = graphics.getFontMetrics();
+        graphics.drawString(action, chipX + (chipWidth - metrics.stringWidth(action)) / 2,
+                chipY + (chipHeight + metrics.getAscent() - metrics.getDescent()) / 2);
     }
 
     /** Recorta a fotografia proporcionalmente para preencher o formato sem distorção. */

--- a/lead-portal-payments-service/src/main/resources/prompts/agenda-cheia/nail-photo.md
+++ b/lead-portal-payments-service/src/main/resources/prompts/agenda-cheia/nail-photo.md
@@ -1,4 +1,4 @@
 Crie uma fotografia publicitária premium e hiper-realista de nail design para uma publicação comercial brasileira.
-Mostre uma mão humana anatomicamente correta, com cinco dedos naturais e unhas impecáveis no estilo {{NAIL_STYLE}}.
-Direção: {{SCENE}}. Iluminação editorial suave, textura real da pele, acabamento de salão, fundo elegante e espaço negativo para aplicação posterior de texto.
+As unhas são o produto e devem ocupar de 35% a 55% do enquadramento, grandes, nítidas, completas e imediatamente reconhecíveis no celular. Mostre uma mão humana anatomicamente correta, com cinco dedos naturais e unhas impecáveis no estilo {{NAIL_STYLE}}.
+Direção: {{SCENE}}. Varie de verdade pose, ângulo de câmera, cor dominante, fundo e contexto em relação às demais fotografias do kit. Use iluminação editorial suave, textura real da pele, acabamento de salão e fundo elegante. Preserve espaço negativo apenas em uma lateral ou no terço inferior, sem reduzir o protagonismo das unhas.
 Não inclua letras, logotipos, marcas d'água, celulares, interfaces, mãos deformadas, dedos extras, unhas duplicadas ou aparência de ilustração/3D.

--- a/lead-portal-payments-service/src/test/java/com/marketinghub/payments/service/AgendaCheiaKitProductionServiceTest.java
+++ b/lead-portal-payments-service/src/test/java/com/marketinghub/payments/service/AgendaCheiaKitProductionServiceTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.payments.model.AgendaCheiaBriefing;
 import com.marketinghub.payments.model.AgendaCheiaDelivery;
 import com.marketinghub.payments.repository.AgendaCheiaDeliveryRepository;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -92,6 +93,18 @@ class AgendaCheiaKitProductionServiceTest {
         assertThatThrownBy(() -> service.produceAndDeliver(briefing(), payment))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Não foi possível concluir o kit personalizado");
+    }
+
+    /** Deve manter no prompt o protagonismo das unhas e a diversidade visual exigida para venda. */
+    @Test
+    void requiresNailsAsThePhotographicHeroAndRealVariation() throws Exception {
+        String prompt = new String(getClass().getResourceAsStream(
+                "/prompts/agenda-cheia/nail-photo.md").readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(prompt).contains("35% a 55% do enquadramento")
+                .contains("imediatamente reconhecíveis no celular")
+                .contains("Varie de verdade pose, ângulo de câmera, cor dominante, fundo e contexto")
+                .contains("sem reduzir o protagonismo das unhas");
     }
 
     /** Simula fotografias variadas e detalhadas sem chamar provedor externo no teste. */


### PR DESCRIPTION
## O que mudou

- exige unhas grandes e protagonistas nas fotografias do kit;
- amplia a diversidade de pose, ângulo, cor, fundo e contexto;
- reduz os cards para preservar a fotografia;
- adiciona chamada visível para WhatsApp ou reserva;
- protege as regras comerciais centrais com teste de contrato;
- registra causa-raiz e gate de liberação no histórico do experimento.

## Causa-raiz

O pacote tecnicamente válido ainda podia receber fotografias com unhas pequenas e composições pouco comerciais, enquanto os cards cobriam área excessiva da imagem.

## Validação

- `mvn -q test` no lead-portal-payments-service: 28 testes aprovados;
- gate existente reprova imagens planas/repetidas;
- `git diff --check` aprovado.

## Liberação

O tráfego permanece bloqueado até deploy, reprocessamento do pagamento de teste e avaliação humana mínima de 9/10.
