### PR TITLE
Informa entrega da microamostra ao Operador

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -372,6 +372,36 @@ public class ExperimentFunnelService {
         detailedEvents);
   }
 
+  /** Consolida geração, entrega e abertura das microamostras para decisões do Operador. */
+  public Map<String, Object> buildPersonalizedSampleDeliveryEvidence(Long experimentId) {
+    Map<String, Object> metrics =
+        jdbcTemplate.queryForMap(
+            """
+                SELECT COUNT(*) AS requestedPackages,
+                       SUM(CASE WHEN p.status = 'COMPLETED' THEN 1 ELSE 0 END) AS completedPackages,
+                       COALESCE(SUM(p.planned_outputs), 0) AS plannedImages,
+                       COALESCE(SUM((SELECT COUNT(*) FROM flow_submission_image_item i WHERE i.package_id = p.id)), 0) AS generatedImages,
+                       SUM(CASE WHEN p.zip_generated_at IS NOT NULL THEN 1 ELSE 0 END) AS packagesWithZip,
+                       SUM(CASE WHEN p.notified_at IS NOT NULL THEN 1 ELSE 0 END) AS deliveredEmails,
+                       SUM(CASE WHEN p.email_opened_at IS NOT NULL THEN 1 ELSE 0 END) AS openedEmails,
+                       COALESCE(SUM(p.image_total_price_usd), 0) AS generationCostUsd,
+                       MAX(p.updated_at) AS lastPackageUpdateAt
+                FROM flow_submission_image_package p
+                JOIN flow_submissions s ON s.id = p.submission_id
+                JOIN lead_portal_flow f ON f.slug = s.flow_slug
+                WHERE %s
+                """
+                .formatted(FLOW_SCOPE_CONDITION),
+            experimentId,
+            experimentId);
+    LinkedHashMap<String, Object> evidence = new LinkedHashMap<>();
+    evidence.put("available", true);
+    evidence.put("experimentId", experimentId);
+    evidence.putAll(metrics);
+    evidence.put("scope", "TECHNICAL_AUDIT_NOT_HUMAN_SALES");
+    return evidence;
+  }
+
   /** Entrega jornadas PDE detalhadas e anonimizadas quando o experimento usa essa experiência. */
   public Map<String, Object> buildDetailedPdeAnalyticsEvidence(Long experimentId) {
     Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();

--- a/backend/ads-service/src/main/java/com/marketinghub/growthoperator/service/GrowthOperatorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/growthoperator/service/GrowthOperatorService.java
@@ -306,6 +306,9 @@ public class GrowthOperatorService {
         "landingAnalytics",
         experimentFunnelService.buildDetailedAnalyticsEvidence(experimentId, eventLimit));
     intelligence.put(
+        "personalizedSampleDelivery",
+        experimentFunnelService.buildPersonalizedSampleDeliveryEvidence(experimentId));
+    intelligence.put(
         "pdeAnalytics", experimentFunnelService.buildDetailedPdeAnalyticsEvidence(experimentId));
     return intelligence;
   }

--- a/backend/ads-service/src/test/java/com/marketinghub/growthoperator/service/GrowthOperatorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/growthoperator/service/GrowthOperatorServiceTest.java
@@ -364,6 +364,8 @@ class GrowthOperatorServiceTest {
     when(planService.getPlan(2L)).thenReturn(plan);
     when(funnelService.buildDetailedAnalyticsEvidence(81L, 2000))
         .thenReturn(new ExperimentLandingAnalyticsEvidenceDto(81L, 0, 0, false, null, List.of()));
+    when(funnelService.buildPersonalizedSampleDeliveryEvidence(81L))
+        .thenReturn(Map.of("deliveredEmails", 1L, "openedEmails", 1L));
     when(funnelService.buildDetailedPdeAnalyticsEvidence(81L))
         .thenReturn(Map.of("available", false));
     GrowthOperatorService service =
@@ -383,7 +385,10 @@ class GrowthOperatorServiceTest {
     assertThat(result.get("planId")).isEqualTo(2L);
     assertThat(result.get("experimentId")).isEqualTo(81L);
     assertThat(result.get("appliedEventLimit")).isEqualTo(2000);
+    assertThat(result.get("personalizedSampleDelivery"))
+        .isEqualTo(Map.of("deliveredEmails", 1L, "openedEmails", 1L));
     verify(funnelService).buildDetailedAnalyticsEvidence(81L, 2000);
+    verify(funnelService).buildPersonalizedSampleDeliveryEvidence(81L);
   }
 
   /** Confirma que o agente recebe estrategia e custos sem depender da tela do Estudio. */

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -15,6 +15,12 @@
 - Prevenção: toda sessão vinculada a experimento fake é classificada como automação, preservando os eventos para auditoria técnica sem contaminá-los como evidência comercial.
 - Contrato: teste garante zero sessões humanas no analytics de experimento fake.
 
+## LOOP-OPERADOR-SEM-EVIDENCIA-DE-ENTREGA-DA-MICROAMOSTRA — Inteligência incompleta
+
+- Sintoma: o pacote era gerado, entregue e aberto, mas o Operador afirmava que essas etapas não estavam comprovadas.
+- Causa-raiz: a evidência congelada continha apenas eventos da landing e não incluía o estado persistido dos pacotes de imagem.
+- Prevenção: a inteligência de sessão também expõe pacotes solicitados/concluídos, imagens planejadas/geradas, ZIP, envio, abertura e custo de geração, sempre marcados como auditoria técnica quando o experimento é fake.
+
 ## LOOP-AGENT-RUNNING-WITHOUT-PROGRESS — Agentes Codex
 
 - Sintoma: execução permanece `RUNNING`, mas não é possível comprovar se o processo Codex está vivo ou avançando.


### PR DESCRIPTION
## Objetivo
Entregar ao Operador de Crescimento evidências persistidas de geração, ZIP, envio e abertura da microamostra.

## Alterações
- adiciona inteligência consolidada dos pacotes do experimento;
- informa imagens planejadas e geradas, entregas, aberturas e custo;
- marca homologações como auditoria técnica, não venda humana;
- adiciona teste contra recorrência.

## Validação local
- testes de `GrowthOperatorServiceTest` e `ExperimentFunnelServiceRenderCompleteTest`;
- Spotless;
- integridade do diff.

Nenhuma campanha, orçamento ou venda foi alterado.