### PR TITLE
AI Hub: {"titulo":"Analytics corrigido, campanha protegida","comentario":"Os workflows do PR #4687 terminaram com sucesso e a página foi regenerada.\n\nNa validação final encontrei a causa do erro restante: a campanha usa a rota pública `/flows/{slug}`, m…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
@@ -71,6 +71,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
       """
             select e from Experiment e
             where e.followUpActionUrl like concat(concat('%/api/flows/', :slug), '/page%')
+               or e.followUpActionUrl like concat(concat('%/flows/', :slug), '%')
                or e.followUpActionUrl like concat(concat('%/', :slug), '.html%')
             """)
   Optional<Experiment> findFirstByFollowUpActionUrlFlowSlug(@Param("slug") String slug);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -67,6 +67,37 @@ class ExperimentRepositoryTest {
         .hasValueSatisfying(found -> assertThat(found.getId()).isEqualTo(experiment.getId()));
   }
 
+  /**
+   * Garante que analytics encontre o experimento quando a campanha usa a rota pública amigável do
+   * Lead Portal.
+   */
+  @Test
+  void findFirstByFollowUpActionUrlFlowSlugAcceptsPublicFlowRoute() {
+    MarketNiche niche =
+        nicheRepository.save(MarketNiche.builder().name("Public flow niche").build());
+    Hypothesis hypothesis =
+        hypothesisRepository.save(
+            Hypothesis.builder().marketNiche(niche).title("Public flow hypothesis").build());
+    JourneyTemplate template =
+        journeyTemplateRepository.save(JourneyTemplate.builder().name("Venda direta").build());
+    Experiment experiment =
+        repository.save(
+            Experiment.builder()
+                .name("Public sales page")
+                .niche(niche)
+                .hypothesisRef(hypothesis)
+                .journeyTemplate(template)
+                .followUpActionUrl(
+                    "https://oportunidadebrasil.shop/flows/exp-81-gerasalespage-v1")
+                .build());
+
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(repository.findFirstByFollowUpActionUrlFlowSlug("exp-81-gerasalespage-v1"))
+        .hasValueSatisfying(found -> assertThat(found.getId()).isEqualTo(experiment.getId()));
+  }
+
   @Test
   void findAllToGenerateCreativesFetchesHypothesis() {
     MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N1").build());

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -352,6 +352,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
 ## LOOP-LANDING-ANALYTICS-FUNNEL — Analytics, funil e submissão
 
 - Em 2026-08-03, o GeraSalesPage foi protegido contra publicar o coletor público usando a rota administrativa `/mh-api/internal/...`. Páginas servidas pelo Lead Portal devem enviar eventos para `/api/flows/{slug}/page-analytics`; o endpoint interno continua sendo responsabilidade exclusiva do backend do Lead Portal ao encaminhar o evento.
+- Em 2026-08-03, a resolução do experimento pelo destino da campanha passou a aceitar também a rota pública amigável `/flows/{slug}`. O gate do GeraSalesPage já exigia essa URL, mas o analytics reconhecia apenas `/api/flows/{slug}/page`, fazendo a página aprovada retornar 502 ao registrar eventos.
 
 - **Severidade**: CRÍTICO.
 - **Status**: recorrente.


### PR DESCRIPTION
- Você está em uma conversa interativa da Fase 2 do Codex ChatGPT Managed no modo MKT. Responda à última mensagem do usuário e mantenha contexto das mensagens anteriores. Não crie Pull Request até o usuário pedir explicitamente o PR ou até o botão Pedir PR ser usado. Nosso objetivo principal é gerar vendas em larga escala de produtos digitais de alto valor com comunicação sedutora pelo sistema Marketing Hub. Use a sandbox para baixar e analisar o repositório como uma base de relatórios de marketi…