### PR TITLE
Corrige homologação direcionada do deploy PDE

### DIFF
--- a/.github/workflows/pde-platform-metodo-musa-ci.yml
+++ b/.github/workflows/pde-platform-metodo-musa-ci.yml
@@ -495,35 +495,16 @@ jobs:
             curl --fail --show-error --silent --retry 12 --retry-delay 10 --retry-connrefused --output /dev/null https://kit-whatsapp-pronto.digicomdigital.com.br/
           fi
       - name: Set up Node for production rendering smoke
+        if: inputs.frontend_version != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: pde-platform/frontend/package-lock.json
-      - name: Validate production public rendering
+      - name: Validate targeted production public contracts
+        if: inputs.frontend_version != 'none'
         working-directory: pde-platform/frontend
         run: |
           npm ci --include=dev
           npx playwright install --with-deps chromium
-          PDE_PUBLIC_HEALTH_URL=https://v5.clubemusa.com.br npm run test:public-health
-          PDE_PUBLIC_HEALTH_URL=https://v6.clubemusa.com.br npm run test:public-health
-          if [ "${PDE_DEPLOY_FRONTEND_VERSION}" = "kit-whatsapp" ] || [ "${PDE_DEPLOY_FRONTEND_VERSION}" = "all" ]; then
-            PDE_PUBLIC_HEALTH_URL=https://kit-whatsapp-pronto.digicomdigital.com.br npm run test:public-health
-          fi
-      - name: Validate production public diagnostic smoke
-        working-directory: pde-platform/frontend
-        run: |
-          PDE_PUBLIC_HEALTH_URL=https://v5.clubemusa.com.br npm run test:public-diagnostic-smoke
-          PDE_PUBLIC_HEALTH_URL=https://v6.clubemusa.com.br npm run test:public-diagnostic-smoke
-      - name: Validate production versioned PDE contracts
-        run: |
-          PRODUCT_SLUG=metodo-musa-7-dias \
-          PDE_PUBLIC_BASE_URL=https://v5.clubemusa.com.br \
-          EXPECTED_EXPERIENCE_VERSION=musa-pde-entry-v5-video-explicativo \
-          bash scripts/check-musa-pde-public-consistency.sh
-
-          PRODUCT_SLUG=metodo-musa-7-dias \
-          PDE_PUBLIC_BASE_URL=https://v6.clubemusa.com.br \
-          EXPECTED_EXPERIENCE_VERSION=musa-pde-entry-v6-video-motivacional \
-          EXPECTED_PUBLIC_FIRST_FOLD_HEADLINE="Se o look parece certo, por que você ainda sente que falta presença?" \
-          bash scripts/check-musa-pde-public-consistency.sh
+          bash ../scripts/run-targeted-production-smokes.sh "${PDE_DEPLOY_FRONTEND_VERSION}"

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -8,6 +8,13 @@
 >
 > Uso obrigatório recomendado: antes de corrigir problema em GeraLanding, Facebook Ads, Lead Portal, OpenAI/schema, pipelines administrativos ou pipeline de hipótese, verificar se a solicitação reabre algum loop listado aqui.
 
