### PR TITLE
Segrega métricas de experimentos fake

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -218,6 +218,7 @@ public class ExperimentFunnelService {
   /** Consolida sessões e eventos de analytics da landing publicados no experimento. */
   public ExperimentLandingAnalyticsDto summarizeLandingAnalytics(Long experimentId) {
     Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
+    boolean fakeExperiment = isFakeExperiment(experiment);
     Instant baseline = resolveBaseline(experiment);
     List<LandingAnalyticsEventRow> rows = fetchLandingAnalyticsEvents(experimentId, baseline);
     Map<String, LandingAnalyticsSessionAccumulator> sessions = new LinkedHashMap<>();
@@ -233,7 +234,8 @@ public class ExperimentFunnelService {
       Integer screenWidth = parsePositiveInteger(payload.get("screenWidth"));
       Integer screenHeight = parsePositiveInteger(payload.get("screenHeight"));
       long elapsedMs = parseLong(payload.get("elapsedMs"));
-      TrafficDiagnosis traffic = classifyLandingTraffic(payload, payload.get("visitorId"));
+      TrafficDiagnosis traffic =
+          classifyLandingTraffic(payload, payload.get("visitorId"), fakeExperiment);
 
       LandingAnalyticsSessionAccumulator session =
           sessions.computeIfAbsent(sessionId, LandingAnalyticsSessionAccumulator::new);
@@ -318,6 +320,7 @@ public class ExperimentFunnelService {
   public ExperimentLandingAnalyticsEvidenceDto buildDetailedAnalyticsEvidence(
       Long experimentId, int requestedLimit) {
     Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
+    boolean fakeExperiment = isFakeExperiment(experiment);
     Instant baseline = resolveBaseline(experiment);
     int limit = Math.max(1, Math.min(requestedLimit, 2000));
     var events =
@@ -343,7 +346,8 @@ public class ExperimentFunnelService {
                       new LinkedHashMap<>(parseDelimitedPayload(event.getPayload()));
                   String visitorId = attributes.remove("visitorId");
                   String sessionId = attributes.remove("sessionId");
-                  TrafficDiagnosis traffic = classifyLandingTraffic(attributes, visitorId);
+                  TrafficDiagnosis traffic =
+                      classifyLandingTraffic(attributes, visitorId, fakeExperiment);
                   attributes.remove("clientIp");
                   attributes.remove("userAgent");
                   attributes.remove("eventId");
@@ -2642,7 +2646,7 @@ public class ExperimentFunnelService {
    * não possui evidência suficiente de automação.
    */
   private static TrafficDiagnosis classifyLandingTraffic(
-      Map<String, String> payload, String visitorId) {
+      Map<String, String> payload, String visitorId, boolean fakeExperiment) {
     String pageUrl = firstNonBlankStatic(payload.get("pageUrl"), "").toLowerCase();
     String userAgent = firstNonBlankStatic(payload.get("userAgent"), "").toLowerCase();
     String width = firstNonBlankStatic(payload.get("screenWidth"), "");
@@ -2656,6 +2660,9 @@ public class ExperimentFunnelService {
             || userAgent.contains("bot")
             || userAgent.contains("crawler");
     boolean canonicalMonitorViewport = "1600".equals(width) && "1200".equals(height);
+    if (fakeExperiment) {
+      return new TrafficDiagnosis(TrafficQuality.AUTOMATED, "FAKE_EXPERIMENT");
+    }
     if (knownAutomationAgent) {
       return new TrafficDiagnosis(TrafficQuality.AUTOMATED, "AUTOMATION_USER_AGENT");
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowRepublisher.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowRepublisher.java
@@ -19,7 +19,9 @@ public class LeadPortalFlowRepublisher {
   private final LeadPortalFlowPublisher publisher;
   private final LeadPortalIntegrationProperties properties;
 
-  /** Configura o republicador com a leitura canônica, o publicador e as propriedades da integração. */
+  /**
+   * Configura o republicador com a leitura canônica, o publicador e as propriedades da integração.
+   */
   public LeadPortalFlowRepublisher(
       LeadPortalFlowService flowService,
       LeadPortalFlowPublisher publisher,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -756,6 +756,32 @@ class ExperimentFunnelServiceRenderCompleteTest {
             .count());
   }
 
+  /** Garante que homologações fake permaneçam auditáveis sem virar tráfego humano. */
+  @Test
+  void summarizeLandingAnalyticsClassifiesFakeExperimentAsAutomated() {
+    Experiment experiment =
+        Experiment.builder().id(84L).experimentType(ExperimentType.FAKE_EXPERIMENT).build();
+    when(experimentRepository.findById(84L)).thenReturn(Optional.of(experiment));
+    when(eventRepository.findLandingAnalyticsEvents(
+            eq(84L),
+            eq(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE),
+            eq(null),
+            any(Pageable.class)))
+        .thenReturn(
+            List.of(
+                landingEvent(
+                    1L,
+                    "eventId=f1;eventType=form_start;visitorId=visitor-test;sessionId=session-test;pageUrl=https://example.test/flows/fake;deviceType=mobile",
+                    Instant.parse("2026-08-07T06:00:00Z"))));
+
+    var summary = service.summarizeLandingAnalytics(84L);
+
+    assertEquals(0, summary.totalSessions());
+    assertEquals(0, summary.trafficQuality().humanSessions());
+    assertEquals(1, summary.trafficQuality().automatedSessions());
+    assertEquals("FAKE_EXPERIMENT", summary.sessions().getFirst().trafficQualityReason());
+  }
+
   /** Valida que visitantes com sessões diferentes são marcados como recorrentes prováveis. */
   @Test
   void summarizeLandingAnalyticsVisitorsMarksVisitorWithMultipleSessionsAsRecurrent() {

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -8,6 +8,13 @@
 >
 > Uso obrigatório recomendado: antes de corrigir problema em GeraLanding, Facebook Ads, Lead Portal, OpenAI/schema, pipelines administrativos ou pipeline de hipótese, verificar se a solicitação reabre algum loop listado aqui.
 
+## LOOP-EXPERIMENTO-FAKE-CONTABILIZADO-COMO-HUMANO — Métricas de homologação
+
+- Sintoma: sessões de homologação do experimento fake apareciam como humanas para o Operador de Crescimento.
+- Causa-raiz: a classificação dependia apenas de URL, viewport e user-agent, sem considerar o tipo canônico `FAKE_EXPERIMENT`.
+- Prevenção: toda sessão vinculada a experimento fake é classificada como automação, preservando os eventos para auditoria técnica sem contaminá-los como evidência comercial.
+- Contrato: teste garante zero sessões humanas no analytics de experimento fake.
+
 ## LOOP-AGENT-RUNNING-WITHOUT-PROGRESS — Agentes Codex
 
 - Sintoma: execução permanece `RUNNING`, mas não é possível comprovar se o processo Codex está vivo ou avançando.


### PR DESCRIPTION
## Objetivo
Impedir que sessões de homologação de experimentos fake sejam interpretadas como comportamento humano ou sinal comercial.

## Alterações
- classifica analytics de `FAKE_EXPERIMENT` como automação;
- preserva eventos para auditoria técnica;
- adiciona teste contra recorrência;
- registra a causa-raiz em `docs/registros/loops.md`;
- corrige uma formatação preexistente que bloqueava o Spotless.

## Validação local
- `mvn -q -Dtest=ExperimentFunnelServiceRenderCompleteTest test`
- `mvn -q spotless:check`
- `git diff --check`

Nenhuma campanha, orçamento ou venda foi alterado.