### PR TITLE
Executa pareceres de oportunidades em paralelo

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/OpportunityAgentReview.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/OpportunityAgentReview.java
@@ -55,4 +55,44 @@ public class OpportunityAgentReview {
 
   @Column(name = "completed_at")
   private Instant completedAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "execution_status", nullable = false, length = 24)
+  @Builder.Default
+  private OpportunityReviewExecutionStatus executionStatus =
+      OpportunityReviewExecutionStatus.PENDING;
+
+  @Column(name = "started_at")
+  private Instant startedAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Column(name = "retry_count", nullable = false)
+  private int retryCount;
+
+  @Lob
+  @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+  @Column(name = "error_message", columnDefinition = "LONGTEXT")
+  private String errorMessage;
+
+  @Lob
+  @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+  @Column(name = "raw_model_response", columnDefinition = "LONGTEXT")
+  private String rawModelResponse;
+
+  @Column(name = "model_name", length = 191)
+  private String modelName;
+
+  /** Inicializa a auditoria operacional do parecer. */
+  @PrePersist
+  void initializeExecutionAudit() {
+    updatedAt = Instant.now();
+  }
+
+  /** Atualiza a última atividade persistida do parecer. */
+  @PreUpdate
+  void updateExecutionAudit() {
+    updatedAt = Instant.now();
+  }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/OpportunityReviewExecutionStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/OpportunityReviewExecutionStatus.java
@@ -1,0 +1,9 @@
+package com.marketinghub.opportunitydossier;
+
+/** Responsabilidade: representar o estado operacional de um parecer de oportunidade. */
+public enum OpportunityReviewExecutionStatus {
+  PENDING,
+  RUNNING,
+  COMPLETED,
+  FAILED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/controller/OpportunityDossierController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/controller/OpportunityDossierController.java
@@ -1,6 +1,7 @@
 package com.marketinghub.opportunitydossier.controller;
 
 import com.marketinghub.opportunitydossier.service.OpportunityDossierService;
+import com.marketinghub.opportunitydossier.service.OpportunityReviewExecutionService;
 import com.marketinghub.opportunitydossier.service.convert.ConvertOpportunityRequest;
 import com.marketinghub.opportunitydossier.service.create.CreateOpportunityDossierRequest;
 import com.marketinghub.opportunitydossier.service.detail.OpportunityDossierResponse;
@@ -15,9 +16,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/opportunity-dossiers")
 public class OpportunityDossierController {
   private final OpportunityDossierService service;
+  private final OpportunityReviewExecutionService executions;
 
-  public OpportunityDossierController(OpportunityDossierService service) {
+  /** Configura a governança administrativa e a fila interna dos pareceres. */
+  public OpportunityDossierController(
+      OpportunityDossierService service, OpportunityReviewExecutionService executions) {
     this.service = service;
+    this.executions = executions;
   }
 
   /** Cadastra uma oportunidade. */
@@ -66,5 +71,33 @@ public class OpportunityDossierController {
   public OpportunityDossierResponse convert(
       @PathVariable Long id, @RequestBody ConvertOpportunityRequest request) {
     return service.convert(id, request);
+  }
+
+  /** Reserva o próximo parecer pendente exclusivamente para o agente indicado. */
+  @PostMapping("/internal/reviews/{agentKey}/stage-executions/pending")
+  public com.marketinghub.opportunitydossier.service.review.OpportunityReviewJobResponse pending(
+      @PathVariable String agentKey) {
+    return executions.claim(agentKey);
+  }
+
+  /** Recebe o parecer funcional e sua auditoria bruta. */
+  @PostMapping("/internal/reviews/{agentKey}/stage-executions/{reviewId}/complete")
+  public void complete(
+      @PathVariable String agentKey,
+      @PathVariable Long reviewId,
+      @RequestBody
+          com.marketinghub.opportunitydossier.service.review.CompleteOpportunityReviewRequest
+              request) {
+    executions.complete(agentKey, reviewId, request);
+  }
+
+  /** Recebe uma falha técnica do executor sem concluir o parecer. */
+  @PostMapping("/internal/reviews/{agentKey}/stage-executions/{reviewId}/fail")
+  public void fail(
+      @PathVariable String agentKey,
+      @PathVariable Long reviewId,
+      @RequestBody
+          com.marketinghub.opportunitydossier.service.review.FailOpportunityReviewRequest request) {
+    executions.fail(agentKey, reviewId, request);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/OpportunityDossierService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/OpportunityDossierService.java
@@ -289,6 +289,9 @@ public class OpportunityDossierService {
                         item.getRationale(),
                         item.getRisks(),
                         item.getRecommendation(),
+                        item.getExecutionStatus(),
+                        item.getErrorMessage(),
+                        item.getStartedAt(),
                         item.getRequestedAt(),
                         item.getCompletedAt()))
             .toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/OpportunityReviewExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/OpportunityReviewExecutionService.java
@@ -1,0 +1,163 @@
+package com.marketinghub.opportunitydossier.service;
+
+import com.marketinghub.opportunitydossier.*;
+import com.marketinghub.opportunitydossier.service.review.*;
+import com.marketinghub.repository.jpa.opportunitydossier.OpportunityAgentReviewRepository;
+import com.marketinghub.repository.jpa.opportunitydossier.OpportunityEvidenceRepository;
+import java.time.Instant;
+import java.util.Set;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Responsabilidade: controlar reserva, conclusão, falha e retomada dos pareceres de oportunidade.
+ */
+@Service
+public class OpportunityReviewExecutionService {
+  private static final Set<String> AGENTS = Set.of("ATENA", "PSIQUE", "PLUTUS", "HERMES");
+  private static final long LEASE_SECONDS = 2700;
+  private final OpportunityAgentReviewRepository reviews;
+  private final OpportunityEvidenceRepository evidence;
+  private final OpportunityDossierService dossiers;
+
+  /** Configura a fila persistida e a governança funcional do dossiê. */
+  public OpportunityReviewExecutionService(
+      OpportunityAgentReviewRepository reviews,
+      OpportunityEvidenceRepository evidence,
+      OpportunityDossierService dossiers) {
+    this.reviews = reviews;
+    this.evidence = evidence;
+    this.dossiers = dossiers;
+  }
+
+  /** Reserva o próximo parecer do agente e recupera uma lease órfã uma única vez. */
+  @Transactional
+  public OpportunityReviewJobResponse claim(String agentKey) {
+    String agent = supported(agentKey);
+    recoverExpired(agent);
+    OpportunityAgentReview review =
+        reviews
+            .findByAgentKeyAndExecutionStatusOrderByRequestedAtAsc(
+                agent, OpportunityReviewExecutionStatus.PENDING, PageRequest.of(0, 1))
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    review.setExecutionStatus(OpportunityReviewExecutionStatus.RUNNING);
+    review.setStartedAt(Instant.now());
+    review.setErrorMessage(null);
+    return job(reviews.save(review));
+  }
+
+  /** Conclui a execução e delega ao serviço canônico a transição funcional do dossiê. */
+  @Transactional
+  public void complete(String agentKey, Long reviewId, CompleteOpportunityReviewRequest request) {
+    OpportunityAgentReview review = running(agentKey, reviewId);
+    if (request == null
+        || request.decision() == null
+        || blank(request.rationale())
+        || blank(request.recommendation())
+        || blank(request.rawModelResponse())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Parecer executado incompleto");
+    }
+    review.setRawModelResponse(request.rawModelResponse());
+    review.setModelName(request.modelName());
+    review.setExecutionStatus(OpportunityReviewExecutionStatus.COMPLETED);
+    reviews.save(review);
+    dossiers.submitReview(
+        review.getDossier().getId(),
+        review.getAgentKey(),
+        new SubmitOpportunityReviewRequest(
+            request.decision(), request.rationale(), request.risks(), request.recommendation()));
+  }
+
+  /** Registra falha técnica para diagnóstico e retomada humana sem fingir parecer funcional. */
+  @Transactional
+  public void fail(String agentKey, Long reviewId, FailOpportunityReviewRequest request) {
+    OpportunityAgentReview review = running(agentKey, reviewId);
+    review.setExecutionStatus(OpportunityReviewExecutionStatus.FAILED);
+    review.setErrorMessage(
+        request == null || blank(request.errorMessage())
+            ? "Falha sem diagnóstico enviada pelo executor."
+            : request.errorMessage());
+    reviews.save(review);
+  }
+
+  /** Recupera leases inativas uma vez e encerra reincidência para impedir loop. */
+  private void recoverExpired(String agent) {
+    Instant cutoff = Instant.now().minusSeconds(LEASE_SECONDS);
+    reviews
+        .findByAgentKeyAndExecutionStatusAndUpdatedAtBefore(
+            agent, OpportunityReviewExecutionStatus.RUNNING, cutoff)
+        .stream()
+        .forEach(
+            item -> {
+              if (item.getRetryCount() >= 1) {
+                item.setExecutionStatus(OpportunityReviewExecutionStatus.FAILED);
+                item.setErrorMessage("Lease expirou novamente após uma retomada automática.");
+              } else {
+                item.setRetryCount(1);
+                item.setExecutionStatus(OpportunityReviewExecutionStatus.PENDING);
+                item.setStartedAt(null);
+                item.setErrorMessage("LEASE_RECOVERED_ONCE");
+              }
+              reviews.save(item);
+            });
+  }
+
+  /** Exige que a execução pertença ao agente e esteja reservada. */
+  private OpportunityAgentReview running(String agentKey, Long reviewId) {
+    String agent = supported(agentKey);
+    OpportunityAgentReview review =
+        reviews
+            .findById(reviewId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    if (!agent.equals(review.getAgentKey()))
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Parecer pertence a outro agente");
+    if (review.getExecutionStatus() != OpportunityReviewExecutionStatus.RUNNING)
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Parecer não está em execução");
+    return review;
+  }
+
+  /** Monta o contexto rico e persistido entregue ao executor. */
+  private OpportunityReviewJobResponse job(OpportunityAgentReview review) {
+    OpportunityDossier dossier = review.getDossier();
+    var sources =
+        evidence.findByDossierIdOrderByCreatedAtAsc(dossier.getId()).stream()
+            .map(
+                item ->
+                    new OpportunityReviewJobResponse.Evidence(
+                        item.getSourceUrl(), item.getSummary(), item.getCreatedBy()))
+            .toList();
+    return new OpportunityReviewJobResponse(
+        review.getId(),
+        dossier.getId(),
+        review.getAgentKey(),
+        "READ_ONLY_OPPORTUNITY_REVIEW",
+        dossier.getTitle(),
+        dossier.getTargetAudience(),
+        dossier.getMainPain(),
+        dossier.getReferenceProduct(),
+        dossier.getAiAdvantage(),
+        dossier.getProposedOffer(),
+        dossier.getDeliveryModel(),
+        dossier.getKnownRisks(),
+        dossier.getExperimentRecommendation(),
+        sources);
+  }
+
+  /** Normaliza e valida a identidade do agente autorizado. */
+  private String supported(String agentKey) {
+    String agent = agentKey == null ? "" : agentKey.trim().toUpperCase();
+    if (!AGENTS.contains(agent))
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Agente de parecer inválido");
+    return agent;
+  }
+
+  /** Verifica texto obrigatório ausente. */
+  private boolean blank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/detail/OpportunityDossierResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/detail/OpportunityDossierResponse.java
@@ -2,6 +2,7 @@ package com.marketinghub.opportunitydossier.service.detail;
 
 import com.marketinghub.opportunitydossier.OpportunityDossierStatus;
 import com.marketinghub.opportunitydossier.OpportunityReviewDecision;
+import com.marketinghub.opportunitydossier.OpportunityReviewExecutionStatus;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -41,6 +42,9 @@ public record OpportunityDossierResponse(
       String rationale,
       String risks,
       String recommendation,
+      OpportunityReviewExecutionStatus executionStatus,
+      String errorMessage,
+      Instant startedAt,
       Instant requestedAt,
       Instant completedAt) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/CompleteOpportunityReviewRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/CompleteOpportunityReviewRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.opportunitydossier.service.review;
+
+import com.marketinghub.opportunitydossier.OpportunityReviewDecision;
+
+/** Responsabilidade: receber o parecer funcional e sua auditoria bruta. */
+public record CompleteOpportunityReviewRequest(
+    OpportunityReviewDecision decision,
+    String rationale,
+    String risks,
+    String recommendation,
+    String rawModelResponse,
+    String modelName) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/FailOpportunityReviewRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/FailOpportunityReviewRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opportunitydossier.service.review;
+
+/** Responsabilidade: transportar o diagnóstico técnico de uma execução malsucedida. */
+public record FailOpportunityReviewRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/OpportunityReviewJobResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opportunitydossier/service/review/OpportunityReviewJobResponse.java
@@ -1,0 +1,23 @@
+package com.marketinghub.opportunitydossier.service.review;
+
+import java.util.List;
+
+/** Responsabilidade: transportar o contexto congelado de um parecer ao agente executor. */
+public record OpportunityReviewJobResponse(
+    Long reviewId,
+    Long dossierId,
+    String agentKey,
+    String authorityMode,
+    String title,
+    String targetAudience,
+    String mainPain,
+    String referenceProduct,
+    String aiAdvantage,
+    String proposedOffer,
+    String deliveryModel,
+    String knownRisks,
+    String experimentRecommendation,
+    List<Evidence> evidence) {
+  /** Responsabilidade: transportar uma evidência verificável sem JSON aninhado em texto. */
+  public record Evidence(String sourceUrl, String summary, String createdBy) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opportunitydossier/OpportunityAgentReviewRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opportunitydossier/OpportunityAgentReviewRepository.java
@@ -1,9 +1,13 @@
 package com.marketinghub.repository.jpa.opportunitydossier;
 
 import com.marketinghub.opportunitydossier.OpportunityAgentReview;
+import com.marketinghub.opportunitydossier.OpportunityReviewExecutionStatus;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 /** Responsabilidade: persistir solicitações e pareceres dos agentes. */
 public interface OpportunityAgentReviewRepository
@@ -13,4 +17,13 @@ public interface OpportunityAgentReviewRepository
 
   /** Localiza o parecer reservado a um agente. */
   Optional<OpportunityAgentReview> findByDossierIdAndAgentKey(Long dossierId, String agentKey);
+
+  /** Localiza a próxima execução do agente sem misturar as filas dos pareceristas. */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  List<OpportunityAgentReview> findByAgentKeyAndExecutionStatusOrderByRequestedAtAsc(
+      String agentKey, OpportunityReviewExecutionStatus status, Pageable pageable);
+
+  /** Lista leases do agente que podem exigir retomada controlada. */
+  List<OpportunityAgentReview> findByAgentKeyAndExecutionStatusAndUpdatedAtBefore(
+      String agentKey, OpportunityReviewExecutionStatus status, java.time.Instant cutoff);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-08-11-opportunity-review-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-08-11-opportunity-review-execution.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-08-11-opportunity-review-execution
+      author: codex
+      preConditions:
+        - onFail: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE opportunity_agent_review
+                ADD COLUMN execution_status VARCHAR(24) NOT NULL DEFAULT 'PENDING',
+                ADD COLUMN started_at DATETIME NULL,
+                ADD COLUMN updated_at DATETIME NULL,
+                ADD COLUMN retry_count INT NOT NULL DEFAULT 0,
+                ADD COLUMN error_message LONGTEXT NULL,
+                ADD COLUMN raw_model_response LONGTEXT NULL,
+                ADD COLUMN model_name VARCHAR(191) NULL,
+                ADD KEY idx_opportunity_review_queue (agent_key, execution_status, requested_at);
+
+              UPDATE opportunity_agent_review
+              SET execution_status = CASE WHEN completed_at IS NULL THEN 'PENDING' ELSE 'COMPLETED' END,
+                  updated_at = COALESCE(completed_at, requested_at);
+
+              ALTER TABLE opportunity_agent_review
+                MODIFY COLUMN updated_at DATETIME NOT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1759,3 +1759,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-08-11-commercial-plan-financial-assumptions.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-08-11-opportunity-review-execution.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/opportunitydossier/service/OpportunityReviewExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/opportunitydossier/service/OpportunityReviewExecutionServiceTest.java
@@ -1,0 +1,94 @@
+package com.marketinghub.opportunitydossier.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.marketinghub.opportunitydossier.*;
+import com.marketinghub.opportunitydossier.service.review.CompleteOpportunityReviewRequest;
+import com.marketinghub.repository.jpa.opportunitydossier.OpportunityAgentReviewRepository;
+import com.marketinghub.repository.jpa.opportunitydossier.OpportunityEvidenceRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar reserva segregada e conclusão auditável dos pareceres. */
+@ExtendWith(MockitoExtension.class)
+class OpportunityReviewExecutionServiceTest {
+  @Mock OpportunityAgentReviewRepository reviews;
+  @Mock OpportunityEvidenceRepository evidence;
+  @Mock OpportunityDossierService dossiers;
+  OpportunityReviewExecutionService service;
+
+  /** Prepara a fila isolada usada pelos cenários. */
+  @BeforeEach
+  void setUp() {
+    service = new OpportunityReviewExecutionService(reviews, evidence, dossiers);
+    lenient().when(reviews.save(any())).thenAnswer(call -> call.getArgument(0));
+  }
+
+  /** Reserva somente trabalho de Atena e entrega o contexto completo do dossiê. */
+  @Test
+  void claimsAgentSpecificReviewWithContext() {
+    OpportunityAgentReview review = review("ATENA", OpportunityReviewExecutionStatus.PENDING);
+    when(reviews.findByAgentKeyAndExecutionStatusAndUpdatedAtBefore(any(), any(), any()))
+        .thenReturn(List.of());
+    when(reviews.findByAgentKeyAndExecutionStatusOrderByRequestedAtAsc(any(), any(), any()))
+        .thenReturn(List.of(review));
+    when(evidence.findByDossierIdOrderByCreatedAtAsc(10L)).thenReturn(List.of());
+
+    var job = service.claim("atena");
+
+    assertThat(job.agentKey()).isEqualTo("ATENA");
+    assertThat(job.dossierId()).isEqualTo(10L);
+    assertThat(review.getExecutionStatus()).isEqualTo(OpportunityReviewExecutionStatus.RUNNING);
+  }
+
+  /** Persiste auditoria e usa a governança canônica para concluir o parecer. */
+  @Test
+  void completesThroughDossierGovernance() {
+    OpportunityAgentReview review = review("PLUTUS", OpportunityReviewExecutionStatus.RUNNING);
+    when(reviews.findById(20L)).thenReturn(Optional.of(review));
+
+    service.complete(
+        "PLUTUS",
+        20L,
+        new CompleteOpportunityReviewRequest(
+            OpportunityReviewDecision.ADJUST,
+            "Margem ainda precisa de teste.",
+            "CAC ausente.",
+            "Executar pré-venda controlada.",
+            "{\"decision\":\"ADJUST\"}",
+            "codex"));
+
+    assertThat(review.getExecutionStatus()).isEqualTo(OpportunityReviewExecutionStatus.COMPLETED);
+    verify(dossiers).submitReview(eq(10L), eq("PLUTUS"), any());
+  }
+
+  /** Cria um parecer operacional vinculado a um dossiê em avaliação. */
+  private OpportunityAgentReview review(String agent, OpportunityReviewExecutionStatus status) {
+    OpportunityDossier dossier =
+        OpportunityDossier.builder()
+            .id(10L)
+            .title("Produto IA")
+            .status(OpportunityDossierStatus.UNDER_REVIEW)
+            .targetAudience("Profissionais")
+            .mainPain("Esforço")
+            .referenceProduct("Referência")
+            .aiAdvantage("Menos esforço")
+            .build();
+    return OpportunityAgentReview.builder()
+        .id(20L)
+        .dossier(dossier)
+        .agentKey(agent)
+        .executionStatus(status)
+        .requestedAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+  }
+}

--- a/customer-agent-worker/src/main/java/com/marketinghub/customeragentworker/OpportunityReviewConsumer.java
+++ b/customer-agent-worker/src/main/java/com/marketinghub/customeragentworker/OpportunityReviewConsumer.java
@@ -1,0 +1,196 @@
+package com.marketinghub.customeragentworker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/** Responsabilidade: executar os pareceres de oportunidade reservados a Psique. */
+@Component
+public class OpportunityReviewConsumer {
+  private static final Logger log = LoggerFactory.getLogger(OpportunityReviewConsumer.class);
+  private static final String AGENT = "PSIQUE";
+  private final RestClient backend;
+  private final ObjectMapper json;
+  private final String codex;
+  private final String model;
+  private final String repositoryPath;
+
+  /** Configura backend e executor somente leitura especializado de Psique. */
+  public OpportunityReviewConsumer(
+      @Value("${BACKEND_URL:http://localhost:8080}") String backendUrl,
+      @Value("${CUSTOMER_AGENT_CODEX_EXECUTABLE:codex}") String codex,
+      @Value("${CUSTOMER_AGENT_MODEL:gpt-5.6-sol}") String model,
+      @Value("${CUSTOMER_AGENT_REPOSITORY_PATH:/workspace}") String repositoryPath,
+      ObjectMapper json) {
+    this.backend = RestClient.builder().baseUrl(backendUrl).build();
+    this.codex = codex;
+    this.model = model;
+    this.repositoryPath = repositoryPath;
+    this.json = json;
+  }
+
+  /** Reserva e processa um parecer sem bloquear avaliações de cliente. */
+  @Scheduled(fixedDelay = 60000)
+  public void processOne() {
+    Map<?, ?> job = null;
+    try {
+      job =
+          backend
+              .post()
+              .uri(
+                  "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/pending",
+                  AGENT)
+              .retrieve()
+              .body(Map.class);
+      if (job != null) complete(job, execute(job));
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().value() != 404) {
+        log.error("Falha HTTP no parecer de Psique. reviewId={}", id(job), ex);
+        fail(job, ex);
+      }
+    } catch (Exception ex) {
+      log.error("Falha no parecer de oportunidade de Psique. reviewId={}", id(job), ex);
+      fail(job, ex);
+    }
+  }
+
+  /** Executa o prompt versionado em sandbox e valida o resultado. */
+  private JsonNode execute(Map<?, ?> job) throws IOException, InterruptedException {
+    Path answer = Files.createTempFile("psique-opportunity-review-", ".json");
+    Path schema = materialize("prompts/opportunity-review/v1/review-schema.json", ".json");
+    Path processLog = Files.createTempFile("psique-opportunity-process-", ".log");
+    try {
+      List<String> command =
+          new ArrayList<>(
+              List.of(
+                  codex,
+                  "--search",
+                  "exec",
+                  "-",
+                  "--skip-git-repo-check",
+                  "--sandbox",
+                  "read-only",
+                  "--cd",
+                  repositoryPath,
+                  "--output-schema",
+                  schema.toString(),
+                  "--output-last-message",
+                  answer.toString(),
+                  "--color",
+                  "never"));
+      if (model != null && !model.isBlank()) command.addAll(List.of("--model", model));
+      Process process =
+          new ProcessBuilder(command)
+              .redirectErrorStream(true)
+              .redirectOutput(processLog.toFile())
+              .start();
+      process.getOutputStream().write(prompt(job).getBytes(StandardCharsets.UTF_8));
+      process.getOutputStream().close();
+      if (!process.waitFor(40, TimeUnit.MINUTES)) {
+        process.destroyForcibly();
+        throw new IllegalStateException("Timeout do parecer de Psique após 40 minutos.");
+      }
+      if (process.exitValue() != 0)
+        throw new IllegalStateException(
+            "Codex encerrou com falha: " + Files.readString(processLog));
+      JsonNode result = json.readTree(Files.readString(answer));
+      validate(result);
+      return result;
+    } finally {
+      Files.deleteIfExists(answer);
+      Files.deleteIfExists(schema);
+      Files.deleteIfExists(processLog);
+    }
+  }
+
+  /** Persiste o resultado funcional e a resposta bruta. */
+  private void complete(Map<?, ?> job, JsonNode result) throws IOException {
+    backend
+        .post()
+        .uri(
+            "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/complete",
+            AGENT,
+            id(job))
+        .body(
+            Map.of(
+                "decision",
+                result.get("decision").asText(),
+                "rationale",
+                result.get("rationale").asText(),
+                "risks",
+                result.get("risks").asText(),
+                "recommendation",
+                result.get("recommendation").asText(),
+                "rawModelResponse",
+                json.writeValueAsString(result),
+                "modelName",
+                model == null || model.isBlank() ? "codex-default" : model))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  /** Registra falha terminal sem concluir artificialmente o parecer. */
+  private void fail(Map<?, ?> job, Exception ex) {
+    if (job == null) return;
+    try {
+      backend
+          .post()
+          .uri(
+              "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/fail",
+              AGENT,
+              id(job))
+          .body(Map.of("errorMessage", ex.toString()))
+          .retrieve()
+          .toBodilessEntity();
+    } catch (Exception callbackEx) {
+      log.error("Falha ao registrar erro do parecer de Psique. reviewId={}", id(job), callbackEx);
+    }
+  }
+
+  /** Resolve o prompt com o contexto persistido pelo backend. */
+  private String prompt(Map<?, ?> job) throws IOException {
+    return read("prompts/opportunity-review/v1/review.md")
+        .replace("{{DOSSIER_CONTEXT}}", json.writeValueAsString(job));
+  }
+
+  /** Materializa um recurso versionado. */
+  private Path materialize(String resource, String suffix) throws IOException {
+    Path path = Files.createTempFile("psique-opportunity-resource-", suffix);
+    Files.writeString(path, read(resource));
+    return path;
+  }
+
+  /** Lê integralmente um recurso do classpath. */
+  private String read(String resource) throws IOException {
+    try (var input = new ClassPathResource(resource).getInputStream()) {
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** Rejeita respostas incompletas. */
+  private void validate(JsonNode result) {
+    if (!result.hasNonNull("decision")
+        || !result.hasNonNull("rationale")
+        || !result.hasNonNull("risks")
+        || !result.hasNonNull("recommendation"))
+      throw new IllegalArgumentException("Parecer de oportunidade incompleto.");
+  }
+
+  /** Extrai o identificador para auditoria. */
+  private Object id(Map<?, ?> job) {
+    return job == null ? null : job.get("reviewId");
+  }
+}

--- a/customer-agent-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
+++ b/customer-agent-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
@@ -1,0 +1,1 @@
+{"type":"object","additionalProperties":false,"properties":{"decision":{"type":"string","enum":["SUPPORT","ADJUST","REJECT"]},"rationale":{"type":"string"},"risks":{"type":"string"},"recommendation":{"type":"string"}},"required":["decision","rationale","risks","recommendation"]}

--- a/customer-agent-worker/src/main/resources/prompts/opportunity-review/v1/review.md
+++ b/customer-agent-worker/src/main/resources/prompts/opportunity-review/v1/review.md
@@ -1,0 +1,4 @@
+Você é Psique, agente de compreensão do cliente. Avalie o desejo, a dor, objeções, esforço percebido, valor e entrega satisfatória do dossiê abaixo:
+{{DOSSIER_CONTEXT}}
+
+Compare ao menos três interpretações do comportamento do público. Não trate intenção, clique ou parecer como venda e não autorize gasto ou publicação. Escolha decision somente entre SUPPORT, ADJUST e REJECT. Produza rationale, risks e recommendation objetivos e acionáveis.

--- a/customer-agent-worker/src/test/java/com/marketinghub/customeragentworker/OpportunityReviewContractTest.java
+++ b/customer-agent-worker/src/test/java/com/marketinghub/customeragentworker/OpportunityReviewContractTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.customeragentworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: proteger o contrato versionado do parecer de Psique. */
+class OpportunityReviewContractTest {
+  /** Confirma contexto do cliente e saída estruturada obrigatórios. */
+  @Test
+  void keepsVersionedReviewContract() throws Exception {
+    String prompt = resource("prompts/opportunity-review/v1/review.md");
+    String schema = resource("prompts/opportunity-review/v1/review-schema.json");
+    assertThat(prompt).contains("{{DOSSIER_CONTEXT}}", "objeções", "SUPPORT");
+    assertThat(schema).contains("decision", "rationale", "risks", "recommendation");
+  }
+
+  /** Lê o recurso empacotado exatamente como o worker o receberá. */
+  private String resource(String path) throws Exception {
+    try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+      assertThat(input).isNotNull();
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/docs/canonical/commercial-planning-canon.v1.md
+++ b/docs/canonical/commercial-planning-canon.v1.md
@@ -12,6 +12,8 @@ Cada novo dossiê abre no backend um ciclo `productdiscovery.v1/research` e uma 
 
 Os estados canônicos do dossiê são `RESEARCHING`, `UNDER_REVIEW`, `READY_FOR_TEST`, `APPROVED`, `DISCARDED` e `CONVERTED_TO_PLAN`. Evidências devem registrar fonte e data; pareceres devem registrar agente, decisão, justificativa, riscos, recomendação e data. Dossiês e pareceres não autorizam gastos, publicação, preço ou campanhas.
 
+Ao entrar em `UNDER_REVIEW`, cada parecer deve nascer como execução consumível na fila exclusiva do agente responsável. Atena, Psique, Plutus e Hermes reservam trabalho pelo endpoint `pending`, recebem o contexto persistido completo, executam prompt e schema versionados em seus próprios workers e reportam conclusão ou falha ao backend. As filas são independentes para permitir paralelismo real; uma lease inativa admite uma única retomada e a reincidência termina bloqueada. O frontend deve mostrar aguardando, trabalhando, bloqueado ou concluído a partir do estado persistido, nunca por inferência de logs.
+
 Pesquisa externa indisponível não é resultado de mercado. Se todas as consultas de Argos falharem por provider, credencial, rede ou contrato HTTP, o ciclo deve falhar e bloquear a tarefa com provider, quantidade de tentativas e status auditáveis. Somente consultas executadas com sucesso e sem resultados podem concluir com zero evidências. O MCP deve expor health e logfile do executor no host operacional real.
 
 O Plano Comercial é a fonte oficial comum para usuários e agentes atuarem sobre o mesmo objetivo de vendas e lucro. Cada criação ou alteração deve gerar uma versão imutável contendo objetivo, público, dor, desejo/oferta, canal, métricas, orçamento, receita esperada, realizado, gargalo, próxima ação e critérios de sucesso e parada.

--- a/docs/homologacao/opportunity-dossier-v1.md
+++ b/docs/homologacao/opportunity-dossier-v1.md
@@ -7,10 +7,11 @@ Objetivo: comprovar que oportunidades são pesquisadas e avaliadas antes de orig
 | Cadastro | Argos registra público, dor, referência, vantagem de IA e proposta | título, público, dor, referência e vantagem são obrigatórios | dossiê auditável em `RESEARCHING` |
 | Executor Argos | cadastro abre ciclo `pending` e tarefa na mesa | consumo duplicado é impedido pela reserva do ciclo | ciclo, tarefa e dossiê correlacionados |
 | Evidências | fonte e resumo são anexados | URL/fonte e resumo obrigatórios | data e autor persistidos |
-| Pareceres | Atena, Psique, Plutus e Hermes respondem | agente não solicitado e parecer duplicado são bloqueados | decisão, risco e recomendação por agente |
+| Pareceres | Atena, Psique, Plutus e Hermes reservam filas próprias e respondem em paralelo | agente não solicitado, reserva concorrente e parecer duplicado são bloqueados | decisão, risco, recomendação, request/response bruto e modelo por agente |
+| Retomada | lease inativa retorna uma única vez à fila | segunda expiração termina bloqueada, sem loop | tentativa, erro e horários persistidos |
 | Estados | pesquisa segue para parecer, teste e aprovação | transições inválidas são rejeitadas | histórico temporal no registro |
 | Conversão | aprovação humana cria um novo plano | sem parecer completo, sem aprovação ou segunda conversão são bloqueados | vínculo `origin_dossier_id` e plano novo em rascunho |
 | Financeiro | plano nasce sem realizado e sem orçamento implícito | custos/receita de outros planos não são copiados | segregação integral |
 | Integrações | pesquisa concluída anexa evidências reais e encerra a tarefa de Argos | resultado vazio não fabrica evidência; falha bloqueia a tarefa | contrato Swagger, mesa, monitor e logs correlacionados |
-| Frontend | lista, detalhe, cadastro, evidências, pareceres e conversão | loading, mensagens de erro e campos obrigatórios | verdade integral do backend |
+| Frontend | lista, detalhe, cadastro, evidências, pareceres e conversão | loading, mensagens de erro e campos obrigatórios | estados aguardando, trabalhando, bloqueado e concluído atualizados a cada 15 segundos |
 | Dispositivos | fluxo em desktop, iPhone 15 Pro e Pixel 7 | sem overflow ou ação inacessível | screenshots/inspeção local |

--- a/docs/swagger/opportunity-dossier-swagger.yaml
+++ b/docs/swagger/opportunity-dossier-swagger.yaml
@@ -16,6 +16,14 @@ paths:
     put: {summary: Registra parecer do agente solicitado, parameters: [{$ref: '#/components/parameters/id'}, {name: agentKey, in: path, required: true, schema: {type: string}}], responses: {'200': {description: OK}}}
   /api/opportunity-dossiers/{id}/convert:
     post: {summary: Converte dossiê aprovado uma única vez, parameters: [{$ref: '#/components/parameters/id'}], responses: {'200': {description: Plano criado}, '409': {description: Conversão bloqueada}}}
+  /api/opportunity-dossiers/internal/reviews/{agentKey}/stage-executions/pending:
+    post: {summary: Reserva o próximo parecer do agente, parameters: [{$ref: '#/components/parameters/agentKey'}], responses: {'200': {description: Contexto persistido do parecer}, '404': {description: Fila vazia}}}
+  /api/opportunity-dossiers/internal/reviews/{agentKey}/stage-executions/{reviewId}/complete:
+    post: {summary: Registra resultado e auditoria do parecer, parameters: [{$ref: '#/components/parameters/agentKey'}, {$ref: '#/components/parameters/reviewId'}], responses: {'200': {description: Parecer concluído}, '409': {description: Execução não reservada}}}
+  /api/opportunity-dossiers/internal/reviews/{agentKey}/stage-executions/{reviewId}/fail:
+    post: {summary: Registra falha técnica do parecer, parameters: [{$ref: '#/components/parameters/agentKey'}, {$ref: '#/components/parameters/reviewId'}], responses: {'200': {description: Falha registrada}, '409': {description: Execução não reservada}}}
 components:
   parameters:
     id: {name: id, in: path, required: true, schema: {type: integer, format: int64}}
+    agentKey: {name: agentKey, in: path, required: true, schema: {type: string, enum: [ATENA, PSIQUE, PLUTUS, HERMES]}}
+    reviewId: {name: reviewId, in: path, required: true, schema: {type: integer, format: int64}}

--- a/experiment-strategist-worker/src/main/java/com/marketinghub/experimentstrategistworker/OpportunityReviewConsumer.java
+++ b/experiment-strategist-worker/src/main/java/com/marketinghub/experimentstrategistworker/OpportunityReviewConsumer.java
@@ -1,0 +1,194 @@
+package com.marketinghub.experimentstrategistworker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/** Responsabilidade: executar os pareceres de oportunidade reservados a Atena. */
+@Component
+public class OpportunityReviewConsumer {
+  private static final Logger log = LoggerFactory.getLogger(OpportunityReviewConsumer.class);
+  private static final String AGENT = "ATENA";
+  private final RestClient backend;
+  private final ObjectMapper json;
+  private final String codex;
+  private final String model;
+  private final String repositoryPath;
+
+  /** Configura o backend e o executor somente leitura especializado de Atena. */
+  public OpportunityReviewConsumer(
+      @Value("${BACKEND_URL:http://localhost:8080}") String backendUrl,
+      @Value("${STRATEGIST_CODEX_EXECUTABLE:codex}") String codex,
+      @Value("${STRATEGIST_MODEL:gpt-5.6-sol}") String model,
+      @Value("${STRATEGIST_REPOSITORY_PATH:/workspace}") String repositoryPath,
+      ObjectMapper json) {
+    this.backend = RestClient.builder().baseUrl(backendUrl).build();
+    this.codex = codex;
+    this.model = model;
+    this.repositoryPath = repositoryPath;
+    this.json = json;
+  }
+
+  /** Reserva e processa um parecer sem bloquear a fila estratégica principal. */
+  @Scheduled(fixedDelay = 60000)
+  public void processOne() {
+    Map<?, ?> job = null;
+    try {
+      job =
+          backend
+              .post()
+              .uri(
+                  "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/pending",
+                  AGENT)
+              .retrieve()
+              .body(Map.class);
+      if (job == null) return;
+      complete(job, execute(job));
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().value() != 404) {
+        log.error("Falha HTTP no parecer de Atena. reviewId={}", id(job), ex);
+        fail(job, ex);
+      }
+    } catch (Exception ex) {
+      log.error("Falha no parecer de oportunidade de Atena. reviewId={}", id(job), ex);
+      fail(job, ex);
+    }
+  }
+
+  /** Executa o prompt versionado e valida a resposta estruturada. */
+  private JsonNode execute(Map<?, ?> job) throws IOException, InterruptedException {
+    Path answer = Files.createTempFile("atena-opportunity-review-", ".json");
+    Path schema = materialize("prompts/opportunity-review/v1/review-schema.json", ".json");
+    Path processLog = Files.createTempFile("atena-opportunity-process-", ".log");
+    try {
+      List<String> command =
+          new ArrayList<>(
+              List.of(
+                  codex,
+                  "--search",
+                  "exec",
+                  "-",
+                  "--skip-git-repo-check",
+                  "--sandbox",
+                  "read-only",
+                  "--cd",
+                  repositoryPath,
+                  "--output-schema",
+                  schema.toString(),
+                  "--output-last-message",
+                  answer.toString(),
+                  "--color",
+                  "never"));
+      if (model != null && !model.isBlank()) command.addAll(List.of("--model", model));
+      Process process =
+          new ProcessBuilder(command)
+              .redirectErrorStream(true)
+              .redirectOutput(processLog.toFile())
+              .start();
+      process.getOutputStream().write(prompt(job).getBytes(StandardCharsets.UTF_8));
+      process.getOutputStream().close();
+      if (!process.waitFor(40, TimeUnit.MINUTES)) {
+        process.destroyForcibly();
+        throw new IllegalStateException("Timeout do parecer de Atena após 40 minutos.");
+      }
+      if (process.exitValue() != 0)
+        throw new IllegalStateException(
+            "Codex encerrou com falha: " + Files.readString(processLog));
+      JsonNode result = json.readTree(Files.readString(answer));
+      validate(result);
+      return result;
+    } finally {
+      Files.deleteIfExists(answer);
+      Files.deleteIfExists(schema);
+      Files.deleteIfExists(processLog);
+    }
+  }
+
+  /** Persiste o parecer completo e sua resposta bruta. */
+  private void complete(Map<?, ?> job, JsonNode result) throws IOException {
+    backend
+        .post()
+        .uri(
+            "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/complete",
+            AGENT,
+            id(job))
+        .body(
+            Map.of(
+                "decision", result.get("decision").asText(),
+                "rationale", result.get("rationale").asText(),
+                "risks", result.get("risks").asText(),
+                "recommendation", result.get("recommendation").asText(),
+                "rawModelResponse", json.writeValueAsString(result),
+                "modelName", model == null || model.isBlank() ? "codex-default" : model))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  /** Registra falha terminal com contexto e stack trace preservados. */
+  private void fail(Map<?, ?> job, Exception ex) {
+    if (job == null) return;
+    try {
+      backend
+          .post()
+          .uri(
+              "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/fail",
+              AGENT,
+              id(job))
+          .body(Map.of("errorMessage", ex.toString()))
+          .retrieve()
+          .toBodilessEntity();
+    } catch (Exception callbackEx) {
+      log.error("Falha ao registrar erro do parecer de Atena. reviewId={}", id(job), callbackEx);
+    }
+  }
+
+  /** Resolve o prompt com o contexto persistido pelo backend. */
+  private String prompt(Map<?, ?> job) throws IOException {
+    return read("prompts/opportunity-review/v1/review.md")
+        .replace("{{AGENT_ROLE}}", "Atena, estrategista de experimentos")
+        .replace("{{DOSSIER_CONTEXT}}", json.writeValueAsString(job));
+  }
+
+  /** Materializa o schema versionado para o Codex CLI. */
+  private Path materialize(String resource, String suffix) throws IOException {
+    Path path = Files.createTempFile("atena-opportunity-resource-", suffix);
+    Files.writeString(path, read(resource));
+    return path;
+  }
+
+  /** Lê integralmente um recurso do classpath. */
+  private String read(String resource) throws IOException {
+    try (var input = new ClassPathResource(resource).getInputStream()) {
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** Rejeita respostas sem decisão e orientação acionável. */
+  private void validate(JsonNode result) {
+    if (!result.hasNonNull("decision")
+        || !result.hasNonNull("rationale")
+        || !result.hasNonNull("risks")
+        || !result.hasNonNull("recommendation"))
+      throw new IllegalArgumentException("Parecer de oportunidade incompleto.");
+  }
+
+  /** Extrai o identificador da execução para auditoria. */
+  private Object id(Map<?, ?> job) {
+    return job == null ? null : job.get("reviewId");
+  }
+}

--- a/experiment-strategist-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
+++ b/experiment-strategist-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "decision": {"type": "string", "enum": ["SUPPORT", "ADJUST", "REJECT"]},
+    "rationale": {"type": "string"},
+    "risks": {"type": "string"},
+    "recommendation": {"type": "string"}
+  },
+  "required": ["decision", "rationale", "risks", "recommendation"]
+}

--- a/experiment-strategist-worker/src/main/resources/prompts/opportunity-review/v1/review.md
+++ b/experiment-strategist-worker/src/main/resources/prompts/opportunity-review/v1/review.md
@@ -1,0 +1,6 @@
+Você é {{AGENT_ROLE}} no Marketing Hub. Emita um parecer independente sobre o dossiê abaixo.
+
+Contexto persistido:
+{{DOSSIER_CONTEXT}}
+
+Compare ao menos três caminhos plausíveis. Avalie evidência de demanda, Dor → Resultado → Mecanismo → Prova → Oferta, teste mínimo, risco e capacidade de gerar vendas com entrega satisfatória. Não trate projeção, parecer ou clique como venda. Não autorize gasto, preço, campanha ou publicação. Escolha decision somente entre SUPPORT, ADJUST e REJECT. Escreva rationale, risks e recommendation de forma objetiva e acionável.

--- a/experiment-strategist-worker/src/test/java/com/marketinghub/experimentstrategistworker/OpportunityReviewContractTest.java
+++ b/experiment-strategist-worker/src/test/java/com/marketinghub/experimentstrategistworker/OpportunityReviewContractTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.experimentstrategistworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: proteger o contrato versionado do parecer de Atena. */
+class OpportunityReviewContractTest {
+  /** Confirma decisão governada, contexto e saída estruturada obrigatórios. */
+  @Test
+  void keepsVersionedReviewContract() throws Exception {
+    String prompt = resource("prompts/opportunity-review/v1/review.md");
+    String schema = resource("prompts/opportunity-review/v1/review-schema.json");
+    assertThat(prompt).contains("{{DOSSIER_CONTEXT}}", "SUPPORT", "Não autorize gasto");
+    assertThat(schema).contains("decision", "rationale", "risks", "recommendation");
+  }
+
+  /** Lê o recurso empacotado exatamente como o worker o receberá. */
+  private String resource(String path) throws Exception {
+    try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+      assertThat(input).isNotNull();
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/financial-agent-worker/src/main/java/com/marketinghub/financialagentworker/OpportunityReviewConsumer.java
+++ b/financial-agent-worker/src/main/java/com/marketinghub/financialagentworker/OpportunityReviewConsumer.java
@@ -1,0 +1,189 @@
+package com.marketinghub.financialagentworker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/** Responsabilidade: executar os pareceres de oportunidade reservados a Plutus. */
+@Component
+public class OpportunityReviewConsumer {
+  private static final Logger log = LoggerFactory.getLogger(OpportunityReviewConsumer.class);
+  private static final String AGENT = "PLUTUS";
+  private final RestClient backend;
+  private final ObjectMapper json;
+  private final FinancialAgentProperties properties;
+
+  /** Configura backend, limites e executor somente leitura de Plutus. */
+  public OpportunityReviewConsumer(FinancialAgentProperties properties, ObjectMapper json) {
+    this.properties = properties;
+    this.backend = RestClient.builder().baseUrl(properties.getBackendUrl()).build();
+    this.json = json;
+  }
+
+  /** Reserva um parecer antes da conciliação seguinte, sem bloquear a fila financeira. */
+  @Scheduled(fixedDelay = 60000)
+  public void processOne() {
+    Map<?, ?> job = null;
+    try {
+      job =
+          backend
+              .post()
+              .uri(
+                  "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/pending",
+                  AGENT)
+              .retrieve()
+              .body(Map.class);
+      if (job != null) complete(job, execute(job));
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().value() != 404) {
+        log.error("Falha HTTP no parecer de Plutus. reviewId={}", id(job), ex);
+        fail(job, ex);
+      }
+    } catch (Exception ex) {
+      log.error("Falha no parecer de oportunidade de Plutus. reviewId={}", id(job), ex);
+      fail(job, ex);
+    }
+  }
+
+  /** Executa o prompt financeiro versionado e valida o resultado. */
+  private JsonNode execute(Map<?, ?> job) throws IOException, InterruptedException {
+    Path answer = Files.createTempFile("plutus-opportunity-review-", ".json");
+    Path schema = materialize("prompts/opportunity-review/v1/review-schema.json", ".json");
+    Path processLog = Files.createTempFile("plutus-opportunity-process-", ".log");
+    try {
+      List<String> command =
+          new ArrayList<>(
+              List.of(
+                  properties.getCodexCommand(),
+                  "--search",
+                  "exec",
+                  "-",
+                  "--skip-git-repo-check",
+                  "--sandbox",
+                  "read-only",
+                  "--cd",
+                  properties.getRepositoryPath(),
+                  "--output-schema",
+                  schema.toString(),
+                  "--output-last-message",
+                  answer.toString(),
+                  "--color",
+                  "never"));
+      if (properties.getModel() != null && !properties.getModel().isBlank())
+        command.addAll(List.of("--model", properties.getModel()));
+      Process process =
+          new ProcessBuilder(command)
+              .redirectErrorStream(true)
+              .redirectOutput(processLog.toFile())
+              .start();
+      process.getOutputStream().write(prompt(job).getBytes(StandardCharsets.UTF_8));
+      process.getOutputStream().close();
+      if (!process.waitFor(properties.getCodexTimeout().toMinutes(), TimeUnit.MINUTES)) {
+        process.destroyForcibly();
+        throw new IllegalStateException("Timeout do parecer financeiro.");
+      }
+      if (process.exitValue() != 0)
+        throw new IllegalStateException(
+            "Codex encerrou com falha: " + Files.readString(processLog));
+      JsonNode result = json.readTree(Files.readString(answer));
+      validate(result);
+      return result;
+    } finally {
+      Files.deleteIfExists(answer);
+      Files.deleteIfExists(schema);
+      Files.deleteIfExists(processLog);
+    }
+  }
+
+  /** Persiste o resultado funcional sem liberar orçamento. */
+  private void complete(Map<?, ?> job, JsonNode result) throws IOException {
+    backend
+        .post()
+        .uri(
+            "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/complete",
+            AGENT,
+            id(job))
+        .body(
+            Map.of(
+                "decision",
+                result.get("decision").asText(),
+                "rationale",
+                result.get("rationale").asText(),
+                "risks",
+                result.get("risks").asText(),
+                "recommendation",
+                result.get("recommendation").asText(),
+                "rawModelResponse",
+                json.writeValueAsString(result),
+                "modelName",
+                properties.getModel() == null || properties.getModel().isBlank()
+                    ? "codex-default"
+                    : properties.getModel()))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  /** Registra falha técnica preservando o diagnóstico. */
+  private void fail(Map<?, ?> job, Exception ex) {
+    if (job == null) return;
+    try {
+      backend
+          .post()
+          .uri(
+              "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/fail",
+              AGENT,
+              id(job))
+          .body(Map.of("errorMessage", ex.toString()))
+          .retrieve()
+          .toBodilessEntity();
+    } catch (Exception callbackEx) {
+      log.error("Falha ao registrar erro do parecer de Plutus. reviewId={}", id(job), callbackEx);
+    }
+  }
+
+  /** Resolve o prompt com o contexto auditável. */
+  private String prompt(Map<?, ?> job) throws IOException {
+    return read("prompts/opportunity-review/v1/review.md")
+        .replace("{{DOSSIER_CONTEXT}}", json.writeValueAsString(job));
+  }
+
+  /** Materializa um recurso versionado. */
+  private Path materialize(String resource, String suffix) throws IOException {
+    Path path = Files.createTempFile("plutus-opportunity-resource-", suffix);
+    Files.writeString(path, read(resource));
+    return path;
+  }
+
+  /** Lê integralmente um recurso do classpath. */
+  private String read(String resource) throws IOException {
+    try (var input = new ClassPathResource(resource).getInputStream()) {
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** Rejeita respostas incompletas. */
+  private void validate(JsonNode result) {
+    if (!result.hasNonNull("decision")
+        || !result.hasNonNull("rationale")
+        || !result.hasNonNull("risks")
+        || !result.hasNonNull("recommendation"))
+      throw new IllegalArgumentException("Parecer de oportunidade incompleto.");
+  }
+
+  /** Extrai o identificador para auditoria. */
+  private Object id(Map<?, ?> job) {
+    return job == null ? null : job.get("reviewId");
+  }
+}

--- a/financial-agent-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
+++ b/financial-agent-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
@@ -1,0 +1,1 @@
+{"type":"object","additionalProperties":false,"properties":{"decision":{"type":"string","enum":["SUPPORT","ADJUST","REJECT"]},"rationale":{"type":"string"},"risks":{"type":"string"},"recommendation":{"type":"string"}},"required":["decision","rationale","risks","recommendation"]}

--- a/financial-agent-worker/src/main/resources/prompts/opportunity-review/v1/review.md
+++ b/financial-agent-worker/src/main/resources/prompts/opportunity-review/v1/review.md
@@ -1,0 +1,4 @@
+Você é Plutus, agente financeiro. Avalie a viabilidade econômica do dossiê abaixo sem inventar vendas ou dados ausentes:
+{{DOSSIER_CONTEXT}}
+
+Compare três cenários, explicite lacunas de preço, margem, CAC, entrega e reembolso, e indique o teste financeiramente seguro. Não autorize orçamento, gasto ou publicação. Escolha decision somente entre SUPPORT, ADJUST e REJECT. Produza rationale, risks e recommendation objetivos.

--- a/financial-agent-worker/src/test/java/com/marketinghub/financialagentworker/OpportunityReviewContractTest.java
+++ b/financial-agent-worker/src/test/java/com/marketinghub/financialagentworker/OpportunityReviewContractTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.financialagentworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: proteger o contrato versionado do parecer de Plutus. */
+class OpportunityReviewContractTest {
+  /** Confirma cenários financeiros e saída estruturada obrigatórios. */
+  @Test
+  void keepsVersionedReviewContract() throws Exception {
+    String prompt = resource("prompts/opportunity-review/v1/review.md");
+    String schema = resource("prompts/opportunity-review/v1/review-schema.json");
+    assertThat(prompt).contains("{{DOSSIER_CONTEXT}}", "três cenários", "Não autorize");
+    assertThat(schema).contains("decision", "rationale", "risks", "recommendation");
+  }
+
+  /** Lê o recurso empacotado exatamente como o worker o receberá. */
+  private String resource(String path) throws Exception {
+    try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+      assertThat(input).isNotNull();
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/frontend/src/api/opportunityDossiers.ts
+++ b/frontend/src/api/opportunityDossiers.ts
@@ -36,7 +36,11 @@ export interface OpportunityDossier {
     agentKey: string;
     decision?: string;
     rationale?: string;
+    risks?: string;
     recommendation?: string;
+    executionStatus: "PENDING" | "RUNNING" | "COMPLETED" | "FAILED";
+    errorMessage?: string;
+    startedAt?: string;
     completedAt?: string;
   }[];
 }
@@ -59,6 +63,7 @@ export function useOpportunityDossiers() {
     queryKey: ["opportunity-dossiers"],
     queryFn: async () =>
       (await axios.get<OpportunityDossier[]>("/api/opportunity-dossiers")).data,
+    refetchInterval: 15_000,
   });
 }
 export function useCreateOpportunityDossier() {

--- a/frontend/src/pages/opportunity/OpportunityDossiersPage.tsx
+++ b/frontend/src/pages/opportunity/OpportunityDossiersPage.tsx
@@ -257,8 +257,21 @@ export default function OpportunityDossiersPage() {
                   <div className="col-md-6" key={r.id}>
                     <div className="border rounded p-2">
                       <strong>{r.agentKey}</strong>
-                      <div>{r.completedAt ? r.decision : "Pendente"}</div>
+                      <div>
+                        {r.executionStatus === "RUNNING"
+                          ? "Trabalhando"
+                          : r.executionStatus === "FAILED"
+                            ? "Bloqueado"
+                            : r.completedAt
+                              ? r.decision
+                              : "Aguardando"}
+                      </div>
                       <small>{r.recommendation}</small>
+                      {r.errorMessage && (
+                        <small className="d-block text-danger">
+                          {r.errorMessage}
+                        </small>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/growth-operator-worker/src/main/java/com/marketinghub/growthoperatorworker/OpportunityReviewConsumer.java
+++ b/growth-operator-worker/src/main/java/com/marketinghub/growthoperatorworker/OpportunityReviewConsumer.java
@@ -1,0 +1,189 @@
+package com.marketinghub.growthoperatorworker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/** Responsabilidade: executar os pareceres de oportunidade reservados a Hermes. */
+@Component
+public class OpportunityReviewConsumer {
+  private static final Logger log = LoggerFactory.getLogger(OpportunityReviewConsumer.class);
+  private static final String AGENT = "HERMES";
+  private final RestClient backend;
+  private final ObjectMapper json;
+  private final WorkerProperties properties;
+
+  /** Configura backend e executor somente leitura de Hermes. */
+  public OpportunityReviewConsumer(WorkerProperties properties, ObjectMapper json) {
+    this.properties = properties;
+    this.backend = RestClient.builder().baseUrl(properties.getBackendUrl()).build();
+    this.json = json;
+  }
+
+  /** Reserva um parecer sem bloquear os diagnósticos dos planos comerciais. */
+  @Scheduled(fixedDelay = 60000)
+  public void processOne() {
+    Map<?, ?> job = null;
+    try {
+      job =
+          backend
+              .post()
+              .uri(
+                  "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/pending",
+                  AGENT)
+              .retrieve()
+              .body(Map.class);
+      if (job != null) complete(job, execute(job));
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().value() != 404) {
+        log.error("Falha HTTP no parecer de Hermes. reviewId={}", id(job), ex);
+        fail(job, ex);
+      }
+    } catch (Exception ex) {
+      log.error("Falha no parecer de oportunidade de Hermes. reviewId={}", id(job), ex);
+      fail(job, ex);
+    }
+  }
+
+  /** Executa o prompt coordenador versionado e valida o resultado. */
+  private JsonNode execute(Map<?, ?> job) throws IOException, InterruptedException {
+    Path answer = Files.createTempFile("hermes-opportunity-review-", ".json");
+    Path schema = materialize("prompts/opportunity-review/v1/review-schema.json", ".json");
+    Path processLog = Files.createTempFile("hermes-opportunity-process-", ".log");
+    try {
+      List<String> command =
+          new ArrayList<>(
+              List.of(
+                  properties.getCodexCommand(),
+                  "--search",
+                  "exec",
+                  "-",
+                  "--skip-git-repo-check",
+                  "--sandbox",
+                  "read-only",
+                  "--cd",
+                  properties.getRepositoryPath(),
+                  "--output-schema",
+                  schema.toString(),
+                  "--output-last-message",
+                  answer.toString(),
+                  "--color",
+                  "never"));
+      if (properties.getModel() != null && !properties.getModel().isBlank())
+        command.addAll(List.of("--model", properties.getModel()));
+      Process process =
+          new ProcessBuilder(command)
+              .redirectErrorStream(true)
+              .redirectOutput(processLog.toFile())
+              .start();
+      process.getOutputStream().write(prompt(job).getBytes(StandardCharsets.UTF_8));
+      process.getOutputStream().close();
+      if (!process.waitFor(properties.getCodexTimeout().toMinutes(), TimeUnit.MINUTES)) {
+        process.destroyForcibly();
+        throw new IllegalStateException("Timeout do parecer de Hermes.");
+      }
+      if (process.exitValue() != 0)
+        throw new IllegalStateException(
+            "Codex encerrou com falha: " + Files.readString(processLog));
+      JsonNode result = json.readTree(Files.readString(answer));
+      validate(result);
+      return result;
+    } finally {
+      Files.deleteIfExists(answer);
+      Files.deleteIfExists(schema);
+      Files.deleteIfExists(processLog);
+    }
+  }
+
+  /** Persiste a coordenação recomendada sem executar decisões. */
+  private void complete(Map<?, ?> job, JsonNode result) throws IOException {
+    backend
+        .post()
+        .uri(
+            "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/complete",
+            AGENT,
+            id(job))
+        .body(
+            Map.of(
+                "decision",
+                result.get("decision").asText(),
+                "rationale",
+                result.get("rationale").asText(),
+                "risks",
+                result.get("risks").asText(),
+                "recommendation",
+                result.get("recommendation").asText(),
+                "rawModelResponse",
+                json.writeValueAsString(result),
+                "modelName",
+                properties.getModel() == null || properties.getModel().isBlank()
+                    ? "codex-default"
+                    : properties.getModel()))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  /** Registra falha técnica com contexto operacional. */
+  private void fail(Map<?, ?> job, Exception ex) {
+    if (job == null) return;
+    try {
+      backend
+          .post()
+          .uri(
+              "/api/opportunity-dossiers/internal/reviews/{agent}/stage-executions/{id}/fail",
+              AGENT,
+              id(job))
+          .body(Map.of("errorMessage", ex.toString()))
+          .retrieve()
+          .toBodilessEntity();
+    } catch (Exception callbackEx) {
+      log.error("Falha ao registrar erro do parecer de Hermes. reviewId={}", id(job), callbackEx);
+    }
+  }
+
+  /** Resolve o prompt com o contexto auditável. */
+  private String prompt(Map<?, ?> job) throws IOException {
+    return read("prompts/opportunity-review/v1/review.md")
+        .replace("{{DOSSIER_CONTEXT}}", json.writeValueAsString(job));
+  }
+
+  /** Materializa um recurso versionado. */
+  private Path materialize(String resource, String suffix) throws IOException {
+    Path path = Files.createTempFile("hermes-opportunity-resource-", suffix);
+    Files.writeString(path, read(resource));
+    return path;
+  }
+
+  /** Lê integralmente um recurso do classpath. */
+  private String read(String resource) throws IOException {
+    try (var input = new ClassPathResource(resource).getInputStream()) {
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /** Rejeita respostas incompletas. */
+  private void validate(JsonNode result) {
+    if (!result.hasNonNull("decision")
+        || !result.hasNonNull("rationale")
+        || !result.hasNonNull("risks")
+        || !result.hasNonNull("recommendation"))
+      throw new IllegalArgumentException("Parecer de oportunidade incompleto.");
+  }
+
+  /** Extrai o identificador para auditoria. */
+  private Object id(Map<?, ?> job) {
+    return job == null ? null : job.get("reviewId");
+  }
+}

--- a/growth-operator-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
+++ b/growth-operator-worker/src/main/resources/prompts/opportunity-review/v1/review-schema.json
@@ -1,0 +1,1 @@
+{"type":"object","additionalProperties":false,"properties":{"decision":{"type":"string","enum":["SUPPORT","ADJUST","REJECT"]},"rationale":{"type":"string"},"risks":{"type":"string"},"recommendation":{"type":"string"}},"required":["decision","rationale","risks","recommendation"]}

--- a/growth-operator-worker/src/main/resources/prompts/opportunity-review/v1/review.md
+++ b/growth-operator-worker/src/main/resources/prompts/opportunity-review/v1/review.md
@@ -1,0 +1,4 @@
+Você é Hermes, coordenador de crescimento. Avalie o dossiê abaixo em relação aos planos ativos, foco, sequência de execução e aprendizado comercial:
+{{DOSSIER_CONTEXT}}
+
+Compare ao menos três prioridades possíveis. Não trate parecer como venda e não autorize gasto, preço, campanha ou publicação. Escolha decision somente entre SUPPORT, ADJUST e REJECT. Produza rationale, risks e recommendation com responsável, próxima ação e critério de continuar, ajustar ou parar.

--- a/growth-operator-worker/src/test/java/com/marketinghub/growthoperatorworker/OpportunityReviewContractTest.java
+++ b/growth-operator-worker/src/test/java/com/marketinghub/growthoperatorworker/OpportunityReviewContractTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.growthoperatorworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: proteger o contrato versionado do parecer de Hermes. */
+class OpportunityReviewContractTest {
+  /** Confirma priorização e saída estruturada obrigatórias. */
+  @Test
+  void keepsVersionedReviewContract() throws Exception {
+    String prompt = resource("prompts/opportunity-review/v1/review.md");
+    String schema = resource("prompts/opportunity-review/v1/review-schema.json");
+    assertThat(prompt).contains("{{DOSSIER_CONTEXT}}", "três prioridades", "SUPPORT");
+    assertThat(schema).contains("decision", "rationale", "risks", "recommendation");
+  }
+
+  /** Lê o recurso empacotado exatamente como o worker o receberá. */
+  private String resource(String path) throws Exception {
+    try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+      assertThat(input).isNotNull();
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}


### PR DESCRIPTION
## Resultado comercial\n\nTransforma os pareceres dos Dossiês de Oportunidade em trabalho executável e auditável para Atena, Psique, Plutus e Hermes, permitindo avaliação paralela antes da conversão em Plano Comercial.\n\n## Mudanças\n\n- cria filas segregadas por agente com reserva pessimista, falha e retomada única de lease;\n- adiciona consumidores, prompts e schemas versionados nos quatro workers;\n- persiste status, horários, erro, modelo e resposta bruta;\n- mostra aguardando, trabalhando, bloqueado e concluído no frontend com atualização a cada 15 segundos;\n- adiciona migration incremental, Swagger, cânone, matriz de homologação e testes preventivos;\n- preserva gates: parecer não autoriza gasto, preço, campanha ou publicação.\n\n## Validação local\n\nDuas rodadas completas e consecutivas sem falhas após a última correção:\n\n- backend e testes funcionais;\n- 91 regras ArchUnit;\n- contrato Liquibase estático;\n- suítes integrais de Atena, Psique, Plutus e Hermes;\n- frontend, typecheck, build, Spotless e Prettier;\n- inspeção visual em desktop, iPhone 15 Pro e Pixel 7, sem overflow.\n\nO runner Liquibase MySQL 5.7 do PR deve validar a migration antes do deploy.