+## LOOP-PDE-TARGETED-DEPLOY-CROSS-SURFACE-SMOKE — publicação isolada falha por versão não publicada
+
+- **Sintoma confirmado em 2026-08-23:** o deploy direcionado ao frontend `kit-whatsapp` publicou a imagem correta, passou nos contratos públicos do Kit e terminou vermelho ao tentar validar `version-diagnostics.json` das versões v5 e v6 do MUSA.
+- **Causa-raiz:** a seleção do frontend controlava publicação, portas e HTTPS, mas o smoke Playwright e os contratos finais continuavam executando incondicionalmente para v5 e v6. Além disso, o contrato do Kit duplicava um CTA estático que já era governado pela oferta persistida no backend. Assim, uma superfície legada não alterada ou uma copy antiga podiam reprovar a entrega saudável.
+- **Correção sistêmica:** a homologação final passa a selecionar pelo mesmo `frontend_version` somente os testes de renderização, diagnóstico e consistência pertencentes à superfície publicada; `all` continua validando todas. CTA, preço e checkout passam a ser lidos da oferta pública canônica durante o smoke.
+- **Prevenção:** testes com executores falsos exigem isolamento para `kit-whatsapp` e v5, cobertura completa para `all`, rejeição de versão desconhecida e ausência de CTA comercial duplicado no contrato estático. A saúde básica das rotas compartilhadas continua sendo verificada antes do smoke direcionado.
+
 ## LOOP-EXPERIMENT-TERMINAL-STATE-DIVERGENCE — campanha pausada com run e agente ativos
 
 - **Sintoma confirmado em 2026-08-23:** o experimento #88 ficou `USER_STOPPED` e a campanha `PAUSED` após R$ 25,24 sem resultado primário, mas o run #6 permaneceu `RUNNING` e a tarefa de Hermes #188 ficou `PENDING`.

--- a/pde-platform/docker-compose.assisted-service-validation.yml
+++ b/pde-platform/docker-compose.assisted-service-validation.yml
@@ -65,7 +65,6 @@ services:
       VITE_PDE_PRODUCT_SLUG: kit-whatsapp-pronto
       VITE_MUSA_EXPERIENCE_VERSION_OVERRIDE: kit-whatsapp-pronto-pde-v1
       PDE_HEALTH_REQUIRED_TEXT: Implantação personalizada
-      PDE_HEALTH_REQUIRED_SALES_TEXT: Quero meu atendimento sob medida
       PDE_FRONTEND_VERSION: kit-whatsapp-v1
       PDE_FRONTEND_PUBLIC_URL: http://pde-platform-frontend-kit-validation
       PDE_FRONTEND_VERSION_ID: kit-whatsapp-v1

--- a/pde-platform/docker-compose.deploy.yml
+++ b/pde-platform/docker-compose.deploy.yml
@@ -167,7 +167,6 @@ services:
       VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
       VITE_MUSA_EXPERIENCE_VERSION_OVERRIDE: kit-whatsapp-pronto-pde-v1
       PDE_HEALTH_REQUIRED_TEXT: Implantação personalizada
-      PDE_HEALTH_REQUIRED_SALES_TEXT: Quero meu atendimento sob medida
       PDE_FRONTEND_VERSION: kit-whatsapp-v1
       PDE_FRONTEND_PUBLIC_URL: https://kit-whatsapp-pronto.digicomdigital.com.br
       PDE_FRONTEND_IMAGE: ${PDE_PLATFORM_FRONTEND_KIT_WHATSAPP_IMAGE:-}

--- a/pde-platform/frontend/docker-entrypoint.d/10-runtime-config.sh
+++ b/pde-platform/frontend/docker-entrypoint.d/10-runtime-config.sh
@@ -8,8 +8,6 @@ HEALTH_CONTRACT_FILE="${PDE_HEALTH_CONTRACT_FILE:-/usr/share/nginx/html/pde-heal
 CHECKOUT_URL="${VITE_MUSA_CHECKOUT_URL:-}"
 PRODUCT_SLUG="${VITE_PDE_PRODUCT_SLUG:-metodo-musa-7-dias}"
 HEALTH_REQUIRED_TEXT="${PDE_HEALTH_REQUIRED_TEXT:-Experiência assistida e manual}"
-HEALTH_REQUIRED_SALES_TEXT="${PDE_HEALTH_REQUIRED_SALES_TEXT:-}"
-HEALTH_REQUIRED_PRICE_TEXT="${PDE_HEALTH_REQUIRED_PRICE_TEXT:-}"
 GOOGLE_CLIENT_ID="${VITE_GOOGLE_CLIENT_ID:-}"
 EXPERIENCE_VERSION_OVERRIDE="${VITE_MUSA_EXPERIENCE_VERSION_OVERRIDE:-}"
 HERO_VIDEO_URL="${VITE_MUSA_HERO_VIDEO_URL:-}"
