### PR TITLE
Corrige vínculo do Apolo em projetos MUSA legados

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/CreateVideoProjectRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/CreateVideoProjectRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Size;
 /** Payload para criação de projeto de vídeo no estúdio. */
 public record CreateVideoProjectRequest(
     @NotNull Long productId,
-    @NotNull Long commercialPlanId,
+    Long commercialPlanId,
     Long experimentId,
     Long salesVideoProfileId,
     @Size(max = 191) String campaignKey,

--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/UpdateVideoProjectRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/dto/UpdateVideoProjectRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size;
 /** Payload para edição de projeto de vídeo no estúdio. */
 public record UpdateVideoProjectRequest(
     @NotNull Long productId,
-    @NotNull Long commercialPlanId,
+    Long commercialPlanId,
     Long experimentId,
     Long salesVideoProfileId,
     @Size(max = 191) String campaignKey,

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/VideoProjectServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/service/VideoProjectServiceTest.java
@@ -128,7 +128,7 @@ class VideoProjectServiceTest {
     UpdateVideoProjectRequest request =
         new UpdateVideoProjectRequest(
             4L,
-            99L,
+            null,
             null,
             null,
             "musa-campanha",
@@ -182,6 +182,7 @@ class VideoProjectServiceTest {
     assertThat(result.contextType()).isEqualTo("CAMPAIGN");
     assertThat(result.storyText()).contains("rotina guiada por IA");
     assertThat(result.status()).isEqualTo(VideoProjectStatus.READY_FOR_RENDER);
+    assertThat(result.commercialPlanId()).isNull();
   }
 
   /** Permite projeto comercial curto quando a categoria declara esse uso no funil. */

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -1074,3 +1074,11 @@ Use este checklist quando o problema estiver em algum loop acima:
 - **Causa-raiz:** o avanço automático wireframe → copy não verificava se uma copy igual ou mais recente já havia sido enfileirada para o experimento.
 - **Correção:** o backend só cria a próxima copy quando a última copy é anterior ao wireframe que acabou de concluir.
 - **Prevenção:** teste de contrato simula callback tardio de wireframe e impede duplicação da próxima etapa.
+
+## LOOP-MUSA-PROJETO-LEGADO-PLANO-OBRIGATORIO — perfil de Apolo não é salvo
+
+- **Data:** 2026-08-12.
+- **Sintoma:** ao vincular um perfil de vídeo a um projeto MUSA legado, a edição retorna HTTP 400 e o ciclo de Apolo retorna HTTP 409 por ausência do perfil.
+- **Causa-raiz:** os DTOs REST ainda exigiam `commercialPlanId`, embora a entidade, o ledger e o ciclo autônomo já suportassem projetos legados sem plano comercial.
+- **Correção:** criação e edição de projetos aceitam plano comercial ausente, preservando o vínculo opcional e a segregação financeira já aplicada pelo serviço.
+- **Prevenção:** teste atualiza um projeto sem plano, persiste o perfil e comprova que o contrato continua aceitando o cenário legado.


### PR DESCRIPTION
## Resultado\n\nPermite salvar o perfil de vídeo e abrir o ciclo autônomo de Apolo em projetos MUSA legados sem plano comercial, preservando o gate financeiro de Plutus.\n\n## Causa-raiz\n\nOs DTOs REST ainda exigiam commercialPlanId, embora entidade, ledger e ciclo autônomo já suportassem esse vínculo opcional.\n\n## Validação local\n\n- Duas rodadas consecutivas de VideoProjectServiceTest e VideoProductionCycleServiceTest: 9 testes, sem falhas em cada rodada.\n- Spotless aprovado nas duas rodadas.\n- Diff check sem erros.\n\n## Segurança operacional\n\nNão publica vídeo, não ativa campanha e não realiza gasto; apenas restaura o fluxo para o gate obrigatório de Plutus.