### PR TITLE
Corrige navegador do Agente Cliente

### DIFF
--- a/.github/workflows/customer-agent-worker-ci.yml
+++ b/.github/workflows/customer-agent-worker-ci.yml
@@ -39,6 +39,11 @@ jobs:
         run: bash customer-agent-worker/test-dockerfile-contract.sh
       - name: Validate container build
         run: docker build -t marketing-hub/customer-agent-worker:${{ github.sha }} customer-agent-worker
+      - name: Validate bundled Chromium as runtime user
+        run: |
+          docker run --rm --entrypoint node marketing-hub/customer-agent-worker:${{ github.sha }} \
+            --input-type=module -e \
+            'import { chromium } from "playwright-core"; const browser = await chromium.launch({headless: true, args: ["--no-sandbox"]}); console.log(await browser.version()); await browser.close();'
 
   deploy:
     name: Deploy worker

--- a/customer-agent-worker/Dockerfile
+++ b/customer-agent-worker/Dockerfile
@@ -4,13 +4,16 @@ COPY pom.xml .
 COPY src src
 RUN mvn -q -DskipTests package
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-noble
 ARG CODEX_VERSION=0.146.0
 WORKDIR /app
 COPY package.json package-lock.json /app/
-RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git ca-certificates chromium \
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git ca-certificates \
     && npm install -g @openai/codex@${CODEX_VERSION} \
     && npm ci --omit=dev \
+    && npx playwright-core install --with-deps chromium \
+    && chmod -R a+rX /ms-playwright \
     && rm -rf /var/lib/apt/lists/* \
     && (getent group operator >/dev/null || groupadd --gid 10001 operator) \
     && (id --user operator >/dev/null 2>&1 || useradd --create-home --uid 10001 --gid operator operator)

--- a/customer-agent-worker/docker-compose.yml
+++ b/customer-agent-worker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       CUSTOMER_AGENT_MODEL: ${CUSTOMER_AGENT_MODEL:-gpt-5.6-sol}
       CUSTOMER_AGENT_POLL_MS: ${CUSTOMER_AGENT_POLL_MS:-60000}
       CUSTOMER_AGENT_OBSERVATION_POLL_MS: ${CUSTOMER_AGENT_OBSERVATION_POLL_MS:-60000}
-      CHROMIUM_BIN: /usr/bin/chromium
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     volumes:
       - ${CODEX_HOME_PATH:-/opt/growth-operator/codex-home}:/home/operator/.codex
       - ${MARKETING_HUB_REPOSITORY:-..}:/workspace:ro

--- a/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
+++ b/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 const [inputPath, outputPath, evidenceDirectory] = process.argv.slice(2);
 const input = JSON.parse(await fs.readFile(inputPath, "utf8"));
 const browser = await chromium.launch({
-  executablePath: process.env.CHROMIUM_BIN || "/usr/bin/chromium",
+  ...(process.env.CHROMIUM_BIN ? { executablePath: process.env.CHROMIUM_BIN } : {}),
   headless: true,
   args: ["--no-sandbox", "--disable-dev-shm-usage"],
 });

--- a/customer-agent-worker/test-dockerfile-contract.sh
+++ b/customer-agent-worker/test-dockerfile-contract.sh
@@ -3,11 +3,25 @@ set -euo pipefail
 
 dockerfile="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Dockerfile"
 
+grep -Fq 'FROM eclipse-temurin:21-jre-noble' "${dockerfile}"
 grep -Fq 'getent group operator >/dev/null || groupadd --gid 10001 operator' "${dockerfile}"
 grep -Fq 'id --user operator >/dev/null 2>&1 || useradd --create-home --uid 10001 --gid operator operator' "${dockerfile}"
-grep -Fq 'chromium' "${dockerfile}"
 grep -Fq 'npm ci --omit=dev' "${dockerfile}"
+grep -Fq 'ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright' "${dockerfile}"
+grep -Fq 'npx playwright-core install --with-deps chromium' "${dockerfile}"
+grep -Fq 'chmod -R a+rX /ms-playwright' "${dockerfile}"
 grep -Fq 'COPY --from=build /build/src/main/resources/browser /app/browser' "${dockerfile}"
+
+compose="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/docker-compose.yml"
+grep -Fq 'PLAYWRIGHT_BROWSERS_PATH: /ms-playwright' "${compose}"
+if grep -Fq 'CHROMIUM_BIN: /usr/bin/chromium' "${compose}"; then
+  echo "[ARQUITETURA] O worker não pode apontar para um Chromium ausente da imagem." >&2
+  exit 1
+fi
+
+workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/customer-agent-worker-ci.yml"
+grep -Fq 'Validate bundled Chromium as runtime user' "${workflow}"
+grep -Fq 'await chromium.launch' "${workflow}"
 
 if grep -Eq '&& groupadd --gid 10001 operator' "${dockerfile}"; then
   echo "[ARQUITETURA] O Dockerfile não pode recriar incondicionalmente o grupo operator." >&2


### PR DESCRIPTION
## O que mudou

- empacota o Chromium compatível com a versão do Playwright dentro da imagem do worker;
- remove o caminho fixo inexistente `/usr/bin/chromium`;
- valida no CI que o navegador inicia como o usuário real do container;
- reforça o teste de contrato contra regressão.

## Causa-raiz

A observação mobile #2 foi consumida, mas falhou antes da captura porque o Compose apontava para um executável que não existia na imagem publicada.

## Impacto

Restaura a captura mobile auditável necessária para o Agente Cliente produzir o vetor motivacional sem inventar evidência.

## Validações

- testes Maven do customer-agent-worker;
- contrato do Dockerfile/Compose/workflow;
- sintaxe do observador Playwright;
- Prettier e `git diff --check`.