### PR TITLE
Usa Chromium completo na observação de vídeo

### DIFF
--- a/.github/workflows/customer-agent-worker-ci.yml
+++ b/.github/workflows/customer-agent-worker-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           docker run --rm --entrypoint node marketing-hub/customer-agent-worker:${{ github.sha }} \
             --input-type=module -e \
-            'import { chromium } from "playwright-core"; const browser = await chromium.launch({headless: true, args: ["--no-sandbox"]}); console.log(await browser.version()); await browser.close();'
+            'import { chromium } from "playwright-core"; const browser = await chromium.launch({channel: "chromium", headless: true, args: ["--no-sandbox"]}); console.log(await browser.version()); await browser.close();'
 
   deploy:
     name: Deploy worker

--- a/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
+++ b/customer-agent-worker/src/main/resources/browser/mobile-observation.mjs
@@ -7,7 +7,7 @@ const input = JSON.parse(await fs.readFile(inputPath, "utf8"));
 const browser = await chromium.launch({
   ...(process.env.CHROMIUM_BIN
     ? { executablePath: process.env.CHROMIUM_BIN }
-    : {}),
+    : { channel: "chromium" }),
   headless: true,
   args: ["--no-sandbox", "--disable-dev-shm-usage"],
 });
@@ -121,8 +121,8 @@ try {
               duration: Number.isFinite(video.duration) ? video.duration : null,
               hasAudio: Boolean(
                 video.mozHasAudio ||
-                video.webkitAudioDecodedByteCount > 0 ||
-                video.audioTracks?.length,
+                  video.webkitAudioDecodedByteCount > 0 ||
+                  video.audioTracks?.length,
               ),
             };
           } catch (error) {

--- a/customer-agent-worker/test-dockerfile-contract.sh
+++ b/customer-agent-worker/test-dockerfile-contract.sh
@@ -22,9 +22,11 @@ fi
 workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/customer-agent-worker-ci.yml"
 grep -Fq 'Validate bundled Chromium as runtime user' "${workflow}"
 grep -Fq 'await chromium.launch' "${workflow}"
+grep -Fq 'channel: "chromium"' "${workflow}"
 
 observer="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/src/main/resources/browser/mobile-observation.mjs"
 grep -Fq 'const isDirectVideo' "${observer}"
+grep -Fq 'channel: "chromium"' "${observer}"
 grep -Fq 'video.src = source' "${observer}"
 grep -Fq 'loadedmetadata' "${observer}"
 


### PR DESCRIPTION
## O que mudou

- usa o canal Chromium completo empacotado pelo Playwright em produção;
- mantém `CHROMIUM_BIN` apenas como substituição explícita para testes locais;
- valida no CI a inicialização do mesmo canal utilizado pelo worker.

## Causa-raiz

O `headless_shell` padrão não reproduziu o MP4 H.264 da MUSA, embora o player e a URL estivessem corretos.

## Impacto

Permite capturar reprodução, duração, áudio e screenshot do vídeo real antes da análise motivacional.

## Validações

- testes Maven;
- sintaxe e formatação do observador;
- contrato do container e workflow.