@@ -39,20 +37,12 @@ window.__MUSA_RUNTIME_CONFIG__ = {
 EOF
 
 if [ "$PRODUCT_SLUG" != "metodo-musa-7-dias" ]; then
-  REQUIRED_TEXTS="[\"$(json_escape "$HEALTH_REQUIRED_TEXT")\""
-  if [ -n "$HEALTH_REQUIRED_SALES_TEXT" ]; then
-    REQUIRED_TEXTS="$REQUIRED_TEXTS, \"$(json_escape "$HEALTH_REQUIRED_SALES_TEXT")\""
-  fi
-  if [ -n "$HEALTH_REQUIRED_PRICE_TEXT" ]; then
-    REQUIRED_TEXTS="$REQUIRED_TEXTS, \"$(json_escape "$HEALTH_REQUIRED_PRICE_TEXT")\""
-  fi
-  REQUIRED_TEXTS="$REQUIRED_TEXTS]"
   cat > "$HEALTH_CONTRACT_FILE" <<EOF
 {
   "slug": "$(json_escape "$PRODUCT_SLUG")",
   "healthPath": "/",
   "commercialOfferPath": "/api/pde/products/$(json_escape "$PRODUCT_SLUG")/commercial-offer",
-  "requiredTexts": $REQUIRED_TEXTS,
+  "requiredTexts": ["$(json_escape "$HEALTH_REQUIRED_TEXT")"],
   "requiredHlsStreams": [],
   "forbiddenTexts": [
     "Application error",

--- a/pde-platform/frontend/tests/public-health.spec.ts
+++ b/pde-platform/frontend/tests/public-health.spec.ts
@@ -3,6 +3,7 @@ import { expect, test, type APIRequestContext } from '@playwright/test';
 type PublicHealthContract = {
   slug?: string;
   healthPath?: string;
+  commercialOfferPath?: string;
   requiredTexts?: string[];
   forbiddenTexts?: string[];
 };
@@ -27,9 +28,16 @@ type PublicProductContract = {
   };
 };
 
+type PublicCommercialOffer = {
+  primaryCta?: string;
+  priceBrl?: number;
+  checkoutUrl?: string;
+};
+
 const defaultContract: Required<PublicHealthContract> = {
   slug: 'metodo-musa-7-dias',
   healthPath: '/',
+  commercialOfferPath: '',
   requiredTexts: [
     'Seu primeiro ajuste MUSA',
   ],
@@ -61,9 +69,33 @@ async function loadContract(request: APIRequestContext) {
   return {
     slug: process.env.PDE_PUBLIC_HEALTH_PRODUCT_SLUG || fileContract.slug || defaultContract.slug,
     healthPath: process.env.PDE_PUBLIC_HEALTH_PATH || fileContract.healthPath || defaultContract.healthPath,
+    commercialOfferPath: fileContract.commercialOfferPath || defaultContract.commercialOfferPath,
     requiredTexts: envRequiredTexts.length > 0 ? envRequiredTexts : fileContract.requiredTexts || defaultContract.requiredTexts,
     forbiddenTexts: envForbiddenTexts.length > 0 ? envForbiddenTexts : fileContract.forbiddenTexts || defaultContract.forbiddenTexts,
   };
+}
+
+async function loadCommercialOffer(request: APIRequestContext, commercialOfferPath: string) {
+  if (!commercialOfferPath) {
+    return null;
+  }
+
+  const response = await request.get(commercialOfferPath);
+  expect(response.ok(), `Oferta comercial publica indisponivel: ${commercialOfferPath}`).toBeTruthy();
+  const offer = (await response.json()) as PublicCommercialOffer;
+  expect(offer.primaryCta?.trim(), 'Oferta comercial sem CTA primario').toBeTruthy();
+  expect(offer.priceBrl, 'Oferta comercial sem preco positivo').toBeGreaterThan(0);
+  expect(offer.checkoutUrl?.trim(), 'Oferta comercial sem checkout').toBeTruthy();
+  return offer;
+}
+
+function formatBrl(value: number) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
 }
 
 async function loadPublishedFirstFoldTexts(request: APIRequestContext, slug: string, diagnostics: VersionDiagnostics) {
@@ -125,6 +157,7 @@ test('health publico renderiza app, javascript e texto comercial', async ({ page
     );
   }
   const publishedFirstFoldTexts = await loadPublishedFirstFoldTexts(request, contract.slug, diagnostics);
+  const commercialOffer = await loadCommercialOffer(request, contract.commercialOfferPath);
   const staticRequiredTexts = removeMutableFallbackTexts(contract.requiredTexts, publishedFirstFoldTexts);
 
   const response = await page.goto(contract.healthPath, { waitUntil: 'networkidle' });
@@ -133,6 +166,12 @@ test('health publico renderiza app, javascript e texto comercial', async ({ page
   await expect(page.locator('#root').locator(':scope > *').first()).toBeVisible();
   for (const text of [...publishedFirstFoldTexts, ...staticRequiredTexts]) {
     await expect(page.locator('body'), `Texto obrigatorio ausente no PDE ${contract.slug}: ${text}`).toContainText(text);
+  }
+  if (commercialOffer) {
+    const offerCard = page.getByTestId('commercial-offer');
+    await expect(offerCard).toContainText(commercialOffer.primaryCta!);
+    await expect(offerCard).toContainText(formatBrl(commercialOffer.priceBrl!));
+    await expect(offerCard.locator('.assisted-pde-checkout-cta')).toHaveAttribute('href', commercialOffer.checkoutUrl!);
   }
   const publicBodyText = await page.locator('body').innerText();
   for (const text of contract.forbiddenTexts) {

--- a/pde-platform/scripts/run-targeted-production-smokes.sh
+++ b/pde-platform/scripts/run-targeted-production-smokes.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_frontend="${1:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_dir}/../.." && pwd)"
+frontend_dir="${repository_root}/pde-platform/frontend"
+npm_command="${PDE_SMOKE_NPM_COMMAND:-npm}"
+consistency_script="${PDE_SMOKE_CONSISTENCY_SCRIPT:-${repository_root}/scripts/check-musa-pde-public-consistency.sh}"
+
+run_public_health() {
+  local public_url="$1"
+  (
+    cd "${frontend_dir}"
+    PDE_PUBLIC_HEALTH_URL="${public_url}" "${npm_command}" run test:public-health
+  )
+}
+
+run_public_diagnostic() {
+  local public_url="$1"
+  (
+    cd "${frontend_dir}"
+    PDE_PUBLIC_HEALTH_URL="${public_url}" "${npm_command}" run test:public-diagnostic-smoke
+  )
+}
+
+run_musa_consistency() {
+  local public_url="$1"
+  local experience_version="$2"
+  local first_fold_headline="${3:-}"
+
+  PRODUCT_SLUG=metodo-musa-7-dias \
+    PDE_PUBLIC_BASE_URL="${public_url}" \
+    EXPECTED_EXPERIENCE_VERSION="${experience_version}" \
+    EXPECTED_PUBLIC_FIRST_FOLD_HEADLINE="${first_fold_headline}" \
+    bash "${consistency_script}"
+}
+
+validate_v5() {
+  run_public_health https://v5.clubemusa.com.br
+  run_public_diagnostic https://v5.clubemusa.com.br
+  run_musa_consistency \
+    https://v5.clubemusa.com.br \
+    musa-pde-entry-v5-video-explicativo
+}
+
+validate_v6() {
+  run_public_health https://v6.clubemusa.com.br
+  run_public_diagnostic https://v6.clubemusa.com.br
+  run_musa_consistency \
+    https://v6.clubemusa.com.br \
+    musa-pde-entry-v6-video-motivacional \
+    "Se o look parece certo, por que você ainda sente que falta presença?"
+}
+
+validate_v7() {
+  run_public_health https://v7.clubemusa.com.br
+}
+
+validate_kit_whatsapp() {
+  run_public_health https://kit-whatsapp-pronto.digicomdigital.com.br
+}
+
+case "${target_frontend}" in
+  v5)
+    validate_v5
+    ;;
+  v6)
+    validate_v6
+    ;;
+  v7)
+    validate_v7
+    ;;
+  kit-whatsapp)
+    validate_kit_whatsapp
+    ;;
+  all)
+    validate_v5
+    validate_v6
+    validate_v7
+    validate_kit_whatsapp
+    ;;
+  none)
+    ;;
+  *)
+    echo "Versao frontend PDE invalida para homologacao: ${target_frontend}" >&2
+    exit 1
+    ;;
+esac

