### PR TITLE
Versiona promoção do acervo premium Agenda Cheia

### DIFF
--- a/docs/marketing/agenda-cheia-biblioteca-visual-aprovada.md
+++ b/docs/marketing/agenda-cheia-biblioteca-visual-aprovada.md
@@ -21,6 +21,8 @@ São personalizados por compra: nome profissional, região, WhatsApp, serviços,
 - Somente fotografias revisadas visualmente e liberadas para uso comercial podem entrar em `approved`.
 - A ausência de acervo suficiente bloqueia a entrega; não existe fallback para geração improvisada durante a compra.
 - Novas fotografias devem ser geradas em lotes pelo fluxo versionado, revisadas fora da jornada da compradora e promovidas ao diretório aprovado somente após nota visual mínima 9/10.
+- Cada acervo aprovado deve conter `approved-manifest.tsv`, com SHA-256, modelo exato, nota humana, decisão e confirmação de ausência de texto incorporado para cada fotografia.
+- O runtime recalcula o SHA-256 antes de usar a fotografia. Arquivo ausente do manifesto, alterado depois da aprovação, repetido, com nota abaixo de 9 ou com texto incorporado bloqueia a entrega.
 
 ## Modelo de geração do acervo
 
@@ -28,6 +30,17 @@ São personalizados por compra: nome profissional, região, WhatsApp, serviços,
 - O modelo é configurável e deve seguir `docs/canonical/image-generation-model-canon.v1.md`; o identificador exato efetivamente usado fica persistido no lote para auditoria.
 - A geração acontece antes das vendas. Durante a compra, o pipeline apenas seleciona fotografias aprovadas e personaliza o material da cliente.
 - A troca para um modelo de ponta mais novo exige novo lote comparativo e aprovação visual humana mínima 9/10 antes de substituir fotografias do acervo comercial.
+
+## Operação versionada
+
+O script `lead-portal-payments-service/scripts/agenda-cheia-photo-library.sh` é o único fluxo de promoção do acervo:
+
+1. `generate <batch-id>` cria dez candidatas limpas com GPT Image 2 e registra hashes/modelo em `candidate-manifest.tsv`.
+2. A revisão humana registra em TSV: arquivo, nota, presença de texto, decisão e observação.
+3. `promote <batch-id> <review.tsv>` aceita somente dez ou mais imagens com nota mínima 9, sem texto e com hash intacto.
+4. A promoção é atômica e arquiva o acervo anterior para rollback.
+
+É proibido copiar manualmente imagens para `approved` ou promover fotos que já contenham nome, telefone, cidade, marca ou CTA de uma cliente. Esses dados são aplicados somente pelo compositor depois da seleção.
 
 ## Razão comercial
 

