### PR TITLE
Impede smoke PDE de contaminar métricas humanas

### DIFF
--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -1654,6 +1654,13 @@ Use este checklist quando o problema estiver em algum loop acima:
   `HUMAN`. A classificação passa a reconhecer o domínio reservado e a origem do acesso antes do
   tipo funcional. O E2E exige compra, acesso, entrega, reembolso e venda líquida humanos em zero e
   preserva o ciclo somente no breakdown bruto `INTERNAL_QA`.
+- **Fechamento complementar do smoke público em 2026-08-24:** o deploy direcionado de Rigel abriu a
+  raiz pública com os perfis Desktop Chrome e Pixel 5 sem marcador de homologação e registrou dois
+  `PAGE_VIEW` como `HUMAN`, apesar de a navegação manual de QA já estar segregada. O runner agora
+  impõe `mh_preview=qa&pde_analytics=off`; o próprio Playwright normaliza qualquer `healthPath` para
+  esse modo e reprova se houver tentativa de `POST /api/pde/access/events`. O contrato falso do
+  deploy exige o parâmetro seguro em todas as superfícies, evitando dependência de IP ou User-Agent
+  volátil do GitHub Actions.
 
 ## LOOP-PDE-COMPRA-SEM-VERSAO-E-REEMBOLSO — receita não fecha o ciclo da experiência
 

--- a/pde-platform/README.md
+++ b/pde-platform/README.md
@@ -35,7 +35,10 @@ O health check publico do frontend fica em `GET /healthz` para validar resposta
 HTTP simples do container. Para validar o que evita tela branca comercial, use
 `npm run test:public-health` com `PDE_PUBLIC_HEALTH_URL`: o teste abre a URL
 publicada, exige JavaScript carregado e confere os textos comerciais obrigatorios
-do contrato publico em `GET /pde-health-contract.json`.
+do contrato publico em `GET /pde-health-contract.json`. A navegacao automatizada
+usa obrigatoriamente `mh_preview=qa&pde_analytics=off` e falha se o navegador
+tentar enviar qualquer evento de funil, impedindo que smoke de deploy seja contado
+como visita humana ou mesmo como amostra de QA.
 
 Cada versao publica tambem deve expor `GET /version-diagnostics.json`, com
 `version`, `publicUrl`, `experienceVersion`, `image`, `imageVersionId`,

--- a/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
+++ b/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
@@ -2,9 +2,9 @@
   "evidenceVersion": "kit-whatsapp-tasting-homologation-v1",
   "productSlug": "kit-whatsapp-pronto",
   "experimentId": 89,
-  "verifiedAt": "2026-08-24T02:48:27Z",
+  "verifiedAt": "2026-08-24T12:53:01Z",
   "status": "PASSED",
