### PR TITLE
AI Hub: {"titulo":"Causa do funil corrigida","comentario":"Identifiquei o bloqueio real ao executar o funil pela tela: o backend retornava HTTP 500 por duplicação da pergunta `nome_profissional` durante a reconciliação JPA.\n\nCorrigi a causa-raiz no repo…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelService.java
@@ -12,7 +12,6 @@ import com.marketinghub.productai.dto.PersonalizedSampleFunnelDto;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -153,19 +152,19 @@ public class ProductAiPersonalizedSampleFunnelService {
     for (LeadPortalFlowQuestion question : flow.getQuestions()) {
       existingByDataKey.putIfAbsent(question.getDataKey(), question);
     }
-    List<LeadPortalFlowQuestion> reconciled = new ArrayList<>();
+    Map<String, QuestionSpec> specsByDataKey = new LinkedHashMap<>();
+    specs.forEach(spec -> specsByDataKey.put(spec.dataKey(), spec));
+    flow.getQuestions().removeIf(question -> !specsByDataKey.containsKey(question.getDataKey()));
     for (int index = 0; index < specs.size(); index++) {
       QuestionSpec spec = specs.get(index);
       LeadPortalFlowQuestion question = existingByDataKey.get(spec.dataKey());
       if (question == null) {
         question = LeadPortalFlowQuestion.builder().flow(flow).dataKey(spec.dataKey()).build();
+        flow.getQuestions().add(question);
       }
       applyQuestionSpec(question, flow, spec, index);
-      reconciled.add(question);
     }
-    flow.getQuestions().removeIf(question -> !reconciled.contains(question));
-    flow.getQuestions().clear();
-    flow.getQuestions().addAll(reconciled);
+    flow.getQuestions().sort(Comparator.comparingInt(LeadPortalFlowQuestion::getPosition));
   }
 
   /** Atualiza uma pergunta existente ou nova com o contrato atual do template. */

--- a/backend/ads-service/src/test/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/productai/service/ProductAiPersonalizedSampleFunnelServiceTest.java
@@ -3,6 +3,8 @@ package com.marketinghub.productai.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +18,7 @@ import com.marketinghub.productai.PersonalizedSampleFunnelTemplate;
 import com.marketinghub.productai.ProductAiSubtype;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository;
+import java.util.ArrayList;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,7 +107,9 @@ class ProductAiPersonalizedSampleFunnelServiceTest {
             .type(LeadPortalQuestionType.TEXT)
             .position(4)
             .build();
-    existingFlow.getQuestions().add(existingName);
+    var managedQuestions = spy(new ArrayList<LeadPortalFlowQuestion>());
+    managedQuestions.add(existingName);
+    existingFlow.setQuestions(managedQuestions);
     experiment.setLeadPortalFlow(existingFlow);
 
     var result =
@@ -117,5 +122,6 @@ class ProductAiPersonalizedSampleFunnelServiceTest {
     assertThat(existingFlow.getQuestions().get(0)).isSameAs(existingName);
     assertThat(existingName.getId()).isEqualTo(101L);
     assertThat(existingName.getTitle()).isEqualTo("Qual é o seu nome profissional?");
+    verify(managedQuestions, never()).clear();
   }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6533,3 +6533,10 @@
 - Causa-raiz: o serviço substituía toda a coleção JPA com `orphanRemoval`; a ordenação do flush do Hibernate não garantia os deletes antes dos inserts.
 - Correção: as perguntas passam a ser reconciliadas por `dataKey`, preservando entidades e IDs existentes, atualizando o contrato vigente, criando somente chaves ausentes e removendo somente chaves obsoletas.
 - Prevenção: teste unitário cobre reexecução sobre fluxo persistido e exige chaves únicas, ordem canônica e preservação do ID da pergunta existente.
+
+## 2026-08-07 — Reconciliação idempotente do funil de microamostra sem reinserção JPA
+
+- evidência em produção: repetir pela tela o comando do funil do experimento 84 retornava HTTP 500 com `Duplicate entry '57-nome_profissional' for key 'uq_lead_portal_question_key'`, embora o banco mantivesse uma única pergunta por `data_key`.
+- causa-raiz: a reconciliação reaproveitava a entidade existente, mas limpava e readicionava toda a coleção JPA com `orphanRemoval`; o Hibernate tentava inserir novamente a chave canônica antes de concluir a remoção anterior.
+- correção: a coleção gerenciada deixa de ser limpa; perguntas obsoletas são removidas seletivamente, perguntas existentes são atualizadas no lugar e apenas chaves ausentes são adicionadas.
+- prevenção: teste de contrato impede que a reconciliação idempotente volte a executar `clear()` na coleção gerenciada.


### PR DESCRIPTION
- Modo Operador de Crescimento ativo. Fonte de verdade comercial atual: {"id":1,"product":"Agenda Cheia","objective":"Gerar as primeiras cinco vendas com entrega satisfatória","targetSales":5,"budgetLimit":400,"endsAt":"2026-08-09","status":"ACTIVE","visitors":0,"ctaClicks":0,"checkoutsStarted":0,"salesApproved":0,"briefingsCompleted":0,"deliveriesCompleted":0,"refunds":0,"revenue":0,"spend":0,"cac":null,"conversionRate":null,"bottleneck":"INSTRUMENTACAO","recommendedAction":"Aguardar ou corrigir…