--- a/lead-portal-payments-service/scripts/agenda-cheia-photo-library.sh
+++ b/lead-portal-payments-service/scripts/agenda-cheia-photo-library.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gera, revisa e promove lotes fotográficos do Agenda Cheia sem expor credenciais.
+command_name="${1:-}"
+library_root="${AGENDA_CHEIA_LIBRARY_ROOT:-/var/lib/marketinghub/agenda-cheia/photo-library}"
+model="${OPENAI_IMAGE_MODEL:-gpt-image-2-2026-04-21}"
+batch_id="${2:-$(date -u +%Y%m%dT%H%M%SZ)}"
+candidate_dir="$library_root/candidates/$batch_id"
+approved_dir="$library_root/approved"
+
+require_tool() { command -v "$1" >/dev/null || { echo "Ferramenta obrigatória ausente: $1" >&2; exit 2; }; }
+
+generate() {
+  : "${OPENAI_API_KEY:?OPENAI_API_KEY é obrigatória}"
+  require_tool curl; require_tool jq; require_tool base64; require_tool sha256sum
+  mkdir -p "$candidate_dir"
+  touch "$candidate_dir/candidate-manifest.tsv"
+  styles=("clean leitoso" "french moderno" "cat-eye vinho" "chrome rose" "jelly nude" "micro french dourado" "baby boomer" "vermelho cereja" "nude mocha" "azul profundo")
+  for index in "${!styles[@]}"; do
+    filename="photo-$(printf '%02d' "$((index + 1))").png"
+    if [[ -s "$candidate_dir/$filename" ]] && grep -q "^$filename"$'\t' "$candidate_dir/candidate-manifest.tsv"; then
+      echo "Candidata já concluída: $filename"
+      continue
+    fi
+    prompt="Fotografia macro editorial premium e fotorrealista de nail design ${styles[$index]}. Unhas grandes, nítidas e protagonistas; mãos anatomicamente corretas; composição comercial distinta; fundo elegante. Sem letras, logotipos, marcas d'água, telefone, interface, moldura ou texto incorporado."
+    response="$(curl --fail --silent --show-error --connect-timeout 20 --max-time 300 \
+      --retry 2 --retry-delay 5 --retry-all-errors https://api.openai.com/v1/images/generations \
+      -H "Authorization: Bearer $OPENAI_API_KEY" -H 'Content-Type: application/json' \
+      --data "$(jq -n --arg model "$model" --arg prompt "$prompt" '{model:$model,prompt:$prompt,size:"1024x1024",quality:"high"}')")"
+    jq -er '.data[0].b64_json' <<<"$response" | base64 -d > "$candidate_dir/$filename"
+    hash="$(sha256sum "$candidate_dir/$filename" | cut -d' ' -f1)"
+    printf '%s\t%s\t%s\tPENDING\n' "$filename" "$hash" "$model" >> "$candidate_dir/candidate-manifest.tsv"
+  done
+  echo "Lote candidato gerado em $candidate_dir"
+}
+
+promote() {
+  review_file="${3:?Informe o TSV de revisão humana}"
+  require_tool sha256sum
+  [[ -f "$candidate_dir/candidate-manifest.tsv" && -f "$review_file" ]] || { echo "Lote ou revisão inexistente" >&2; exit 3; }
+  tmp_dir="$library_root/approved.next.$batch_id"; mkdir -p "$tmp_dir"
+  : > "$tmp_dir/approved-manifest.tsv"; unique_hashes=""
+  while IFS=$'\t' read -r filename score detected_text decision notes; do
+    [[ "$filename" == \#* || -z "$filename" ]] && continue
+    [[ "$decision" == "APPROVED" ]] || continue
+    awk "BEGIN { exit !($score >= 9.0) }" || { echo "Nota inferior a 9: $filename" >&2; exit 4; }
+    [[ "$detected_text" == "false" ]] || { echo "Texto incorporado detectado: $filename" >&2; exit 5; }
+    source_file="$candidate_dir/$filename"; [[ -f "$source_file" ]] || exit 6
+    hash="$(sha256sum "$source_file" | cut -d' ' -f1)"
+    grep -q $'\t'"$hash"$'\t' "$candidate_dir/candidate-manifest.tsv" || { echo "Hash não auditado: $filename" >&2; exit 7; }
+    [[ "$unique_hashes" != *"$hash"* ]] || { echo "Imagem repetida: $filename" >&2; exit 8; }
+    unique_hashes="$unique_hashes $hash"; cp "$source_file" "$tmp_dir/$filename"
+    printf '%s\t%s\t%s\t%s\tAPPROVED\tfalse\t%s\n' "$filename" "$hash" "$model" "$score" "$notes" >> "$tmp_dir/approved-manifest.tsv"
+  done < "$review_file"
+  count="$(find "$tmp_dir" -maxdepth 1 -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \) | wc -l)"
+  [[ "$count" -ge 10 ]] || { echo "São necessárias 10 fotos aprovadas; recebidas: $count" >&2; exit 9; }
+  backup="$library_root/archive/approved-$(date -u +%Y%m%dT%H%M%SZ)"; mkdir -p "$(dirname "$backup")"
+  [[ ! -d "$approved_dir" ]] || mv "$approved_dir" "$backup"
+  mv "$tmp_dir" "$approved_dir"
+  echo "Lote $batch_id promovido com $count fotos; acervo anterior: $backup"
+}
+
+case "$command_name" in
+  generate) generate ;;
+  promote) promote ;;
+  *) echo "Uso: $0 generate [batch-id] | promote <batch-id> <review.tsv>" >&2; exit 1 ;;
+esac

--- a/lead-portal-payments-service/src/main/java/com/marketinghub/payments/integration/image/ApprovedAgendaCheiaPhotoLibrary.java
+++ b/lead-portal-payments-service/src/main/java/com/marketinghub/payments/integration/image/ApprovedAgendaCheiaPhotoLibrary.java
@@ -5,7 +5,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.imageio.ImageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class ApprovedAgendaCheiaPhotoLibrary implements AgendaCheiaPhotoGenerator {
     private static final Logger log = LoggerFactory.getLogger(ApprovedAgendaCheiaPhotoLibrary.class);
     private static final int MINIMUM_LIBRARY_SIZE = 10;
+    private static final String MANIFEST_NAME = "approved-manifest.tsv";
     private final Path approvedRoot;
 
     /** Configura o diretório persistente que contém exclusivamente fotografias aprovadas. */
@@ -63,10 +66,44 @@ public class ApprovedAgendaCheiaPhotoLibrary implements AgendaCheiaPhotoGenerato
             if (assets.size() < MINIMUM_LIBRARY_SIZE) {
                 throw new IllegalStateException("Biblioteca fotográfica aprovada precisa de ao menos 10 imagens");
             }
+            validateManifest(assets);
             return assets;
         } catch (IOException ex) {
             log.error("Falha ao listar biblioteca fotográfica aprovada. root={}", approvedRoot, ex);
             throw new IllegalStateException("Não foi possível consultar a biblioteca fotográfica aprovada", ex);
+        }
+    }
+
+    /** Confirma que cada fotografia foi promovida por revisão humana e corresponde ao hash auditado. */
+    private void validateManifest(List<Path> assets) throws IOException {
+        Path manifest = approvedRoot.resolve(MANIFEST_NAME);
+        if (!Files.isRegularFile(manifest)) {
+            throw new IllegalStateException("Biblioteca fotográfica aprovada não possui manifesto auditável");
+        }
+        Map<String, String> approvedHashes = new HashMap<>();
+        for (String line : Files.readAllLines(manifest)) {
+            if (line.isBlank() || line.startsWith("#")) continue;
+            String[] columns = line.split("\\t", -1);
+            if (columns.length < 6 || !"APPROVED".equals(columns[4]) || Double.parseDouble(columns[3]) < 9.0
+                    || !"false".equals(columns[5])) continue;
+            approvedHashes.put(columns[0], columns[1]);
+        }
+        for (Path asset : assets) {
+            String expected = approvedHashes.get(asset.getFileName().toString());
+            String actual = sha256(asset);
+            if (!actual.equals(expected)) {
+                throw new IllegalStateException("Fotografia sem aprovação auditável: " + asset.getFileName());
+            }
+        }
+    }
+
+    /** Calcula a identidade imutável do arquivo aprovado. */
+    private String sha256(Path asset) throws IOException {
+        try {
+            return java.util.HexFormat.of().formatHex(
+                    java.security.MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(asset)));
+        } catch (java.security.NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 indisponível no runtime", ex);
         }
     }
 