--- a/pde-platform/scripts/test-deploy-isolation-contract.sh
+++ b/pde-platform/scripts/test-deploy-isolation-contract.sh
@@ -19,11 +19,15 @@ for required_contract in \
   'PROXY_CONTAINERS=' \
   'docker network connect ${PDE_PLATFORM_NETWORK}' \
   'docker kill -s HUP' \
-  'Nenhum container de proxy HTTPS'; do
+  'Nenhum container de proxy HTTPS' \
+  'run-targeted-production-smokes.sh "${PDE_DEPLOY_FRONTEND_VERSION}"'; do
   if ! grep -Fq "${required_contract}" "${workflow}"; then
     echo "[ARQUITETURA] O deploy PDE perdeu o contrato de integração segura com o proxy existente: ${required_contract}" >&2
     exit 1
   fi
 done
+
+bash "${script_dir}/test-targeted-production-smokes.sh"
+bash "${script_dir}/test-public-health-commercial-source.sh"
 
 echo 'Contrato de isolamento do deploy PDE aprovado.'

--- a/pde-platform/scripts/test-public-health-commercial-source.sh
+++ b/pde-platform/scripts/test-public-health-commercial-source.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runtime_script="${script_dir}/../frontend/docker-entrypoint.d/10-runtime-config.sh"
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "${temporary_dir}"' EXIT
+
+MUSA_RUNTIME_CONFIG_FILE="${temporary_dir}/runtime-config.js" \
+  MUSA_VERSION_DIAGNOSTICS_FILE="${temporary_dir}/version-diagnostics.json" \
+  MUSA_SLOT_DIAGNOSTICS_FILE="${temporary_dir}/slot-diagnostics.json" \
+  PDE_HEALTH_CONTRACT_FILE="${temporary_dir}/pde-health-contract.json" \
+  VITE_PDE_PRODUCT_SLUG=kit-whatsapp-pronto \
+  PDE_HEALTH_REQUIRED_TEXT='Implantação personalizada' \
+  PDE_HEALTH_REQUIRED_SALES_TEXT='CTA estatico obsoleto' \
+  sh "${runtime_script}"
+
+jq -e '
+  .slug == "kit-whatsapp-pronto"
+  and .commercialOfferPath == "/api/pde/products/kit-whatsapp-pronto/commercial-offer"
+  and .requiredTexts == ["Implantação personalizada"]
+' "${temporary_dir}/pde-health-contract.json" >/dev/null
+
+if grep -Fq 'CTA estatico obsoleto' "${temporary_dir}/pde-health-contract.json"; then
+  echo '[ARQUITETURA] O health publico duplicou o CTA dinamico da oferta comercial.' >&2
+  exit 1
+fi
+
+echo 'Contrato comercial dinamico do health publico aprovado.'

