### PR TITLE
Protege custo não canônico da microamostra

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -384,7 +384,6 @@ public class ExperimentFunnelService {
                        SUM(CASE WHEN p.zip_generated_at IS NOT NULL THEN 1 ELSE 0 END) AS packagesWithZip,
                        SUM(CASE WHEN p.notified_at IS NOT NULL THEN 1 ELSE 0 END) AS deliveredEmails,
                        SUM(CASE WHEN p.email_opened_at IS NOT NULL THEN 1 ELSE 0 END) AS openedEmails,
-                       COALESCE(SUM(p.image_total_price_usd), 0) AS generationCostUsd,
                        MAX(p.updated_at) AS lastPackageUpdateAt
                 FROM flow_submission_image_package p
                 JOIN flow_submissions s ON s.id = p.submission_id
@@ -398,6 +397,8 @@ public class ExperimentFunnelService {
     evidence.put("available", true);
     evidence.put("experimentId", experimentId);
     evidence.putAll(metrics);
+    evidence.put("generationCostAvailable", false);
+    evidence.put("generationCostUnavailableReason", "PACKAGE_COST_FIELDS_NOT_CANONICAL");
     evidence.put("scope", "TECHNICAL_AUDIT_NOT_HUMAN_SALES");
     return evidence;
   }

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -19,7 +19,8 @@
 
 - Sintoma: o pacote era gerado, entregue e aberto, mas o Operador afirmava que essas etapas não estavam comprovadas.
 - Causa-raiz: a evidência congelada continha apenas eventos da landing e não incluía o estado persistido dos pacotes de imagem.
-- Prevenção: a inteligência de sessão também expõe pacotes solicitados/concluídos, imagens planejadas/geradas, ZIP, envio, abertura e custo de geração, sempre marcados como auditoria técnica quando o experimento é fake.
+- Prevenção: a inteligência de sessão também expõe pacotes solicitados/concluídos, imagens planejadas/geradas, ZIP, envio e abertura, sempre marcados como auditoria técnica quando o experimento é fake.
+- Proteção financeira: enquanto os campos legados de custo do pacote não forem canônicos, o Operador recebe `generationCostAvailable=false` em vez de interpretar o preço comercial de R$ 67 como custo em USD.
 
 ## LOOP-AGENT-RUNNING-WITHOUT-PROGRESS — Agentes Codex
 


### PR DESCRIPTION
## Objetivo
Impedir que o preço comercial de R$ 67 seja interpretado pelo Operador como custo de geração em USD.

## Alterações
- remove a soma financeira de campos legados não canônicos;
- informa indisponibilidade do custo com causa explícita;
- preserva métricas comprovadas de geração, ZIP, envio e abertura.

## Validação local
- `GrowthOperatorServiceTest`;
- Spotless;
- integridade do diff.