### PR TITLE
Conclui o preflight produtivo da Vega pela tela

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -6635,3 +6635,11 @@
 - **Gate:** continuar apenas com prova materializada e eventos íntegros; ajustar se houver valor sem avanço para checkout; parar diante de vazamento de dados, canibalização da entrega, custo inesperado ou contaminação de vendas.
 - **Revisão independente:** Têmis bloqueou corretamente a tarefa #197 por ausência de provas executáveis no pacote de revisão. Depois que código, testes, duas rodadas e autoridade dos eventos foram injetados como evidência versionada, a tarefa #198 terminou `APPROVED`, com clareza de preço 98/100 e nenhuma mudança pendente.
 - **Telemetria das revisões #197–198:** 322.520 tokens de entrada, 159.232 em cache, 2.814 de saída e custo estimado de US$ 0,77312480. Nenhum contato, publicação, pagamento, gasto ou venda foi gerado.
+
+## 2026-08-24 — Vega v7: preflight produtivo auditável pela tela
+
+- **Evidência operacional:** a versão `musa-pde-entry-v7-espelho-antes-de-sair` foi publicada e respondeu com identidade exata, mas o smoke exigia um CTA de vídeo condicional que a v7 não renderiza; além disso, a tela permitia iniciar o preflight, mas não registrar seus quatro resultados funcionais.
+- **Causa-raiz:** o smoke confundia configuração opcional com primeira dobra efetiva, e o frontend não consumia o endpoint canônico de homologação já disponível no backend.
+- **Correção:** o smoke valida headline e texto de apoio sempre renderizados, permanece sem analytics, e o painel do run passa a exigir resultado, conclusão e referência auditável para os quatro gates funcionais.
+- **Prevenção:** ausência de qualquer evidência mantém o comando desabilitado; `FAIL` permanece registrável; grupos de evidência comercial e distribuição são representados no contrato frontend; teste impede envio incompleto.
+- **Estado comercial preservado:** a Vega continua em `VALIDACAO_COMERCIAL` até a nova tela ser publicada e o run produtivo terminar `READY_TO_PUBLISH`; não houve contato, gasto, pagamento humano ou venda.

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -1654,6 +1654,13 @@ Use este checklist quando o problema estiver em algum loop acima:
   `HUMAN`. A classificação passa a reconhecer o domínio reservado e a origem do acesso antes do
   tipo funcional. O E2E exige compra, acesso, entrega, reembolso e venda líquida humanos em zero e
   preserva o ciclo somente no breakdown bruto `INTERNAL_QA`.
+- **Fechamento complementar do smoke público em 2026-08-24:** o deploy direcionado de Rigel abriu a
+  raiz pública com os perfis Desktop Chrome e Pixel 5 sem marcador de homologação e registrou dois
+  `PAGE_VIEW` como `HUMAN`, apesar de a navegação manual de QA já estar segregada. O runner agora
+  impõe `mh_preview=qa&pde_analytics=off`; o próprio Playwright normaliza qualquer `healthPath` para
+  esse modo e reprova se houver tentativa de `POST /api/pde/access/events`. O contrato falso do
+  deploy exige o parâmetro seguro em todas as superfícies, evitando dependência de IP ou User-Agent
+  volátil do GitHub Actions.
 
 ## LOOP-PDE-COMPRA-SEM-VERSAO-E-REEMBOLSO — receita não fecha o ciclo da experiência
 

--- a/frontend/src/api/experiment/useExperimentRuns.ts
+++ b/frontend/src/api/experiment/useExperimentRuns.ts
@@ -26,11 +26,7 @@ export type ExperimentEvidenceValidity =
   | "INSUFFICIENT_DATA"
   | "COMMERCIALLY_VALID";
 export type ExperimentRunDataQualityStatus =
-  | "UNKNOWN"
-  | "VALID"
-  | "WARNING"
-  | "BLOCKED"
-  | "STALE";
+  "UNKNOWN" | "VALID" | "WARNING" | "BLOCKED" | "STALE";
 export type ExperimentRunStopPolicy =
   | "FIRST_VALID_LEAD_STANDBY"
   | "FIXED_WINDOW"
@@ -38,19 +34,24 @@ export type ExperimentRunStopPolicy =
   | "STOP_LOSS"
   | "MANUAL_ONLY";
 export type ExperimentRunGateStatus =
-  | "PASS"
-  | "WARNING"
-  | "FAIL"
-  | "NOT_APPLICABLE"
-  | "PENDING";
+  "PASS" | "WARNING" | "FAIL" | "NOT_APPLICABLE" | "PENDING";
 export type ExperimentRunGateSeverity = "INFO" | "WARNING" | "BLOCKER";
 export type ExperimentRunGateGroup =
   | "UPSTREAM_QUALITY"
+  | "COMMERCIAL_EVIDENCE"
   | "EXPERIMENT_DESIGN"
   | "ASSET_QUALITY"
   | "FUNCTIONAL_E2E"
+  | "DISTRIBUTION"
   | "META_PUBLICATION"
   | "MEASUREMENT";