-  "revalidationReason": "Revisão aprovada após preservar o contexto de QA e preview em toda a jornada pública, inclusive políticas abertas em nova aba.",
+  "revalidationReason": "Revisão aprovada após preservar o contexto de QA e preview em toda a jornada pública, inclusive políticas e o smoke automatizado do deploy.",
   "scope": "Degustação determinística, privacidade, eventos, segregação de QA no build público, fronteira paga, checkout e experiência responsiva.",
   "implementationEvidence": [
     {
@@ -53,10 +53,11 @@
     },
     {
       "path": "pde-platform/frontend/tests/public-health.spec.ts",
-      "sha256": "9a7547e8294ba950dbb055c7cf9752c9f0abe5f608f00ae8eccf282f46ddb21a",
+      "sha256": "a7f09ea360ed62231d212d66fa6acf351933950a1ab5186beedcaf37b0bfb52b",
       "proves": [
         "o deploy do Kit falha se a degustação não estiver renderizada",
-        "oferta, preço, checkout e degustação pertencem à mesma superfície pública"
+        "oferta, preço, checkout e degustação pertencem à mesma superfície pública",
+        "o smoke público usa preview sem analytics e falha diante de qualquer tentativa de registrar evento"
       ]
     },
     {

--- a/pde-platform/frontend/tests/public-health.spec.ts
+++ b/pde-platform/frontend/tests/public-health.spec.ts
@@ -181,15 +181,31 @@ function removeMutableFallbackTexts(
   return requiredTexts.filter((text) => !mutableFallbackTexts.has(text));
 }
 
+function safeSmokeHealthPath(healthPath: string) {
+  const url = new URL(healthPath, "http://pde-smoke.local");
+  url.searchParams.set("mh_preview", "qa");
+  url.searchParams.set("pde_analytics", "off");
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 test("health publico renderiza app, javascript e texto comercial", async ({
   page,
   request,
 }) => {
   const pageErrors: string[] = [];
+  const analyticsRequests: string[] = [];
   const contract = await loadContract(request);
 
   page.on("pageerror", (error) => {
     pageErrors.push(error.message);
+  });
+  page.on("request", (browserRequest) => {
+    if (
+      browserRequest.method() === "POST" &&
+      browserRequest.url().includes("/api/pde/access/events")
+    ) {
+      analyticsRequests.push(browserRequest.url());
+    }
   });
 
   const staticHealth = await request.get("/healthz");
@@ -206,7 +222,9 @@ test("health publico renderiza app, javascript e texto comercial", async ({
   expect(diagnostics.imageVersionId).toBeTruthy();
   expect(diagnostics.commitSha).toBeTruthy();
   if (contract.slug === "metodo-musa-7-dias") {
-    expect(diagnostics.knownPointedDomains?.map((domain) => domain.role)).not.toContain("active");
+    expect(
+      diagnostics.knownPointedDomains?.map((domain) => domain.role),
+    ).not.toContain("active");
     expect(
       diagnostics.knownPointedDomains?.map((domain) => domain.host),
     ).toEqual(
@@ -231,7 +249,7 @@ test("health publico renderiza app, javascript e texto comercial", async ({
     publishedFirstFoldTexts,
   );
 
-  const response = await page.goto(contract.healthPath, {
+  const response = await page.goto(safeSmokeHealthPath(contract.healthPath), {
     waitUntil: "networkidle",
   });
   expect(response?.ok()).toBeTruthy();
@@ -276,5 +294,9 @@ test("health publico renderiza app, javascript e texto comercial", async ({
   expect(
     pageErrors,
     `Erros de execucao no health publico: ${pageErrors.join(" | ")}`,
+  ).toEqual([]);
+  expect(
+    analyticsRequests,
+    "O smoke publico nao pode alterar metricas humanas ou de QA.",
   ).toEqual([]);
 });

--- a/pde-platform/scripts/run-targeted-production-smokes.sh
+++ b/pde-platform/scripts/run-targeted-production-smokes.sh
@@ -12,7 +12,9 @@ run_public_health() {
   local public_url="$1"
   (
     cd "${frontend_dir}"
-    PDE_PUBLIC_HEALTH_URL="${public_url}" "${npm_command}" run test:public-health
+    PDE_PUBLIC_HEALTH_URL="${public_url}" \
+      PDE_PUBLIC_HEALTH_PATH='/?mh_preview=qa&pde_analytics=off' \
+      "${npm_command}" run test:public-health
   )
 }
 

--- a/pde-platform/scripts/test-targeted-production-smokes.sh
+++ b/pde-platform/scripts/test-targeted-production-smokes.sh
@@ -13,7 +13,10 @@ fake_consistency="${temporary_dir}/consistency.sh"
 cat >"${fake_npm}" <<'FAKE_NPM'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'npm\t%s\t%s\n' "${PDE_PUBLIC_HEALTH_URL:-}" "$*" >>"${PDE_SMOKE_INVOCATION_LOG}"
+printf 'npm\t%s\t%s\t%s\n' \
+  "${PDE_PUBLIC_HEALTH_URL:-}" \
+  "${PDE_PUBLIC_HEALTH_PATH:-}" \
+  "$*" >>"${PDE_SMOKE_INVOCATION_LOG}"
 FAKE_NPM
 
 cat >"${fake_consistency}" <<'FAKE_CONSISTENCY'
@@ -37,15 +40,15 @@ run_target() {
 }
 
 run_target kit-whatsapp
-grep -Fqx $'npm\thttps://kit-whatsapp-pronto.digicomdigital.com.br\trun test:public-health' "${invocation_log}"
+grep -Fqx $'npm\thttps://kit-whatsapp-pronto.digicomdigital.com.br\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}"
 if grep -Fq 'clubemusa.com.br' "${invocation_log}" || grep -Fq 'consistency' "${invocation_log}"; then
   echo '[ARQUITETURA] O deploy direcionado ao Kit WhatsApp validou um produto nao publicado.' >&2
   exit 1
 fi
 
 run_target v5
-grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-health' "${invocation_log}"
-grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-diagnostic-smoke' "${invocation_log}"
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}"
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\t\trun test:public-diagnostic-smoke' "${invocation_log}"
 grep -Fqx $'consistency\thttps://v5.clubemusa.com.br\tmusa-pde-entry-v5-video-explicativo\t' "${invocation_log}"
 if grep -Fq 'v6.clubemusa.com.br' "${invocation_log}" || grep -Fq 'kit-whatsapp-pronto' "${invocation_log}"; then
   echo '[ARQUITETURA] O deploy direcionado ao v5 validou um produto nao publicado.' >&2
@@ -53,8 +56,8 @@ if grep -Fq 'v6.clubemusa.com.br' "${invocation_log}" || grep -Fq 'kit-whatsapp-
 fi
 
 run_target all
-test "$(grep -c $'npm\t.*\trun test:public-health' "${invocation_log}")" -eq 4
-test "$(grep -c $'npm\t.*\trun test:public-diagnostic-smoke' "${invocation_log}")" -eq 2
+test "$(grep -c $'npm\t.*\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}")" -eq 4
+test "$(grep -c $'npm\t.*\t\trun test:public-diagnostic-smoke' "${invocation_log}")" -eq 2
 test "$(grep -c '^consistency' "${invocation_log}")" -eq 2
 
 if PDE_SMOKE_NPM_COMMAND="${fake_npm}" \


### PR DESCRIPTION
## Objetivo

Impede que o smoke automatizado do deploy PDE seja contabilizado como visita humana ou como amostra de QA.

## Causa-raiz

O health público navegava a raiz sem o contexto seguro de preview. No deploy direcionado de Rigel, os perfis Desktop e Pixel registraram dois PAGE_VIEW como HUMAN.

## Correção

- força preview com analytics desativado no runner direcionado;
- normaliza o caminho dentro do próprio teste Playwright;
- reprova qualquer tentativa de POST no endpoint de eventos;
- atualiza o contrato auditável de Têmis e o registro do loop recorrente.

## Validação

Duas rodadas locais completas e consecutivas passaram com contrato de deploy, carregador de artefatos, build, três testes de analytics e dois smokes produtivos em desktop/mobile. O banco permaneceu em 134 eventos, 23 humanos e 72 QA antes, entre e depois das rodadas.