### PR TITLE
Fecha o contrato comercial do Kit WhatsApp para revisão de Têmis

### DIFF
--- a/docs/canonical/cadeia-produtos-pde-canon.v1.md
+++ b/docs/canonical/cadeia-produtos-pde-canon.v1.md
@@ -304,8 +304,18 @@ valor, oferta, compra e acesso, usando o produto real como fonte da comunicaçã
 - explicar qualquer recomendação personalizada com “por que você está vendo isto”, permitir ajustar
   preferências ou recusá-la e manter uma jornada neutra funcional;
 - configurar paywall, checkout e continuidade pós-compra;
+- declarar preço total e modelo de cobrança (`ONE_TIME` ou `RECURRING`) sem ambiguidade em contrato,
+  criativo, destino e checkout; compra única deve dizer explicitamente “pagamento único, sem
+  recorrência”;
 - garantir correspondência entre promessa, criativo, experiência, oferta e entrega;
-- instrumentar visita, interação de valor, CTA, checkout, compra, acesso e primeiro uso.
+- instrumentar visita, interação de valor, CTA, checkout, compra, acesso e primeiro uso;
+- versionar o contrato de eventos com nome, gatilho, metadados mínimos, chaves de correlação, fonte
+  de verdade e significado comercial. A jornada mínima usa `PURCHASE_COMPLETED`, `ACCESS_RELEASED`,
+  `MISSION_COMPLETED` para o marco de entrega, `FIRST_USE` e `REFUND_CONFIRMED`; a homologação deve
+  bloquear ativação se algum deles não possuir persistência e correlação comprovadas;
+- em coorte inicial de até cinco vendas, qualquer reembolso pausa novos contatos para análise de
+  causa-raiz. Reembolso causado por promessa, entrega, privacidade ou margem bloqueia a continuidade;
+  a taxa percentual isolada só passa a orientar decisão com amostra compatível.
 - para uma superfície que recebe aquisição, renderizar antes da compra a oferta canônica do
   experimento, incluindo dor, promessa, prova, CTA, preço, fornecedor, contato, políticas e checkout;
   uma área de acesso pós-compra isolada não pode ser homologada como landing comercial;
@@ -314,6 +324,12 @@ valor, oferta, compra e acesso, usando o produto real como fonte da comunicaçã
 
 **Saída final:** kit comercial aprovado com criativos, destino de campanha, jornada de venda,
 checkout, acesso e eventos preparados, sem ativação automática de mídia.
+
+Nesta etapa, `preparados` significa que URL, checkout, rota de acesso e contratos versionados de
+eventos existem, são coerentes e podem ser entregues à homologação. A comprovação com pagamento de
+teste, persistência, correlação, retomada e falhas pertence exclusivamente à Homologação e ativação
+comercial. Comunicação deve registrar essas verificações como próximo gate, sem duplicá-las nem
+bloquear seu próprio contrato apenas porque a homologação posterior ainda não foi executada.
 
 **Gate para avançar:** a cliente deve reconhecer para quem é, entender o benefício, encontrar resposta
 para as dúvidas prioritárias, verificar o produto real, saber o próximo passo e chegar à compra sem

--- a/growth-operator-worker/src/main/java/com/marketinghub/growthoperatorworker/GrowthOperatorBpmRunner.java
+++ b/growth-operator-worker/src/main/java/com/marketinghub/growthoperatorworker/GrowthOperatorBpmRunner.java
@@ -204,7 +204,13 @@ public class GrowthOperatorBpmRunner {
     }
     if (COMMUNICATION_PROCESS.equals(processCode)
         && (result.path("communicationContract").isMissingNode()
-            || result.path("priceDecision").isMissingNode())) {
+            || result.path("priceDecision").isMissingNode()
+            || result.path("priceDecision").path("billingModel").asText().isBlank()
+            || result.path("priceDecision").path("billingDescription").asText().isBlank()
+            || result.path("communicationContract").path("includedItems").isEmpty()
+            || result.path("communicationContract").path("excludedItems").isEmpty()
+            || result.path("communicationContract").path("eventContracts").size() < 5
+            || result.path("communicationContract").path("refundGuardrail").asText().isBlank())) {
       throw new IllegalArgumentException("Contrato de comunicação do PDE incompleto.");
     }
   }

--- a/growth-operator-worker/src/main/resources/prompts/bpm/v1/pde-communication-contract-schema.json
+++ b/growth-operator-worker/src/main/resources/prompts/bpm/v1/pde-communication-contract-schema.json
@@ -47,9 +47,11 @@
     "priceDecision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["approvedPriceBrl", "decision", "rationale", "marketReference", "marginGuardrail", "comprehensionTest"],
