### PR TITLE
Permite observar vídeos diretos no Agente Cliente

### DIFF
--- a/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
+++ b/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
@@ -5,7 +5,9 @@ import path from "node:path";
 const [inputPath, outputPath, evidenceDirectory] = process.argv.slice(2);
 const input = JSON.parse(await fs.readFile(inputPath, "utf8"));
 const browser = await chromium.launch({
-  ...(process.env.CHROMIUM_BIN ? { executablePath: process.env.CHROMIUM_BIN } : {}),
+  ...(process.env.CHROMIUM_BIN
+    ? { executablePath: process.env.CHROMIUM_BIN }
+    : {}),
   headless: true,
   args: ["--no-sandbox", "--disable-dev-shm-usage"],
 });
@@ -21,19 +23,25 @@ const context = await browser.newContext({
 await fs.mkdir(evidenceDirectory, { recursive: true });
 const allowedHosts = new Set(input.urls.map((value) => new URL(value).host));
 const isPrivateHost = (hostname) =>
-  hostname === "localhost"
-  || hostname === "0.0.0.0"
-  || hostname === "::1"
-  || /^127\./.test(hostname)
-  || /^10\./.test(hostname)
-  || /^192\.168\./.test(hostname)
-  || /^169\.254\./.test(hostname)
-  || /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
+  hostname === "localhost" ||
+  hostname === "0.0.0.0" ||
+  hostname === "::1" ||
+  /^127\./.test(hostname) ||
+  /^10\./.test(hostname) ||
+  /^192\.168\./.test(hostname) ||
+  /^169\.254\./.test(hostname) ||
+  /^172\.(1[6-9]|2\d|3[01])\./.test(hostname);
 await context.route("**/*", async (route) => {
   const url = new URL(route.request().url());
-  const safeProtocol = ["http:", "https:", "data:", "blob:"].includes(url.protocol);
-  const authorizedNavigation = !route.request().isNavigationRequest() || allowedHosts.has(url.host);
-  const publicDestination = url.protocol === "data:" || url.protocol === "blob:" || !isPrivateHost(url.hostname);
+  const safeProtocol = ["http:", "https:", "data:", "blob:"].includes(
+    url.protocol,
+  );
+  const authorizedNavigation =
+    !route.request().isNavigationRequest() || allowedHosts.has(url.host);
+  const publicDestination =
+    url.protocol === "data:" ||
+    url.protocol === "blob:" ||
+    !isPrivateHost(url.hostname);
   if (safeProtocol && authorizedNavigation && publicDestination) {
     await route.continue();
   } else {
@@ -47,39 +55,102 @@ try {
     const requestedUrl = input.urls[index];
     const page = await context.newPage();
     const startedAt = new Date().toISOString();
-    const response = await page.goto(requestedUrl, { waitUntil: "domcontentloaded", timeout: 45_000 });
+    const isDirectVideo = /\.(mp4|webm)(?:$|[?#])/i.test(requestedUrl);
+    let response = null;
+    if (isDirectVideo) {
+      await page.setContent(
+        '<!doctype html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"></head>' +
+          '<body style="margin:0;background:#000;display:grid;min-height:100vh;place-items:center">' +
+          '<video controls muted playsinline style="display:block;max-width:100%;max-height:100vh"></video></body></html>',
+        { waitUntil: "domcontentloaded" },
+      );
+      await page.locator("video").evaluate((video, source) => {
+        video.src = source;
+      }, requestedUrl);
+      await page.locator("video").evaluate(
+        (video) =>
+          new Promise((resolve, reject) => {
+            if (video.readyState >= 1) {
+              resolve();
+              return;
+            }
+            const timeout = setTimeout(
+              () =>
+                reject(new Error("Timeout ao carregar metadados do vídeo.")),
+              45_000,
+            );
+            video.addEventListener(
+              "loadedmetadata",
+              () => {
+                clearTimeout(timeout);
+                resolve();
+              },
+              { once: true },
+            );
+            video.addEventListener(
+              "error",
+              () => {
+                clearTimeout(timeout);
+                reject(new Error("Falha ao carregar o vídeo autorizado."));
+              },
+              { once: true },
+            );
+          }),
+      );
+    } else {
+      response = await page.goto(requestedUrl, {
+        waitUntil: "domcontentloaded",
+        timeout: 45_000,
+      });
+    }
     await page.waitForTimeout(1_500);
     const videos = await page.locator("video").count();
     let videoPlayback = null;
     if (videos > 0) {
-      videoPlayback = await page.locator("video").first().evaluate(async (video) => {
-        try {
-          video.muted = true;
-          await video.play();
-          await new Promise((resolve) => setTimeout(resolve, 1200));
-          return {
-            played: !video.paused && video.currentTime > 0,
-            currentTime: video.currentTime,
-            duration: Number.isFinite(video.duration) ? video.duration : null,
-            hasAudio: Boolean(video.mozHasAudio || video.webkitAudioDecodedByteCount > 0 || video.audioTracks?.length),
-          };
-        } catch (error) {
-          return { played: false, error: String(error) };
-        }
-      });
+      videoPlayback = await page
+        .locator("video")
+        .first()
+        .evaluate(async (video) => {
+          try {
+            video.muted = true;
+            await video.play();
+            await new Promise((resolve) => setTimeout(resolve, 1200));
+            return {
+              played: !video.paused && video.currentTime > 0,
+              currentTime: video.currentTime,
+              duration: Number.isFinite(video.duration) ? video.duration : null,
+              hasAudio: Boolean(
+                video.mozHasAudio ||
+                video.webkitAudioDecodedByteCount > 0 ||
+                video.audioTracks?.length,
+              ),
+            };
+          } catch (error) {
+            return { played: false, error: String(error) };
+          }
+        });
     }
     const screenshot = path.join(evidenceDirectory, `page-${index + 1}.png`);
     await page.screenshot({ path: screenshot, fullPage: true });
     pages.push({
       requestedUrl,
-      finalUrl: page.url(),
+      finalUrl: isDirectVideo ? requestedUrl : page.url(),
       observedAt: startedAt,
       status: response?.status() ?? null,
       title: await page.title(),
-      viewport: await page.evaluate(() => ({ width: innerWidth, height: innerHeight, scrollWidth: document.documentElement.scrollWidth })),
+      viewport: await page.evaluate(() => ({
+        width: innerWidth,
+        height: innerHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+      })),
       headings: await page.locator("h1, h2").allTextContents(),
       visibleCtas: await page.locator("a, button").evaluateAll((elements) =>
-        elements.filter((element) => element.checkVisibility()).map((element) => element.textContent?.trim()).filter(Boolean).slice(0, 30)),
+        elements
+          .filter((element) => element.checkVisibility())
+          .map((element) => element.textContent?.trim())
+          .filter(Boolean)
+          .slice(0, 30),
+      ),
       formCount: await page.locator("form").count(),
       videoCount: videos,
       videoPlayback,
@@ -91,4 +162,8 @@ try {
   await browser.close();
 }
 
-await fs.writeFile(outputPath, JSON.stringify({ deviceProfile: "IPHONE_15_PRO", pages }), "utf8");
+await fs.writeFile(
+  outputPath,
+  JSON.stringify({ deviceProfile: "IPHONE_15_PRO", pages }),
+  "utf8",
+);

--- a/customer-agent-worker/test-dockerfile-contract.sh
+++ b/customer-agent-worker/test-dockerfile-contract.sh
@@ -23,6 +23,11 @@ workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/cus
 grep -Fq 'Validate bundled Chromium as runtime user' "${workflow}"
 grep -Fq 'await chromium.launch' "${workflow}"
 
+observer="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/src/main/resources/browser/mobile-observation.mjs"
+grep -Fq 'const isDirectVideo' "${observer}"
+grep -Fq 'video.src = source' "${observer}"
+grep -Fq 'loadedmetadata' "${observer}"
+
 if grep -Eq '&& groupadd --gid 10001 operator' "${dockerfile}"; then
   echo "[ARQUITETURA] O Dockerfile não pode recriar incondicionalmente o grupo operator." >&2
   exit 1


### PR DESCRIPTION
## O que mudou

- renderiza URLs MP4/WebM em um player mobile controlado;
- aguarda metadados do vídeo com timeout explícito;
- preserva reprodução, duração, presença de áudio e screenshot como fatos observáveis;
- adiciona contrato preventivo para mídia direta.

## Causa-raiz

O observador tratava MP4 como página HTML e a navegação não concluía antes do timeout de três minutos.

## Impacto

Permite analisar o vídeo MUSA isoladamente, sem misturar controles administrativos da página do Estúdio.

## Validações

- MP4 real da MUSA reproduzido em emulação iPhone;
- `played=true`, duração 10,04s e ausência de áudio detectada;
- screenshot de evidência gerado;
- testes Maven, sintaxe Node e contrato do worker aprovados.