--- a/pde-platform/scripts/test-targeted-production-smokes.sh
+++ b/pde-platform/scripts/test-targeted-production-smokes.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="${script_dir}/run-targeted-production-smokes.sh"
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "${temporary_dir}"' EXIT
+
+invocation_log="${temporary_dir}/invocations.log"
+fake_npm="${temporary_dir}/npm"
+fake_consistency="${temporary_dir}/consistency.sh"
+
+cat >"${fake_npm}" <<'FAKE_NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm\t%s\t%s\n' "${PDE_PUBLIC_HEALTH_URL:-}" "$*" >>"${PDE_SMOKE_INVOCATION_LOG}"
+FAKE_NPM
+
+cat >"${fake_consistency}" <<'FAKE_CONSISTENCY'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'consistency\t%s\t%s\t%s\n' \
+  "${PDE_PUBLIC_BASE_URL:-}" \
+  "${EXPECTED_EXPERIENCE_VERSION:-}" \
+  "${EXPECTED_PUBLIC_FIRST_FOLD_HEADLINE:-}" >>"${PDE_SMOKE_INVOCATION_LOG}"
+FAKE_CONSISTENCY
+
+chmod +x "${fake_npm}" "${fake_consistency}"
+
+run_target() {
+  local target="$1"
+  : >"${invocation_log}"
+  PDE_SMOKE_NPM_COMMAND="${fake_npm}" \
+    PDE_SMOKE_CONSISTENCY_SCRIPT="${fake_consistency}" \
+    PDE_SMOKE_INVOCATION_LOG="${invocation_log}" \
+    bash "${runner}" "${target}"
+}
+
+run_target kit-whatsapp
+grep -Fqx $'npm\thttps://kit-whatsapp-pronto.digicomdigital.com.br\trun test:public-health' "${invocation_log}"
+if grep -Fq 'clubemusa.com.br' "${invocation_log}" || grep -Fq 'consistency' "${invocation_log}"; then
+  echo '[ARQUITETURA] O deploy direcionado ao Kit WhatsApp validou um produto nao publicado.' >&2
+  exit 1
+fi
+
+run_target v5
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-health' "${invocation_log}"
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-diagnostic-smoke' "${invocation_log}"
+grep -Fqx $'consistency\thttps://v5.clubemusa.com.br\tmusa-pde-entry-v5-video-explicativo\t' "${invocation_log}"
+if grep -Fq 'v6.clubemusa.com.br' "${invocation_log}" || grep -Fq 'kit-whatsapp-pronto' "${invocation_log}"; then
+  echo '[ARQUITETURA] O deploy direcionado ao v5 validou um produto nao publicado.' >&2
+  exit 1
+fi
+
+run_target all
+test "$(grep -c $'npm\t.*\trun test:public-health' "${invocation_log}")" -eq 4
+test "$(grep -c $'npm\t.*\trun test:public-diagnostic-smoke' "${invocation_log}")" -eq 2
+test "$(grep -c '^consistency' "${invocation_log}")" -eq 2
+
+if PDE_SMOKE_NPM_COMMAND="${fake_npm}" \
+  PDE_SMOKE_CONSISTENCY_SCRIPT="${fake_consistency}" \
+  PDE_SMOKE_INVOCATION_LOG="${invocation_log}" \
+  bash "${runner}" desconhecida; then
+  echo '[ARQUITETURA] A homologacao aceitou uma versao frontend desconhecida.' >&2
+  exit 1
+fi
+
+echo 'Contrato de homologacao direcionada do PDE aprovado.'


### PR DESCRIPTION
## Resultado

Impede que um deploy específico do Kit WhatsApp falhe ao homologar versões MUSA que não foram publicadas.

## Mudanças

- direciona os smokes públicos pelo frontend selecionado;
- mantém a opção all para homologação completa;
- valida CTA, preço e checkout pela oferta comercial canônica;
- elimina CTA comercial estático e registra o loop de recorrência.

## Validação local

- duas rodadas consecutivas com 12 jornadas E2E em desktop, iPhone 15 Pro e Pixel 7;
- MySQL 5.7, backend, frontend e SMTP descartável;
- build TypeScript/Vite;
- contratos de isolamento e oferta dinâmica;
- smoke público produtivo do Kit com 2/2 testes.