+      "required": ["approvedPriceBrl", "billingModel", "billingDescription", "decision", "rationale", "marketReference", "marginGuardrail", "comprehensionTest"],
       "properties": {
         "approvedPriceBrl": { "type": "number", "exclusiveMinimum": 0 },
+        "billingModel": { "type": "string", "enum": ["ONE_TIME", "RECURRING"] },
+        "billingDescription": { "type": "string", "minLength": 5 },
         "decision": { "type": "string", "enum": ["KEEP", "ADJUST", "BLOCK"] },
         "rationale": { "type": "string", "minLength": 10 },
         "marketReference": { "type": "string", "minLength": 10 },
@@ -60,13 +62,15 @@
     "communicationContract": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["audience", "pain", "promise", "mechanism", "offerFraming", "proof", "limitations", "primaryChannel", "creativeBrief", "destinationBrief", "primaryCta", "checkoutAndAccess", "events", "samplePlan", "testTrafficSegregation"],
+      "required": ["audience", "pain", "promise", "mechanism", "offerFraming", "includedItems", "excludedItems", "proof", "limitations", "primaryChannel", "creativeBrief", "destinationBrief", "primaryCta", "checkoutAndAccess", "events", "eventContracts", "refundGuardrail", "samplePlan", "testTrafficSegregation"],
       "properties": {
         "audience": { "type": "string", "minLength": 5 },
         "pain": { "type": "string", "minLength": 5 },
         "promise": { "type": "string", "minLength": 5 },
         "mechanism": { "type": "string", "minLength": 5 },
         "offerFraming": { "type": "string", "minLength": 5 },
+        "includedItems": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "excludedItems": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
         "proof": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
         "limitations": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
         "primaryChannel": { "type": "string", "minLength": 3 },
@@ -75,6 +79,24 @@
         "primaryCta": { "type": "string", "minLength": 3 },
         "checkoutAndAccess": { "type": "string", "minLength": 10 },
         "events": { "type": "array", "minItems": 4, "items": { "type": "string", "minLength": 3 } },
+        "eventContracts": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["eventName", "trigger", "requiredMetadata", "correlationKeys", "authoritativeSource", "commercialMeaning"],
+            "properties": {
+              "eventName": { "type": "string", "minLength": 3 },
+              "trigger": { "type": "string", "minLength": 5 },
+              "requiredMetadata": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 2 } },
+              "correlationKeys": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 2 } },
+              "authoritativeSource": { "type": "string", "minLength": 3 },
+              "commercialMeaning": { "type": "string", "minLength": 5 }
+            }
+          }
+        },
+        "refundGuardrail": { "type": "string", "minLength": 10 },
         "samplePlan": { "type": "string", "minLength": 10 },
         "testTrafficSegregation": { "type": "string", "minLength": 5 }
       }

--- a/growth-operator-worker/src/main/resources/prompts/bpm/v1/pde-communication-contract.md
+++ b/growth-operator-worker/src/main/resources/prompts/bpm/v1/pde-communication-contract.md
@@ -25,11 +25,26 @@ envia mensagens e não avança o processo.
    subprocessos canônicos posteriores.
 6. Revise explicitamente o preço. Compare-o com alternativas do mercado presentes no contexto,
    margem e mecanismo de entrega. Não recomende desconto sem hipótese e métrica. Diferencie
-   biblioteca genérica de implantação personalizada.
+   biblioteca genérica de implantação personalizada. Declare `billingModel`, preço total,
+   recorrência ou ausência de recorrência e uma descrição inequívoca da cobrança. Repita essa
+   verdade no enquadramento da oferta, no briefing do criativo e no destino.
 7. Preserve controle humano, consentimento, privacidade, atribuição e tráfego de teste segregado.