--- a/lead-portal-payments-service/src/test/java/com/marketinghub/payments/integration/image/ApprovedAgendaCheiaPhotoLibraryTest.java
+++ b/lead-portal-payments-service/src/test/java/com/marketinghub/payments/integration/image/ApprovedAgendaCheiaPhotoLibraryTest.java
@@ -19,6 +19,7 @@ class ApprovedAgendaCheiaPhotoLibraryTest {
     @Test
     void selectsTenDistinctApprovedPhotos() throws Exception {
         for (int index = 0; index < 10; index++) writeImage(index);
+        writeManifest(10);
         ApprovedAgendaCheiaPhotoLibrary library = new ApprovedAgendaCheiaPhotoLibrary(storage.toString());
 
         java.util.Set<Integer> colors = new java.util.HashSet<>();
@@ -33,11 +34,26 @@ class ApprovedAgendaCheiaPhotoLibraryTest {
     @Test
     void rejectsInsufficientApprovedLibrary() throws Exception {
         for (int index = 0; index < 9; index++) writeImage(index);
+        writeManifest(9);
         ApprovedAgendaCheiaPhotoLibrary library = new ApprovedAgendaCheiaPhotoLibrary(storage.toString());
 
         assertThatThrownBy(() -> library.generate("purchase-123", 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("ao menos 10 imagens");
+    }
+
+    /** Deve bloquear arquivo alterado depois da revisão humana. */
+    @Test
+    void rejectsPhotoChangedAfterApproval() throws Exception {
+        for (int index = 0; index < 10; index++) writeImage(index);
+        writeManifest(10);
+        Files.writeString(storage.resolve("approved-00.png"), "alterada");
+
+        ApprovedAgendaCheiaPhotoLibrary library = new ApprovedAgendaCheiaPhotoLibrary(storage.toString());
+
+        assertThatThrownBy(() -> library.generate("purchase-123", 0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("sem aprovação auditável");
     }
 
     /** Cria uma fotografia raster válida e identificável para o teste. */
@@ -48,5 +64,18 @@ class ApprovedAgendaCheiaPhotoLibraryTest {
         graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
         graphics.dispose();
         ImageIO.write(image, "png", storage.resolve("approved-%02d.png".formatted(index)).toFile());
+    }
+
+    /** Registra o manifesto humano auditável das fotografias do teste. */
+    private void writeManifest(int count) throws Exception {
+        StringBuilder manifest = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            Path image = storage.resolve("approved-%02d.png".formatted(index));
+            String hash = java.util.HexFormat.of().formatHex(java.security.MessageDigest.getInstance("SHA-256")
+                    .digest(Files.readAllBytes(image)));
+            manifest.append(image.getFileName()).append('\t').append(hash)
+                    .append("\tgpt-image-2-2026-04-21\t9.5\tAPPROVED\tfalse\tteste\n");
+        }
+        Files.writeString(storage.resolve("approved-manifest.tsv"), manifest.toString());
     }
 }


### PR DESCRIPTION
## O que mudou

- adiciona fluxo versionado para gerar, revisar e promover lotes GPT Image 2;
- exige nota humana mínima 9/10, ausência de texto incorporado e hashes SHA-256;
- faz o runtime bloquear acervo antigo, alterado ou sem manifesto auditável;
- arquiva o acervo anterior para rollback.

## Causa-raiz

O runtime aceitava qualquer imagem raster no diretório aprovado; por isso fotos antigas, repetidas ou já personalizadas podiam voltar ao kit mesmo após melhorias no gerador.

## Validação

- suíte completa do lead-portal-payments-service aprovada;
- testes de seleção, acervo insuficiente e arquivo alterado aprovados;
- script Bash validado com bash -n;
- git diff --check aprovado.