### PR TITLE
AI Hub: {"titulo":"Edição do teto do MUSA corrigida","comentario":"A versão publicada exibe o orçamento, mas não permitia alterá-lo pela interface. Corrigi a causa-raiz adicionando ao formulário o campo **Teto total do plano (R$)**, usando o endpoint ofic…

### DIFF
--- a/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.test.tsx
@@ -558,6 +558,7 @@ describe("CommercialPlanningPage", () => {
     expect(screen.getByLabelText("Status")).toBeTruthy();
     expect(screen.getByLabelText("Prazo da meta")).toBeTruthy();
     expect(screen.getByLabelText("Meta de receita")).toBeTruthy();
+    expect(screen.getByLabelText("Teto total do plano (R$)")).toHaveValue(300);
     expect(screen.getByLabelText("Objetivo comercial")).toBeTruthy();
     expect(screen.getByLabelText("Critério de sucesso")).toBeTruthy();
     expect(screen.getByLabelText("Critério de parada")).toBeTruthy();

--- a/frontend/src/pages/planning/CommercialPlanningPage.tsx
+++ b/frontend/src/pages/planning/CommercialPlanningPage.tsx
@@ -1920,6 +1920,27 @@ export default function CommercialPlanningPage() {
                       }
                     />
                   </div>
+                  <div className="col-md-4">
+                    <label className="form-label" htmlFor="planning-max-budget">
+                      Teto total do plano (R$)
+                    </label>
+                    <input
+                      id="planning-max-budget"
+                      className="form-control"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={planDraft.maxBudget ?? ""}
+                      onChange={(event) =>
+                        updatePlanDraft(
+                          "maxBudget",
+                          event.target.value === ""
+                            ? null
+                            : Number(event.target.value),
+                        )
+                      }
+                    />
+                  </div>
                   {(
                     [
                       ["offerPriceBrl", "Preço da oferta (R$)", "0.01"],


### PR DESCRIPTION
- Modo Operador de Crescimento ativo. Fonte de verdade comercial atual: {"id":1,"product":"Agenda Cheia","objective":"Gerar as primeiras cinco vendas com entrega satisfatória","targetSales":5,"budgetLimit":400,"endsAt":"2026-08-09","status":"ACTIVE","visitors":0,"ctaClicks":0,"checkoutsStarted":0,"salesApproved":0,"briefingsCompleted":0,"deliveriesCompleted":0,"refunds":0,"revenue":0,"spend":0,"cac":null,"conversionRate":null,"bottleneck":"INSTRUMENTACAO","recommendedAction":"Aguardar ou corrigir…