-8. Defina métrica esperada e critérios objetivos para continuar, ajustar e parar.
-9. Use `BLOCKED` se faltar produto aprovado, preço íntegro, checkout/acesso possível, prova honesta,
-   fonte de tráfego autorizada ou mensuração mínima. Caso contrário use `COMPLETED`.
+8. Liste o que está incluído e excluído. Em `eventContracts`, declare pelo menos compra confirmada,
+   acesso liberado, entrega concluída, primeiro uso/aplicação e reembolso. Para cada evento informe
+   nome canônico, gatilho, metadados mínimos, chaves de correlação, fonte de verdade e significado
+   comercial. Não invente evento como se estivesse implementado: quando o contrato canônico não
+   existir, use `BLOCKED` e registre a lacuna. Quando o contrato existir, preserve a comprovação da
+   persistência, correlação, retomada e falhas como gate obrigatório do processo posterior de
+   Homologação e ativação; não duplique a homologação técnica nesta atividade.
+9. Defina métrica esperada e critérios objetivos para continuar, ajustar e parar. Em amostra inicial
+   pequena, use regra absoluta de reembolso; taxa percentual isolada não é estatisticamente coerente.
+   Qualquer reembolso pausa a coorte para análise de causa, e falha de promessa, entrega, privacidade
+   ou margem bloqueia novos contatos.
+10. Use `BLOCKED` se faltar produto aprovado, preço íntegro, URL e checkout configurados, rota de
+    acesso possível, prova honesta, fonte de tráfego autorizada ou contrato mínimo de mensuração.
+    Caso esses elementos estejam preparados, use `COMPLETED` e encaminhe sua comprovação ponta a
+    ponta ao processo posterior de Homologação e ativação, que continua bloqueando qualquer contato
+    ou gasto até aprovar o preflight.
 
 ## Restrições comerciais
 
@@ -38,4 +53,3 @@ envia mensagens e não avança o processo.
 - Não personalize preço ocultamente e não faça diagnóstico psicológico individual.
 - Não autorize comunicação em massa, mídia paga, publicação ou gasto.
 - O resultado deve ser JSON válido conforme o schema fornecido.
-

--- a/growth-operator-worker/src/test/java/com/marketinghub/growthoperatorworker/GrowthOperatorBpmRunnerTest.java
+++ b/growth-operator-worker/src/test/java/com/marketinghub/growthoperatorworker/GrowthOperatorBpmRunnerTest.java
@@ -53,6 +53,35 @@ class GrowthOperatorBpmRunnerTest {
     assertThat(scope.reference()).isEqualTo("commercial-plan:4@v2");
   }
 