+
+export type ExperimentRunHomologationGateEvidence = {
+  gateCode: string;
+  status: Extract<ExperimentRunGateStatus, "PASS" | "FAIL">;
+  summary: string;
+  evidenceReference: string;
+};
 
 export type ExperimentRun = {
   id: number;
@@ -149,6 +150,37 @@ export function useRunExperimentPreflight(experimentId?: string | number) {
     mutationFn: async (runId: number) => {
       const { data } = await axios.post<ExperimentRunPreflight>(
         `/api/experiment-runs/${runId}/preflight`,
+      );
+      return data;
+    },
+    onSuccess: async (preflight) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: experimentRunsQueryKey(experimentId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: experimentRunPreflightQueryKey(preflight.runId),
+        }),
+      ]);
+    },
+  });
+}
+
+export function useRecordExperimentRunHomologation(
+  experimentId?: string | number,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      runId,
+      gates,
+    }: {
+      runId: number;
+      gates: ExperimentRunHomologationGateEvidence[];
+    }) => {
+      const { data } = await axios.post<ExperimentRunPreflight>(
+        `/api/experiment-runs/${runId}/homologation-results`,
+        { gates },
       );
       return data;
     },

--- a/frontend/src/pages/experiment/ExperimentRunPanel.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentRunPanel.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useCreateExperimentRun,
+  useExperimentRunPreflight,
+  useExperimentRuns,
+  useRecordExperimentRunHomologation,
+  useRunExperimentPreflight,
+} from "../../api/experiment/useExperimentRuns";
+import ExperimentRunPanel from "./ExperimentRunPanel";
+
+vi.mock("../../api/experiment/useExperimentRuns", () => ({
+  useCreateExperimentRun: vi.fn(),
+  useExperimentRunPreflight: vi.fn(),
+  useExperimentRuns: vi.fn(),
+  useRecordExperimentRunHomologation: vi.fn(),
+  useRunExperimentPreflight: vi.fn(),
+}));
+
+const gateCodes = [
+  "LANDING_QUALITY_REVIEW_APPROVED",
+  "CHECKOUT_AND_DELIVERY_CAN_BE_COMPLETED",
+  "DIRECT_CHANNEL_READINESS_CONFIRMED",
+  "DATA_FRESHNESS_VALID",
+];
+
+describe("ExperimentRunPanel", () => {
+  const recordHomologation = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(useExperimentRuns).mockReturnValue({
+      data: [
+        {
+          id: 51,
+          experimentId: 99,
+          runNumber: 1,
+          mode: "PRODUCTION",
+          status: "PREFLIGHT_FAILED",
+          evidenceValidity: "TECHNICALLY_INVALID",
+          dataQualityStatus: "BLOCKED",
+          stopPolicy: "MANUAL_ONLY",
+          requestedAt: "2026-08-24T12:00:00Z",
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useExperimentRuns>);
+    vi.mocked(useExperimentRunPreflight).mockReturnValue({
+      data: {
+        runId: 51,
+        runStatus: "PREFLIGHT_FAILED",
+        hasBlockers: true,
+        gates: gateCodes.map((gateCode, index) => ({
+          gateCode,
+          gateGroup:
+            index === 0
+              ? "ASSET_QUALITY"
+              : index === 1
+                ? "FUNCTIONAL_E2E"
+                : index === 2
+                  ? "DISTRIBUTION"
+                  : "MEASUREMENT",
+          status: "PENDING",
+          severity: "WARNING",
+          summary: "Evidência pendente.",
+          evaluatedAt: "2026-08-24T12:01:00Z",
+          evaluatorType: "DETERMINISTIC",
+        })),
+      },
+      isLoading: false,
+    } as ReturnType<typeof useExperimentRunPreflight>);
+    vi.mocked(useCreateExperimentRun).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateExperimentRun>);
+    vi.mocked(useRunExperimentPreflight).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useRunExperimentPreflight>);
+    vi.mocked(useRecordExperimentRunHomologation).mockReturnValue({
+      mutate: recordHomologation,
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useRecordExperimentRunHomologation>);
+  });
+
+  afterEach(cleanup);
+
+  it("registra os quatro gates funcionais somente com evidências completas", () => {
+    render(<ExperimentRunPanel experimentId="99" />);
+
+    const submit = screen.getByRole("button", {
+      name: "Registrar homologação",
+    });
+    expect(submit).toBeDisabled();
+
+    for (const gateCode of gateCodes) {
+      fireEvent.change(screen.getByLabelText(`Resultado ${gateCode}`), {
+        target: { value: "PASS" },
+      });
+      fireEvent.change(screen.getByLabelText(`Evidência ${gateCode}`), {
+        target: { value: `evidence://${gateCode}` },
+      });
+      fireEvent.change(screen.getByLabelText(`Conclusão ${gateCode}`), {
+        target: { value: `Gate ${gateCode} comprovado.` },
+      });
+    }
+
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+
+    expect(recordHomologation).toHaveBeenCalledWith({
+      runId: 51,
+      gates: gateCodes.map((gateCode) => ({
+        gateCode,
+        status: "PASS",
+        summary: `Gate ${gateCode} comprovado.`,
+        evidenceReference: `evidence://${gateCode}`,
+      })),
+    });
+  });
+});