+  /** Bloqueia contrato sem cobrança, itens, eventos correlacionados e regra de reembolso. */
+  @Test
+  void shouldRejectIncompletePdeCommunicationContract() throws Exception {
+    var incomplete =
+        new ObjectMapper()
+            .readTree(
+                """
+                {
+                  "executionStatus":"COMPLETED",
+                  "activityOutcome":"Contrato antigo sem campos comerciais novos.",
+                  "observedFacts":["Produto aprovado"],
+                  "alternatives":[{"name":"A"},{"name":"B"},{"name":"C"}],
+                  "selectedAlternative":"A",
+                  "priceDecision":{},
+                  "communicationContract":{},
+                  "expectedMetric":"Três vendas",
+                  "continueCriteria":"Entrega íntegra",
+                  "adjustCriteria":"Sem checkout",
+                  "stopCriteria":"Falha de entrega",
+                  "recommendedAction":"Corrigir o contrato"
+                }
+                """);
+
+    assertThatThrownBy(
+            () -> GrowthOperatorBpmRunner.validate(incomplete, "pde-communication-sales-journey"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Contrato de comunicação");
+  }
+
   /** Mantém o Codex em sandbox somente leitura com saída estruturada e MCP local. */
   @Test
   void shouldBuildReadOnlyAuditableCommand() {
@@ -204,7 +233,7 @@ class GrowthOperatorBpmRunnerTest {
             shift
           done
           cat >/dev/null
-          printf '%s' '{"executionStatus":"COMPLETED","activityOutcome":"Contrato comercial pronto para subprocessos.","observedFacts":["Produto aprovado"],"inferences":[],"contradictoryEvidence":[],"evidenceGaps":[],"alternatives":[{"name":"A","benefit":"B","risk":"R","effort":"E","fit":"F"},{"name":"B","benefit":"B","risk":"R","effort":"E","fit":"F"},{"name":"C","benefit":"B","risk":"R","effort":"E","fit":"F"}],"selectedAlternative":"A","priceDecision":{"approvedPriceBrl":349,"decision":"KEEP","rationale":"Preço de implantação personalizada.","marketReference":"Bibliotecas genéricas são mais baratas.","marginGuardrail":"Margem positiva","comprehensionTest":"Testar entendimento antes de desconto."},"communicationContract":{"audience":"Prestadores locais","pain":"Demora no atendimento","promise":"Atendimento pronto","mechanism":"Personalização assistida","offerFraming":"Implantação em 48 horas","proof":["Materiais reais"],"limitations":["Sem garantia"],"primaryChannel":"Abordagem individual","creativeBrief":"Demonstrar antes e depois sem promessa falsa.","destinationBrief":"Explicar entrega e responder objeções prioritárias.","primaryCta":"Quero meu atendimento pronto","checkoutAndAccess":"Checkout único e acesso por link mágico.","events":["visit","cta","checkout","purchase"],"samplePlan":"Quinze contatos qualificados consentidos.","testTrafficSegregation":"mh_test"},"expectedMetric":"Três vendas","continueCriteria":"Compromisso comercial","adjustCriteria":"Sem checkout","stopCriteria":"Sem entrega","recommendedAction":"Produzir criativo e destino nos subprocessos."}' > "$answer"
+          printf '%s' '{"executionStatus":"COMPLETED","activityOutcome":"Contrato comercial pronto para subprocessos.","observedFacts":["Produto aprovado"],"inferences":[],"contradictoryEvidence":[],"evidenceGaps":[],"alternatives":[{"name":"A","benefit":"B","risk":"R","effort":"E","fit":"F"},{"name":"B","benefit":"B","risk":"R","effort":"E","fit":"F"},{"name":"C","benefit":"B","risk":"R","effort":"E","fit":"F"}],"selectedAlternative":"A","priceDecision":{"approvedPriceBrl":349,"billingModel":"ONE_TIME","billingDescription":"Pagamento único, sem recorrência.","decision":"KEEP","rationale":"Preço de implantação personalizada.","marketReference":"Bibliotecas genéricas são mais baratas.","marginGuardrail":"Margem positiva","comprehensionTest":"Testar entendimento antes de desconto."},"communicationContract":{"audience":"Prestadores locais","pain":"Demora no atendimento","promise":"Atendimento pronto","mechanism":"Personalização assistida","offerFraming":"Implantação em 48 horas","includedItems":["Respostas personalizadas"],"excludedItems":["Automação"],"proof":["Materiais reais"],"limitations":["Sem garantia"],"primaryChannel":"Abordagem individual","creativeBrief":"Demonstrar antes e depois sem promessa falsa.","destinationBrief":"Explicar entrega e responder objeções prioritárias.","primaryCta":"Quero meu atendimento pronto","checkoutAndAccess":"Checkout único e acesso por link mágico.","events":["visit","cta","checkout","purchase"],"eventContracts":[{"eventName":"PURCHASE_COMPLETED","trigger":"Pagamento aprovado","requiredMetadata":["paymentId"],"correlationKeys":["paymentId"],"authoritativeSource":"Pagamento","commercialMeaning":"Venda real"},{"eventName":"ACCESS_RELEASED","trigger":"Acesso liberado","requiredMetadata":["accessToken"],"correlationKeys":["accessToken"],"authoritativeSource":"PDE","commercialMeaning":"Acesso real"},{"eventName":"DELIVERY_COMPLETED","trigger":"Entrega concluída","requiredMetadata":["missionId"],"correlationKeys":["missionId"],"authoritativeSource":"PDE","commercialMeaning":"Entrega real"},{"eventName":"FIRST_USE","trigger":"Primeiro uso","requiredMetadata":["accessToken"],"correlationKeys":["accessToken"],"authoritativeSource":"PDE","commercialMeaning":"Uso real"},{"eventName":"REFUND_CONFIRMED","trigger":"Reembolso confirmado","requiredMetadata":["paymentId"],"correlationKeys":["paymentId"],"authoritativeSource":"Pagamento","commercialMeaning":"Receita revertida"}],"refundGuardrail":"Qualquer reembolso pausa a primeira coorte.","samplePlan":"Quinze contatos qualificados consentidos.","testTrafficSegregation":"mh_test"},"expectedMetric":"Três vendas","continueCriteria":"Compromisso comercial","adjustCriteria":"Sem checkout","stopCriteria":"Sem entrega","recommendedAction":"Produzir criativo e destino nos subprocessos."}' > "$answer"
           printf '%s\n' '{"usage":{"input_tokens":110,"cached_input_tokens":20,"output_tokens":35}}'
           """,
           StandardCharsets.UTF_8);
@@ -276,12 +305,19 @@ class GrowthOperatorBpmRunnerTest {
             "biblioteca genérica",
             "implantação personalizada",
             "não ativa mídia",
-            "tráfego de teste segregado");
+            "tráfego de teste segregado",
+            "billingModel",
+            "eventContracts",
+            "regra absoluta de reembolso",
+            "não duplique a homologação técnica");
     assertThat(schema)
         .contains(
             "priceDecision",
+            "billingModel",
             "communicationContract",
             "checkoutAndAccess",
+            "eventContracts",
+            "refundGuardrail",
             "continueCriteria",
             "stopCriteria");
     assertThat(GrowthOperatorBpmRunner.promptResourceFor("pde-communication-sales-journey"))

--- a/meta-ad-approver-worker/src/main/java/com/marketinghub/metaadapproverworker/CommercialBpmTaskConsumer.java
+++ b/meta-ad-approver-worker/src/main/java/com/marketinghub/metaadapproverworker/CommercialBpmTaskConsumer.java
@@ -223,11 +223,14 @@ public class CommercialBpmTaskConsumer {
         .toBodilessEntity();
   }
 
-  /** Resolve o contexto congelado da tarefa no prompt versionado. */
+  /** Resolve o contexto congelado e injeta os artefatos da revisão comercial correspondente. */
   private String prompt(Map<String, Object> task) throws IOException {
     Map<String, Object> promptContext = new HashMap<>(task);
     if ("pde-construction-approval".equals(processCode(task))) {
       promptContext.put("versionedArtifactEvidence", pdeArtifactLoader.load());
+    } else if ("pde-communication-sales-journey".equals(processCode(task))) {
+      promptContext.put(
+          "versionedArtifactEvidence", pdeArtifactLoader.loadCommunicationContracts());
     }
     return read(promptResourceFor(processCode(task)))
         .replace("{{TASK_CONTEXT}}", json.writeValueAsString(promptContext));

--- a/meta-ad-approver-worker/src/main/java/com/marketinghub/metaadapproverworker/PdeReviewArtifactLoader.java
+++ b/meta-ad-approver-worker/src/main/java/com/marketinghub/metaadapproverworker/PdeReviewArtifactLoader.java
@@ -3,16 +3,20 @@ package com.marketinghub.metaadapproverworker;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.util.zip.CRC32;
 
 /**
  * Responsabilidade: carregar evidências versionadas do PDE para a revisão independente de Têmis.
  */
 final class PdeReviewArtifactLoader {
+  private static final String COMMUNICATION_CONTRACT_DIRECTORY = "pde-platform/contracts";
   private static final List<String> ARTIFACT_PATHS =
       List.of(
           "pde-platform/contracts/kit-whatsapp-pronto-v1.json",
@@ -50,6 +54,42 @@ final class PdeReviewArtifactLoader {
               checksum(content),
               "content",
               content));
+    }
+    return evidence;
+  }
+
+  /** Lê todos os contratos comerciais JSON versionados para produtos atuais e futuros. */
+  List<Map<String, Object>> loadCommunicationContracts() throws IOException {
+    Path contractsDirectory = repositoryRoot.resolve(COMMUNICATION_CONTRACT_DIRECTORY).normalize();
+    if (!contractsDirectory.startsWith(repositoryRoot) || !Files.isDirectory(contractsDirectory)) {
+      throw new IOException("Diretório de contratos comerciais PDE não encontrado");
+    }
+    List<Map<String, Object>> evidence = new ArrayList<>();
+    try (Stream<Path> files = Files.list(contractsDirectory)) {
+      for (Path artifact :
+          files
+              .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+              .filter(path -> path.getFileName().toString().endsWith(".json"))
+              .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+              .toList()) {
+        if (!artifact.normalize().startsWith(contractsDirectory)) {
+          throw new IllegalArgumentException("Contrato comercial fora do diretório autorizado");
+        }
+        String content = Files.readString(artifact, StandardCharsets.UTF_8);
+        evidence.add(
+            Map.of(
+                "path",
+                repositoryRoot.relativize(artifact).toString(),
+                "contentLength",
+                content.length(),
+                "contentChecksum",
+                checksum(content),
+                "content",
+                content));
+      }
+    }
+    if (evidence.isEmpty()) {
+      throw new IOException("Nenhum contrato comercial PDE versionado foi encontrado");
     }
     return evidence;
   }

--- a/meta-ad-approver-worker/src/main/resources/prompts/bpm/pde-communication-review.md
+++ b/meta-ad-approver-worker/src/main/resources/prompts/bpm/pde-communication-review.md
@@ -14,13 +14,24 @@ autorize mídia ou comunicação externa.
 ## Critérios obrigatórios
 
 - coerência entre produto aprovado, público, dor, promessa, mecanismo, entrega e limitações;
-- preço compreensível pelo enquadramento e compatível com margem, sem desconto arbitrário;
+- preço compreensível pelo enquadramento, cobrança única ou recorrente declarada e compatível com
+  margem, sem desconto arbitrário;
 - prova honesta e ausência de depoimentos, vendas, urgência ou garantia fabricados;
 - CTA, checkout e acesso compatíveis com o que será entregue;
 - canal permitido pelo Plano Comercial e amostra suficiente para aprender;
 - eventos até compra e primeiro uso, com tráfego de teste segregado;
+- contratos canônicos para compra, acesso, entrega, primeiro uso/aplicação e reembolso, cada um com
+  gatilho, metadados mínimos, chaves de correlação, fonte de verdade e significado comercial;
+- regra absoluta de reembolso para a primeira coorte pequena, sem usar percentual isolado como falsa
+  precisão estatística;
 - criativo e destino delegados aos subprocessos canônicos, sem produção duplicada;
 - nenhum gasto, publicação ou comunicação em massa autorizados implicitamente.
+
+Esta revisão decide se o contrato comercial está completo para seguir aos subprocessos e à
+Homologação e ativação. Não repita o preflight técnico do processo posterior: persistência real,
+correlação ponta a ponta, pagamento de teste, retomada e falhas devem permanecer como requisitos
+explícitos da homologação e continuar bloqueando contato e gasto, mas não causam `ADJUST` aqui quando
+URL, checkout, rota de acesso e contratos versionados já estão preparados.
 
 `priceClarityScore` mede somente a clareza e a compreensão do preço, em escala inteira de 0 a 100:
 
@@ -30,6 +41,11 @@ autorize mídia ou comunicação externa.
 
 Um bloqueio técnico ou de publicação não reduz automaticamente essa nota. A nota precisa ser
 coerente com `commercialRationale`, `evidence`, `risks` e `requiredChanges`.
+
+As evidências versionadas já entregues em `versionedArtifactEvidence` são a fonte primária para
+contratos de produto e eventos. Não crie subagente, worktree ou ambiente auxiliar. Se precisar
+confirmar outro arquivo, use leitura direta e somente leitura dentro do repositório atual; falha de
+uma ferramenta auxiliar não comprova ausência do artefato.
 
 Retorne `APPROVED` somente quando o contrato puder seguir para produção dos subprocessos sem lacuna
 comercial. Use `ADJUST` para correção objetiva e `BLOCKED` quando faltar entrada essencial. O resultado

--- a/meta-ad-approver-worker/src/test/java/com/marketinghub/metaadapproverworker/CommercialBpmTaskConsumerTest.java
+++ b/meta-ad-approver-worker/src/test/java/com/marketinghub/metaadapproverworker/CommercialBpmTaskConsumerTest.java
@@ -71,6 +71,9 @@ class CommercialBpmTaskConsumerTest {
             "preço compreensível",
             "tráfego de teste segregado",
             "autorize mídia",
+            "compra, acesso, entrega, primeiro uso/aplicação e reembolso",
+            "Não crie subagente, worktree ou ambiente auxiliar",
+            "Não repita o preflight técnico do processo posterior",
             "80–100",
             "não reduz automaticamente");
     org.assertj.core.api.Assertions.assertThat(schema)

--- a/meta-ad-approver-worker/src/test/java/com/marketinghub/metaadapproverworker/PdeReviewArtifactLoaderTest.java
+++ b/meta-ad-approver-worker/src/test/java/com/marketinghub/metaadapproverworker/PdeReviewArtifactLoaderTest.java
@@ -30,4 +30,30 @@ class PdeReviewArtifactLoaderTest {
               assertThat(artifact.get("contentChecksum").toString()).isNotBlank();
             });
   }
+
+  /** Descobre contratos comerciais novos sem exigir lista manual no executor de Têmis. */
+  @Test
+  void loadsAllCommunicationContractsForCurrentAndFutureProducts() throws Exception {
+    Path contracts = tempDir.resolve("pde-platform/contracts");
+    Files.createDirectories(contracts);
+    Files.writeString(contracts.resolve("produto-b-v1.json"), "{\"slug\":\"produto-b\"}");
+    Files.writeString(contracts.resolve("produto-a-v1.json"), "{\"slug\":\"produto-a\"}");
+    Files.writeString(contracts.resolve("nota.md"), "não é contrato");
+    Path outsideContract = tempDir.resolve("fora-do-diretorio.json");
+    Files.writeString(outsideContract, "{\"slug\":\"externo\"}");
+    Files.createSymbolicLink(contracts.resolve("atalho-externo.json"), outsideContract);
+
+    var evidence = new PdeReviewArtifactLoader(tempDir.toString()).loadCommunicationContracts();
+
+    assertThat(evidence)
+        .extracting(item -> item.get("path"))
+        .containsExactly(
+            "pde-platform/contracts/produto-a-v1.json", "pde-platform/contracts/produto-b-v1.json");
+    assertThat(evidence)
+        .allSatisfy(
+            artifact -> {
+              assertThat(artifact.get("content").toString()).contains("slug");
+              assertThat(artifact.get("contentChecksum").toString()).isNotBlank();
+            });
+  }
 }

--- a/pde-platform/contracts/commercial-journey-event-contract-v1.json
+++ b/pde-platform/contracts/commercial-journey-event-contract-v1.json
@@ -1,0 +1,61 @@
+{
+  "contractVersion": "commercial-journey-event-contract-v1",
+  "purpose": "Correlacionar venda, acesso, entrega, primeiro uso e reembolso sem contar intenção ou tráfego de teste como receita.",
+  "activationRule": "A homologação comercial deve bloquear a ativação enquanto algum evento obrigatório não possuir fonte persistida e correlação comprovada.",
+  "events": [
+    {
+      "eventName": "PURCHASE_COMPLETED",
+      "trigger": "Pagamento aprovado e confirmado pelo provedor.",
+      "requiredMetadata": ["paymentId", "productSlug", "experimentId", "amountBrl", "currency", "approvedAt"],
+      "correlationKeys": ["paymentId", "productSlug", "experimentId"],
+      "authoritativeSource": "Webhook ou consulta autenticada do provedor de pagamentos.",
+      "commercialMeaning": "Único evento que incrementa venda e receita para produto de compra única."
+    },
+    {
+      "eventName": "ACCESS_RELEASED",
+      "trigger": "Acesso persistido depois da confirmação do pagamento.",
+      "requiredMetadata": ["paymentId", "accessToken", "productSlug", "experimentId", "releasedAt"],
+      "correlationKeys": ["paymentId", "accessToken", "experimentId"],
+      "authoritativeSource": "Backend PDE responsável pela concessão de acesso.",
+      "commercialMeaning": "Confirma que a compra produziu acesso retomável; não cria nova venda."
+    },
+    {
+      "eventName": "MISSION_COMPLETED",
+      "trigger": "Marco operacional de entrega concluído com artefato auditável.",
+      "requiredMetadata": ["accessToken", "productSlug", "experimentId", "missionId", "completedAt"],
+      "correlationKeys": ["accessToken", "missionId", "experimentId"],
+      "authoritativeSource": "Backend PDE no endpoint operacional autorizado.",
+      "commercialMeaning": "Com missionId entrega-completa-48h, comprova entrega; não cria nova venda."
+    },
+    {
+      "eventName": "FIRST_USE",
+      "trigger": "Primeiro uso autenticado registrado depois da liberação do acesso.",
+      "requiredMetadata": ["accessToken", "productSlug", "experimentId", "occurredAt"],
+      "correlationKeys": ["accessToken", "experimentId"],
+      "authoritativeSource": "Backend PDE após interação autenticada da cliente.",
+      "commercialMeaning": "Confirma início de uso do valor entregue; não cria nova venda."
+    },
+    {
+      "eventName": "MISSION_COMPLETED",
+      "trigger": "Primeira aplicação prática concluída com o material personalizado.",
+      "requiredMetadata": ["accessToken", "productSlug", "experimentId", "missionId", "completedAt"],
+      "correlationKeys": ["accessToken", "missionId", "experimentId"],
+      "authoritativeSource": "Backend PDE no endpoint operacional autorizado.",
+      "commercialMeaning": "Com missionId primeira-aplicacao-e-revisao, comprova aplicação real; não cria nova venda."
+    },
+    {
+      "eventName": "REFUND_CONFIRMED",
+      "trigger": "Provedor confirma reembolso, estorno ou chargeback de pagamento antes aprovado.",
+      "requiredMetadata": ["paymentId", "productSlug", "experimentId", "amountBrl", "providerStatus", "confirmedAt", "reason"],
+      "correlationKeys": ["paymentId", "productSlug", "experimentId"],
+      "authoritativeSource": "Webhook persistido do provedor de pagamentos e seu payload bruto auditável.",
+      "commercialMeaning": "Subtrai receita líquida e aciona o gate de causa-raiz; não deve ser inferido por pedido de suporte."
+    }
+  ],
+  "testTraffic": {
+    "requiredClassification": "INTERNAL_QA",
+    "requiredReason": "EXPLICIT_TEST_MARKER",
+    "countsAsSale": false
+  },
+  "firstCohortRefundGuardrail": "Até cinco vendas, qualquer reembolso pausa novos contatos e exige causa-raiz. Parar se decorrer de promessa, entrega, privacidade ou margem; percentuais só orientam decisão após amostra compatível."
+}

--- a/pde-platform/contracts/kit-whatsapp-pronto-v1.json
+++ b/pde-platform/contracts/kit-whatsapp-pronto-v1.json
@@ -4,9 +4,32 @@
   "layoutKey": "assisted-service-v1",
   "funnelVersion": "pde-assisted-service-v1",
   "name": "Kit WhatsApp Pronto",
-  "promise": "Em até 48 horas, receba respostas, perguntas e follow-ups ajustados ao seu atendimento para usar manualmente no WhatsApp com mais clareza e menos retrabalho.",
+  "promise": "Após o pagamento confirmado e o briefing mínimo completo, em até 48 horas receba respostas, perguntas e follow-ups ajustados ao seu atendimento para usar manualmente no WhatsApp com mais clareza e menos retrabalho.",
   "audience": "Pequenos prestadores de serviços locais que já atendem pelo WhatsApp.",
   "priceLabel": "R$ 349",
+  "billing": {
+    "model": "ONE_TIME",
+    "label": "Pagamento único, sem recorrência",
+    "totalPriceBrl": 349
+  },
+  "commercialEventContract": "commercial-journey-event-contract-v1",
+  "serviceScope": {
+    "includedItems": [
+      "Briefing inicial guiado",
+      "10 a 20 respostas personalizadas",
+      "5 a 10 perguntas de qualificação",
+      "3 a 5 follow-ups manuais",
+      "Regras de escalonamento",
+      "Guia, checklist, revisão humana e entrega"
+    ],
+    "excludedItems": [
+      "Software, bot ou automação",
+      "Integração ou disparo automático",
+      "Assinatura ou cobrança recorrente",
+      "Garantia de conversão, faturamento ou agenda cheia"
+    ],
+    "deadlineStartsWhen": "O pagamento estiver confirmado e as informações mínimas do briefing estiverem completas."
+  },
   "theme": {
     "primary": "#145C52",
     "accent": "#E9A23B",

--- a/pde-platform/frontend/src/AssistedServiceApp.tsx
+++ b/pde-platform/frontend/src/AssistedServiceApp.tsx
@@ -445,8 +445,9 @@ export function AssistedServiceApp({ productSlug }: AssistedServiceAppProps) {
                 {commercialOffer.primaryCta} <ChevronRight />
               </a>
               <small>
-                Você revisa os dados e as condições no checkout antes de
-                confirmar.
+                Pagamento único, sem recorrência. O briefing inicial está
+                incluído e o prazo de até 48 horas começa após o pagamento
+                confirmado e o recebimento das informações mínimas completas.
               </small>
               <nav
                 className="assisted-pde-offer-policies"

--- a/pde-platform/frontend/tests/assisted-service-local.spec.ts
+++ b/pde-platform/frontend/tests/assisted-service-local.spec.ts
@@ -78,6 +78,15 @@ test("conclui a jornada assistida com marcos operacionais, preserva progresso e 
   await expect(page.getByText("Microvalor em até 12 horas")).toBeVisible();
   await expect(page.getByText("Revisão humana antes do uso")).toBeVisible();
   await expect(page.getByTestId("commercial-offer")).toContainText("R$ 349");
+  await expect(page.getByTestId("commercial-offer")).toContainText(
+    "Pagamento único, sem recorrência",
+  );
+  await expect(page.getByTestId("commercial-offer")).toContainText(
+    /briefing inicial está incluído/i,
+  );
+  await expect(page.getByTestId("commercial-offer")).toContainText(
+    /prazo de até 48 horas começa após o pagamento confirmado/i,
+  );
   const checkout = page.getByRole("link", {
     name: "Quero meu atendimento sob medida",
   });


### PR DESCRIPTION
## Objetivo

Fechar as lacunas encontradas por Têmis no processo Comunicação e jornada de venda do Kit WhatsApp Pronto.

## Alterações

- declara pagamento único de R$ 349, sem recorrência;
- inclui briefing mínimo e explicita quando começa o prazo de 48 horas;
- separa itens incluídos e excluídos;
- versiona eventos de compra, acesso, entrega, primeiro uso e reembolso;
- entrega os contratos versionados diretamente à revisão de Têmis;
- preserva a homologação técnica como gate posterior, sem liberar contato ou gasto.

## Validação

- checks do GitHub Actions aprovados;
- testes e Spotless de Hermes e Têmis aprovados localmente;
- build frontend aprovado;
- 12 jornadas locais com MySQL 5.7 e SMTP descartável em desktop, iPhone 15 Pro e Pixel 7;
- oferta produtiva atual validada em desktop e mobile, sem clique de pagamento ou evento comercial real.

## Pós-merge

Publicar os workers e o frontend Kit WhatsApp, reabrir a atividade BPM e permitir que Hermes e Têmis executem novamente. Nenhuma ativação, contato ou gasto deve ocorrer antes do processo posterior de Homologação comercial.