--- a/frontend/src/pages/experiment/ExperimentRunPanel.tsx
+++ b/frontend/src/pages/experiment/ExperimentRunPanel.tsx
@@ -3,22 +3,41 @@ import type {
   ExperimentRun,
   ExperimentRunGateGroup,
   ExperimentRunGateResult,
+  ExperimentRunGateStatus,
   ExperimentRunPreflight,
 } from "../../api/experiment/useExperimentRuns";
 import {
   useCreateExperimentRun,
   useExperimentRunPreflight,
   useExperimentRuns,
+  useRecordExperimentRunHomologation,
   useRunExperimentPreflight,
 } from "../../api/experiment/useExperimentRuns";
 
 const gateGroupLabels: Record<ExperimentRunGateGroup, string> = {
   UPSTREAM_QUALITY: "Qualidade upstream",
+  COMMERCIAL_EVIDENCE: "Evidência comercial",
   EXPERIMENT_DESIGN: "Desenho experimental",
   ASSET_QUALITY: "Qualidade dos ativos",
   FUNCTIONAL_E2E: "Teste ponta a ponta",
+  DISTRIBUTION: "Distribuição",
   META_PUBLICATION: "Publicação Meta",
   MEASUREMENT: "Mensuração",
+};
+
+const homologationGateCodes = new Set([
+  "LANDING_QUALITY_REVIEW_APPROVED",
+  "FORM_CAN_BE_SUBMITTED",
+  "CHECKOUT_AND_DELIVERY_CAN_BE_COMPLETED",
+  "META_EFFECTIVE_STATUS_CONFIRMED",
+  "DIRECT_CHANNEL_READINESS_CONFIRMED",
+  "DATA_FRESHNESS_VALID",
+]);
+
+type HomologationDraft = {
+  status: Extract<ExperimentRunGateStatus, "PASS" | "FAIL"> | "";
+  summary: string;
+  evidenceReference: string;
 };
 
 const statusLabels: Record<string, string> = {
@@ -57,10 +76,21 @@ function label(value?: string | null) {
 
 function badgeClass(value?: string | null) {
   if (!value) return "text-bg-secondary";
-  if (["READY_TO_PUBLISH", "COMMERCIALLY_VALID", "VALID", "PASS"].includes(value)) {
+  if (
+    ["READY_TO_PUBLISH", "COMMERCIALLY_VALID", "VALID", "PASS"].includes(value)
+  ) {
     return "text-bg-success";
   }
-  if (["PREFLIGHT_FAILED", "TECHNICALLY_INVALID", "MEASUREMENT_INVALID", "STRATEGICALLY_INVALID", "BLOCKED", "FAIL"].includes(value)) {
+  if (
+    [
+      "PREFLIGHT_FAILED",
+      "TECHNICALLY_INVALID",
+      "MEASUREMENT_INVALID",
+      "STRATEGICALLY_INVALID",
+      "BLOCKED",
+      "FAIL",
+    ].includes(value)
+  ) {
     return "text-bg-danger";
   }
   if (["WARNING", "INSUFFICIENT_DATA", "PENDING"].includes(value)) {
@@ -70,14 +100,19 @@ function badgeClass(value?: string | null) {
 }
 
 function latestRun(runs?: ExperimentRun[]) {
-  return [...(runs ?? [])].sort((left, right) => right.runNumber - left.runNumber)[0];
+  return [...(runs ?? [])].sort(
+    (left, right) => right.runNumber - left.runNumber,
+  )[0];
 }
 
 function groupGates(gates: ExperimentRunGateResult[]) {
-  return gates.reduce<Record<string, ExperimentRunGateResult[]>>((acc, gate) => {
-    acc[gate.gateGroup] = [...(acc[gate.gateGroup] ?? []), gate];
-    return acc;
-  }, {});
+  return gates.reduce<Record<string, ExperimentRunGateResult[]>>(
+    (acc, gate) => {
+      acc[gate.gateGroup] = [...(acc[gate.gateGroup] ?? []), gate];
+      return acc;
+    },
+    {},
+  );
 }
 
 type ExperimentRunPanelProps = {
@@ -85,15 +120,34 @@ type ExperimentRunPanelProps = {
   compact?: boolean;
 };
 
-export default function ExperimentRunPanel({ experimentId, compact = false }: ExperimentRunPanelProps) {
+export default function ExperimentRunPanel({
+  experimentId,
+  compact = false,
+}: ExperimentRunPanelProps) {
   const runsQuery = useExperimentRuns(experimentId);
   const currentRun = latestRun(runsQuery.data);
   const preflightQuery = useExperimentRunPreflight(currentRun?.id);
   const createRun = useCreateExperimentRun(experimentId);
   const runPreflight = useRunExperimentPreflight(experimentId);
+  const recordHomologation = useRecordExperimentRunHomologation(experimentId);
   const preflight = preflightQuery.data;
   const gateGroups = groupGates(preflight?.gates ?? []);
+  const homologationGates = (preflight?.gates ?? []).filter((gate) =>
+    homologationGateCodes.has(gate.gateCode),
+  );
   const [openGateGroup, setOpenGateGroup] = useState<string | null>(null);
+  const [homologationDrafts, setHomologationDrafts] = useState<
+    Record<string, HomologationDraft>
+  >({});
+
+  const homologationReady =
+    homologationGates.length === 4 &&
+    homologationGates.every((gate) => {
+      const draft = homologationDrafts[gate.gateCode];
+      return Boolean(
+        draft?.status && draft.summary.trim() && draft.evidenceReference.trim(),
+      );
+    });
 
   const handleCreateRun = () => {
     if (!createRun.isPending) {
@@ -107,6 +161,43 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
     }
   };
 
+  const updateHomologationDraft = (
+    gateCode: string,
+    field: keyof HomologationDraft,
+    value: string,
+  ) => {
+    setHomologationDrafts((current) => ({
+      ...current,
+      [gateCode]: {
+        status: current[gateCode]?.status ?? "",
+        summary: current[gateCode]?.summary ?? "",
+        evidenceReference: current[gateCode]?.evidenceReference ?? "",
+        [field]: value,
+      } as HomologationDraft,
+    }));
+  };
+
+  const handleRecordHomologation = () => {
+    if (!currentRun || !homologationReady || recordHomologation.isPending) {
+      return;
+    }
+    recordHomologation.mutate({
+      runId: currentRun.id,
+      gates: homologationGates.map((gate) => {
+        const draft = homologationDrafts[gate.gateCode];
+        return {
+          gateCode: gate.gateCode,
+          status: draft.status as Extract<
+            ExperimentRunGateStatus,
+            "PASS" | "FAIL"
+          >,
+          summary: draft.summary.trim(),
+          evidenceReference: draft.evidenceReference.trim(),
+        };
+      }),
+    });
+  };
+
   return (
     <div className="card">
       <div className="card-body">
@@ -114,7 +205,8 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
           <div>
             <h5 className="card-title mb-1">Execução atual</h5>
             <p className="text-muted small mb-0">
-              Verdade operacional do backend sobre a tentativa de colocar este experimento no mercado.
+              Verdade operacional do backend sobre a tentativa de colocar este
+              experimento no mercado.
             </p>
           </div>
           <div className="d-flex flex-wrap gap-2">
@@ -125,7 +217,10 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
               disabled={createRun.isPending || runsQuery.isLoading}
             >
               {createRun.isPending ? (
-                <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
               ) : null}
               Criar run
             </button>
@@ -136,7 +231,10 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
               disabled={!currentRun || runPreflight.isPending}
             >
               {runPreflight.isPending ? (
-                <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
               ) : null}
               Rodar preflight
             </button>
@@ -144,20 +242,38 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
         </div>
 
         {runsQuery.isLoading ? (
-          <div className="text-muted small mt-3">Carregando execução atual...</div>
+          <div className="text-muted small mt-3">
+            Carregando execução atual...
+          </div>
         ) : !currentRun ? (
           <div className="alert alert-info mt-3 mb-0">
-            Nenhum run foi criado para este experimento. Crie um run antes de interpretar falha técnica como resultado de mercado.
+            Nenhum run foi criado para este experimento. Crie um run antes de
+            interpretar falha técnica como resultado de mercado.
           </div>
         ) : (
           <>
             <div className="row g-3 mt-1">
               <StatusItem label="Run" value={`#${currentRun.runNumber}`} />
               <StatusItem label="Modo" value={currentRun.mode} />
-              <StatusItem label="Status" value={label(currentRun.status)} badge={currentRun.status} />
-              <StatusItem label="Validade" value={label(currentRun.evidenceValidity)} badge={currentRun.evidenceValidity} />
-              <StatusItem label="Dados" value={label(currentRun.dataQualityStatus)} badge={currentRun.dataQualityStatus} />
-              <StatusItem label="Exposição confirmada" value={currentRun.firstVerifiedImpressionAt ?? "—"} />
+              <StatusItem
+                label="Status"
+                value={label(currentRun.status)}
+                badge={currentRun.status}
+              />
+              <StatusItem
+                label="Validade"
+                value={label(currentRun.evidenceValidity)}
+                badge={currentRun.evidenceValidity}
+              />
+              <StatusItem
+                label="Dados"
+                value={label(currentRun.dataQualityStatus)}
+                badge={currentRun.dataQualityStatus}
+              />
+              <StatusItem
+                label="Exposição confirmada"
+                value={currentRun.firstVerifiedImpressionAt ?? "—"}
+              />
             </div>
 
             {!compact ? (
@@ -165,58 +281,205 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
                 <div className="d-flex justify-content-between align-items-center mb-2">
                   <h6 className="mb-0">Checklist de preparação</h6>
                   {preflight ? (
-                    <span className={`badge ${preflight.hasBlockers ? "text-bg-danger" : "text-bg-success"}`}>
-                      {preflight.hasBlockers ? "Com bloqueadores" : "Sem bloqueadores"}
+                    <span
+                      className={`badge ${preflight.hasBlockers ? "text-bg-danger" : "text-bg-success"}`}
+                    >
+                      {preflight.hasBlockers
+                        ? "Com bloqueadores"
+                        : "Sem bloqueadores"}
                     </span>
                   ) : null}
                 </div>
                 {preflightQuery.isLoading ? (
-                  <div className="text-muted small">Carregando preflight...</div>
-                ) : !preflight || preflight.gates.length === 0 ? (
-                  <div className="text-muted small">Preflight ainda não executado.</div>
-                ) : (
-                  <div className="accordion" id={`experiment-run-preflight-${currentRun.id}`}>
-                    {Object.entries(gateGroups).map(([group, gates], index) => (
-                      <div className="accordion-item" key={group}>
-                        <h2 className="accordion-header">
-                          <button
-                            className={`accordion-button ${openGateGroup === group || (!openGateGroup && index === 0) ? "" : "collapsed"}`}
-                            type="button"
-                            aria-expanded={openGateGroup === group || (!openGateGroup && index === 0)}
-                            aria-controls={`experiment-run-preflight-${currentRun.id}-${group}`}
-                            onClick={() => setOpenGateGroup(group)}
-                          >
-                            {gateGroupLabels[group as ExperimentRunGateGroup] ?? group}
-                          </button>
-                        </h2>
-                        <div
-                          id={`experiment-run-preflight-${currentRun.id}-${group}`}
-                          className={`accordion-collapse collapse ${openGateGroup === group || (!openGateGroup && index === 0) ? "show" : ""}`}
-                        >
-                          <div className="accordion-body p-0">
-                            <ul className="list-group list-group-flush">
-                              {gates.map((gate) => (
-                                <li className="list-group-item" key={gate.gateCode}>
-                                  <div className="d-flex flex-wrap justify-content-between gap-2">
-                                    <div>
-                                      <div className="fw-semibold">{gate.gateCode}</div>
-                                      <div className="text-muted small">{gate.summary}</div>
-                                      {gate.remediationCode ? (
-                                        <div className="small text-danger">Remediação: {gate.remediationCode}</div>
-                                      ) : null}
-                                    </div>
-                                    <span className={`badge align-self-start ${badgeClass(gate.status)}`}>
-                                      {gate.status}
-                                    </span>
-                                  </div>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
+                  <div className="text-muted small">
+                    Carregando preflight...
                   </div>
+                ) : !preflight || preflight.gates.length === 0 ? (
+                  <div className="text-muted small">
+                    Preflight ainda não executado.
+                  </div>
+                ) : (
+                  <>
+                    <div
+                      className="accordion"
+                      id={`experiment-run-preflight-${currentRun.id}`}
+                    >
+                      {Object.entries(gateGroups).map(
+                        ([group, gates], index) => (
+                          <div className="accordion-item" key={group}>
+                            <h2 className="accordion-header">
+                              <button
+                                className={`accordion-button ${openGateGroup === group || (!openGateGroup && index === 0) ? "" : "collapsed"}`}
+                                type="button"
+                                aria-expanded={
+                                  openGateGroup === group ||
+                                  (!openGateGroup && index === 0)
+                                }
+                                aria-controls={`experiment-run-preflight-${currentRun.id}-${group}`}
+                                onClick={() => setOpenGateGroup(group)}
+                              >
+                                {gateGroupLabels[
+                                  group as ExperimentRunGateGroup
+                                ] ?? group}
+                              </button>
+                            </h2>
+                            <div
+                              id={`experiment-run-preflight-${currentRun.id}-${group}`}
+                              className={`accordion-collapse collapse ${openGateGroup === group || (!openGateGroup && index === 0) ? "show" : ""}`}
+                            >
+                              <div className="accordion-body p-0">
+                                <ul className="list-group list-group-flush">
+                                  {gates.map((gate) => (
+                                    <li
+                                      className="list-group-item"
+                                      key={gate.gateCode}
+                                    >
+                                      <div className="d-flex flex-wrap justify-content-between gap-2">
+                                        <div>
+                                          <div className="fw-semibold">
+                                            {gate.gateCode}
+                                          </div>
+                                          <div className="text-muted small">
+                                            {gate.summary}
+                                          </div>
+                                          {gate.remediationCode ? (
+                                            <div className="small text-danger">
+                                              Remediação: {gate.remediationCode}
+                                            </div>
+                                          ) : null}
+                                        </div>
+                                        <span
+                                          className={`badge align-self-start ${badgeClass(gate.status)}`}
+                                        >
+                                          {gate.status}
+                                        </span>
+                                      </div>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        ),
+                      )}
+                    </div>
+                    {homologationGates.length > 0 ? (
+                      <section
+                        className="card border-primary mt-3"
+                        aria-label="Evidências da homologação funcional"
+                      >
+                        <div className="card-body">
+                          <h6 className="mb-1">
+                            Evidências da homologação funcional
+                          </h6>
+                          <p className="text-muted small">
+                            Registre os quatro resultados do run. Evidência
+                            ausente ou reprovada mantém o preflight bloqueado.
+                          </p>
+                          <div className="d-flex flex-column gap-3">
+                            {homologationGates.map((gate) => {
+                              const draft = homologationDrafts[
+                                gate.gateCode
+                              ] ?? {
+                                status: "",
+                                summary: "",
+                                evidenceReference: "",
+                              };
+                              return (
+                                <fieldset
+                                  className="border rounded p-3"
+                                  key={gate.gateCode}
+                                >
+                                  <legend className="float-none w-auto fs-6 px-1">
+                                    {gate.gateCode}
+                                  </legend>
+                                  <div className="row g-2">
+                                    <div className="col-12 col-md-3">
+                                      <label className="form-label small fw-semibold">
+                                        Resultado
+                                        <select
+                                          className="form-select"
+                                          aria-label={`Resultado ${gate.gateCode}`}
+                                          value={draft.status}
+                                          onChange={(event) =>
+                                            updateHomologationDraft(
+                                              gate.gateCode,
+                                              "status",
+                                              event.target.value,
+                                            )
+                                          }
+                                        >
+                                          <option value="">Selecione</option>
+                                          <option value="PASS">Aprovado</option>
+                                          <option value="FAIL">
+                                            Reprovado
+                                          </option>
+                                        </select>
+                                      </label>
+                                    </div>
+                                    <div className="col-12 col-md-9">
+                                      <label className="form-label small fw-semibold">
+                                        Evidência ou artefato
+                                        <input
+                                          className="form-control"
+                                          aria-label={`Evidência ${gate.gateCode}`}
+                                          value={draft.evidenceReference}
+                                          onChange={(event) =>
+                                            updateHomologationDraft(
+                                              gate.gateCode,
+                                              "evidenceReference",
+                                              event.target.value,
+                                            )
+                                          }
+                                          placeholder="URL, contrato ou referência auditável"
+                                        />
+                                      </label>
+                                    </div>
+                                    <div className="col-12">
+                                      <label className="form-label small fw-semibold">
+                                        Conclusão observada
+                                        <textarea
+                                          className="form-control"
+                                          aria-label={`Conclusão ${gate.gateCode}`}
+                                          rows={2}
+                                          value={draft.summary}
+                                          onChange={(event) =>
+                                            updateHomologationDraft(
+                                              gate.gateCode,
+                                              "summary",
+                                              event.target.value,
+                                            )
+                                          }
+                                        />
+                                      </label>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              );
+                            })}
+                          </div>
+                          {recordHomologation.isError ? (
+                            <div className="alert alert-danger py-2 mt-3 mb-0">
+                              Não foi possível registrar a homologação. Revise
+                              os quatro gates e tente novamente.
+                            </div>
+                          ) : null}
+                          <button
+                            type="button"
+                            className="btn btn-primary mt-3"
+                            disabled={
+                              !homologationReady || recordHomologation.isPending
+                            }
+                            onClick={handleRecordHomologation}
+                          >
+                            {recordHomologation.isPending
+                              ? "Registrando..."
+                              : "Registrar homologação"}
+                          </button>
+                        </div>
+                      </section>
+                    ) : null}
+                  </>
                 )}
               </div>
             ) : null}
@@ -227,7 +490,15 @@ export default function ExperimentRunPanel({ experimentId, compact = false }: Ex
   );
 }
 
-function StatusItem({ label, value, badge }: { label: string; value: string; badge?: string }) {
+function StatusItem({
+  label,
+  value,
+  badge,
+}: {
+  label: string;
+  value: string;
+  badge?: string;
+}) {
   return (
     <div className="col-12 col-md-4 col-xl-2">
       <div className="text-muted small">{label}</div>

--- a/pde-platform/README.md
+++ b/pde-platform/README.md
@@ -35,7 +35,10 @@ O health check publico do frontend fica em `GET /healthz` para validar resposta
 HTTP simples do container. Para validar o que evita tela branca comercial, use
 `npm run test:public-health` com `PDE_PUBLIC_HEALTH_URL`: o teste abre a URL
 publicada, exige JavaScript carregado e confere os textos comerciais obrigatorios
-do contrato publico em `GET /pde-health-contract.json`.
+do contrato publico em `GET /pde-health-contract.json`. A navegacao automatizada
+usa obrigatoriamente `mh_preview=qa&pde_analytics=off` e falha se o navegador
+tentar enviar qualquer evento de funil, impedindo que smoke de deploy seja contado
+como visita humana ou mesmo como amostra de QA.
 
 Cada versao publica tambem deve expor `GET /version-diagnostics.json`, com
 `version`, `publicUrl`, `experienceVersion`, `image`, `imageVersionId`,

--- a/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
+++ b/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
@@ -53,7 +53,7 @@
     },
     {
       "path": "pde-platform/frontend/tests/public-health.spec.ts",
-      "sha256": "a7f09ea360ed62231d212d66fa6acf351933950a1ab5186beedcaf37b0bfb52b",
+      "sha256": "7962c91752e9ebd883ba84e467b8f824819226727fb41b53e3d53a4592018cd1",
       "proves": [
         "o deploy do Kit falha se a degustação não estiver renderizada",
         "oferta, preço, checkout e degustação pertencem à mesma superfície pública",

--- a/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
+++ b/pde-platform/contracts/kit-whatsapp-tasting-homologation-v1.json
@@ -2,9 +2,9 @@
   "evidenceVersion": "kit-whatsapp-tasting-homologation-v1",
   "productSlug": "kit-whatsapp-pronto",
   "experimentId": 89,
-  "verifiedAt": "2026-08-24T02:48:27Z",
+  "verifiedAt": "2026-08-24T12:53:01Z",
   "status": "PASSED",
-  "revalidationReason": "Revisão aprovada após preservar o contexto de QA e preview em toda a jornada pública, inclusive políticas abertas em nova aba.",
+  "revalidationReason": "Revisão aprovada após preservar o contexto de QA e preview em toda a jornada pública, inclusive políticas e o smoke automatizado do deploy.",
   "scope": "Degustação determinística, privacidade, eventos, segregação de QA no build público, fronteira paga, checkout e experiência responsiva.",
   "implementationEvidence": [
     {
@@ -53,10 +53,11 @@
     },
     {
       "path": "pde-platform/frontend/tests/public-health.spec.ts",
-      "sha256": "9a7547e8294ba950dbb055c7cf9752c9f0abe5f608f00ae8eccf282f46ddb21a",
+      "sha256": "a7f09ea360ed62231d212d66fa6acf351933950a1ab5186beedcaf37b0bfb52b",
       "proves": [
         "o deploy do Kit falha se a degustação não estiver renderizada",
-        "oferta, preço, checkout e degustação pertencem à mesma superfície pública"
+        "oferta, preço, checkout e degustação pertencem à mesma superfície pública",
+        "o smoke público usa preview sem analytics e falha diante de qualquer tentativa de registrar evento"
       ]
     },
     {

--- a/pde-platform/frontend/tests/public-health.spec.ts
+++ b/pde-platform/frontend/tests/public-health.spec.ts
@@ -181,15 +181,31 @@ function removeMutableFallbackTexts(
   return requiredTexts.filter((text) => !mutableFallbackTexts.has(text));
 }
 
+function safeSmokeHealthPath(healthPath: string) {
+  const url = new URL(healthPath, "http://pde-smoke.local");
+  url.searchParams.set("mh_preview", "qa");
+  url.searchParams.set("pde_analytics", "off");
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 test("health publico renderiza app, javascript e texto comercial", async ({
   page,
   request,
 }) => {
   const pageErrors: string[] = [];
+  const analyticsRequests: string[] = [];
   const contract = await loadContract(request);
 
   page.on("pageerror", (error) => {
     pageErrors.push(error.message);
+  });
+  page.on("request", (browserRequest) => {
+    if (
+      browserRequest.method() === "POST" &&
+      browserRequest.url().includes("/api/pde/access/events")
+    ) {
+      analyticsRequests.push(browserRequest.url());
+    }
   });
 
   const staticHealth = await request.get("/healthz");
@@ -206,7 +222,9 @@ test("health publico renderiza app, javascript e texto comercial", async ({
   expect(diagnostics.imageVersionId).toBeTruthy();
   expect(diagnostics.commitSha).toBeTruthy();
   if (contract.slug === "metodo-musa-7-dias") {
-    expect(diagnostics.knownPointedDomains?.map((domain) => domain.role)).not.toContain("active");
+    expect(
+      diagnostics.knownPointedDomains?.map((domain) => domain.role),
+    ).not.toContain("active");
     expect(
       diagnostics.knownPointedDomains?.map((domain) => domain.host),
     ).toEqual(
@@ -231,7 +249,7 @@ test("health publico renderiza app, javascript e texto comercial", async ({
     publishedFirstFoldTexts,
   );
 
-  const response = await page.goto(contract.healthPath, {
+  const response = await page.goto(safeSmokeHealthPath(contract.healthPath), {
     waitUntil: "networkidle",
   });
   expect(response?.ok()).toBeTruthy();
@@ -276,5 +294,9 @@ test("health publico renderiza app, javascript e texto comercial", async ({
   expect(
     pageErrors,
     `Erros de execucao no health publico: ${pageErrors.join(" | ")}`,
+  ).toEqual([]);
+  expect(
+    analyticsRequests,
+    "O smoke publico nao pode alterar metricas humanas ou de QA.",
   ).toEqual([]);
 });

--- a/pde-platform/frontend/tests/public-health.spec.ts
+++ b/pde-platform/frontend/tests/public-health.spec.ts
@@ -29,6 +29,7 @@ type VersionDiagnostics = {
 type PublicProductContract = {
   publicFirstFold?: {
     headline?: string;
+    supportingText?: string;
     videoCtaLabel?: string;
   };
 };
@@ -160,7 +161,7 @@ async function loadPublishedFirstFoldTexts(
   const product = (await response.json()) as PublicProductContract;
   return [
     product.publicFirstFold?.headline,
-    product.publicFirstFold?.videoCtaLabel,
+    product.publicFirstFold?.supportingText,
   ]
     .map((item) => item?.trim())
     .filter((item): item is string => Boolean(item));

--- a/pde-platform/scripts/run-targeted-production-smokes.sh
+++ b/pde-platform/scripts/run-targeted-production-smokes.sh
@@ -12,7 +12,9 @@ run_public_health() {
   local public_url="$1"
   (
     cd "${frontend_dir}"
-    PDE_PUBLIC_HEALTH_URL="${public_url}" "${npm_command}" run test:public-health
+    PDE_PUBLIC_HEALTH_URL="${public_url}" \
+      PDE_PUBLIC_HEALTH_PATH='/?mh_preview=qa&pde_analytics=off' \
+      "${npm_command}" run test:public-health
   )
 }
 

--- a/pde-platform/scripts/test-targeted-production-smokes.sh
+++ b/pde-platform/scripts/test-targeted-production-smokes.sh
@@ -13,7 +13,10 @@ fake_consistency="${temporary_dir}/consistency.sh"
 cat >"${fake_npm}" <<'FAKE_NPM'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'npm\t%s\t%s\n' "${PDE_PUBLIC_HEALTH_URL:-}" "$*" >>"${PDE_SMOKE_INVOCATION_LOG}"
+printf 'npm\t%s\t%s\t%s\n' \
+  "${PDE_PUBLIC_HEALTH_URL:-}" \
+  "${PDE_PUBLIC_HEALTH_PATH:-}" \
+  "$*" >>"${PDE_SMOKE_INVOCATION_LOG}"
 FAKE_NPM
 
 cat >"${fake_consistency}" <<'FAKE_CONSISTENCY'
@@ -37,15 +40,15 @@ run_target() {
 }
 
 run_target kit-whatsapp
-grep -Fqx $'npm\thttps://kit-whatsapp-pronto.digicomdigital.com.br\trun test:public-health' "${invocation_log}"
+grep -Fqx $'npm\thttps://kit-whatsapp-pronto.digicomdigital.com.br\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}"
 if grep -Fq 'clubemusa.com.br' "${invocation_log}" || grep -Fq 'consistency' "${invocation_log}"; then
   echo '[ARQUITETURA] O deploy direcionado ao Kit WhatsApp validou um produto nao publicado.' >&2
   exit 1
 fi
 
 run_target v5
-grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-health' "${invocation_log}"
-grep -Fqx $'npm\thttps://v5.clubemusa.com.br\trun test:public-diagnostic-smoke' "${invocation_log}"
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}"
+grep -Fqx $'npm\thttps://v5.clubemusa.com.br\t\trun test:public-diagnostic-smoke' "${invocation_log}"
 grep -Fqx $'consistency\thttps://v5.clubemusa.com.br\tmusa-pde-entry-v5-video-explicativo\t' "${invocation_log}"
 if grep -Fq 'v6.clubemusa.com.br' "${invocation_log}" || grep -Fq 'kit-whatsapp-pronto' "${invocation_log}"; then
   echo '[ARQUITETURA] O deploy direcionado ao v5 validou um produto nao publicado.' >&2
@@ -53,8 +56,8 @@ if grep -Fq 'v6.clubemusa.com.br' "${invocation_log}" || grep -Fq 'kit-whatsapp-
 fi
 
 run_target all
-test "$(grep -c $'npm\t.*\trun test:public-health' "${invocation_log}")" -eq 4
-test "$(grep -c $'npm\t.*\trun test:public-diagnostic-smoke' "${invocation_log}")" -eq 2
+test "$(grep -c $'npm\t.*\t/?mh_preview=qa&pde_analytics=off\trun test:public-health' "${invocation_log}")" -eq 4
+test "$(grep -c $'npm\t.*\t\trun test:public-diagnostic-smoke' "${invocation_log}")" -eq 2
 test "$(grep -c '^consistency' "${invocation_log}")" -eq 2
 
 if PDE_SMOKE_NPM_COMMAND="${fake_npm}" \


### PR DESCRIPTION
## Objetivo
Fechar as causas que impedem Vega v7 e os smokes PDE de serem homologados sem contaminar métricas.

## Mudanças
- impede analytics em smoke e preview administrativo;
- valida somente conteúdo efetivamente renderizado na primeira dobra;
- permite registrar pela tela os quatro gates funcionais do run, com PASS/FAIL, conclusão e evidência auditável;
- representa evidência comercial e distribuição no contrato frontend;
- adiciona teste preventivo e registro da causa-raiz.

## Validação local
Duas rodadas completas e consecutivas: 387 testes do frontend por rodada, tipagem, builds do frontend administrativo e PDE e smoke produtivo da Vega em desktop/mobile sem POST de analytics.

## Limites comerciais
Nenhum contato, gasto, pagamento humano ou venda foi produzido. Vega permanece em VALIDACAO_COMERCIAL até este PR ser mergeado, o frontend ser publicado e o run produtivo terminar sem bloqueadores.